### PR TITLE
Changes to let the user enter new rows of soil water data.

### DIFF
--- a/ApsimNG/Commands/ChangeProperty.cs
+++ b/ApsimNG/Commands/ChangeProperty.cs
@@ -149,9 +149,12 @@ namespace UserInterface.Commands
                         this.wasModified = ReflectionUtilities.SetValueOfProperty(this.Name, this.Obj, this.NewValue);
                     }
                 }
-                catch (Exception)
+                catch (Exception e)
                 {
                     this.wasModified = false;
+                    if (e is System.Reflection.TargetInvocationException)
+                        e = (e as System.Reflection.TargetInvocationException).InnerException;
+                    throw e; // Pass the exception on for further handling
                 }
 
                 return this.wasModified;

--- a/ApsimNG/Presenters/ExplorerPresenter.cs
+++ b/ApsimNG/Presenters/ExplorerPresenter.cs
@@ -855,6 +855,8 @@ namespace UserInterface.Presenters
             }
             catch (Exception err)
             {
+                if (err is System.Reflection.TargetInvocationException)
+                    err = (err as System.Reflection.TargetInvocationException).InnerException;
                 string message = err.Message;
                 message += "\r\n" + err.StackTrace;
                 MainPresenter.ShowMessage(message, DataStore.ErrorLevel.Error);

--- a/ApsimNG/Presenters/ProfilePresenter.cs
+++ b/ApsimNG/Presenters/ProfilePresenter.cs
@@ -334,7 +334,14 @@ namespace UserInterface.Presenters
                     columnName = columnName + "\r\n" + total.ToString("N1");
                 }
 
