### PR TITLE
Null reference in auto documentation

### DIFF
--- a/Models/Core/Simulations.cs
+++ b/Models/Core/Simulations.cs
@@ -447,7 +447,7 @@ namespace Models.Core
                 IModel modelToDocument = Apsim.Find(simulation, modelNameToDocument);
 
                 if (modelToDocument == null)
-                    throw new ApsimXException(this, "Cold not find a model of the name " + modelNameToDocument + ". Simulation file name must match the name of the node to document.");
+                    throw new ApsimXException(this, "Could not find a model of the name " + modelNameToDocument + ". Simulation file name must match the name of the node to document.");
 
                 // Get the path of the model (relative to parentSimulation) to document so that 
                 // when replacements happen below we will point to the replacement model not the 

--- a/Models/Core/Simulations.cs
+++ b/Models/Core/Simulations.cs
@@ -446,6 +446,9 @@ namespace Models.Core
                 // Find the model of the right name.
                 IModel modelToDocument = Apsim.Find(simulation, modelNameToDocument);
 
+                if (modelToDocument == null)
+                    throw new ApsimXException(this, "Cold not find a model of the name " + modelNameToDocument + ". Simulation file name must match the name of the node to document.");
+
                 // Get the path of the model (relative to parentSimulation) to document so that 
                 // when replacements happen below we will point to the replacement model not the 
                 // one passed into this method.


### PR DESCRIPTION
Working on #359. Added better error message where auto docs can't find the model to document.