### PR TITLE
Use proper syntax for file filter.

### DIFF
--- a/Models/PostSimulationTools/ExcelInput.cs
+++ b/Models/PostSimulationTools/ExcelInput.cs
@@ -46,6 +46,10 @@ namespace Models.PostSimulationTools
             }
         }
 
+        /// <summary>Gets or sets the texture metadata.</summary>
+        /// <value>The texture metadata.</value>
+        public string[] FileNameMetadata { get; set; }
+
         /// <summary>
         /// Gets or sets the list of EXCEL sheet names to read from.
         /// </summary>

--- a/UserInterface/Classes/GridCell.cs
+++ b/UserInterface/Classes/GridCell.cs
@@ -113,7 +113,9 @@ namespace UserInterface.Classes
 
                     case EditorTypeEnum.Button:
                         {
-                            this.gridView.Grid[this.ColumnIndex, this.RowIndex] = new DataGridViewButtonCell();
+                            DataGridViewButtonCell buttonCell = new DataGridViewButtonCell();
+                            this.gridView.Grid[this.ColumnIndex, this.RowIndex] = buttonCell;
+                            buttonCell.Tag = DropDownStrings;
                             break;
                         }
 
@@ -146,6 +148,8 @@ namespace UserInterface.Classes
             }
         }
 
+        private string[] _DropDownStrings = null;
+
         /// <summary>
         /// Gets or sets the strings to be used in the drop down editor for this cell
         /// </summary>
@@ -161,9 +165,10 @@ namespace UserInterface.Classes
                     {
                         strings.Add(comboItem.ToString());
                     }
+                    return strings.ToArray();
                 }
-
-                return null;
+                else
+                  return _DropDownStrings;
             }
 
             set
@@ -186,6 +191,8 @@ namespace UserInterface.Classes
                         }
                     }
                 }
+                else
+                    _DropDownStrings = value;
             }
         }
 

--- a/UserInterface/Presenters/PropertyPresenter.cs
+++ b/UserInterface/Presenters/PropertyPresenter.cs
@@ -254,6 +254,7 @@ namespace UserInterface.Presenters
                 }
                 else if (this.properties[i].DisplayType == DisplayAttribute.DisplayTypeEnum.FileName)
                 {
+                    cell.DropDownStrings = this.properties[i].Metadata;
                     cell.EditorType = EditorTypeEnum.Button;
                 }
                 else if (this.properties[i].DisplayType == DisplayAttribute.DisplayTypeEnum.FieldName)
@@ -431,7 +432,20 @@ namespace UserInterface.Presenters
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         private void OnFileBrowseClick(object sender, GridCellsChangedArgs e)
         {
-            string fileName = explorerPresenter.MainPresenter.AskUserForOpenFileName("All files (*.*)|*.*");
+            string filterString = "";
+            string[] fileFilters = e.ChangedCells[0].DropDownStrings;
+            if (fileFilters != null)
+            {
+                for (int i = 0; i < fileFilters.Length; i++)
+                {
+                    if (i > 0)
+                        filterString += '|';
+                    filterString += fileFilters[i];
+                }
+            }
+            else
+              filterString = "All files (*.*)|*.*";
+            string fileName = explorerPresenter.MainPresenter.AskUserForOpenFileName(filterString);
             if (fileName != null)
             {
                 e.ChangedCells[0].Value = fileName;

--- a/UserInterface/Presenters/PropertyPresenter.cs
+++ b/UserInterface/Presenters/PropertyPresenter.cs
@@ -431,7 +431,7 @@ namespace UserInterface.Presenters
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
         private void OnFileBrowseClick(object sender, GridCellsChangedArgs e)
         {
-            string fileName = explorerPresenter.MainPresenter.AskUserForOpenFileName("*.*");
+            string fileName = explorerPresenter.MainPresenter.AskUserForOpenFileName("All files (*.*)|*.*");
             if (fileName != null)
             {
                 e.ChangedCells[0].Value = fileName;

--- a/UserInterface/Resources/Toolboxes/StandardToolbox.apsimx
+++ b/UserInterface/Resources/Toolboxes/StandardToolbox.apsimx
@@ -844,7 +844,13 @@
     <Input>
       <Name>Input</Name>
     </Input>
-    <ExcelInput />
+    <ExcelInput>
+      <Name>ExcelInput</Name>
+      <FileNameMetadata>
+        <string>Excel files (*.xlsx)|*.xlsx</string>
+        <string>All files (*.*)|*.*</string>
+      </FileNameMetadata>
+    </ExcelInput>
     <PredictedObserved/>
     <TimeSeriesStats>
       <TableName>PredictedObserved</TableName>

--- a/UserInterface/Views/GridView.cs
+++ b/UserInterface/Views/GridView.cs
@@ -829,6 +829,9 @@ namespace UserInterface.Views
             IGridCell cell = this.GetCell(e.ColumnIndex, e.RowIndex);
             if (cell != null && cell.EditorType == EditorTypeEnum.Button)
             {
+                DataGridViewButtonCell gridCell = Grid[e.ColumnIndex, e.RowIndex] as DataGridViewButtonCell;
+                if (gridCell != null)
+                    cell.DropDownStrings = (string[])gridCell.Tag;
                 GridCellsChangedArgs cellClicked = new GridCellsChangedArgs();
                 cellClicked.ChangedCells = new List<IGridCell>();
                 cellClicked.ChangedCells.Add(cell);


### PR DESCRIPTION
Resolves #813 .

This small change fixes the immediate problem, which was a consequence of bad syntax in the file filter being passed to the FIleOpen dialog, but I don't want to mark it as resolved just yet, because what's really needed is a mechanism for passing in the correct file filter. In this specific case, we want to be able to look for *.xlsx files, not all files.