### PR TITLE
Add timing information to simulations.

### DIFF
--- a/Models/Core/Simulation.cs
+++ b/Models/Core/Simulation.cs
@@ -150,6 +150,7 @@ namespace Models.Core
         /// <exception cref="ApsimXException">Cannot invoke Commenced</exception>
         public void DoRun(object sender)
         {
+            Console.WriteLine("File: " + Path.GetFileNameWithoutExtension(this.FileName) + ", Simulation " + this.Name + " has commenced.");
             if (DoCommence != null)
                 DoCommence.Invoke(sender, new EventArgs());
             else
@@ -173,10 +174,7 @@ namespace Models.Core
             }
 
             timer.Stop();
+            Console.WriteLine("File: " + Path.GetFileNameWithoutExtension(this.FileName) + ", Simulation " + this.Name + " complete. Time: " + timer.Elapsed.TotalSeconds.ToString("0.00 sec"));
         }
-
-
     }
-
-
 }


### PR DESCRIPTION
Resolves #539 
Simulation run time is now output to console when running from the command line.