### PR TITLE
Fix for grid cell copy crash

### DIFF
--- a/UserInterface/Views/GridView.cs
+++ b/UserInterface/Views/GridView.cs
@@ -693,7 +693,24 @@ namespace UserInterface.Views
         /// <param name="e">The event arguments</param>
         private void OnCopyToClipboard(object sender, EventArgs e)
         {
-            DataObject content = this.Grid.GetClipboardContent();
+            // this.Grid.EndEdit();
+            DataObject content = new DataObject();
+            if (this.Grid.SelectedCells.Count==1)
+            {
+                if (this.Grid.CurrentCell.IsInEditMode)
+                {
+                    if (this.Grid.EditingControl is System.Windows.Forms.TextBox)
+                    {
+                        string text = ((System.Windows.Forms.TextBox)this.Grid.EditingControl).SelectedText;
+                        content.SetText(text);
+                    }
+                }
+                else
+                    content.SetText(this.Grid.CurrentCell.Value.ToString());
+            }
+            else
+            content = this.Grid.GetClipboardContent();
+
             Clipboard.SetDataObject(content);
         }
 


### PR DESCRIPTION
Resolves #334 The error occurred any time a user tried to copy from a grid cell while the cell was in edit mode. This would cause the GetClipboardContent method to return null. Added code to handle the user being in edit mode when copying.