### PR TITLE
Don't rely on focus loss to know when to store editor changes, since …

### DIFF
--- a/ApsimNG/Presenters/CultivarPresenter.cs
+++ b/ApsimNG/Presenters/CultivarPresenter.cs
@@ -46,6 +46,7 @@ namespace UserInterface.Presenters
         /// <summary>Detach the model from the view</summary>
         public void Detach()
         {
+            this.OnCommandsChanged(this, new EventArgs());
             this.view.LeaveEditor -= this.OnCommandsChanged;
             this.view.ContextItemsNeeded -= this.OnContextItemsNeeded;
             this.explorerPresenter.CommandHistory.ModelChanged -= this.OnModelChanged;
@@ -56,12 +57,15 @@ namespace UserInterface.Presenters
         /// <param name="e">Event arguments</param>
         private void OnCommandsChanged(object sender, EventArgs e)
         {
-            this.explorerPresenter.CommandHistory.ModelChanged -= this.OnModelChanged;
+            if (this.view.Lines != this.cultivar.Commands)
+            {
+                this.explorerPresenter.CommandHistory.ModelChanged -= this.OnModelChanged;
 
-            Commands.ChangeProperty command = new Commands.ChangeProperty(this.cultivar, "Commands", this.view.Lines);
-            this.explorerPresenter.CommandHistory.Add(command);
+                Commands.ChangeProperty command = new Commands.ChangeProperty(this.cultivar, "Commands", this.view.Lines);
+                this.explorerPresenter.CommandHistory.Add(command);
 
-            this.explorerPresenter.CommandHistory.ModelChanged += this.OnModelChanged;
+                this.explorerPresenter.CommandHistory.ModelChanged += this.OnModelChanged;
+            }
         }
 
         /// <summary>User has pressed a '.' in the commands window - supply context items.</summary>

--- a/ApsimNG/Views/EditorView.cs
+++ b/ApsimNG/Views/EditorView.cs
@@ -104,7 +104,7 @@
             options.HighlightCaretLine = true;
             textEditor.Options = options;
             textEditor.Document.LineChanged += OnTextHasChanged;
-            textEditor.LeaveNotifyEvent += OnTextBoxLeave;
+            textEditor.TextArea.FocusOutEvent += OnTextBoxLeave;
             _mainWidget.Destroyed += _mainWidget_Destroyed;
 
             CompletionForm = new Window(WindowType.Toplevel);
@@ -156,7 +156,7 @@
         private void _mainWidget_Destroyed(object sender, EventArgs e)
         {
             textEditor.Document.LineChanged -= OnTextHasChanged;
-            textEditor.LeaveNotifyEvent -= OnTextBoxLeave;
+            textEditor.TextArea.FocusOutEvent -= OnTextBoxLeave;
             _mainWidget.Destroyed -= _mainWidget_Destroyed;
             textEditor.TextArea.KeyPressEvent -= OnKeyPress;
             CompletionForm.FocusOutEvent -= OnLeaveCompletion;


### PR DESCRIPTION
…focus loss may occur after detachment of the view. Resolves #1697 