### PR TITLE
Use a more generic format when displaying user-provided property values.

### DIFF
--- a/ApsimNG/Presenters/PropertyPresenter.cs
+++ b/ApsimNG/Presenters/PropertyPresenter.cs
@@ -85,6 +85,7 @@ namespace UserInterface.Presenters
 
             string[] split;
 
+            grid.NumericFormat = "G6"; 
             this.FindAllProperties(this.model);
             if (this.grid.DataSource == null)
             {


### PR DESCRIPTION
Resolves #1688