### PR TITLE
Return null rather than "()" when no units apply.

### DIFF
--- a/Models/Core/VariableProperty.cs
+++ b/Models/Core/VariableProperty.cs
@@ -175,7 +175,10 @@ namespace Models.Core
                 }
                 else if (unitsToStringInfo != null)
                     unitString = (string)unitsToStringInfo.Invoke(this.Object, new object[] { null });
-                return "(" + unitString + ")";
+                if (unitString != null)
+                    return "(" + unitString + ")";
+                else
+                    return null;
             }
         }
 


### PR DESCRIPTION
Resolves #1139