### PR TITLE
Use "short" names on tabs, with the full path displayed as a tooltip.

### DIFF
--- a/UserInterface/Commands/ExportNodeCommand.cs
+++ b/UserInterface/Commands/ExportNodeCommand.cs
@@ -262,37 +262,42 @@ namespace UserInterface.Commands
                 // Open the related example .apsimx file and get its presenter.
                 ExplorerPresenter examplePresenter = ExplorerPresenter.MainPresenter.OpenApsimXFileInTab(exampleFileName, onLeftTabControl:true);
 
-                Memo instructionsMemo = userDocumentation.Children[0] as Memo;
-                string[] instructions = instructionsMemo.MemoText.Split("\r\n".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
-                foreach (string instruction in instructions)
+                try
                 {
-                    IModel model = Apsim.Find(examplePresenter.ApsimXFile, instruction);
-                    if (model != null)
+                    Memo instructionsMemo = userDocumentation.Children[0] as Memo;
+                    string[] instructions = instructionsMemo.MemoText.Split("\r\n".ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
+                    foreach (string instruction in instructions)
                     {
-                        examplePresenter.SelectNode(Apsim.FullPath(model));
-                        Application.DoEvents();
-                        if (model is Memo)
-                            model.Document(tags, 1, 0);
-                        else
+                        IModel model = Apsim.Find(examplePresenter.ApsimXFile, instruction);
+                        if (model != null)
                         {
-                            System.Drawing.Image image;
-
-                            if (model is Manager)
-                                image = (examplePresenter.CurrentPresenter as ManagerPresenter).GetScreenshot();
+                            examplePresenter.SelectNode(Apsim.FullPath(model));
+                            Application.DoEvents();
+                            if (model is Memo)
+                                model.Document(tags, 1, 0);
                             else
-                                image = examplePresenter.GetScreenhotOfRightHandPanel();
-
-                            if (image != null)
                             {
-                                string name = "Example" + instruction;
-                                tags.Add(new AutoDocumentation.Image() { name = name, image = image });
+                                System.Drawing.Image image;
+
+                                if (model is Manager)
+                                    image = (examplePresenter.CurrentPresenter as ManagerPresenter).GetScreenshot();
+                                else
+                                    image = examplePresenter.GetScreenhotOfRightHandPanel();
+
+                                if (image != null)
+                                {
+                                    string name = "Example" + instruction;
+                                    tags.Add(new AutoDocumentation.Image() { name = name, image = image });
+                                }
                             }
                         }
                     }
                 }
-
-                // Close the tab
-                examplePresenter.MainPresenter.CloseTab(exampleFileName);
+                finally
+                {
+                    // Close the tab
+                    examplePresenter.MainPresenter.CloseTabContaining(examplePresenter.GetView());
+                }
             }
         }
 

--- a/UserInterface/Presenters/ExplorerPresenter.cs
+++ b/UserInterface/Presenters/ExplorerPresenter.cs
@@ -223,7 +223,7 @@ namespace UserInterface.Presenters
                         Utility.Configuration.Settings.DelMruFile(this.ApsimXFile.FileName);
 
                     Utility.Configuration.Settings.AddMruFile(newFileName);
-                    MainPresenter.ChangeTabText(this.ApsimXFile.FileName, newFileName);
+                    MainPresenter.ChangeTabText(this.view, Path.GetFileNameWithoutExtension(newFileName), newFileName);
                     this.ApsimXFile.Write(newFileName);
                     return true;
                 }
@@ -862,6 +862,10 @@ namespace UserInterface.Presenters
             return view.GetScreenshotOfRightHandPanel();
         }
 
+        public ExplorerView GetView()
+        {
+            return view as ExplorerView;
+        }
         #endregion
     }
 

--- a/UserInterface/Presenters/ExplorerPresenter.cs
+++ b/UserInterface/Presenters/ExplorerPresenter.cs
@@ -862,6 +862,10 @@ namespace UserInterface.Presenters
             return view.GetScreenshotOfRightHandPanel();
         }
 
+        /// <summary>
+        /// Return the view attached to this presenter
+        /// </summary>
+        /// <returns>The attached ExplorerView, or null if not attached</returns>
         public ExplorerView GetView()
         {
             return view as ExplorerView;

--- a/UserInterface/Views/ExplorerView.cs
+++ b/UserInterface/Views/ExplorerView.cs
@@ -610,6 +610,11 @@ namespace UserInterface.Views
 
         #endregion
 
+        /// <summary>
+        /// Intercept right mouse clicks, and cause them to change the selection
+        /// </summary>
+        /// <param name="sender">Object sending the event</param>
+        /// <param name="e">Event arguments</param>
         private void TreeView_NodeMouseClick(object sender, TreeNodeMouseClickEventArgs e)
         {
             if (e.Button == MouseButtons.Right)

--- a/UserInterface/Views/MainView.Designer.cs
+++ b/UserInterface/Views/MainView.Designer.cs
@@ -40,16 +40,16 @@
             this.splitContainer = new System.Windows.Forms.SplitContainer();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.startPage1 = new System.Windows.Forms.TabPage();
+            this.listButtonView1 = new ListButtonView();
             this.tabControl2 = new System.Windows.Forms.TabControl();
             this.tabPopupMenu2 = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.startPage2 = new System.Windows.Forms.TabPage();
+            this.listButtonView2 = new ListButtonView();
             this.statusPanel = new System.Windows.Forms.Panel();
             this.StatusWindow = new System.Windows.Forms.TextBox();
             this.progressBar = new System.Windows.Forms.ProgressBar();
             this.splitter1 = new System.Windows.Forms.Splitter();
-            this.listButtonView1 = new ListButtonView();
-            this.listButtonView2 = new ListButtonView();
             this.tabPopupMenu1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer)).BeginInit();
             this.splitContainer.Panel1.SuspendLayout();
