### PR TITLE
For GTK# GUI, ensure the temporary window used when creating maps for…

### DIFF
--- a/ApsimNG/MainForm.cs
+++ b/ApsimNG/MainForm.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using APSIM.Shared.Utilities;
 using Glade;
@@ -26,6 +27,7 @@ namespace UserInterface
 
     public class ViewBase
     {
+        static string[] resources = Assembly.GetExecutingAssembly().GetManifestResourceNames();
         protected ViewBase _owner = null;
         protected Widget _mainWidget = null;
         public ViewBase Owner { get { return _owner; } }
@@ -35,6 +37,10 @@ namespace UserInterface
         protected Gdk.Window mainWindow { get { return MainWidget == null ? null : MainWidget.Toplevel.GdkWindow; } }
         private bool waiting = false;
 
+        protected bool hasResource(string name)
+        {
+            return resources.Contains(name);
+        }
         public bool WaitCursor
         {
             get

--- a/ApsimNG/Views/ExplorerView.cs
+++ b/ApsimNG/Views/ExplorerView.cs
@@ -353,16 +353,27 @@ namespace UserInterface.Views
                 toolStrip.Remove(child);
             foreach (MenuDescriptionArgs description in menuDescriptions)
             {
-                Gdk.Pixbuf pixbuf = new Gdk.Pixbuf(null, description.ResourceNameForImage, 20, 20);
-                ToolButton button = new ToolButton(new Gtk.Image(pixbuf), description.Name);
-                button.Homogeneous = false;
-                button.LabelWidget = new Label(description.Name);
-                Pango.FontDescription font = new Pango.FontDescription();
-                font.Size = (int)(8 * Pango.Scale.PangoScale);
-                button.LabelWidget.ModifyFont(font);
-                if (description.OnClick != null)
-                    button.Clicked += description.OnClick;
-                toolStrip.Add(button);
+                if (!hasResource(description.ResourceNameForImage))
+                {
+                    MessageDialog md = new MessageDialog(MainWidget.Toplevel as Window, DialogFlags.Modal, MessageType.Error, ButtonsType.Ok,
+                        "Program error. Could not locate the resource named " + description.ResourceNameForImage);
+                    md.Run();
+                    md.Destroy();
+                }
+                else
+                {
+
+                    Gdk.Pixbuf pixbuf = new Gdk.Pixbuf(null, description.ResourceNameForImage, 20, 20);
+                    ToolButton button = new ToolButton(new Gtk.Image(pixbuf), description.Name);
+                    button.Homogeneous = false;
+                    button.LabelWidget = new Label(description.Name);
+                    Pango.FontDescription font = new Pango.FontDescription();
+                    font.Size = (int)(8 * Pango.Scale.PangoScale);
+                    button.LabelWidget.ModifyFont(font);
+                    if (description.OnClick != null)
+                        button.Clicked += description.OnClick;
+                    toolStrip.Add(button);
+                }
             }
             ToolItem item = new ToolItem();
             item.Expand = true;
@@ -391,14 +402,8 @@ namespace UserInterface.Views
             foreach (MenuDescriptionArgs Description in menuDescriptions)
             {
                 ImageMenuItem item = new ImageMenuItem(Description.Name);
-                if (!String.IsNullOrEmpty(Description.ResourceNameForImage))
-                    try
-                    {
-                        item.Image = new Image(null, Description.ResourceNameForImage);
-                    }
-                    catch (Exception /*e*/)
-                    {
-                    }
+                if (!String.IsNullOrEmpty(Description.ResourceNameForImage) && hasResource(Description.ResourceNameForImage) )
+                    item.Image = new Image(null, Description.ResourceNameForImage);
                 item.Activated += Description.OnClick;
                 Popup.Append(item);
             }
@@ -656,14 +661,10 @@ namespace UserInterface.Views
         private void RefreshNode(TreeIter node, NodeDescriptionArgs description)
         {
             Gdk.Pixbuf pixbuf;
-            try
-            {
+            if (hasResource(description.ResourceNameForImage))
                 pixbuf = new Gdk.Pixbuf(null, description.ResourceNameForImage);
-            }
-            catch (ArgumentException /*e*/)
-            {
-                pixbuf = new Gdk.Pixbuf(null, "ApsimNG.Resources.TreeViewImages.Simulations.png"); // Something else we could use as a default?
-            }
+            else
+                pixbuf = new Gdk.Pixbuf(null, "ApsimNG.Resources.TreeViewImages.Simulations.png"); // It there something else we could use as a default?
 
             treemodel.SetValues(node, description.Name, pixbuf, description.ToolTip);
 

--- a/ApsimNG/Views/MapView.cs
+++ b/ApsimNG/Views/MapView.cs
@@ -121,7 +121,7 @@ var locations = [";
        center:myCenter,
        zoom: 1,
 ";
-            if (tempWindow) // When exporting into a report, leave off the controls
+            if (popupWin != null) // When exporting into a report, leave off the controls
             {
                 html += "zoomControl: false,";
                 html += "mapTypeControl: false,";
@@ -163,10 +163,10 @@ google.maps.event.addDomListener(window, 'load', initialize);
             SetContents(html, false);
         }
 
-    /// <summary>
-    /// Export the map to an image.
-    /// </summary>
-    public Image Export()
+        /// <summary>
+        /// Export the map to an image.
+        /// </summary>
+        public Image Export()
         {
             // Create a Bitmap and draw the DataGridView on it.
             int width;


### PR DESCRIPTION
… documentation is properly destroyed.

Check for the existence of icon resources, rather than rely on exception handling when they are absent.

Working on #626