### PR TITLE
Allow plant to die as population decrease and retranslocation on SimpleLeaf

### DIFF
--- a/Models/Plant/Organs/GenericOrgan.cs
+++ b/Models/Plant/Organs/GenericOrgan.cs
@@ -193,25 +193,36 @@ namespace Models.PMF.Organs
                 PotentialDMAllocation = value.Structural + value.Metabolic;
             }
         }
+
         /// <summary>Gets or sets the dm supply.</summary>
         /// <value>The dm supply.</value>
         public override BiomassSupplyType DMSupply
         {
             get
             {
-                double _DMRetranslocationFactor = 0;
-                if (DMRetranslocationFactor != null) //Default of 0 means retranslocation is always truned off!!!!
-                    _DMRetranslocationFactor = DMRetranslocationFactor.Value;
                 return new BiomassSupplyType
                 {
-                    Fixation = 0,
-                    Retranslocation = StartLive.NonStructuralWt * _DMRetranslocationFactor,
-                    Reallocation = 0
+                    Fixation = 0.0,
+                    Retranslocation = availableDMRetranslocation(),
+                    Reallocation = 0.0
                 };
             }
         }
-        /// <summary>Gets or sets the n demand.</summary>
-        /// <value>The n demand.</value>
+
+        /// <summary>Gets the amount of DM available for retranslocation</summary>
+        /// <returns>DM available to retranslocate</returns>
+        public double availableDMRetranslocation()
+        {
+            if (DMRetranslocationFactor != null)
+                return StartLive.NonStructuralWt * DMRetranslocationFactor.Value;
+            else
+            { //Default of 0 means retranslocation is always turned off!!!!
+                return 0.0;
+            }
+        }
+
+        /// <summary>Gets or sets the N demand.</summary>
+        /// <value>The N demand.</value>
         public override BiomassPoolType NDemand
         {
             get
@@ -226,30 +237,49 @@ namespace Models.PMF.Organs
                 return new BiomassPoolType { Structural = StructuralNDemand, NonStructural = NonStructuralNDemand };
             }
         }
-        /// <summary>Gets or sets the n supply.</summary>
-        /// <value>The n supply.</value>
+        /// <summary>Gets or sets the N supply.</summary>
+        /// <value>The N supply.</value>
         public override BiomassSupplyType NSupply
         {
             get
             {
-                BiomassSupplyType Supply = new BiomassSupplyType();
-
-                // Calculate Reallocation Supply.
-                double _NReallocationFactor = 0;
-                if (NReallocationFactor != null) //Default of zero means N reallocation is truned off
-                    _NReallocationFactor = NReallocationFactor.Value;
-                Supply.Reallocation = SenescenceRate * StartLive.NonStructuralN * _NReallocationFactor;
-
-                // Calculate Retranslocation Supply.
-                double _NRetranslocationFactor = 0;
-                if (NRetranslocationFactor != null) //Default of zero means retranslocation is turned off
-                    _NRetranslocationFactor = NRetranslocationFactor.Value;
-                double LabileN = Math.Max(0, StartLive.NonStructuralN - StartLive.NonStructuralWt * MinimumNConc.Value);
-                Supply.Retranslocation = (LabileN - StartNReallocationSupply) * _NRetranslocationFactor;
-
-                return Supply;
+                return new BiomassSupplyType()
+                {
+                    Reallocation = availableNReallocation(),
+                    Retranslocation = availableNRetranslocation(),
+                    Uptake = 0.0
+                };
             }
         }
+
+        /// <summary>Gets the N amount available for retranslocation</summary>
+        /// <returns>N available to retranslocate</returns>
+        public double availableNRetranslocation()
+        {
+            if (NRetranslocationFactor != null)
+            {
+                double LabileN = Math.Max(0, StartLive.NonStructuralN - StartLive.NonStructuralWt * MinimumNConc.Value);
+                return (LabileN - StartNReallocationSupply) * NRetranslocationFactor.Value;
+            }
+            else
+            {
+                //Default of 0 means retranslocation is always turned off!!!!
+                return 0.0;
+            }
+        }
+
+        /// <summary>Gets the N amount available for reallocation</summary>
+        /// <returns>DM available to reallocate</returns>
+        public double availableNReallocation()
+        {
+            if (NReallocationFactor != null)
+                return SenescenceRate * StartLive.NonStructuralN * NReallocationFactor.Value;
+            else
+            { //Default of 0 means reallocation is always turned off!!!!
+                return 0.0;
+            }
+        }
+
         /// <summary>Sets the dm allocation.</summary>
         /// <value>The dm allocation.</value>
         /// <exception cref="System.Exception">