@@ -127,6 +127,7 @@
             this.tabControl1.Margin = new System.Windows.Forms.Padding(4);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
+            this.tabControl1.ShowToolTips = true;
             this.tabControl1.Size = new System.Drawing.Size(769, 441);
             this.tabControl1.TabIndex = 1;
             this.tabControl1.MouseDown += new System.Windows.Forms.MouseEventHandler(this.OnTabControlMouseDown);
@@ -143,6 +144,15 @@
             this.startPage1.Text = "+";
             this.startPage1.UseVisualStyleBackColor = true;
             // 
+            // listButtonView1
+            // 
+            this.listButtonView1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.listButtonView1.Location = new System.Drawing.Point(4, 4);
+            this.listButtonView1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.listButtonView1.Name = "listButtonView1";
+            this.listButtonView1.Size = new System.Drawing.Size(753, 404);
+            this.listButtonView1.TabIndex = 0;
+            // 
             // tabControl2
             // 
             this.tabControl2.ContextMenuStrip = this.tabPopupMenu2;
@@ -152,6 +162,7 @@
             this.tabControl2.Margin = new System.Windows.Forms.Padding(4);
             this.tabControl2.Name = "tabControl2";
             this.tabControl2.SelectedIndex = 0;
+            this.tabControl2.ShowToolTips = true;
             this.tabControl2.Size = new System.Drawing.Size(96, 100);
             this.tabControl2.TabIndex = 1;
             this.tabControl2.MouseDown += new System.Windows.Forms.MouseEventHandler(this.OnTabControlMouseDown);
@@ -182,6 +193,15 @@
             this.startPage2.TabIndex = 0;
             this.startPage2.Text = "+";
             this.startPage2.UseVisualStyleBackColor = true;
+            // 
+            // listButtonView2
+            // 
+            this.listButtonView2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.listButtonView2.Location = new System.Drawing.Point(4, 4);
+            this.listButtonView2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.listButtonView2.Name = "listButtonView2";
+            this.listButtonView2.Size = new System.Drawing.Size(80, 63);
+            this.listButtonView2.TabIndex = 0;
             // 
             // statusPanel
             // 
@@ -225,24 +245,6 @@
             this.splitter1.Size = new System.Drawing.Size(769, 3);
             this.splitter1.TabIndex = 16;
             this.splitter1.TabStop = false;
-            // 
-            // listButtonView1
-            // 
-            this.listButtonView1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.listButtonView1.Location = new System.Drawing.Point(4, 4);
-            this.listButtonView1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.listButtonView1.Name = "listButtonView1";
-            this.listButtonView1.Size = new System.Drawing.Size(753, 404);
-            this.listButtonView1.TabIndex = 0;
-            // 
-            // listButtonView2
-            // 
-            this.listButtonView2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.listButtonView2.Location = new System.Drawing.Point(4, 4);
-            this.listButtonView2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.listButtonView2.Name = "listButtonView2";
-            this.listButtonView2.Size = new System.Drawing.Size(80, 63);
-            this.listButtonView2.TabIndex = 0;
             // 
             // MainView
             // 

--- a/UserInterface/Views/MainView.cs
+++ b/UserInterface/Views/MainView.cs
@@ -31,8 +31,9 @@ namespace UserInterface.Views
         void AddTab(string text, Image image, UserControl control, bool onLeftTabControl);
 
         /// <summary>Change the text of a tab.</summary>
-        /// <param name="currentTabName">Current tab text.</param>
+        /// <param name="ownerView">A control (normally an ExplorerView) on the tab to be modified.</param>
         /// <param name="newTabName">New text of the tab.</param>
+        /// <param name="tooltip">Tooltip to apply to the tab.</param>
         void ChangeTabText(object ownerView, string newTabName, string tooltip);
 
         /// <summary>Gets or set the main window position.</summary>
@@ -186,8 +187,9 @@ namespace UserInterface.Views
         }
 
         /// <summary>Change the text of a tab.</summary>
-        /// <param name="currentTabName">Current tab text.</param>
+        /// <param name="ownerView">A control (normally an ExplorerView) on the tab to be modified.</param>
         /// <param name="newTabName">New text of the tab.</param>
+        /// <param name="tooltip">Tooltip to apply to the tab.</param>
         public void ChangeTabText(object ownerView, string newTabName, string tooltip)
         {
             TabPage page = null;
@@ -278,6 +280,7 @@ namespace UserInterface.Views
         /// <summary>
         /// Returns true if the object is a control on the left side
         /// </summary>
+        /// <param name="control">The control that is to be tested</param>
         public bool IsControlOnLeft(object control)
         {
             Control test = (control as Control);


### PR DESCRIPTION
Resolves #998 