### PR TITLE
Include Simulations and Messages when "all" database tables are delet…

### DIFF
--- a/ApsimNG/Menus/ContextMenu.cs
+++ b/ApsimNG/Menus/ContextMenu.cs
@@ -289,7 +289,7 @@ namespace UserInterface.Presenters
             DataStore dataStore = Apsim.Get(this.explorerPresenter.ApsimXFile, this.explorerPresenter.CurrentNodePath) as DataStore;
             if (dataStore != null)
             {
-                dataStore.DeleteAllTables();
+                dataStore.DeleteAllTables(false);
             }
         }
 

--- a/Models/Core/Runners/RunOrganiser.cs
+++ b/Models/Core/Runners/RunOrganiser.cs
@@ -42,7 +42,7 @@
             // Otherwise just remove the unwanted simulations from the DataStore.
             DataStore store = Apsim.Child(simulations, typeof(DataStore)) as DataStore;
             if (model is Simulations)
-                store.DeleteAllTables();
+                store.DeleteAllTables(true);
             else
                 store.RemoveUnwantedSimulations(simulations, simulationNames);
             store.Disconnect();

--- a/Models/DataStore.cs
+++ b/Models/DataStore.cs
@@ -271,10 +271,11 @@ namespace Models
         }
 
         /// <summary>Delete all tables</summary>
-        public void DeleteAllTables()
+        /// <param name="cleanSlate">If true, all tables are deleted; otherwise Simulations and Messages tables are retained</param>
+        public void DeleteAllTables(bool cleanSlate = false)
         {
             foreach (string tableName in this.TableNames)
-                if (tableName != "Simulations" && tableName != "Messages")
+                if (cleanSlate || (tableName != "Simulations" && tableName != "Messages"))
                     DeleteTable(tableName);
         }
 

--- a/UserInterface/Menus/ContextMenu.cs
+++ b/UserInterface/Menus/ContextMenu.cs
@@ -289,7 +289,7 @@ namespace UserInterface.Presenters
             DataStore dataStore = Apsim.Get(this.explorerPresenter.ApsimXFile, this.explorerPresenter.CurrentNodePath) as DataStore;
             if (dataStore != null)
             {
-                dataStore.DeleteAllTables();
+                dataStore.DeleteAllTables(false);
             }
         }
 


### PR DESCRIPTION
…ed at the start of a run.
Resolves #1536.
@hol353 - please review these changes before committing. I'm not sure why the Simulations and Messages tables were being retained, so the approach I've taken may break something.