--- a/Models/Plant/Organs/GenericOrgan.cs
+++ b/Models/Plant/Organs/GenericOrgan.cs
@@ -203,7 +203,7 @@ namespace Models.PMF.Organs
                 return new BiomassSupplyType
                 {
                     Fixation = 0.0,
-                    Retranslocation = availableDMRetranslocation(),
+                    Retranslocation = AvailableDMRetranslocation(),
                     Reallocation = 0.0
                 };
             }
@@ -211,7 +211,7 @@ namespace Models.PMF.Organs
 
         /// <summary>Gets the amount of DM available for retranslocation</summary>
         /// <returns>DM available to retranslocate</returns>
-        public double availableDMRetranslocation()
+        public double AvailableDMRetranslocation()
         {
             if (DMRetranslocationFactor != null)
                 return StartLive.NonStructuralWt * DMRetranslocationFactor.Value;
@@ -245,8 +245,8 @@ namespace Models.PMF.Organs
             {
                 return new BiomassSupplyType()
                 {
-                    Reallocation = availableNReallocation(),
-                    Retranslocation = availableNRetranslocation(),
+                    Reallocation = AvailableNReallocation(),
+                    Retranslocation = AvailableNRetranslocation(),
                     Uptake = 0.0
                 };
             }
@@ -254,7 +254,7 @@ namespace Models.PMF.Organs
 
         /// <summary>Gets the N amount available for retranslocation</summary>
         /// <returns>N available to retranslocate</returns>
-        public double availableNRetranslocation()
+        public double AvailableNRetranslocation()
         {
             if (NRetranslocationFactor != null)
             {
@@ -270,7 +270,7 @@ namespace Models.PMF.Organs
 
         /// <summary>Gets the N amount available for reallocation</summary>
         /// <returns>DM available to reallocate</returns>
-        public double availableNReallocation()
+        public double AvailableNReallocation()
         {
             if (NReallocationFactor != null)
                 return SenescenceRate * StartLive.NonStructuralN * NReallocationFactor.Value;

--- a/Models/Plant/Organs/Root.cs
+++ b/Models/Plant/Organs/Root.cs
@@ -764,18 +764,31 @@ namespace Models.PMF.Organs
         {
             get
             {
-                if (Soil.Thickness != null)
+                return new BiomassSupplyType()
                 {
-                    double[] no3supply = new double[Soil.Thickness.Length];
-                    double[] nh4supply = new double[Soil.Thickness.Length];
-                    SoilNSupply(no3supply, nh4supply);
-                    double NSupply = (Math.Min(MathUtilities.Sum(no3supply), MaxDailyNUptake.Value) + Math.Min(MathUtilities.Sum(nh4supply), MaxDailyNUptake.Value)) * kgha2gsm;
-                    NuptakeSupply = NSupply;
-                    return new BiomassSupplyType { Uptake = NSupply };
-                    
-                }
-                else
-                    return new BiomassSupplyType();
+                    Reallocation = 0.0,
+                    Retranslocation = 0.0,
+                    Uptake = availableNUptake()
+                };
+            }
+        }
+
+        /// <summary>Gets the N amount available for uptake</summary>
+        /// <returns>N available to be taken up</returns>
+        public double availableNUptake()
+        {
+            if (Soil.Thickness != null)
+            {
+                double[] no3supply = new double[Soil.Thickness.Length];
+                double[] nh4supply = new double[Soil.Thickness.Length];
+                SoilNSupply(no3supply, nh4supply);
+                double NSupply = (Math.Min(MathUtilities.Sum(no3supply), MaxDailyNUptake.Value) +
+                                  Math.Min(MathUtilities.Sum(nh4supply), MaxDailyNUptake.Value)) * kgha2gsm;
+                return NSupply;
+            }
+            else
+            { //Soil not initialised yet
+                return 0.0;
             }
         }
 

--- a/Models/Plant/Organs/Root.cs
+++ b/Models/Plant/Organs/Root.cs
@@ -768,14 +768,14 @@ namespace Models.PMF.Organs
                 {
                     Reallocation = 0.0,
                     Retranslocation = 0.0,
-                    Uptake = availableNUptake()
+                    Uptake = AvailableNUptake()
                 };
             }
         }
 
         /// <summary>Gets the N amount available for uptake</summary>
         /// <returns>N available to be taken up</returns>
-        public double availableNUptake()
+        public double AvailableNUptake()
         {
             if (Soil.Thickness != null)
             {

--- a/Models/Plant/Organs/SimpleLeaf.cs
+++ b/Models/Plant/Organs/SimpleLeaf.cs
@@ -317,12 +317,12 @@ namespace Models.PMF.Organs
         {
             get
             {
-                if (Math.Round(Photosynthesis.Value + availableDMRetranslocation(), 8) < 0)
+                if (Math.Round(Photosynthesis.Value + AvailableDMRetranslocation(), 8) < 0)
                     throw new Exception(this.Name + " organ is returning a negative DM supply.  Check your parameterisation");
                 return new BiomassSupplyType
                 {
                     Fixation = Photosynthesis.Value,
-                    Retranslocation = availableDMRetranslocation(),
+                    Retranslocation = AvailableDMRetranslocation(),
                     Reallocation = 0.0
                 };
             }

--- a/Models/Plant/Organs/SimpleLeaf.cs
+++ b/Models/Plant/Organs/SimpleLeaf.cs
@@ -310,17 +310,24 @@ namespace Models.PMF.Organs
                 return new BiomassPoolType { Structural = Demand };
             }
         }
+
         /// <summary>Gets or sets the dm supply.</summary>
         /// <value>The dm supply.</value>
         public override BiomassSupplyType DMSupply
         {
             get
             {
-                if (Math.Round(Photosynthesis.Value, 8) < 0)
+                if (Math.Round(Photosynthesis.Value + availableDMRetranslocation(), 8) < 0)
                     throw new Exception(this.Name + " organ is returning a negative DM supply.  Check your parameterisation");
-                return new BiomassSupplyType { Fixation = Photosynthesis.Value, Retranslocation = 0, Reallocation = 0 };
+                return new BiomassSupplyType
+                {
+                    Fixation = Photosynthesis.Value,
+                    Retranslocation = availableDMRetranslocation(),
+                    Reallocation = 0.0
+                };
             }
         }
+
         /// <summary>Sets the dm allocation.</summary>
         /// <value>The dm allocation.</value>
         public override BiomassAllocationType DMAllocation

--- a/Models/Plant/Plant.cs
+++ b/Models/Plant/Plant.cs
@@ -159,11 +159,10 @@ namespace Models.PMF
             get { return plantPopulation; }
             set
             {
-                if (value <= 0.0)
+                if (value <= 0.5)
                 {
-                    // the plant is dead
-                    plantPopulation = 0.0;
-                    SowingData = null;
+                    // the plant is dead due to population decline
+                    EndCrop();
                 }
                 else
                     plantPopulation = value;
@@ -357,7 +356,7 @@ namespace Models.PMF
         private void Clear()
         {
             SowingData = null;
-            Population = 0;
+            plantPopulation = 0.0;
         }
         #endregion
         

--- a/Models/Plant/Plant.cs
+++ b/Models/Plant/Plant.cs
@@ -159,9 +159,9 @@ namespace Models.PMF
             get { return plantPopulation; }
             set
             {
-                if (value <= 0.5)
+                if (IsAlive && value <= 0.1)
                 {
-                    // the plant is dead due to population decline
+                    // the plant is dying due to population decline
                     EndCrop();
                 }
                 else

--- a/Models/Plant/Plant.cs
+++ b/Models/Plant/Plant.cs
@@ -146,11 +146,29 @@ namespace Models.PMF
             }
         }
 
-        /// <summary>Gets or sets the population.</summary>
+
+        /// <summary>Holds the number of plants.</summary>
+        private double plantPopulation = 0.0;
+
+        /// <summary>Gets or sets the plant population.</summary>
         [XmlIgnore]
         [Description("Number of plants per meter2")]
         [Units("/m2")]
-        public double Population { get; set; }
+        public double Population
+        {
+            get { return plantPopulation; }
+            set
+            {
+                if (value <= 0.0)
+                {
+                    // the plant is dead
+                    plantPopulation = 0.0;
+                    SowingData = null;
+                }
+                else
+                    plantPopulation = value;
+            }
+        }
 
         /// <summary>Return true if plant is alive and in the ground.</summary>
         public bool IsAlive { get { return SowingData != null; } }


### PR DESCRIPTION
Working on #65  - Chicory model
1) I've changed Population from a field to property, this allows to check the value being set, if population is zero then clear the SowingData (effectively setting IsAlive to False).
 2) I've changed the methods DMSupply and NSupply on GenericOrgan (and so in SimpleLeaf) so that retranslocation can be set to leaf too. I did this by removing the calculations from those methods and created functions to compute reallocated and retranslocated (N and DM), which are called. For consistency I did it too for NUptake. I am not sure not whether these function should be set to overrideable. Ideally Root and Leaf would also have the retranslocation enables, but I did not do it now. Should they inherit GenericOrgan and so have that capability?