### PR TITLE
Hydraulic properties

### DIFF
--- a/Models/Core/Model.cs
+++ b/Models/Core/Model.cs
@@ -87,6 +87,7 @@ namespace Models.Core
         [XmlElement(typeof(Memo))]
         [XmlElement(typeof(Folder))]
         [XmlElement(typeof(Replacements))]
+        [XmlElement(typeof(Soils.HydraulicProperties))]
         [XmlElement(typeof(Soils.MultiPoreWater))]
         [XmlElement(typeof(Soils.Water))]
         [XmlElement(typeof(Soils.SoilCrop))]

--- a/Models/Models.csproj
+++ b/Models/Models.csproj
@@ -230,6 +230,7 @@
     <Compile Include="Soils\Arbitrator\CropUptakes.cs" />
     <Compile Include="Soils\Arbitrator\Estimate.cs" />
     <Compile Include="Soils\Arbitrator\SoilState.cs" />
+    <Compile Include="Soils\HydraulicProperties.cs" />
     <Compile Include="Soils\ISoilCrop.cs" />
     <Compile Include="Soils\Arbitrator\ZoneWaterAndN.cs" />
     <Compile Include="Soils\MultiPoreWater\HourlyData.cs" />

--- a/Models/Soils/HydraulicProperties.cs
+++ b/Models/Soils/HydraulicProperties.cs
@@ -1,0 +1,301 @@
+﻿using Models.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Models.Soils
+{
+    /// <summary>
+    /// Returns theta and ksat values for specified psi and theta values respectively.  Gets its parameters from the soil Water node and a couple of parameters it owns
+    /// </summary>
+    [Serializable]
+    [ViewName("UserInterface.Views.GridView")]
+    [PresenterName("UserInterface.Presenters.PropertyPresenter")]
+    [ValidParent(ParentType = typeof(Soil))]
+    public class HydraulicProperties : Model
+    {
+        #region External links
+        [Link]
+        private Water Water = null;
+        #endregion
+
+        #region Internal States
+        ///// <summary>The de lk</summary>
+        /// <summary>
+        /// The de lk
+        /// </summary>
+        private double[,] DELk = null;
+        ///// <summary>The mk</summary>
+        /// <summary>
+        /// The mk
+        /// </summary>
+        private double[,] Mk = null;
+        /// <summary>
+        /// The m0
+        /// </summary>
+        private double[,] M0 = null;
+        /// <summary>
+        /// The m1
+        /// </summary>
+        private double[,] M1 = null;
+        /// <summary>
+        /// The y0
+        /// </summary>
+        private double[,] Y0 = null;
+        /// <summary>
+        /// The y1
+        /// </summary>
+        private double[,] Y1 = null;
+        /// <summary>
+        /// The micro p
+        /// </summary>
+        private double[] MicroP = null;
+        /// <summary>
+        /// The micro ks
+        /// </summary>
+        private double[] MicroKs = null;
+        ///// <summary>The kdula</summary>
+        /// <summary>
+        /// The kdula
+        /// </summary>
+        private double[] Kdula = null;
+        /// <summary>
+        /// The macro p
+        /// </summary>
+        private double[] MacroP = null;
+
+        /// <summary>
+        /// The psid
+        /// </summary>
+        private double[] psid = null;
+        /// <summary>
+        /// The psi_ll15
+        /// </summary>
+        const double psi_ll15 = -15000.0;
+        /// <summary>
+        /// The psiad
+        /// </summary>
+        const double psiad = -1e6;
+        /// <summary>
+        /// The psi0
+        /// </summary>
+        const double psi0 = -0.6e7;
+
+
+        #endregion
+
+        #region Parameters
+        /// <summary>
+        /// psidul
+        /// </summary>
+        /// <value>
+        /// The psidul.
+        /// </value>
+        [Description("The suction when the soil is at DUL")]
+        [Units("cm")]
+        [Bounds(Lower = -1e3, Upper = 0.0)]
+        public double psidul { get; set; }
+        /// <summary>
+        /// kdul
+        /// </summary>
+        /// <value>
+        /// The kdul.
+        /// </value>
+        [Description("The hydraulic conductivity when the soil is at DUL")]
+        [Units("mm/d")]
+        [Bounds(Lower = 0.0, Upper = 10.0)]
+        public double kdul { get; set; }
+        #endregion
+
+        #region public methods
+        /// <summary>
+        /// Simples the theta.
+        /// </summary>
+        /// <param name="layer">The layer.</param>
+        /// <param name="psiValue">The psi value.</param>
+        /// <returns></returns>
+        public double SimpleTheta(int layer, double psiValue)
+        {
+            //  Purpose
+            //     Calculate Theta for a given node for a specified suction.
+            int i;
+            double t;
+
+            if (psiValue >= -1.0)
+            {
+                i = 0;
+                t = 0.0;
+            }
+            else if (psiValue > psid[layer])
+            {
+                i = 1;
+                t = (Math.Log10(-psiValue) - 0.0) / (Math.Log10(-psid[layer]) - 0.0);
+            }
+            else if (psiValue > psi_ll15)
+            {
+                i = 2;
+                t = (Math.Log10(-psiValue) - Math.Log10(-psid[layer])) / (Math.Log10(-psi_ll15) - Math.Log10(-psid[layer]));
+            }
+            else if (psiValue > psi0)
+            {
+                i = 3;
+                t = (Math.Log10(-psiValue) - Math.Log10(-psi_ll15)) / (Math.Log10(-psi0) - Math.Log10(-psi_ll15));
+            }
+            else
+            {
+                i = 4;
+                t = 0.0;
+            }
+
+            double tSqr = t * t;
+            double tCube = tSqr * t;
+
+            return (2 * tCube - 3 * tSqr + 1) * Y0[layer, i] + (tCube - 2 * tSqr + t) * M0[layer, i]
+                    + (-2 * tCube + 3 * tSqr) * Y1[layer, i] + (tCube - tSqr) * M1[layer, i];
+        }
+
+        /// <summary>
+        /// Simples the k.
+        /// </summary>
+        /// <param name="layer">The layer.</param>
+        /// <param name="psiValue">The psi value.</param>
+        /// <returns></returns>
+        public double SimpleK(int layer, double psiValue)
+        {
+            //  Purpose
+            //      Calculate Conductivity for a given node for a specified suction.
+
+            double S = SimpleS(layer, psiValue);
+            double simpleK;
+
+            if (S <= 0.0)
+                simpleK = 1e-100;
+            else
+            {
+                double microK = MicroKs[layer] * Math.Pow(S, MicroP[layer]);
+
+                if (MicroKs[layer] >= Water.KS[layer])
+                    simpleK = microK;
+                else
+                {
+                    double macroK = (Water.KS[layer] - MicroKs[layer]) * Math.Pow(S, MacroP[layer]);
+                    simpleK = microK + macroK;
+                }
+            }
+            return simpleK / 24.0 / 10.0;
+        }
+
+        /// <summary>
+        /// Called when soil models that require hydraulic properties information initiate their properties
+        /// </summary>
+        public void SetHydraulicProperties()
+        {
+            DELk = new double[Water.Thickness.Length, 4];
+            Mk = new double[Water.Thickness.Length, 4];
+            M0 = new double[Water.Thickness.Length, 5];
+            M1 = new double[Water.Thickness.Length, 5];
+            Y0 = new double[Water.Thickness.Length, 5];
+            Y1 = new double[Water.Thickness.Length, 5];
+            MicroP = new double[Water.Thickness.Length];
+            MicroKs = new double[Water.Thickness.Length];
+            Kdula = new double[Water.Thickness.Length];
+            MacroP = new double[Water.Thickness.Length];
+            psid = new double[Water.Thickness.Length];
+
+            SetupThetaCurve();
+            SetupKCurve();
+        }
+        #endregion
+
+        #region Internal methods
+        /// <summary>
+        /// Simples the s.
+        /// </summary>
+        /// <param name="layer">The layer.</param>
+        /// <param name="psiValue">The psi value.</param>
+        /// <returns></returns>
+        private double SimpleS(int layer, double psiValue)
+        {
+            //  Purpose
+            //      Calculate S for a given node for a specified suction.
+            return SimpleTheta(layer, psiValue) / Water.SAT[layer];
+        }
+
+        /// <summary>
+        /// Sets up the theta curve
+        /// </summary>
+        private void SetupThetaCurve()
+        {
+            for (int layer = 0; layer < Water.Thickness.Length; layer++)
+            {
+                psid[layer] = psidul;  //- (p%x(p%n) - p%x(layer))
+
+                DELk[layer, 0] = (Water.DUL[layer] - Water.SAT[layer]) / (Math.Log10(-psid[layer]));
+                DELk[layer, 1] = (Water.LL15[layer] - Water.DUL[layer]) / (Math.Log10(-psi_ll15) - Math.Log10(-psid[layer]));
+                DELk[layer, 2] = -Water.LL15[layer] / (Math.Log10(-psi0) - Math.Log10(-psi_ll15));
+                DELk[layer, 3] = -Water.LL15[layer] / (Math.Log10(-psi0) - Math.Log10(-psi_ll15));
+
+                Mk[layer, 0] = 0.0;
+                Mk[layer, 1] = (DELk[layer, 0] + DELk[layer, 1]) / 2.0;
+                Mk[layer, 2] = (DELk[layer, 1] + DELk[layer, 2]) / 2.0;
+                Mk[layer, 3] = DELk[layer, 3];
+
+                // First bit might not be monotonic so check and adjust
+                double alpha = Mk[layer, 0] / DELk[layer, 0];
+                double beta = Mk[layer, 1] / DELk[layer, 0];
+                double phi = alpha - (Math.Pow(2.0 * alpha + beta - 3.0, 2.0) / (3.0 * (alpha + beta - 2.0)));
+                if (phi <= 0)
+                {
+                    double tau = 3.0 / Math.Sqrt(alpha * alpha + beta * beta);
+                    Mk[layer, 0] = tau * alpha * DELk[layer, 0];
+                    Mk[layer, 1] = tau * beta * DELk[layer, 0];
+                }
+
+                M0[layer, 0] = 0.0;
+                M1[layer, 0] = 0.0;
+                Y0[layer, 0] = Water.SAT[layer];
+                Y1[layer, 0] = Water.SAT[layer];
+
+                M0[layer, 1] = Mk[layer, 0] * (Math.Log10(-psid[layer]) - 0.0);
+                M1[layer, 1] = Mk[layer, 1] * (Math.Log10(-psid[layer]) - 0.0);
+                Y0[layer, 1] = Water.SAT[layer];
+                Y1[layer, 1] = Water.DUL[layer];
+
+                M0[layer, 2] = Mk[layer, 1] * (Math.Log10(-psi_ll15) - Math.Log10(-psid[layer]));
+                M1[layer, 2] = Mk[layer, 2] * (Math.Log10(-psi_ll15) - Math.Log10(-psid[layer]));
+                Y0[layer, 2] = Water.DUL[layer];
+                Y1[layer, 2] = Water.LL15[layer];
+
+                M0[layer, 3] = Mk[layer, 2] * (Math.Log10(-psi0) - Math.Log10(-psi_ll15));
+                M1[layer, 3] = Mk[layer, 3] * (Math.Log10(-psi0) - Math.Log10(-psi_ll15));
+                Y0[layer, 3] = Water.LL15[layer];
+                Y1[layer, 3] = 0.0;
+
+                M0[layer, 4] = 0.0;
+                M1[layer, 4] = 0.0;
+                Y0[layer, 4] = 0.0;
+                Y1[layer, 4] = 0.0;
+            }
+        }
+
+        /// <summary>
+        /// Sets up the K curve
+        /// </summary>
+        private void SetupKCurve()
+        {
+            for (int layer = 0; layer < Water.Thickness.Length; layer++)
+            {
+                double b = -Math.Log(psidul / psi_ll15) / Math.Log(Water.DUL[layer] / Water.LL15[layer]);
+                MicroP[layer] = b * 2.0 + 3.0;
+                Kdula[layer] = Math.Min(0.99 * kdul, Water.KS[layer]);
+                MicroKs[layer] = Kdula[layer] / Math.Pow(Water.DUL[layer] / Water.SAT[layer], MicroP[layer]);
+
+                double Sdul = Water.DUL[layer] / Water.SAT[layer];
+                MacroP[layer] = Math.Log10(Kdula[layer] / 99.0 / (Water.KS[layer] - MicroKs[layer])) / Math.Log10(Sdul);
+            }
+        }
+        #endregion
+
+    }
+}

