### PR TITLE
Make lookup of model names and properties case-insensitive.

### DIFF
--- a/Models/Core/Apsim.cs
+++ b/Models/Core/Apsim.cs
@@ -26,10 +26,11 @@ namespace Models.Core
         /// </summary>
         /// <param name="model">The reference model</param>
         /// <param name="namePath">The name of the object to return</param>
+        /// <param name="ignoreCase">If true, ignore case when searching for the object or property</param>
         /// <returns>The found object or null if not found</returns>
-        public static object Get(IModel model, string namePath)
+        public static object Get(IModel model, string namePath, bool ignoreCase = false)
         {
-            return Locator(model).Get(namePath, model as Model);
+            return Locator(model).Get(namePath, model as Model, ignoreCase);
         }
 
         /// <summary>

--- a/Models/Core/Locater.cs
+++ b/Models/Core/Locater.cs
@@ -63,10 +63,11 @@ namespace Models.Core
         /// </summary>
         /// <param name="namePath">The name of the object to return</param>
         /// <param name="relativeTo">The model calling this method</param>
+        /// <param name="ignoreCase">If true, ignore case when searching for the object or property</param>
         /// <returns>The found object or null if not found</returns>
-        public object Get(string namePath, Model relativeTo)
+        public object Get(string namePath, Model relativeTo, bool ignoreCase = false)
         {
-            IVariable variable = this.GetInternal(namePath, relativeTo);
+            IVariable variable = this.GetInternal(namePath, relativeTo, ignoreCase);
             if (variable == null)
             {
                 return variable;
@@ -101,11 +102,13 @@ namespace Models.Core
         /// </summary>
         /// <param name="namePath">The name of the object to return</param>
         /// <param name="relativeTo">The model calling this method</param>
+        /// <param name="ignoreCase">If true, ignore case when searching for the object or property</param>
         /// <returns>The found object or null if not found</returns>
-        public IVariable GetInternal(string namePath, Model relativeTo)
+        public IVariable GetInternal(string namePath, Model relativeTo, bool ignoreCase = false)
         {
             Model relativeToModel = relativeTo;
             string cacheKey = namePath;
+            StringComparison compareType = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
             // Look in cache first.
             object value = GetFromCache(cacheKey, relativeToModel);
@@ -181,7 +184,7 @@ namespace Models.Core
                 int i;
                 for (i = 0; i < namePathBits.Length; i++)
                 {
-                    IModel localModel = relativeToModel.Children.FirstOrDefault(m => m.Name.Equals(namePathBits[i], StringComparison.OrdinalIgnoreCase));
+                    IModel localModel = relativeToModel.Children.FirstOrDefault(m => m.Name.Equals(namePathBits[i], compareType));
                     if (localModel == null)
                     {
                         break;
@@ -212,11 +215,13 @@ namespace Models.Core
 
                     // Look for either a property or a child model.
                     IModel localModel = null;
-                    PropertyInfo propertyInfo = relativeToObject.GetType().GetProperty(namePathBits[j], BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance | BindingFlags.IgnoreCase);
+                    PropertyInfo propertyInfo = relativeToObject.GetType().GetProperty(namePathBits[j]);
+                    if (propertyInfo == null && ignoreCase) // If not found, try using a case-insensitive search
+                        propertyInfo = relativeToObject.GetType().GetProperty(namePathBits[j], BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance | BindingFlags.IgnoreCase);
                     if (propertyInfo == null && relativeToObject is Model)
                     {
                         // Not a property, may be a child model.
-                        localModel = (relativeToObject as IModel).Children.FirstOrDefault(m => m.Name.Equals(namePathBits[i], StringComparison.OrdinalIgnoreCase));
+                        localModel = (relativeToObject as IModel).Children.FirstOrDefault(m => m.Name.Equals(namePathBits[i], compareType));
                         if (localModel == null)
                         {
                             return null;

--- a/Models/Core/Locater.cs
+++ b/Models/Core/Locater.cs
@@ -181,7 +181,7 @@ namespace Models.Core
                 int i;
                 for (i = 0; i < namePathBits.Length; i++)
                 {
-                    IModel localModel = relativeToModel.Children.FirstOrDefault(m => m.Name == namePathBits[i]);
+                    IModel localModel = relativeToModel.Children.FirstOrDefault(m => m.Name.Equals(namePathBits[i], StringComparison.OrdinalIgnoreCase));
                     if (localModel == null)
                     {
                         break;
@@ -212,11 +212,11 @@ namespace Models.Core
 
                     // Look for either a property or a child model.
                     IModel localModel = null;
-                    PropertyInfo propertyInfo = relativeToObject.GetType().GetProperty(namePathBits[j]);
+                    PropertyInfo propertyInfo = relativeToObject.GetType().GetProperty(namePathBits[j], BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance | BindingFlags.IgnoreCase);
                     if (propertyInfo == null && relativeToObject is Model)
                     {
                         // Not a property, may be a child model.
-                        localModel = (relativeToObject as IModel).Children.FirstOrDefault(m => m.Name == namePathBits[i]);
+                        localModel = (relativeToObject as IModel).Children.FirstOrDefault(m => m.Name.Equals(namePathBits[i], StringComparison.OrdinalIgnoreCase));
                         if (localModel == null)
                         {
                             return null;

--- a/Models/DataStore.cs
+++ b/Models/DataStore.cs
@@ -845,7 +845,7 @@ namespace Models
 
             for (int i = 0; i < names.Length; i++)
             {
-                if (!columnNames.Contains(names[i]))
+                if (!columnNames.Contains(names[i], StringComparer.OrdinalIgnoreCase))
                 {
                     string sql = "ALTER TABLE " + tableName + " ADD COLUMN [";
                     sql += names[i] + "] " + GetSQLColumnType(types[i]);

--- a/Models/Report/ReportColumn.cs
+++ b/Models/Report/ReportColumn.cs
@@ -372,7 +372,7 @@ namespace Models.Report
         /// </summary>
         private void StoreValue()
         {
-            object value = Apsim.Get(this.parentModel.Parent, this.variableName);
+            object value = Apsim.Get(this.parentModel.Parent, this.variableName, true);
 
             if (value == null)
                 this.values.Add(null);
@@ -403,7 +403,7 @@ namespace Models.Report
         {
             if (this.clock.Today != this.lastStoreDate)
             {
-                object value = Apsim.Get(this.parentModel.Parent, this.variableName);
+                object value = Apsim.Get(this.parentModel.Parent, this.variableName, true);
 
                 if (value == null)
                     this.valuesToAggregate.Add(null);


### PR DESCRIPTION
Resolves #13. However, it does so by making ALL property lookups case-insensitive in Locater.GetInternal. This may have undesired side effects.