### PR TITLE
Prevent WholeFarm modules appearing in the Add list everywhere

### DIFF
--- a/Models/WholeFarm/Resources.cs
+++ b/Models/WholeFarm/Resources.cs
@@ -20,7 +20,7 @@ namespace Models.WholeFarm
     [Serializable]
     [ViewName("UserInterface.Views.GridView")]
     [PresenterName("UserInterface.Presenters.PropertyPresenter")]
-    [ValidParent(DropAnywhere = true)]
+    [ValidParent(ParentType = typeof(Zone))]
     public class Resources: Model
     {
 


### PR DESCRIPTION
Fix Resources so that it can only appear under a Zone.

Most of this was fixed in the previous commit.

Resolves #1016

 