-                Array values = property.Value as Array;
+                Array values = null;
+                try
+                {
+                    values = property.Value as Array;
+                }
+                catch (Exception)
+                {
+                }
 
                 if (table.Columns.IndexOf(columnName) == -1)
                 {
@@ -375,68 +382,77 @@ namespace UserInterface.Presenters
         /// </summary>
         private void SaveGrid()
         {
-            this.explorerPresenter.CommandHistory.ModelChanged -= this.OnModelChanged;
-       
-            // Get the data source of the profile grid.
-            DataTable data = this.view.ProfileGrid.DataSource;
-
-            // Maintain a list of all property changes that we need to make.
-            List<Commands.ChangeProperty.Property> properties = new List<Commands.ChangeProperty.Property>();
-
-            // Loop through all non-readonly properties, get an array of values from the data table
-            // for the property and then set the property value.
-            for (int i = 0; i < this.propertiesInGrid.Count; i++)
+            try
             {
-                // If this property is NOT readonly then set its value.
-                if (!this.propertiesInGrid[i].IsReadOnly)
+                this.explorerPresenter.CommandHistory.ModelChanged -= this.OnModelChanged;
+
+                // Get the data source of the profile grid.
+                DataTable data = this.view.ProfileGrid.DataSource;
+
+                // Maintain a list of all property changes that we need to make.
+                List<Commands.ChangeProperty.Property> properties = new List<Commands.ChangeProperty.Property>();
+
+                // Loop through all non-readonly properties, get an array of values from the data table
+                // for the property and then set the property value.
+                for (int i = 0; i < this.propertiesInGrid.Count; i++)
                 {
-                    // Get an array of values for this property.
-                    Array values;
-                    if (this.propertiesInGrid[i].DataType.GetElementType() == typeof(double))
+                    // If this property is NOT readonly then set its value.
+                    if (!this.propertiesInGrid[i].IsReadOnly)
                     {
-                        values = DataTableUtilities.GetColumnAsDoubles(data, data.Columns[i].ColumnName);
-                        if (!MathUtilities.ValuesInArray((double[])values))
-                            values = null;
+                        // Get an array of values for this property.
+                        Array values;
+                        if (this.propertiesInGrid[i].DataType.GetElementType() == typeof(double))
+                        {
+                            values = DataTableUtilities.GetColumnAsDoubles(data, data.Columns[i].ColumnName);
+                            if (!MathUtilities.ValuesInArray((double[])values))
+                                values = null;
+                            else
+                                values = MathUtilities.RemoveMissingValuesFromBottom((double[])values);
+                        }
                         else
-                            values = MathUtilities.RemoveMissingValuesFromBottom((double[])values);
-                    }
-                    else
-                    {
-                        values = DataTableUtilities.GetColumnAsStrings(data, data.Columns[i].ColumnName);
-                        values = MathUtilities.RemoveMissingValuesFromBottom((string[])values);
-                    }
+                        {
+                            values = DataTableUtilities.GetColumnAsStrings(data, data.Columns[i].ColumnName);
+                            values = MathUtilities.RemoveMissingValuesFromBottom((string[])values);
+                        }
 
-                    // Is the value any different to the former property value?
-                    bool changedValues;
-                    if (this.propertiesInGrid[i].DataType == typeof(double[]))
-                    {
-                        changedValues = !MathUtilities.AreEqual((double[])values, (double[])this.propertiesInGrid[i].Value);
-                    }
-                    else
-                    {
-                        changedValues = !MathUtilities.AreEqual((string[])values, (string[])this.propertiesInGrid[i].Value);
-                    }
+                        // Is the value any different to the former property value?
+                        bool changedValues;
+                        if (this.propertiesInGrid[i].DataType == typeof(double[]))
+                        {
+                            changedValues = !MathUtilities.AreEqual((double[])values, (double[])this.propertiesInGrid[i].Value);
+                        }
+                        else
+                        {
+                            changedValues = !MathUtilities.AreEqual((string[])values, (string[])this.propertiesInGrid[i].Value);
+                        }
 
-                    if (changedValues)
-                    {
-                        // Store the property change.
-                        Commands.ChangeProperty.Property property = new Commands.ChangeProperty.Property();
-                        property.Name = this.propertiesInGrid[i].Name;
-                        property.Obj = this.propertiesInGrid[i].Object;
-                        property.NewValue = values;
-                        properties.Add(property);
+                        if (changedValues)
+                        {
+                            // Store the property change.
+                            Commands.ChangeProperty.Property property = new Commands.ChangeProperty.Property();
+                            property.Name = this.propertiesInGrid[i].Name;
+                            property.Obj = this.propertiesInGrid[i].Object;
+                            property.NewValue = values;
+                            properties.Add(property);
+                        }
                     }
                 }
-            }
 
-            // If there are property changes pending, then commit the changes in a block.
-            if (properties.Count > 0)
+                // If there are property changes pending, then commit the changes in a block.
+                if (properties.Count > 0)
+                {
+                    Commands.ChangeProperty command = new Commands.ChangeProperty(properties);
+                    this.explorerPresenter.CommandHistory.Add(command);
+                }
+
+                this.explorerPresenter.CommandHistory.ModelChanged += this.OnModelChanged;
+            }
+            catch (Exception e)
             {
-                Commands.ChangeProperty command = new Commands.ChangeProperty(properties);
-                this.explorerPresenter.CommandHistory.Add(command);
+                if (e is System.Reflection.TargetInvocationException)
+                    e = (e as System.Reflection.TargetInvocationException).InnerException;
+                this.explorerPresenter.MainPresenter.ShowMessage(e.Message, Models.DataStore.ErrorLevel.Error);
             }
-
-            this.explorerPresenter.CommandHistory.ModelChanged += this.OnModelChanged;
         }
 
         /// <summary>
