### PR TITLE
Bump OxyPlot version to 2.0.0-unstable0960

### DIFF
--- a/ApsimNG/ApsimNG.csproj
+++ b/ApsimNG/ApsimNG.csproj
@@ -626,11 +626,11 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="OxyPlot, Version=2.0.0.0, Culture=neutral, PublicKeyToken=638079a8f0bd61e9, processorArchitecture=MSIL">
-      <HintPath>..\packages\OxyPlot.Core.2.0.0-unstable0941\lib\net45\OxyPlot.dll</HintPath>
+      <HintPath>..\packages\OxyPlot.Core.2.0.0-unstable0960\lib\net45\OxyPlot.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OxyPlot.GtkSharp, Version=2.0.0.0, Culture=neutral, PublicKeyToken=245eacd6b5d2d338, processorArchitecture=MSIL">
-      <HintPath>..\packages\OxyPlot.GtkSharp.2.0.0-unstable0941\lib\net45\OxyPlot.GtkSharp.dll</HintPath>
+      <HintPath>..\packages\OxyPlot.GtkSharp.2.0.0-unstable0960\lib\net45\OxyPlot.GtkSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="pango-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f, processorArchitecture=MSIL">

--- a/ApsimNG/packages.config
+++ b/ApsimNG/packages.config
@@ -7,8 +7,8 @@
   <package id="ICSharpCode.TextEditor" version="3.2.1.6466" targetFramework="net45" />
   <package id="MarkdownDeep.NET" version="1.5" targetFramework="net452" />
   <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net45" />
-  <package id="OxyPlot.Core" version="2.0.0-unstable0941" targetFramework="net45" />
-  <package id="OxyPlot.GtkSharp" version="2.0.0-unstable0941" targetFramework="net45" />
+  <package id="OxyPlot.Core" version="2.0.0-unstable0960" targetFramework="net45" />
+  <package id="OxyPlot.GtkSharp" version="2.0.0-unstable0960" targetFramework="net45" />
   <package id="PDFsharp-gdi" version="1.50.4000-beta3b" targetFramework="net452" />
   <package id="PDFsharp-MigraDoc" version="1.50.4000-beta3b" targetFramework="net45" />
 </packages>

--- a/UserInterface/UserInterface.csproj
+++ b/UserInterface/UserInterface.csproj
@@ -165,11 +165,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="OxyPlot, Version=2.0.0.0, Culture=neutral, PublicKeyToken=638079a8f0bd61e9, processorArchitecture=MSIL">
-      <HintPath>..\packages\OxyPlot.Core.2.0.0-unstable0941\lib\net45\OxyPlot.dll</HintPath>
+      <HintPath>..\packages\OxyPlot.Core.2.0.0-unstable0960\lib\net45\OxyPlot.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OxyPlot.WindowsForms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=245eacd6b5d2d338, processorArchitecture=MSIL">
-      <HintPath>..\packages\OxyPlot.WindowsForms.2.0.0-unstable0941\lib\net45\OxyPlot.WindowsForms.dll</HintPath>
+      <HintPath>..\packages\OxyPlot.WindowsForms.2.0.0-unstable0960\lib\net45\OxyPlot.WindowsForms.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="PdfSharp-gdi">

--- a/UserInterface/packages.config
+++ b/UserInterface/packages.config
@@ -10,7 +10,7 @@
   <package id="MarkdownDeep.NET" version="1.5" targetFramework="net4" />
   <package id="MarkdownSharp" version="1.13.0.0" targetFramework="net4" />
   <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net45" />
-  <package id="OxyPlot.Core" version="2.0.0-unstable0941" targetFramework="net45" />
-  <package id="OxyPlot.WindowsForms" version="2.0.0-unstable0941" targetFramework="net45" />
+  <package id="OxyPlot.Core" version="2.0.0-unstable0960" targetFramework="net45" />
+  <package id="OxyPlot.WindowsForms" version="2.0.0-unstable0960" targetFramework="net45" />
   <package id="PDFsharp-MigraDoc-gdi" version="1.50.3638-beta" targetFramework="net4" />
 </packages>


### PR DESCRIPTION
Looks like the earlier OxyPlot version is no longer in the repository, so switching to the most recent.
Resolves #1474