### PR TITLE
Correct silly markup bug, which triggered error messages on Linux

### DIFF
--- a/ApsimNG/Views/GraphView.cs
+++ b/ApsimNG/Views/GraphView.cs
@@ -583,7 +583,7 @@ namespace UserInterface.Views
             {
                 captionLabel.Text = text;
                 if (italics)
-                    text = "<i>" + text + "<i/>";
+                    text = "<i>" + text + "</i>";
                 captionLabel.Markup = text;
             }
             else


### PR DESCRIPTION
Working on #1351