@@ -450,39 +466,48 @@ namespace UserInterface.Presenters
             {
                 if (this.propertiesInGrid[i].IsReadOnly && i > 0)
                 {
-                    VariableProperty property = this.propertiesInGrid[i];
-                    int col = i;
-                    int row = 0;
-                    foreach (object value in property.Value as IEnumerable<double>)
+                    try
                     {
-                        object valueForCell = value;
-                        bool missingValue = (double)value == MathUtilities.MissingValue || double.IsNaN((double)value);
-
-                        if (missingValue)
+                        VariableProperty property = this.propertiesInGrid[i];
+                        int col = i;
+                        int row = 0;
+                        foreach (object value in property.Value as IEnumerable<double>)
                         {
-                            valueForCell = null;
+                            object valueForCell = value;
+                            bool missingValue = (double)value == MathUtilities.MissingValue || double.IsNaN((double)value);
+
+                            if (missingValue)
+                            {
+                                valueForCell = null;
+                            }
+
+                            IGridCell cell = this.view.ProfileGrid.GetCell(col, row);
+                            cell.Value = valueForCell;
+
+                            row++;
                         }
 
-                        IGridCell cell = this.view.ProfileGrid.GetCell(col, row);
-                        cell.Value = valueForCell;
+                        // add a total to the column header if necessary.
+                        double total = property.Total;
+                        if (!double.IsNaN(total))
+                        {
+                            string columnName = property.Description;
+                            if (property.Units != null)
+                            {
+                                columnName += "\r\n(" + property.Units + ")";
+                            }
 
-                        row++;
+                            columnName = columnName + "\r\n" + total.ToString("N1") + " mm";
+
+                            IGridColumn column = this.view.ProfileGrid.GetColumn(col);
+                            column.HeaderText = columnName;
+                        }
                     }
-
-                    // add a total to the column header if necessary.
-                    double total = property.Total;
-                    if (!double.IsNaN(total))
+                    catch (Exception e)
                     {
-                        string columnName = property.Description;
-                        if (property.Units != null)
-                        {
-                            columnName += "\r\n(" + property.Units + ")";
-                        }
-
-                        columnName = columnName + "\r\n" + total.ToString("N1") + " mm";
-
-                        IGridColumn column = this.view.ProfileGrid.GetColumn(col);
-                        column.HeaderText = columnName;
+                        if (e is System.Reflection.TargetInvocationException)
+                            e = (e as System.Reflection.TargetInvocationException).InnerException;
+                        this.explorerPresenter.MainPresenter.ShowMessage(e.Message, Models.DataStore.ErrorLevel.Error);
                     }
                 }
             }

