### PR TITLE
Empty cells can now be pasted in AgroForestry grids.

### DIFF
--- a/UserInterface/Presenters/ExplorerPresenter.cs
+++ b/UserInterface/Presenters/ExplorerPresenter.cs
@@ -393,7 +393,14 @@ namespace UserInterface.Presenters
             try
             {
                 XmlDocument document = new XmlDocument();
-                document.LoadXml(xml);
+                try
+                {
+                    document.LoadXml(xml);
+                }
+                catch(XmlException)
+                {
+                    this.view.ShowMessage("Invalid XML. Are you sure you're trying to paste an APSIM model?", DataStore.ErrorLevel.Error);
+                }
                 object newModel = XmlUtilities.Deserialise(document.DocumentElement, Assembly.GetExecutingAssembly());
 
                 // See if the presenter is happy with this model being added.

--- a/UserInterface/Views/TreeProxyView.cs
+++ b/UserInterface/Views/TreeProxyView.cs
@@ -921,16 +921,16 @@ namespace UserInterface.Views
             //TODO: Get this working with data copied from other cells in the grid.
             //      Also needs to work with blank cells and block deletes.
             //source: https://social.msdn.microsoft.com/Forums/windows/en-US/e9cee429-5f36-4073-85b4-d16c1708ee1e/how-to-paste-ctrlv-shiftins-the-data-from-clipboard-to-datagridview-datagridview1-c?forum=winforms
+            DataGridView grid = sender as DataGridView;
             if ((e.Shift && e.KeyCode == Keys.Insert) || (e.Control && e.KeyCode == Keys.V))
             {
-                DataGridView grid = sender as DataGridView;
-                char[] rowSplitter = { '\r', '\n' };
+                string[] rowSplitter = { Environment.NewLine };
                 char[] columnSplitter = { '\t' };
                 //get the text from clipboard
                 IDataObject dataInClipboard = Clipboard.GetDataObject();
                 string stringInClipboard = (string)dataInClipboard.GetData(DataFormats.Text);
                 //split it into lines
-                string[] rowsInClipboard = stringInClipboard.Split(rowSplitter, StringSplitOptions.RemoveEmptyEntries);
+                string[] rowsInClipboard = stringInClipboard.Split(rowSplitter, StringSplitOptions.None);
                 //get the row and column of selected cell in Grid
                 int r = grid.SelectedCells[0].RowIndex;
                 int c = grid.SelectedCells[0].ColumnIndex;
@@ -948,6 +948,12 @@ namespace UserInterface.Views
                         if (grid.ColumnCount - 1 >= c + iCol)
                             grid.Rows[r + iRow].Cells[c + iCol].Value = valuesInRow[iCol];
                 }
+            }
+
+            if (e.KeyCode == Keys.Delete)
+            {
+                foreach ( DataGridViewCell cell in grid.SelectedCells)
+                    cell.Value = string.Empty;
             }
         }
 


### PR DESCRIPTION
Resolves #387 
Selections can now be deleted with the Delete key.
Better error message when trying to paste invalid XML to the Explorer view.