### PR TITLE
Use only integer values when setting map zoom levels, as this seems t…

### DIFF
--- a/ApsimNG/Views/MapView.cs
+++ b/ApsimNG/Views/MapView.cs
@@ -255,9 +255,7 @@ google.maps.event.addDomListener(window, 'load', initialize);
             }
             set
             {
-                if (ProcessUtilities.CurrentOS.IsWindows) // Want only integer values with IE
-                   value = Math.Truncate(value + 0.5);
-                browser.ExecJavaScript("SetZoom", new object[] { value });
+                browser.ExecJavaScript("SetZoom", new object[] { (int)Math.Truncate(value + 0.5) });
                 if (popupWin != null)
                 {
                     Stopwatch watch = new Stopwatch();


### PR DESCRIPTION
…o be all Google maps now accepts. Resolves #1762 