### PR TITLE
Old Model.xml still being refered to instead of new Models.xml

### DIFF
--- a/Models/Models.csproj
+++ b/Models/Models.csproj
@@ -9,7 +9,7 @@
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Models</RootNamespace>
-    <AssemblyName>Model</AssemblyName>
+    <AssemblyName>Models</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -41,7 +41,7 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DocumentationFile>..\Bin\Model.xml</DocumentationFile>
+    <DocumentationFile>..\Bin\Models.xml</DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -52,7 +52,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DocumentationFile>..\Bin\Model.xml</DocumentationFile>
+    <DocumentationFile>..\Bin\Models.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -69,7 +69,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>..\Bin\</OutputPath>
     <DefineConstants>TRACE;APSIMX</DefineConstants>
-    <DocumentationFile>..\Bin\Model.xml</DocumentationFile>
+    <DocumentationFile>..\Bin\Models.xml</DocumentationFile>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x86</PlatformTarget>

--- a/Setup/apsimx.iss
+++ b/Setup/apsimx.iss
@@ -164,7 +164,7 @@ Name: {localappdata}\VirtualStore\Apsim; Type: dirifempty
 Source: ..\Bin\*.exe; DestDir: {app}\Bin; Flags: ignoreversion; 
 Source: ..\Bin\*.dll; DestDir: {app}\Bin; Flags: ignoreversion; 
 Source: ..\Bin\UserInterface.exe.config; DestDir: {app}\Bin; Flags: ignoreversion; 
-Source: ..\Bin\Model.xml; DestDir: {app}\Bin; Flags: ignoreversion; 
+Source: ..\Bin\Models.xml; DestDir: {app}\Bin; Flags: ignoreversion; 
 Source: ..\APSIM.bib; DestDir: {app}; Flags: ignoreversion; 
 
 ;Sample files 


### PR DESCRIPTION
This causes a problem with the Create Documentation tool.

You should delete out any binaries in your Bin folder that start with "Model." when updating past this commit.

Resolves #576 