--- a/Models/Soils/MultiPoreWater/MultiPoreWater.cs
+++ b/Models/Soils/MultiPoreWater/MultiPoreWater.cs
@@ -202,6 +202,8 @@ namespace Models.Soils
         private SurfaceOrganicMatter SurfaceOM = null;
         [Link]
         private Weather Met = null;
+        [Link]
+        private HydraulicProperties HyProps = null;
         #endregion
 
         #region Structures
@@ -310,6 +312,8 @@ namespace Models.Soils
 
             }
 
+            HyProps.SetHydraulicProperties();
+
             Pores = new Pore[ProfileLayers][];
             for (int l = 0; l < ProfileLayers; l++)
             {
@@ -324,10 +328,10 @@ namespace Models.Soils
                     Pores[l][c].MaxDiameter = PoreBounds[c];
                     Pores[l][c].MinDiameter = PoreBounds[c + 1];
                     Pores[l][c].Thickness = Water.Thickness[l];
-                    double PoreVolume = Water.SAT[l] * ProportionPoreVolume(PoreBounds[c], PoreBounds[c + 1]);
-                    AccumVolume += PoreVolume;
-                    Pores[l][c].Volume = PoreVolume;
-                    double PoreWaterFilledVolume = Math.Min(PoreVolume, Soil.InitialWaterVolumetric[l] - AccumWaterVolume);
+                    double ThisPoreVolume = PoreVolume(PoreBounds[c], PoreBounds[c + 1],l);
+                    AccumVolume += ThisPoreVolume;
+                    Pores[l][c].Volume = ThisPoreVolume;
+                    double PoreWaterFilledVolume = Math.Min(ThisPoreVolume, Soil.InitialWaterVolumetric[l] - AccumWaterVolume);
                     AccumWaterVolume += PoreWaterFilledVolume;
                     Pores[l][c].WaterDepth = PoreWaterFilledVolume * Water.Thickness[l];
                     Pores[l][c].HydraulicConductivityIn = ProfileParams.Ksat[l] * (PoreCompartments / (c + 1)) / PoreCompartments; //Arbitary function to give different KS values for each pore
@@ -626,19 +630,22 @@ namespace Models.Soils
         /// </summary>
         /// <param name="MaxDiameter"></param>
         /// <param name="MinDiameter"></param>
+        /// <param name="layer"></param>
         /// <returns>proportion of totol porosity</returns>
-        private double ProportionPoreVolume(double MaxDiameter, double MinDiameter)
+        private double PoreVolume(double MaxDiameter, double MinDiameter, int layer)
         {
-            return CumPoreVolume(MaxDiameter) - CumPoreVolume(MinDiameter);
+            return CumPoreVolume(MaxDiameter,layer) - CumPoreVolume(MinDiameter,layer);
         }
         /// <summary>
         /// Calculates the proportion of total porosity below the specified pore diameter
         /// </summary>
         /// <param name="PoreDiameter"></param>
+        /// <param name="layer"></param>
         /// <returns>proportion of total porosity</returns>
-        private double CumPoreVolume(double PoreDiameter)
+        private double CumPoreVolume(double PoreDiameter, int layer)
         {
-            double PoreVolume = PoreDiameter * 0.0003;
+            double psi = -Math.Pow(10.0,(-Math.Log(PoreDiameter,10) + 3.4857)); //psi cm head, the units the Hyprops calculator works in 
+            double PoreVolume = HyProps.SimpleTheta(layer,psi);
             return Math.Min(1,PoreVolume);
         }
         /// <summary>

--- a/Prototypes/MultiPoreWater/Test.apsimx
+++ b/Prototypes/MultiPoreWater/Test.apsimx
@@ -149,7 +149,7 @@
         <MultiPoreWater>
           <Name>MultiPoreWater</Name>
           <PoreBounds>
-            <double>10000</double>
+            <double>30000</double>
             <double>3000</double>
             <double>1000</double>
             <double>300</double>
@@ -157,7 +157,7 @@
             <double>60</double>
             <double>30</double>
             <double>3</double>
-            <double>0</double>
+            <double>0.03</double>
           </PoreBounds>
           <BottomBoundryConductance>100</BottomBoundryConductance>
           <CalculateInfiltration>true</CalculateInfiltration>
@@ -489,6 +489,11 @@
           <OCUnits>Total</OCUnits>
           <PHUnits>Water</PHUnits>
         </Sample>
+        <HydraulicProperties>
+          <Name>HydraulicProperties</Name>
+          <psidul>-3.3</psidul>
+          <kdul>1</kdul>
+        </HydraulicProperties>
         <RecordNumber>0</RecordNumber>
         <ASCOrder>Vertosol</ASCOrder>
         <ASCSubOrder>Black</ASCSubOrder>

--- a/Prototypes/MultiPoreWater/Test.apsimx
+++ b/Prototypes/MultiPoreWater/Test.apsimx
@@ -149,15 +149,15 @@
         <MultiPoreWater>
           <Name>MultiPoreWater</Name>
           <PoreBounds>
-            <double>30000</double>
-            <double>3000</double>
-            <double>1000</double>
-            <double>300</double>
-            <double>100</double>
-            <double>60</double>
+            <double>30598</double>
+            <double>3059</double>
+            <double>305</double>
+            <double>76</double>
             <double>30</double>
             <double>3</double>
-            <double>0.03</double>
+            <double>0.75</double>
+            <double>0.2</double>
+            <double>0.0005</double>
           </PoreBounds>
           <BottomBoundryConductance>100</BottomBoundryConductance>
           <CalculateInfiltration>true</CalculateInfiltration>

--- a/Prototypes/MultiPoreWater/Test.apsimx
+++ b/Prototypes/MultiPoreWater/Test.apsimx
@@ -491,7 +491,7 @@
         </Sample>
         <HydraulicProperties>
           <Name>HydraulicProperties</Name>
-          <psidul>-3.3</psidul>
+          <psidul>-100</psidul>
           <kdul>1</kdul>
         </HydraulicProperties>
         <RecordNumber>0</RecordNumber>


### PR DESCRIPTION
resolves #1075 

New Class (Hydraulic Properties) contains:
- private parameters for the spline to fit moisture release curve to soil data (SAT, DUL, Ll15) and fit hydrulic conductivity using moisture release and kSat.  This h
- private methods to set these parameters when the soil properties are set 
- public methods to return theta and ks for specified suctions, thetas (respectively) and layers
- Links dirrectly to the Water node under soil to get SAT, DUL, Ll15 and Ksat data
- Has two parameters, suction at DUL and ks at DUL which are entered on the grid view for the class

This class must be added onto the soil node to be available to soil water models and the soil water model must call the SetHydraulicProperties() method to initialise the class.  I have done it like this rather than initialing on a particular clock event so if changes are made to a soils properties mid simulation, this can be called to update hydraulic properties data.