### PR TITLE
Issue/fraclayer soil nitrogen#1797

### DIFF
--- a/Models/Soils/SoilNitrogen.CNPatch.Processes.cs
+++ b/Models/Soils/SoilNitrogen.CNPatch.Processes.cs
@@ -118,8 +118,7 @@ namespace Models.Soils
                         for (int layer = 0; layer <= ImmobilisationLayer; layer++)
                         {
                             // 2.3.1. fraction of mineralised stuff going in this layer
-                            //fractionIntoLayer = MathUtilities.Divide(g.dlayer[layer] * fracLayer[layer], g.ResiduesDecompDepth, 0.0);
-                            fractionIntoLayer = MathUtilities.Divide(fracLayer[layer], cumFrac, 0.0);
+                            fractionIntoLayer = MathUtilities.Divide(g.dlayer[layer] * fracLayer[layer], g.ResiduesDecompDepth, 0.0);
 
                             //2.3.2. adjust C and N amounts for each residue and add to soil OM pools
                             for (int residue = 0; residue < g.nResidues; residue++)

--- a/Tests/Validation/Maize/Maize.apsimx
+++ b/Tests/Validation/Maize/Maize.apsimx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Simulations xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="7">
+<Simulations xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="8">
   <Name>Simulations</Name>
   <DataStore>
     <Name>DataStore</Name>
@@ -20,16 +20,16 @@
           <RegrStats>
             <Name>Biomass</Name>
             <n>88</n>
-            <Slope>1.1270587437614767</Slope>
-            <Intercept>-21.696883044807237</Intercept>
-            <SEslope>0.043902921281099516</SEslope>
-            <SEintercept>60.173460444731717</SEintercept>
-            <R2>0.88456866116237176</R2>
-            <RMSE>284.68481784353855</RMSE>
-            <NSE>0.764628246156802</NSE>
-            <ME>135.68280317936186</ME>
-            <MAE>214.88102744681308</MAE>
-            <RSR>0.48238685183393276</RSR>
+            <Slope>1.1275698395945712</Slope>
+            <Intercept>-22.108123315555304</Intercept>
+            <SEslope>0.043887011614175193</SEslope>
+            <SEintercept>60.15165461301428</SEintercept>
+            <R2>0.88473515910262668</R2>
+            <RMSE>284.79666551553623</RMSE>
+            <NSE>0.76444326295755738</NSE>
+            <ME>135.90462521870478</ME>
+            <MAE>215.10284951587406</MAE>
+            <RSR>0.48257637316769619</RSR>
           </RegrStats>
           <RegrStats>
             <Name>FinalLeafNo</Name>
@@ -62,58 +62,58 @@
           <RegrStats>
             <Name>GPSM</Name>
             <n>84</n>
-            <Slope>0.91391560569708441</Slope>
-            <Intercept>244.6395314237493</Intercept>
-            <SEslope>0.042051741619332755</SEslope>
-            <SEintercept>100.80917739687845</SEintercept>
-            <R2>0.85207329179734859</R2>
-            <RMSE>476.81419520645886</RMSE>
-            <NSE>0.84456516543243</NSE>
-            <ME>66.45942777386125</ME>
-            <MAE>350.5339751858055</MAE>
-            <RSR>0.39189848158717966</RSR>
+            <Slope>0.91391560570901065</Slope>
+            <Intercept>244.63953136618898</Intercept>
+            <SEslope>0.042051741618312176</SEslope>
+            <SEintercept>100.80917739443187</SEintercept>
+            <R2>0.85207329180675628</R2>
+            <RMSE>476.81419518793319</RMSE>
+            <NSE>0.84456516544450833</NSE>
+            <ME>66.459427740986669</ME>
+            <MAE>350.53397518269975</MAE>
+            <RSR>0.39189848157195323</RSR>
           </RegrStats>
           <RegrStats>
             <Name>GrainSize</Name>
             <n>78</n>
-            <Slope>0.54923285480704942</Slope>
-            <Intercept>0.14919988273289109</Intercept>
-            <SEslope>0.12968988426698497</SEslope>
-            <SEintercept>0.037228654804242263</SEintercept>
-            <R2>0.19092969587055686</R2>
-            <RMSE>0.071097002225445252</RMSE>
-            <NSE>-0.64220299509797418</NSE>
-            <ME>0.022242817155082813</ME>
-            <MAE>0.05308340093420412</MAE>
-            <RSR>1.273243539369211</RSR>
+            <Slope>0.54923285483072548</Slope>
+            <Intercept>0.14919988271723433</Intercept>
+            <SEslope>0.12968988428121978</SEslope>
+            <SEintercept>0.037228654808328494</SEintercept>
+            <R2>0.19092969584996444</R2>
+            <RMSE>0.071097002228245568</RMSE>
+            <NSE>-0.64220299522733781</NSE>
+            <ME>0.022242817146094281</ME>
+            <MAE>0.053083400934801669</MAE>
+            <RSR>1.2732435394193606</RSR>
           </RegrStats>
           <RegrStats>
             <Name>GrainWt</Name>
             <n>103</n>
-            <Slope>0.90784889354172027</Slope>
-            <Intercept>99.108060686622025</Intercept>
-            <SEslope>0.040682830633935109</SEslope>
-            <SEintercept>28.329020093622812</SEintercept>
-            <R2>0.8313777243882261</R2>
-            <RMSE>150.31508141426889</RMSE>
-            <NSE>0.80845851589846829</NSE>
-            <ME>43.2881237721062</ME>
-            <MAE>119.54436283183723</MAE>
-            <RSR>0.43552480760835383</RSR>
+            <Slope>0.90857739235646029</Slope>
+            <Intercept>98.823806339797216</Intercept>
+            <SEslope>0.040714911924624925</SEslope>
+            <SEintercept>28.351359530540535</SEintercept>
+            <R2>0.83138161128941057</R2>
+            <RMSE>150.41136890952541</RMSE>
+            <NSE>0.80821304542923122</NSE>
+            <ME>43.445152872046044</ME>
+            <MAE>119.70139194452199</MAE>
+            <RSR>0.43580379220824977</RSR>
           </RegrStats>
           <RegrStats>
             <Name>LAImax</Name>
             <n>74</n>
-            <Slope>1.1769923669195421</Slope>
-            <Intercept>0.30109534242504932</Intercept>
-            <SEslope>0.052593782245580749</SEslope>
-            <SEintercept>0.15834180312328075</SEintercept>
-            <R2>0.87430526029816913</R2>
-            <RMSE>1.0109477248612711</RMSE>
-            <NSE>0.43512568278738395</NSE>
-            <ME>0.77781870188323488</ME>
-            <MAE>0.78519072488706876</MAE>
-            <RSR>0.74648568673051374</RSR>
+            <Slope>1.1769923669280487</Slope>
+            <Intercept>0.3010953423737166</Intercept>
+            <SEslope>0.052593782241642455</SEslope>
+            <SEintercept>0.1583418031114239</SEintercept>
+            <R2>0.87430526031621592</R2>
+            <RMSE>1.010947724815408</RMSE>
+            <NSE>0.43512568283863673</NSE>
+            <ME>0.77781870185481361</ME>
+            <MAE>0.7851907248586476</MAE>
+            <RSR>0.74648568669664828</RSR>
           </RegrStats>
           <RegrStats>
             <Name>MaturityDAS</Name>
@@ -891,14 +891,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -2000,14 +1992,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -2828,14 +2812,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -3274,14 +3250,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -3729,14 +3697,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -4164,14 +4124,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -4574,14 +4526,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -4996,14 +4940,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -5410,14 +5346,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -5802,14 +5730,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -6200,14 +6120,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -6592,14 +6504,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -6971,14 +6875,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -7351,14 +7247,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -7741,14 +7629,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -8155,14 +8035,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -8577,14 +8449,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -8988,14 +8852,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -9398,14 +9254,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -9790,14 +9638,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -10155,14 +9995,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -10500,14 +10332,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -10900,14 +10724,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -11320,14 +11136,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -11721,14 +11529,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -12140,14 +11940,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -12876,14 +12668,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -14529,14 +14313,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -15718,14 +15494,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -16664,14 +16432,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -17649,14 +17409,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -18553,14 +18305,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -19598,14 +19342,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -21151,14 +20887,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -22604,14 +22332,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -24299,14 +24019,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -25139,14 +24851,6 @@ namespace Models
                 <double>0.08</double>
                 <double>0.9</double>
               </fract_lign>
-              <wfpsN2N2O_x>
-                <double>22</double>
-                <double>88</double>
-              </wfpsN2N2O_x>
-              <wfpsN2N2O_y>
-                <double>0.1</double>
-                <double>1</double>
-              </wfpsN2N2O_y>
             </SoilNitrogen>
             <SoilOrganicMatter>
               <Name>SoilOrganicMatter</Name>
@@ -26152,14 +25856,6 @@ namespace Models
                 <double>0.08</double>
                 <double>0.9</double>
               </fract_lign>
-              <wfpsN2N2O_x>
-                <double>22</double>
-                <double>88</double>
-              </wfpsN2N2O_x>
-              <wfpsN2N2O_y>
-                <double>0.1</double>
-                <double>1</double>
-              </wfpsN2N2O_y>
             </SoilNitrogen>
             <SoilOrganicMatter>
               <Name>SoilOrganicMatter</Name>
@@ -27019,14 +26715,6 @@ Testing of APSIM Maize under New Zealand conditions was undertaken using the dat
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -33173,14 +32861,6 @@ This trial was conducted to provide data for parametersising the Leaf Area model
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -35753,14 +35433,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -36666,14 +36338,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <wfpsN2N2O_x>
-                  <double>22</double>
-                  <double>88</double>
-                </wfpsN2N2O_x>
-                <wfpsN2N2O_y>
-                  <double>0.1</double>
-                  <double>1</double>
-                </wfpsN2N2O_y>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -38705,14 +38369,6 @@ namespace Models
                 <double>0.08</double>
                 <double>0.9</double>
               </fract_lign>
-              <wfpsN2N2O_x>
-                <double>22</double>
-                <double>88</double>
-              </wfpsN2N2O_x>
-              <wfpsN2N2O_y>
-                <double>0.1</double>
-                <double>1</double>
-              </wfpsN2N2O_y>
             </SoilNitrogen>
             <InitialWater>
               <Name>InitialWater</Name>


### PR DESCRIPTION
Resolves #1797 
This is a simple fix for an error introduced a couple of years back, this changed a bit the calculation of the variable used to distribute residues decomposed in to the soil, the efffect was small and causes more stuff to be added deeper in the profile than it used to be.  This only affected simulation with thin layers, as the maximum depth used in this calculation is 100mm (this was the case of one simulation (Ames) in the maize.apsim tests)