### PR TITLE
Stop autodoc from including the first TitlePage memo it finds.

### DIFF
--- a/ApsimNG/Commands/ExportNodeCommand.cs
+++ b/ApsimNG/Commands/ExportNodeCommand.cs
@@ -200,9 +200,11 @@ namespace UserInterface.Commands
             List<AutoDocumentation.ITag> tags = new List<AutoDocumentation.ITag>();
 
             // See if there is a title page. If so do it first.
-            IModel titlePage = Apsim.Find(ExplorerPresenter.ApsimXFile, "TitlePage");
-            if (titlePage != null)
-                titlePage.Document(tags, 1, 0);
+            foreach (IModel memo in Apsim.FindAll(ExplorerPresenter.ApsimXFile, typeof(Memo)))
+            {
+                if (memo.Name == "TitlePage" && memo.Parent.Name == modelNameToExport)
+                    memo.Document(tags, 1, 0);
+            }
             AddBackground(tags);
 
             // See if there is a title page. If so do it first.

--- a/UserInterface/Commands/ExportNodeCommand.cs
+++ b/UserInterface/Commands/ExportNodeCommand.cs
@@ -199,9 +199,11 @@ namespace UserInterface.Commands
             List<AutoDocumentation.ITag> tags = new List<AutoDocumentation.ITag>();
 
             // See if there is a title page. If so do it first.
-            IModel titlePage = Apsim.Find(ExplorerPresenter.ApsimXFile, "TitlePage");
-            if (titlePage != null)
-                titlePage.Document(tags, 1, 0);
+            foreach (IModel memo in Apsim.FindAll(ExplorerPresenter.ApsimXFile, typeof(Memo)))
+            {
+                if (memo.Name == "TitlePage" && memo.Parent.Name == modelNameToExport)
+                    memo.Document(tags, 1, 0);
+            }
             AddBackground(tags);
 
             // See if there is a title page. If so do it first.


### PR DESCRIPTION
Resolves #1666 