--- a/Models/Core/VariableProperty.cs
+++ b/Models/Core/VariableProperty.cs
@@ -369,20 +369,27 @@ namespace Models.Core
         {
             get
             {
-                DisplayAttribute displayFormatAttribute = ReflectionUtilities.GetAttribute(this.property, typeof(DisplayAttribute), false) as DisplayAttribute;
-                bool hasDisplayTotal = displayFormatAttribute != null && displayFormatAttribute.ShowTotal;
-                if (hasDisplayTotal && this.Value != null && (Units == "mm" || Units == "kg/ha"))
+                try
                 {
-                    double sum = 0.0;
-                    foreach (double doubleValue in this.Value as IEnumerable<double>)
+                    DisplayAttribute displayFormatAttribute = ReflectionUtilities.GetAttribute(this.property, typeof(DisplayAttribute), false) as DisplayAttribute;
+                    bool hasDisplayTotal = displayFormatAttribute != null && displayFormatAttribute.ShowTotal;
+                    if (hasDisplayTotal && this.Value != null && (Units == "mm" || Units == "kg/ha"))
                     {
-                        if (doubleValue != MathUtilities.MissingValue)
+                        double sum = 0.0;
+                        foreach (double doubleValue in this.Value as IEnumerable<double>)
                         {
-                            sum += doubleValue;
+                            if (doubleValue != MathUtilities.MissingValue)
+                            {
+                                sum += doubleValue;
+                            }
                         }
-                    }
 
-                    return sum;
+                        return sum;
+                    }
+                }
+                catch (Exception)
+                {
+                    return Double.NaN;
                 }
 
                 return double.NaN;

--- a/Models/Soils/Soil.cs
+++ b/Models/Soils/Soil.cs
@@ -711,7 +711,6 @@ namespace Models.Soils
         /// <returns></returns>
         private double[] PredictedLL(double[] A, double B)
         {
-            double[] DepthCentre = ToMidPoints(PredictedThickness);
             double[] LL15 = LL15Mapped(PredictedThickness);
             double[] DUL = DULMapped(PredictedThickness);
             double[] LL = new double[PredictedThickness.Length];
@@ -1406,9 +1405,13 @@ namespace Models.Soils
                     if (PosDash == -1)
                         throw new Exception("Invalid layer string: " + DepthStrings[i] +
                                   ". String must be of the form: 10-30");
+                    double TopOfLayer;
+                    double BottomOfLayer;
 
-                    double TopOfLayer = Convert.ToDouble(DepthStrings[i].Substring(0, PosDash));
-                    double BottomOfLayer = Convert.ToDouble(DepthStrings[i].Substring(PosDash + 1));
+                    if (!Double.TryParse(DepthStrings[i].Substring(0, PosDash), out TopOfLayer))
+                        throw new Exception("Invalid string for layer top: '" + DepthStrings[i].Substring(0, PosDash) + "'");
+                    if (!Double.TryParse(DepthStrings[i].Substring(PosDash + 1), out BottomOfLayer))
+                        throw new Exception("Invalid string for layer bottom: '" + DepthStrings[i].Substring(PosDash + 1) + "'");
                     Thickness[i] = (BottomOfLayer - TopOfLayer) * 10;
                 }
             }
@@ -1491,7 +1494,7 @@ namespace Models.Soils
         public static double[] CalcPAWC(double[] Thickness, double[] LL, double[] DUL, double[] XF)
         {
             double[] PAWC = new double[Thickness.Length];
-            if (LL == null)
+            if (LL == null || DUL == null)
                 return PAWC;
             if (Thickness.Length != DUL.Length || Thickness.Length != LL.Length)
                 throw new ApsimXException(null, "Number of soil layers in SoilWater is different to number of layers in SoilWater.Crop");

--- a/UserInterface/Commands/ChangeProperty.cs
+++ b/UserInterface/Commands/ChangeProperty.cs
@@ -149,9 +149,12 @@ namespace UserInterface.Commands
                         this.wasModified = ReflectionUtilities.SetValueOfProperty(this.Name, this.Obj, this.NewValue);
                     }
                 }
-                catch (Exception)
+                catch (Exception e)
                 {
                     this.wasModified = false;
+                    if (e is System.Reflection.TargetInvocationException)
+                        e = (e as System.Reflection.TargetInvocationException).InnerException;
+                    throw e; // Pass the exception on for further handling
                 }
 
                 return this.wasModified;

--- a/UserInterface/Presenters/ExplorerPresenter.cs
+++ b/UserInterface/Presenters/ExplorerPresenter.cs
@@ -848,6 +848,8 @@ namespace UserInterface.Presenters
             }
             catch (Exception err)
             {
+                if (err is System.Reflection.TargetInvocationException)
+                    err = (err as System.Reflection.TargetInvocationException).InnerException;
                 string message = err.Message;
                 message += "\r\n" + err.StackTrace;
                 MainPresenter.ShowMessage(message, DataStore.ErrorLevel.Error);


### PR DESCRIPTION
Resolves #836 

Although this patch eliminates the uncaught exception, there is plenty of scope for improvement. The general problem is one of dealing with a incomplete set of input data (soil water data in this case). Its incompleteness is an error, but we need to be careful how we flag that error if the user is in the midst of entering more data.

I also made some small changes in exception handling. With TargetInvocationExceptions, what we normally want to see are the attributes of the inner exception, not the outer one.