### PR TITLE
Get rid of unused variables which trigger Mono compiler warnings.

### DIFF
--- a/Models/Stock/animgrp.cs
+++ b/Models/Stock/animgrp.cs
@@ -1691,7 +1691,6 @@ namespace Models.GrazPlan
         protected void LoseYoung(TAnimalGroup aGroup, int N)
         {
             TDifferenceRecord YoungDiffs;
-            TAnimalGroup LoseGroup;
             int iMaleYoung;
             int iFemaleYoung;
             int iYoungToLose;
@@ -1722,8 +1721,7 @@ namespace Models.GrazPlan
                     iFemalesToLose = iFemaleYoung;
                 }
 
-                LoseGroup = aGroup.Young.SplitSex(iMalesToLose, iFemalesToLose, false, YoungDiffs);
-                LoseGroup = null;
+                aGroup.Young.SplitSex(iMalesToLose, iFemalesToLose, false, YoungDiffs);
                 aGroup.FNoOffspring -= N;
                 aGroup.Young.FNoOffspring -= N;
             }
@@ -2170,7 +2168,7 @@ namespace Models.GrazPlan
         {
             // these will have to go into the parameter set eventually...
             double[] dFaecesDensity = { 1000.0, 1000.0 };       // kg/m^3
-            double[] dFaecesMoisture = { 4.0, 5.0 };            // kg water/kg DM
+            // double[] dFaecesMoisture = { 4.0, 5.0 };            // kg water/kg DM
             double[] dRefNormalWt = { 50.0, 600.0 };            // kg
             double[] dFaecesRefLength = { 0.012, 0.30 };        // m
             double[] dFaecesPower = { 0.00, 1.0 / 3.0 };

--- a/Models/Stock/stddate.cs
+++ b/Models/Stock/stddate.cs
@@ -14,9 +14,13 @@ namespace StdUnits
     {
         //TODO: may need to change this if overloaded operators are required
         /// <summary>
-        /// Day, Month
+        /// Day
         /// </summary>
-        public int D, M;
+        public int D;
+        /// <summary>
+        /// Month
+        /// </summary>
+        public int M;
         /// <summary>
         /// Year
         /// </summary>

--- a/Models/Stock/stdstrng.cs
+++ b/Models/Stock/stdstrng.cs
@@ -171,7 +171,7 @@ namespace StdUnits
 
             if (token.Length > 0 && token.IndexOf('E') == token.Length - 1)  // Number is in exponential format
             {
-                bool dummy = MatchToken(ref parseSt, "+");
+                MatchToken(ref parseSt, "+");
                 int exponent = 0;
                 if (TokenInt(ref parseSt, ref exponent))
                     token = token + exponent.ToString();  // Add the exponent to token
@@ -215,7 +215,7 @@ namespace StdUnits
 
             if (token.Length > 0 && token.IndexOf('E') == token.Length - 1)  // Number is in exponential format
             {
-                bool dummy = MatchToken(ref parseSt, "+");
+                MatchToken(ref parseSt, "+");
                 int exponent = 0;
                 if (TokenInt(ref parseSt, ref exponent))
                     token = token + exponent.ToString();  // Add the exponent to token


### PR DESCRIPTION
But mainly to test some changes in the windows deployment on Scoop, 
working on #1390 