### PR TITLE
Enable hydrolysis to used actual OC

### DIFF
--- a/Models/Soils/SoilNitrogen.CNPatch.Processes.cs
+++ b/Models/Soils/SoilNitrogen.CNPatch.Processes.cs
@@ -608,7 +608,6 @@ namespace Models.Soils
                 {
                     // potential fraction of urea being hydrolysed
                     double totalC = (hum_c[layer] + biom_c[layer]) * g.convFactor[layer] / 10000;  // (100/1000000) = convert to ppm and then to %
-                    totalC = g.reset_oc[layer];
                     double pot_hydrol_rate = g.UreaHydrol_parmA + g.UreaHydrol_parmB * totalC +
                              g.UreaHydrol_parmC * g.ph[layer] + g.UreaHydrol_parmD * totalC * g.ph[layer];
                     pot_hydrol_rate = Math.Max(g.UreaHydrol_MinRate, Math.Min(1.0, pot_hydrol_rate));

--- a/Models/Soils/SoilNitrogen.CNPatch.Processes.cs
+++ b/Models/Soils/SoilNitrogen.CNPatch.Processes.cs
@@ -101,7 +101,7 @@ namespace Models.Soils
 
                         // 2.2.3. potential N demanded for conversion of residues into soil OM
                         double NDemand = MathUtilities.Divide(g.SumDoubleArray(dltC_into_biom), g.MBiomassCNr, 0.0) +
-                                          MathUtilities.Divide(g.SumDoubleArray(dltC_into_hum), g.hum_cn, 0.0);
+                                          MathUtilities.Divide(g.SumDoubleArray(dltC_into_hum), g.HumusCNr, 0.0);
 
                         // 2.2.4. factor to reduce mineralisation rate, if N available is insufficient
                         double ReductionFactor = 1.0;
@@ -184,7 +184,7 @@ namespace Models.Soils
                         hum_c[layer] += dlt_c_res_to_hum[layer];
 
                         // organic N balance
-                        hum_n[layer] = MathUtilities.Divide(hum_c[layer], g.hum_cn, 0.0);
+                        hum_n[layer] = MathUtilities.Divide(hum_c[layer], g.HumusCNr, 0.0);
                         biom_n[layer] = MathUtilities.Divide(biom_c[layer], g.MBiomassCNr, 0.0);
 
                         // soil mineral N
@@ -257,7 +257,7 @@ namespace Models.Soils
                                        dlt_c_fom_to_hum[0][layer] + dlt_c_fom_to_hum[1][layer] + dlt_c_fom_to_hum[2][layer];
 
                         biom_n[layer] = MathUtilities.Divide(biom_c[layer], g.MBiomassCNr, 0.0);
-                        hum_n[layer] = MathUtilities.Divide(hum_c[layer], g.hum_cn, 0.0);
+                        hum_n[layer] = MathUtilities.Divide(hum_c[layer], g.HumusCNr, 0.0);
 
                         // update FOM pools
                         for (int pool = 0; pool < 3; pool++)
@@ -305,14 +305,14 @@ namespace Models.Soils
                 if (pot_miner >= g.epsilon)
                 {
                     // get the soil temperature factor
-                    double stf = SoilTempFactor(layer, index, g.SOMMiner_TempFactorData);
+                    double stf = SoilTempFactor(layer, index, g.SOMMiner_TemperatureFactorData);
 
                     // get the soil water factor
                     double swf = SoilMoistFactor(layer, index, g.SOMMiner_MoistureFactorData);
 
                     // compute the mineralisation amounts of C and N from the humic pool
                     double dlt_c_miner = pot_miner * stf * swf;
-                    double dlt_n_miner = MathUtilities.Divide(dlt_c_miner, g.hum_cn, 0.0);
+                    double dlt_n_miner = MathUtilities.Divide(dlt_c_miner, g.HumusCNr, 0.0);
 
                     // distribute the mineralised N and C
                     dlt_c_hum_to_biom[layer] = dlt_c_miner * (1.0 - g.AHumusRespirationFactor);
@@ -345,7 +345,7 @@ namespace Models.Soils
                 if (pot_miner >= g.epsilon)
                 {
                     // get the soil temperature factor
-                    double stf = SoilTempFactor(layer, index, g.SOMMiner_TempFactorData);
+                    double stf = SoilTempFactor(layer, index, g.SOMMiner_TemperatureFactorData);
 
                     // get the soil water factor
                     double swf = SoilMoistFactor(layer, index, g.SOMMiner_MoistureFactorData);
@@ -359,7 +359,7 @@ namespace Models.Soils
                     dlt_c_biom_to_atm[layer] = dlt_c_miner * g.MBiomassRespirationFactor;
 
                     // calculate net mineralisation
-                    dlt_n_biom_to_min[layer] = dlt_n_miner - MathUtilities.Divide(dlt_c_biom_to_hum[layer], g.hum_cn, 0.0) -
+                    dlt_n_biom_to_min[layer] = dlt_n_miner - MathUtilities.Divide(dlt_c_biom_to_hum[layer], g.HumusCNr, 0.0) -
                                        MathUtilities.Divide((dlt_c_miner - dlt_c_biom_to_atm[layer] - dlt_c_biom_to_hum[layer]), g.MBiomassCNr, 0.0);
                 }
                 else
@@ -436,7 +436,7 @@ namespace Models.Soils
 
                     // test whether there is adequate N available to meet immobilisation demand
                     double n_demand = MathUtilities.Divide(dlt_c_biom_tot, g.MBiomassCNr, 0.0) +
-                                      MathUtilities.Divide(dlt_c_hum_tot, g.hum_cn, 0.0);
+                                      MathUtilities.Divide(dlt_c_hum_tot, g.HumusCNr, 0.0);
                     double n_available = mineralN_available + dlt_n_fom_gross_miner;
 
                     // factor to reduce mineralisation rates if insufficient N to meet immobilisation demand
@@ -614,7 +614,7 @@ namespace Models.Soils
                     if (pot_hydrol_rate >= g.epsilon)
                     {
                         // get the soil temperature factor
-                        double stf = SoilTempFactor(layer, index, g.UreaHydrolysis_TempFactorData);
+                        double stf = SoilTempFactor(layer, index, g.UreaHydrolysis_TemperatureFactorData);
 
                         // get the soil water factor
                         double swf = SoilMoistFactor(layer, index, g.UreaHydrolysis_MoistureFactorData);
@@ -648,7 +648,7 @@ namespace Models.Soils
 
                 // get the potential rate of nitrification for layer
                 double nh4ppm = nh4[layer] * g.convFactor[layer];
-                double pot_nitrif_rate_ppm = MathUtilities.Divide(g.NitrificationMaxPotential * nh4ppm, nh4ppm + g.NitrificationNH4ForHalf, 0.0);
+                double pot_nitrif_rate_ppm = MathUtilities.Divide(g.NitrificationMaxPotential * nh4ppm, nh4ppm + g.NitrificationNH4ForHalfRate, 0.0);
 
                 if (pot_nitrif_rate_ppm >= g.epsilon)
                 {
@@ -665,7 +665,7 @@ namespace Models.Soils
                     double pni = Math.Min(swf, Math.Min(stf, phf));
 
                     // get the actual rate of nitrification
-                    double nitrif_rate = pot_nitrif_rate_ppm * pni * Math.Max(0.0, 1.0 - g.InhibitionFactor_Nitrification[layer]);
+                    double nitrif_rate = pot_nitrif_rate_ppm * pni * Math.Max(0.0, 1.0 - g.inhibitionFactor_Nitrification[layer]);
 
                     // check that the nitrification rate is not greater than nh4 content
                     nitrif_rate = Math.Min(nitrif_rate, nh4ppm);
@@ -685,7 +685,7 @@ namespace Models.Soils
             /// <returns>delta N coverted into N2O during nitrification</returns>
             private double N2OProducedDuringNitrification(int layer)
             {
-                double result = dlt_nitrification[layer] * g.Denit_LossFactorNitrif;
+                double result = dlt_nitrification[layer] * g.Nitrification_DenitLossFactor;
                 return result;
             }
 
@@ -796,24 +796,24 @@ namespace Models.Soils
 
                 // get the potential nitritation rate for this layer
                 double nh4ppm = nh4[layer] * g.convFactor[layer];
-                double potNitritationRate = MathUtilities.Divide(g.NitritationMaxPotential * nh4ppm, nh4ppm + g.NH4AtHalfNitritationPot, 0.0);
+                double potNitritationRate = MathUtilities.Divide(g.NitritationMaxPotential * nh4ppm, nh4ppm + g.NitritationNH4ForHalfRate, 0.0);
 
                 if (potNitritationRate >= g.epsilon)
                 {
                     // get the soil temperature factor
-                    double stf = SoilTempFactor(layer, 0, g.TemperatureFactorData_Nitrification2);
+                    double stf = SoilTempFactor(layer, 0, g.Nitrification2_TemperatureFactorData);
 
                     // get the soil water factor
-                    double swf = SoilMoistFactor(layer, 0, g.MoistureFactorData_Nitrification2);
+                    double swf = SoilMoistFactor(layer, 0, g.Nitrification2_MoistureFactorData);
 
                     // get the soil pH factor
-                    double phf = SoilpHFactor(layer, 0, g.pHFactorData_Nitritation);
+                    double phf = SoilpHFactor(layer, 0, g.Nitritation_pHFactorData);
 
                     // get most limiting factor
                     double limitingFactor = Math.Min(swf, Math.Min(stf, phf));
 
                     // get the actual rate of nitritation
-                    double nitritationRate = potNitritationRate * limitingFactor * Math.Max(0.0, 1.0 - g.InhibitionFactor_Nitrification[layer]);
+                    double nitritationRate = potNitritationRate * limitingFactor * Math.Max(0.0, 1.0 - g.inhibitionFactor_Nitrification[layer]);
 
                     // check that the nitritation rate is not greater than nh4 content
                     nitritationRate = Math.Min(nitritationRate, nh4ppm);
@@ -837,18 +837,18 @@ namespace Models.Soils
 
                 // get the potential nitratation rate for this layer
                 double no2ppm = no2[layer] * g.convFactor[layer];
-                double potNitratationRate = MathUtilities.Divide(g.NitritationMaxPotential * no2ppm, no2ppm + g.NO2AtHalfNitratationPot, 0.0);
+                double potNitratationRate = MathUtilities.Divide(g.NitritationMaxPotential * no2ppm, no2ppm + g.NitratationNH4ForHalfRate, 0.0);
 
                 if (potNitratationRate >= g.epsilon)
                 {
                     // get the soil temperature factor
-                    double stf = SoilTempFactor(layer, 0, g.TemperatureFactorData_Nitrification2);
+                    double stf = SoilTempFactor(layer, 0, g.Nitrification2_TemperatureFactorData);
 
                     // get the soil water factor
-                    double swf = SoilMoistFactor(layer, 0, g.MoistureFactorData_Nitrification2);
+                    double swf = SoilMoistFactor(layer, 0, g.Nitrification2_MoistureFactorData);
 
                     // get the soil pH factor
-                    double phf = SoilpHFactor(layer, 0, g.pHFactorData_Nitratation);
+                    double phf = SoilpHFactor(layer, 0, g.Nitratation_pHFactorData);
 
                     // get most limiting factor
                     double limitingFactor = Math.Min(swf, Math.Min(stf, phf));
@@ -898,19 +898,19 @@ namespace Models.Soils
                 double waterSolubleOrganicN = Math.Min(biom_n[layer] + fom_n[0][layer], nh3[layer]);
 
                 // get the potential codenitrification rate
-                double potCodenitrificationRate = g.CodenitRateCoefficient * waterSoluble_c[layer];
+                double potCodenitrificationRate = g.CodenitrificationRateCoefficient * waterSoluble_c[layer];
                 double potNCodenitrifiable = 2.0 * Math.Min(no2[layer], waterSolubleOrganicN);
 
                 if ((potCodenitrificationRate >= g.epsilon) && (potNCodenitrifiable >= g.epsilon))
                 {
                     // get the soil temperature factor
-                    double stf = SoilTempFactor(layer, 0, g.TemperatureFactorData_Codenitrification);
+                    double stf = SoilTempFactor(layer, 0, g.Codenitrification_TemperatureFactorData);
 
                     // get the soil water factor
-                    double swf = SoilMoistFactor(layer, 0, g.MoistureFactorData_Codenitrification);
+                    double swf = SoilMoistFactor(layer, 0, g.Codenitrification_MoistureFactorData);
 
                     // get the soil pH factor
-                    double phf = SoilpHFactor(layer, 0, g.pHFactorData_Codenitrification);
+                    double phf = SoilpHFactor(layer, 0, g.Codenitrification_pHFactorData);
 
                     // get most limiting factor
                     double limitingFactor = Math.Min(swf, Math.Min(stf, phf));
@@ -934,8 +934,8 @@ namespace Models.Soils
                 bool DidInterpolate;
                 double totalNN = (nh3[layer] + no2[layer]) * g.convFactor[layer];
                 double result = MathUtilities.LinearInterpReal(totalNN,
-                                g.NH3NO2FactorData_Codenitrification.xVals,
-                                g.NH3NO2FactorData_Codenitrification.yVals,
+                                g.Codenitrification_NH3NO2FactorData.xVals,
+                                g.Codenitrification_NH3NO2FactorData.yVals,
                                 out DidInterpolate);
                 return result;
             }

--- a/Models/Soils/SoilNitrogen.CNPatch.Processes.cs
+++ b/Models/Soils/SoilNitrogen.CNPatch.Processes.cs
@@ -598,8 +598,7 @@ namespace Models.Soils
                 // index = 0 for aerobic and 1 for anaerobic conditions
                 int index = (g.isPondActive) ? 1 : 0;
 
-                if (urea[layer]< 0.1)
-                //if (MathUtilities.Divide(urea[layer], g.SoilDensity[layer] * g.dlayer[layer], 0.0) < 0.0001) // 0.01ppm
+                if (urea[layer] < g.epsilon)
                 {
                     // urea amount is too small, all will be hydrolysed
                     result = urea[layer];

--- a/Models/Soils/SoilNitrogen.CNPatch.cs
+++ b/Models/Soils/SoilNitrogen.CNPatch.cs
@@ -802,7 +802,7 @@ namespace Models.Soils
             /// Gather the information about actual residue decomposition, to be sent back to surface OM
             /// </summary>
             /// <remarks>
-            /// Currently P is not computed in SoilNitrogen, so the corresponding variables are set to zero here 
+            /// Currently P is not being computed by SoilNitrogen, so the corresponding variables are set to zero here 
             /// </remarks>
             private void PackActualResidueDecomposition()
             {

--- a/Models/Soils/SoilNitrogen.CNPatch.cs
+++ b/Models/Soils/SoilNitrogen.CNPatch.cs
@@ -826,8 +826,8 @@ namespace Models.Soils
                     SurfOMActualDecomposition.Pool[residue].Name = g.residueName[residue];
                     SurfOMActualDecomposition.Pool[residue].OrganicMatterType = g.residueType[residue];
                     SurfOMActualDecomposition.Pool[residue].FOM.amount = 0.0F;
-                    SurfOMActualDecomposition.Pool[residue].FOM.C = (float)c_summed;
-                    SurfOMActualDecomposition.Pool[residue].FOM.N = (float)n_summed;
+                    SurfOMActualDecomposition.Pool[residue].FOM.C = c_summed;
+                    SurfOMActualDecomposition.Pool[residue].FOM.N = n_summed;
                     SurfOMActualDecomposition.Pool[residue].FOM.P = 0.0F;
                     SurfOMActualDecomposition.Pool[residue].FOM.AshAlk = 0.0F;
                     // Note: The values for 'amount', 'P', and 'AshAlk' will not be collected by SurfaceOrganicMatter, so send zero as default.

--- a/Models/Soils/SoilNitrogen.CNPatch.cs
+++ b/Models/Soils/SoilNitrogen.CNPatch.cs
@@ -763,7 +763,7 @@ namespace Models.Soils
             public void ClearDeltaVariables()
             {
                 // miscelaneous
-                Array.Clear(g.InhibitionFactor_Nitrification, 0, g.InhibitionFactor_Nitrification.Length);
+                Array.Clear(g.inhibitionFactor_Nitrification, 0, g.inhibitionFactor_Nitrification.Length);
                 dlt_n_loss_in_sed = 0.0;
                 dlt_c_loss_in_sed = 0.0;
 

--- a/Models/Soils/SoilNitrogen.CNPatchHandlers.cs
+++ b/Models/Soils/SoilNitrogen.CNPatchHandlers.cs
@@ -87,7 +87,7 @@ namespace Models.Soils
             }
 
             // check that total area of affected patches is larger than new patch area
-            if (AreaAffected - PatchtoAdd.AreaNewPatch < -MinimumPatchArea)
+            if (AreaAffected - PatchtoAdd.AreaNewPatch < -minimumPatchArea)
             {
                 throw new Exception(" AddSoilCNPatch - area of selected patches (" + AreaAffected.ToString("#0.00#")
                                     + ") is smaller than area of new patch(" + PatchtoAdd.AreaNewPatch.ToString("#0.00#") +
@@ -101,21 +101,21 @@ namespace Models.Soils
                     double OldPatch_OldArea = Patch[idPatchesAffected[i]].RelativeArea;
                     double NewPatch_NewArea = PatchtoAdd.AreaNewPatch * (OldPatch_OldArea / AreaAffected);
                     double OldPatch_NewArea = OldPatch_OldArea - NewPatch_NewArea;
-                    if (NewPatch_NewArea < MinimumPatchArea)
+                    if (NewPatch_NewArea < minimumPatchArea)
                     {
                         // area of patch to create is too small, patch will not be created
                         throw new Exception("   attempt to create a new patch with area too small or negative ("
                                             + NewPatch_NewArea.ToString("#0.00#") +
                                             "). The patch will not be created. Command cannot be executed");
                     }
-                    else if (OldPatch_NewArea < -MinimumPatchArea)
+                    else if (OldPatch_NewArea < -minimumPatchArea)
                     {
                         // area of patch to create is too big, patch will not be created
                         throw new Exception("   attempt to create a new patch with area greater than the existing patch area ("
                                             + NewPatch_NewArea.ToString("#0.00#") +
                                             "). The patch will not be created. Command cannot be executed");
                     }
-                    else if (OldPatch_NewArea < MinimumPatchArea)
+                    else if (OldPatch_NewArea < minimumPatchArea)
                     {
                         // remaining area is too small or negative, patch will be created but old one will be deleted
                         mySummary.WriteWarning(this, " attempt to set the area of existing patch(" + idPatchesAffected[i].ToString()
@@ -212,7 +212,7 @@ namespace Models.Soils
         {
             int nPatches = Patch.Count;
 
-            if (PatchAmalgamationApproach.ToLower() == "CompareAll".ToLower())
+            if (patchAmalgamationApproach.ToLower() == "CompareAll".ToLower())
             {
                 // A1. initialise the lists, for each existing patch, of patches to be merged to it
                 List<List<int>> MergingPatches = new List<List<int>>();
@@ -261,7 +261,7 @@ namespace Models.Soils
                     DeletePatches(PatchesToDelete);
                 }
             }
-            else if (PatchAmalgamationApproach.ToLower() == "CompareBase".ToLower())
+            else if (patchAmalgamationApproach.ToLower() == "CompareBase".ToLower())
             {
                 // B1. initialise the list of patches to be merged/deleted
                 List<int> PatchesToDelete = new List<int>();
@@ -296,7 +296,7 @@ namespace Models.Soils
                     }
                 } while (k < nPatches - 1);
             }
-            else if (PatchAmalgamationApproach.ToLower() == "CompareMerge".ToLower())
+            else if (patchAmalgamationApproach.ToLower() == "CompareMerge".ToLower())
             {
                 // C1. initialise the list of patches to be deleted
                 List<int> PatchesToDelete = new List<int>();
@@ -453,7 +453,7 @@ namespace Models.Soils
         {
 
             double NewPatchArea = Patch[k].RelativeArea + Patch[j].RelativeArea;
-            if (1.0 - NewPatchArea < -MinimumPatchArea)
+            if (1.0 - NewPatchArea < -minimumPatchArea)
                 throw new Exception("THe merge of patch " + j + " into patch " + k + " resulted in area greater than one");
 
             for (int layer = 0; layer < nLayers; layer++)
@@ -555,10 +555,10 @@ namespace Models.Soils
             // Adjust factor for diffs
             //  it is used to differentiate whether the patch is the 'base'. The diffs can then be a bit less stringent
             double AdjustFactor = 1.0;
-            if (PatchbasePatchApproach == "IDBased")
+            if (patchbasePatchApproach == "IDBased")
                 if (k == 1)
                     AdjustFactor = DiffAdjustFactor;
-            if (PatchbasePatchApproach == "AreaBased")
+            if (patchbasePatchApproach == "AreaBased")
                 if (Patch[k].RelativeArea == Patch.Max(x => x.RelativeArea))
                     AdjustFactor = DiffAdjustFactor;
             //else {}  // do not use a different adjustFactor for the base patch
@@ -602,7 +602,7 @@ namespace Models.Soils
             AgreedCount += TestDelta(deltaValue, TotalValueBase, relativeDiff_TotalNO3, absoluteDiff_TotalNO3, AdjustFactor);
 
             // tests by layer (from surface down to a give depth to test) - these are tested im ppm, not kg/ha
-            for (int layer = 0; layer <= LayerDepthToTestDiffs; layer++)
+            for (int layer = 0; layer <= layerDepthToTestDiffs; layer++)
             {
                 // test M. biomass
                 deltaValue = MathUtilities.Divide(Math.Abs(Patch[k].biom_c[layer] - Patch[j].biom_c[layer]), convFactor[layer], 0.0);
@@ -818,7 +818,7 @@ namespace Models.Soils
                                 {
                                     thisLayerPatchSolute[k] += existingSoluteAmount[k][z];
                                     layerUsed += dlayer[z];
-                                    if ((layerNPartition > epsilon) && (layerUsed >= layerNPartition))
+                                    if ((LayerForNPartition > epsilon) && (layerUsed >= LayerForNPartition))
                                         // stop if thickness reaches a defined value
                                         z = -1;
                                 }

--- a/Models/Soils/SoilNitrogen.Variables.cs
+++ b/Models/Soils/SoilNitrogen.Variables.cs
@@ -161,7 +161,7 @@ namespace Models.Soils
         [Bounds(Lower = 5, Upper = 30)]
         [Units("g/g")]
         [XmlIgnore]
-        public double HumusCNr = 0.0;
+        public double HumusCNr = 11.0;
 
         /// <summary>
         /// The C:N ratio of soil microbial biomass.

--- a/Models/Soils/SoilNitrogen.Variables.cs
+++ b/Models/Soils/SoilNitrogen.Variables.cs
@@ -22,33 +22,25 @@ namespace Models.Soils
 
         #region Links to other modules
 
-        /// <summary>
-        /// Link to APSIM's clock (time information)
-        /// </summary>
+        /// <summary>Link to APSIM's Clock (time information).</summary>
         [Link]
         public Clock Clock = null;
 
-        /// <summary>
-        /// Link to APSIM's metFile (weather data)
-        /// </summary>
+        /// <summary>Link to APSIM's WeatherFile (weather data).</summary>
         [Link]
         public IWeather MetFile = null;
 
-        /// <summary>Link to APSIM summary (logs the messages raised during model run).</summary>
+        /// <summary>Link to APSIM Summary (logs the messages raised during model run).</summary>
         [Link]
         private ISummary mySummary = null;
 
-        /// <summary>The surface organic matter</summary>
+        /// <summary>Link to the surface organic matter.</summary>
         [Link]
         public SurfaceOrganicMatter SurfaceOrganicMatter = null;
 
-        /// <summary>The soil</summary>
+        /// <summary>Link to the soil.</summary>
         [Link]
         private Soil Soil = null;
-
-        /// <summary>The soil organic matter</summary>
-        [Link]
-        private SoilOrganicMatter SoilOrganicMatter = null;
 
         #endregion
 
@@ -59,7 +51,7 @@ namespace Models.Soils
         #region General setting parameters
 
         /// <summary>
-        /// Soil parameterisation set to use
+        /// Soil parameterisation set to use.
         /// </summary>
         /// <remarks>
         /// Used to determine which node of xml file will be used to overwrite some [Param]'s
@@ -68,10 +60,14 @@ namespace Models.Soils
         [XmlIgnore]
         public string SoilNParameterSet = "standard";
 
-        /// <summary>flag whether routines for nitrification and codenitrification are to be used (ignore old nitrification)</summary>
+        /// <summary>
+        /// Flag for whether routines for nitrification and codenitrification are to be used (ignore old nitrification).
+        /// </summary>
         private bool usingNewNitrification = false;
 
-        /// <summary>flag whether routines for codenitrification are to be used</summary>
+        /// <summary>
+        /// Gets or sets flag for whether routines for codenitrification are to be used (yes/no).
+        /// </summary>
         /// <remarks>
         /// When 'yes', nitrification is computed using nitritation + nitratation, and codenitrification is also computed
         /// </remarks>
@@ -84,18 +80,18 @@ namespace Models.Soils
         }
 
         /// <summary>
-        /// Indicates whether soil profile reduction is allowed ('on')
+        /// Gets or sets flag for whether soil profile reduction is allowed (yes/no).
         /// </summary>
         [Units("yes/no")]
         [XmlIgnore]
-        public string allowProfileReduction
+        public string AllowProfileReduction
         {
-            get { return (ProfileReductionAllowed) ? "yes" : "no"; }
-            set { ProfileReductionAllowed = value.ToLower().Contains("yes"); }
+            get { return (profileReductionAllowed) ? "yes" : "no"; }
+            set { profileReductionAllowed = value.ToLower().Contains("yes"); }
         }
 
         /// <summary>
-        /// Indicates whether organic solutes are to be simulated ('on')
+        /// Gests or sets flag for whether organic solutes are to be simulated (yes/no).
         /// </summary>
         /// <remarks>
         /// It should always be false, as organic solutes are not implemented yet
@@ -104,20 +100,20 @@ namespace Models.Soils
         [XmlIgnore]
         public string allowOrganicSolutes
         {
-            get { return (useOrganicSolutes) ? "yes" : "no"; }
-            set { useOrganicSolutes = value.ToLower().Contains("yes"); }
+            get { return (organicSolutesAllowed) ? "yes" : "no"; }
+            set { organicSolutesAllowed = value.ToLower().Contains("yes"); }
         }
 
         /// <summary>
-        /// factor to convert organic carbon to organic matter
+        /// Factor to convert organic carbon to organic matter (g/g).
         /// </summary>
         [Units("g/g")]
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [XmlIgnore]
-        public double defaultCarbonInSoilOM = 0.588;
+        public double DefaultCarbonInSoilOM = 0.588;
 
         /// <summary>
-        /// Carbon weight fraction in FOM (0-1)
+        /// Default carbon weight fraction in FOM (g/g).
         /// </summary>
         /// <remarks>
         /// Used to convert FOM amount into fom_c
@@ -125,24 +121,28 @@ namespace Models.Soils
         [Units("g/g")]
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [XmlIgnore]
-        public double defaultCarbonInFOM = 0.4;
+        public double DefaultCarbonInFOM = 0.4;
 
         /// <summary>
-        /// Default initial ph, used case no pH is initialised in model
+        /// Default initial pH, used case no pH is initialised in model.
         /// </summary>
         [Units("")]
         [XmlIgnore]
-        public double defaultInitialpH = 6.0;
+        public double DefaultInitialpH = 6.0;
 
         /// <summary>
-        /// Threshold for raising a warning due to small negative values
+        /// Threshold for raising a warning due to small negative values.
         /// </summary>
+        /// <remarks>
+        /// Any value between this and the FatalNegativeThreshold will be zeroed, but a warning message
+        /// is raised, values smaller than this threshold will be zeroed without any message
+        /// </remarks>
         [Units("")]
         [XmlIgnore]
         public double WarningNegativeThreshold = -0.0000000001;
 
         /// <summary>
-        /// Threshold for a fatal error due to negative values (loss of mass balance)
+        /// Threshold for a fatal error due to negative values (loss of mass balance).
         /// </summary>
         [Units("")]
         [XmlIgnore]
@@ -152,119 +152,93 @@ namespace Models.Soils
 
         #region Parameters for setting up soil organic matter
 
-        /// <summary>The C:N ratio of the soil humus (active + inert)</summary>
-        /// <remarks>Remains fixed throughout the simulation</remarks>
-        private double hum_cn = 0.0;
-        /// <summary>The C:N ratio of the soil OM, from xml/GUI (actually of humus)</summary>
-        /// <value>The soil_cn.</value>
-        [Units("")]
-        private double soil_cn
-        {
-            get { return hum_cn; }
-            set { hum_cn = value; }
-        }
-
         /// <summary>
-        /// The C:N ratio of microbial biomass
+        /// The C:N ratio of the soil humus (active + inert).
         /// </summary>
         /// <remarks>
         /// Remains fixed throughout the simulation
         /// </remarks>
-        [Bounds(Lower = 1, Upper = 50)]
+        [Bounds(Lower = 5, Upper = 30)]
+        [Units("g/g")]
+        [XmlIgnore]
+        public double HumusCNr = 0.0;
+
+        /// <summary>
+        /// The C:N ratio of soil microbial biomass.
+        /// </summary>
+        /// <remarks>
+        /// Remains fixed throughout the simulation
+        /// </remarks>
+        [Bounds(Lower = 5, Upper = 15)]
         [Units("")]
         [XmlIgnore]
         public double MBiomassCNr = 8.0;
 
         /// <summary>
-        /// Proportion of biomass-C in the initial mineralisable humic-C (0-1)
+        /// Proportion of biomass-C in the initial mineralisable humic-C (g/g).
         /// </summary>
         [Bounds(Lower = 0, Upper = 1)]
         [Units("g/g")]
         [XmlIgnore]
-        public double[] fbiom = { 0.05, 0.01 };
+        public double[] FBiom = { 0.05, 0.01 };
 
         /// <summary>
-        /// Proportion of the initial total soil C that is inert, not subject to mineralisation (0-1)
+        /// Proportion of the initial total soil C that is inert, cannot be mineralised (g/g).
         /// </summary>
         [Bounds(Lower = 0, Upper = 1)]
         [Units("g/g")]
         [XmlIgnore]
-        public double[] finert = { 0.5, 0.95 };
+        public double[] FInert = { 0.5, 0.95 };
 
         #endregion params for OM setup
 
         #region Parameters for setting up fresh organic matter (FOM)
 
         /// <summary>
-        /// Initial amount of FOM in the soil (kgDM/ha)
+        /// Initial amount of FOM in the soil (kgDM/ha).
         /// </summary>
         [Bounds(Lower = 0, Upper = 100000)]
         [Units("kg/ha")]
         [XmlIgnore]
-        public double iniFomWt = 2000;
-
-        /// <summary>Gets or sets the root_wt.</summary>
-        /// <value>The root_wt.</value>
-        [Units("kg/ha")]
-        private double root_wt
-        {
-            get { return iniFomWt; }
-            set { iniFomWt = value; }
-        }
+        public double InitialFOMWt = 2000;
 
         /// <summary>
-        /// Initial depth over which FOM is distributed within the soil profile (mm)
+        /// Initial depth over which FOM is distributed within the soil profile (mm).
         /// </summary>
         /// <remarks>
-        /// If not given fom will be distributed over the whole soil profile
+        /// If not given (-ve), FOM will be distributed over the whole soil profile
         /// Distribution follows an exponential function
         /// </remarks>
         [Units("mm")]
         [XmlIgnore]
-        public double iniFomDepth = -99.0;
-
-        /// <summary>Gets or sets the root_depth.</summary>
-        /// <value>The root_depth.</value>
-        [Units("mm")]
-        [XmlIgnore]
-        private double root_depth
-        {
-            get { return iniFomDepth; }
-            set { iniFomDepth = value; }
-        }
-
-        /// <summary>Initial C:N ratio of roots (actually FOM)</summary>
-        private double iniFomCNratio = 40.0;
-        /// <summary>Gets or sets the root_cn.</summary>
-        /// <value>The root_cn.</value>
-        [Units("")]
-        private double root_cn
-        {
-            get { return iniFomCNratio; }
-            set { iniFomCNratio = value; }
-        }
+        public double InitialFOMDepth = -99.0;
 
         /// <summary>
-        /// Exponent of function used to compute initial distribution of FOM in the soil
+        /// Exponent of function used to compute initial distribution of FOM in the soil.
         /// </summary>
-        /// <remarks>
-        /// If not given, a default value  might be considered (3.0)
-        /// </remarks>
         [Bounds(Lower = 0.01, Upper = 10.0)]
         [Units("")]
         [XmlIgnore]
-        public double FOMDistributionCoefficient = 3.0;
+        public double InitialFOMDistCoefficient = 3.0;
+
+        /// <summary>Initial C:N ratio of soil FOM (g/g).</summary>
+        [Units("g/g")]
+        [XmlIgnore]
+        public double InitialFOMCNr = 40.0;
 
         /// <summary>
+        /// FOM type used on initialisation and reset.
         /// </summary>
+        /// <remarks>
+        /// The default value (0) is always assumed
+        /// </remarks>
         private int FOMtypeID_reset = 0;
 
         /// <summary>
-        /// FOM type to be used on initialisation
+        /// FOM type to be used on initialisation.
         /// </summary>
         /// <remarks>
-        /// This sets the partition of FOM C between the different pools (carbohydrate, cellulose, lignine)
-        /// A default value (0) is always assumed
+        /// This sets the partition of FOM C between the different pools (carbohydrate, cellulose, lignin)
         /// </remarks>
         [XmlIgnore]
         public string InitialFOMType
@@ -289,21 +263,30 @@ namespace Models.Soils
             }
         }
 
-        /// <summary>List of available FOM types names</summary>
+        /// <summary>
+        /// List of available FOM types names.
+        /// </summary>
         [XmlArray("fom_type")]
-        public String[] fom_types = { "default", "manure", "mucuna", "lablab", "shemp", "stable" };
+        public string[] fom_types = { "default", "manure", "mucuna", "lablab", "shemp", "stable" };
 
-        /// <summary>Fraction of carbohydrate in FOM (0-1), for each FOM type</summary>
+        /// <summary>
+        /// Pool 1 fraction in FOM [carbohydrate], for each FOM type (g/g).
+        /// </summary>
         [Units("g/g")]
         public double[] fract_carb = { 0.2, 0.3, 0.54, 0.57, 0.45, 0.0 };
 
-        /// <summary>Fraction of cellulose in FOM (0-1), for each FOM type</summary>
+        /// <summary>
+        /// Pool 2 fraction in FOM [cellulose], for each FOM type (g/g).
+        /// </summary>
         [Units("g/g")]
         public double[] fract_cell = { 0.7, 0.3, 0.37, 0.37, 0.47, 0.1 };
 
-        /// <summary>Fraction of lignin in FOM (0-1), for each FOM type</summary>
+        /// <summary>
+        /// Pool 3 fraction in FOM [lignin], for each FOM type (g/g).
+        /// </summary>
         [Units("g/g")]
         public double[] fract_lign = { 0.1, 0.4, 0.09, 0.06, 0.08, 0.9 };
+
         #endregion  params for FOM setup
 
         #region Parameters for the decomposition process of FOM and SurfaceOM
@@ -311,7 +294,7 @@ namespace Models.Soils
         #region Surface OM
 
         /// <summary>
-        /// Fraction of residue C mineralised retained in the soil OM (g/g)
+        /// Fraction of residue C mineralised lost to atmopshere due to respiration (g/g).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("g/g")]
@@ -319,10 +302,10 @@ namespace Models.Soils
         public double ResiduesRespirationFactor = 0.6;
 
         /// <summary>
-        /// Fraction of retained residue C transferred to microbial biomass (g/g)
+        /// Fraction of retained residue C transferred to microbial biomass (g/g).
         /// </summary>
         /// <remarks>
-        /// the remaining will go into humus
+        /// The remaining will go into humus
         /// </remarks>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("g/g")]
@@ -330,7 +313,7 @@ namespace Models.Soils
         public double ResiduesFractionIntoBiomass = 0.9;
 
         /// <summary>
-        /// Depth from which mineral N can be immobilised when decomposing surface residues (mm)
+        /// Depth from which mineral N can be immobilised when decomposing surface residues (mm).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1000.0)]
         [Units("mm")]
@@ -342,7 +325,7 @@ namespace Models.Soils
         #region Fresh OM
 
         /// <summary>
-        /// Optimum rate for decomposition of FOM pool 1 [carbohydrate], aerobic and anaerobic conditions (/day)
+        /// Optimum rate for decomposition of FOM pool 1 [carbohydrate], aerobic and anaerobic conditions (/day).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("/day")]
@@ -350,7 +333,7 @@ namespace Models.Soils
         public double[] Pool1FOMTurnOverRate = { 0.2, 0.1 };
 
         /// <summary>
-        /// Optimum rate for decomposition of FOM pool 2 [cellulose], aerobic and anaerobic conditions  (/day)
+        /// Optimum rate for decomposition of FOM pool 2 [cellulose], aerobic and anaerobic conditions (/day).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("/day")]
@@ -358,7 +341,7 @@ namespace Models.Soils
         public double[] Pool2FOMTurnOverRate = { 0.05, 0.25 };
 
         /// <summary>
-        /// Optimum rate for decomposition of FOM pool 3 [lignin], aerobic and anaerobic conditions  (/day)
+        /// Optimum rate for decomposition of FOM pool 3 [lignin], aerobic and anaerobic conditions (/day).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("/day")]
@@ -366,7 +349,7 @@ namespace Models.Soils
         public double[] Pool3FOMTurnOverRate = { 0.0095, 0.003 };
 
         /// <summary>
-        /// Fraction of the FOM C decomposed retained in the soil OM (g/g)
+        /// Fraction of the FOM C decomposed lost to atmopshere due to respiration (g/g).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("g/g")]
@@ -374,10 +357,10 @@ namespace Models.Soils
         public double FOMRespirationFactor = 0.6;
 
         /// <summary>
-        /// Fraction of the retained FOM C transferred to biomass (g/g)
+        /// Fraction of the retained FOM C transferred to biomass (g/g).
         /// </summary>
         /// <remarks>
-        /// the remaining will go into humus
+        /// The remaining will go into humus
         /// </remarks>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("g/g")]
@@ -387,7 +370,7 @@ namespace Models.Soils
         #region Limiting factors
 
         /// <summary>
-        /// Coefficient for the exponential phase of C:N effects on decomposition of FOM
+        /// Coefficient for the exponential phase of C:N effects on decomposition of FOM.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 10.0)]
         [Units("")]
@@ -395,7 +378,7 @@ namespace Models.Soils
         public double FOMDecomp_CNCoefficient = 0.693;
 
         /// <summary>
-        /// Value of C:N ratio above which decomposition rate of FOM declines
+        /// Value of C:N ratio above which decomposition rate of FOM declines.
         /// </summary>
         [Bounds(Lower = 5.0, Upper = 100.0)]
         [Units("g/g")]
@@ -403,12 +386,12 @@ namespace Models.Soils
         public double FOMDecomp_CNThreshold = 25.0;
 
         /// <summary>
-        /// Data for calculating the temperature effect on FOM decomposition
+        /// Data for calculating the temperature effect on FOM decomposition.
         /// </summary>
         private BentStickData FOMDecomp_TemperatureFactorData = new BentStickData();
 
         /// <summary>
-        /// Optimum temperature for FOM decomposition, aerobic and anaerobic conditions (oC)
+        /// Optimum temperature for FOM decomposition, aerobic and anaerobic conditions (oC).
         /// </summary>
         [Units("oC")]
         [XmlIgnore]
@@ -419,35 +402,35 @@ namespace Models.Soils
         }
 
         /// <summary>
-        /// Temperature factor for FOM decomposition at zero degrees, aerobic and anaerobic conditions
+        /// Temperature factor for FOM decomposition at zero degrees, aerobic and anaerobic conditions.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("")]
         [XmlIgnore]
-        public double[] FOMDecomp_FactorAtZero
+        public double[] FOMDecomp_TFactorAtZero
         {
             get { return FOMDecomp_TemperatureFactorData.yValueAtZero; }
             set { FOMDecomp_TemperatureFactorData.yValueAtZero = value; }
         }
 
         /// <summary>
-        /// Curve coefficient for temperature factor of FOM decomposition, aerobic and anaerobic conditions
+        /// Curve coefficient for temperature factor of FOM decomposition, aerobic and anaerobic conditions.
         /// </summary>
         [Units("")]
         [XmlIgnore]
-        public double[] FMDecomp_CurveCoeff
+        public double[] FOMDecomp_TCurveCoeff
         {
             get { return FOMDecomp_TemperatureFactorData.CurveExponent; }
             set { FOMDecomp_TemperatureFactorData.CurveExponent = value; }
         }
 
         /// <summary>
-        /// Parameters for calculating the soil moisture factor for FOM decomposition
+        /// Parameters for calculating the soil moisture factor for FOM decomposition.
         /// </summary>
         private BrokenStickData FOMDecomp_MoistureFactorData = new BrokenStickData();
 
         /// <summary>
-        /// Values of the modified normalised soil water content at which the moisture factor is given
+        /// Values of the modified normalised soil water content at which the moisture factor is given.
         /// </summary>
         /// <remarks>
         /// X values for the moisture factor function, with: 0=dry, 1=LL, 2=DUL, 3=sat
@@ -459,11 +442,8 @@ namespace Models.Soils
         { set { FOMDecomp_MoistureFactorData.xVals = value; } }
 
         /// <summary>
-        /// Moiture factor values for the given values of normalised soil water content
+        /// Moisture factor values for the given values of normalised soil water content.
         /// </summary>
-        /// <remarks>
-        /// Y values for the moisture factor function
-        /// </remarks>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("")]
         [XmlIgnore]
@@ -474,12 +454,12 @@ namespace Models.Soils
 
         #endregion FOM
 
-        #endregion params for SurfOM + FOM decompostion
+        #endregion params for SurfOM + FOM decomposition
 
         #region Parameters for SOM mineralisation/immobilisation process
 
         /// <summary>
-        /// Potential rate of soil biomass mineralisation, aerobic and anaerobic conditions (/day)
+        /// Potential rate of soil biomass mineralisation, aerobic and anaerobic conditions (/day).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("/day")]
@@ -487,7 +467,7 @@ namespace Models.Soils
         public double[] MBiomassTurnOverRate = { 0.0081, 0.004 };
 
         /// <summary>
-        /// Fraction of microbial biomass C mineralised retained in soil OM (g/g)
+        /// Fraction of microbial biomass C mineralised that is lost to the atmosphere due to respiration (g/g).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("g/g")]
@@ -495,15 +475,18 @@ namespace Models.Soils
         public double MBiomassRespirationFactor = 0.6;
 
         /// <summary>
-        /// Fraction of microbial biomass C mineralised that is lost to the atmosphere (g/g)
+        /// Fraction of retained microbial biomass C that goes back to microbial biomass (g/g).
         /// </summary>
+        /// <remarks>
+        /// The remaining will go in to humus
+        /// </remarks>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("g/g")]
         [XmlIgnore]
         public double MBiomassFractionIntoBiomass = 0.6;
 
         /// <summary>
-        /// Potential rate of active humus mineralisation, aerobic and anaerobic conditions (/day)
+        /// Potential rate of active humus mineralisation, aerobic and anaerobic conditions (/day).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("/day")]
@@ -511,7 +494,7 @@ namespace Models.Soils
         public double[] AHumusTurnOverRate = { 0.00015, 0.00007 };
 
         /// <summary>
-        /// Fraction of active humic C mineralised that is lost to the atmosphere (g/g)
+        /// Fraction of active humic C mineralised that is lost to the atmosphere due to respiration (g/g).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("/g/")]
@@ -521,57 +504,57 @@ namespace Models.Soils
         #region Limiting factors
 
         /// <summary>
-        /// Data to calculate the temperature effect on soil OM mineralisation
+        /// Data to calculate the temperature effect on soil OM mineralisation.
         /// </summary>
-        private BentStickData SOMMiner_TempFactorData = new BentStickData();
+        private BentStickData SOMMiner_TemperatureFactorData = new BentStickData();
 
         /// <summary>
-        /// Optimum temperature for soil OM mineralisation (oC)
+        /// Optimum temperature for soil OM mineralisation (oC).
         /// </summary>
         [Units("oC")]
         [XmlIgnore]
         public double[] SOMMiner_TOptimum
         {
-            get { return SOMMiner_TempFactorData.xValueForOptimum; }
-            set { SOMMiner_TempFactorData.xValueForOptimum = value; }
+            get { return SOMMiner_TemperatureFactorData.xValueForOptimum; }
+            set { SOMMiner_TemperatureFactorData.xValueForOptimum = value; }
         }
 
         /// <summary>
-        /// Temperature factor for soil OM mineralisation at zero degree
+        /// Temperature factor for soil OM mineralisation at zero degree.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("")]
         [XmlIgnore]
-        public double[] SOMMiner_FactorAtZero
+        public double[] SOMMiner_TFactorAtZero
         {
-            get { return SOMMiner_TempFactorData.yValueAtZero; }
-            set { SOMMiner_TempFactorData.yValueAtZero = value; }
+            get { return SOMMiner_TemperatureFactorData.yValueAtZero; }
+            set { SOMMiner_TemperatureFactorData.yValueAtZero = value; }
         }
 
         /// <summary>
-        /// Curve coefficient to calculate temperature factor for soil OM mineralisation
+        /// Curve coefficient to calculate temperature factor for soil OM mineralisation.
         /// </summary>
         [Units("")]
         [XmlIgnore]
-        public double[] SOMMiner_CurveCoeff
+        public double[] SOMMiner_TCurveCoeff
         {
-            get { return SOMMiner_TempFactorData.CurveExponent; }
-            set { SOMMiner_TempFactorData.CurveExponent = value; }
+            get { return SOMMiner_TemperatureFactorData.CurveExponent; }
+            set { SOMMiner_TemperatureFactorData.CurveExponent = value; }
         }
 
         /// <summary>
-        /// Parameters to calculate soil moisture factor for soil OM mineralisation
+        /// Parameters to calculate soil moisture factor for soil OM mineralisation.
         /// </summary>
         private BrokenStickData SOMMiner_MoistureFactorData = new BrokenStickData();
 
         /// <summary>
-        /// Values of the modified normalised soil water content at which moisture factor is given
+        /// Values of the modified normalised soil water content at which moisture factor is given.
         /// </summary>
         /// <remarks>
         /// X values for the moisture factor function, with: 0=dry, 1=LL, 2=DUL, 3=SAT
         /// </remarks>
         [Bounds(Lower = 0.0, Upper = 3.0)]
-        [Units("0-3")]
+        [Units("")]
         [XmlIgnore]
         public double[] SOMMiner_NormWaterContents
         {
@@ -580,13 +563,10 @@ namespace Models.Soils
         }
 
         /// <summary>
-        /// Values of the moisture factor at given values of the normalised water content
+        /// Values of the moisture factor at given values of the normalised water content.
         /// </summary>
-        /// <remarks>
-        /// Y values for the moisture factor function
-        /// </remarks>
         [Bounds(Lower = 0.0, Upper = 1.0)]
-        [Units("0-1")]
+        [Units("")]
         [XmlIgnore]
         public double[] SOMMiner_MoistureFactors
         {
@@ -598,46 +578,84 @@ namespace Models.Soils
 
         #endregion params for OM decomposition
 
-        #region Parameters for urea hydrolisys process
+        #region Parameters for urea hydrolysis process
 
         /// <summary>
-        /// Parameters to calculate the temperature effect on urea hydrolysis
+        /// Minimum potential hydrolysis rate for urea (/day).
         /// </summary>
-        private BentStickData UreaHydrolysis_TempFactorData = new BentStickData();
+        [Bounds(Lower = 0.0, Upper = 1.0)]
+        [Units("/day")]
+        [XmlIgnore]
+        public double UreaHydrol_MinRate = 0.25;
 
         /// <summary>
-        /// Optimum temperature for urea hydrolisys (oC)
+        /// Parameter A for the potential urea hydrolysis function.
+        /// </summary>
+        [Units("")]
+        [XmlIgnore]
+        public double UreaHydrol_parmA = -1.12;
+
+        /// <summary>
+        /// Parameter B for the potential urea hydrolysis function.
+        /// </summary>
+        [Units("")]
+        [XmlIgnore]
+        public double UreaHydrol_parmB = 1.31;
+
+        /// <summary>
+        /// Parameter C for the potential urea hydrolysis function.
+        /// </summary>
+        [Units("")]
+        [XmlIgnore]
+        public double UreaHydrol_parmC = 0.203;
+
+        /// <summary>
+        /// Parameter D for the potential urea hydrolysis function.
+        /// </summary>
+        [Units("")]
+        [XmlIgnore]
+        public double UreaHydrol_parmD = -0.155;
+
+        #region limiting factors
+
+        /// <summary>
+        /// Parameters to calculate the temperature effect on urea hydrolysis.
+        /// </summary>
+        private BentStickData UreaHydrolysis_TemperatureFactorData = new BentStickData();
+
+        /// <summary>
+        /// Optimum temperature for urea hydrolysis (oC).
         /// </summary>
         [Bounds(Lower = 5.0, Upper = 100.0)]
         [Units("oC")]
         [XmlIgnore]
         public double[] UreaHydrol_TOptimum
         {
-            get { return UreaHydrolysis_TempFactorData.xValueForOptimum; }
-            set { UreaHydrolysis_TempFactorData.xValueForOptimum = value; }
+            get { return UreaHydrolysis_TemperatureFactorData.xValueForOptimum; }
+            set { UreaHydrolysis_TemperatureFactorData.xValueForOptimum = value; }
         }
 
         /// <summary>
-        /// Temperature factor for urea hydrolisys at zero degrees
+        /// Temperature factor for urea hydrolysis at zero degrees.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("")]
         [XmlIgnore]
-        public double[] UreaHydrol_FactorAtZero
+        public double[] UreaHydrol_TFactorAtZero
         {
-            get { return UreaHydrolysis_TempFactorData.yValueAtZero; }
-            set { UreaHydrolysis_TempFactorData.yValueAtZero = value; }
+            get { return UreaHydrolysis_TemperatureFactorData.yValueAtZero; }
+            set { UreaHydrolysis_TemperatureFactorData.yValueAtZero = value; }
         }
 
         /// <summary>
-        /// Curve coefficient to calculate the temperature factor for urea hydrolisys
+        /// Curve coefficient to calculate the temperature factor for urea hydrolysis.
         /// </summary>
         [Units("")]
         [XmlIgnore]
-        public double[] UreaHydrol_CurveCoeff
+        public double[] UreaHydrol_TCurveCoeff
         {
-            get { return UreaHydrolysis_TempFactorData.CurveExponent; }
-            set { UreaHydrolysis_TempFactorData.CurveExponent = value; }
+            get { return UreaHydrolysis_TemperatureFactorData.CurveExponent; }
+            set { UreaHydrolysis_TemperatureFactorData.CurveExponent = value; }
         }
 
         /// <summary>
@@ -646,13 +664,13 @@ namespace Models.Soils
         private BrokenStickData UreaHydrolysis_MoistureFactorData = new BrokenStickData();
 
         /// <summary>
-        /// Values of the modified normalised soil water content at which factor is given
+        /// Values of the modified normalised soil water content at which factor is given.
         /// </summary>
         /// <remarks>
         /// X values for the moisture factor function, with: 0=dry, 1=LL, 2=DUL, 3=SAT
         /// </remarks>
         [Bounds(Lower = 0.0, Upper = 3.0)]
-        [Units("0-3")]
+        [Units("")]
         [XmlIgnore]
         public double[] UreaHydrol_NormWaterContents
         {
@@ -661,13 +679,10 @@ namespace Models.Soils
         }
 
         /// <summary>
-        /// Values of the moisture factor at given values of the normalised water content
+        /// Values of the moisture factor at given values of the normalised water content.
         /// </summary>
-        /// <remarks>
-        /// Y values for the moisture factor function
-        /// </remarks>
         [Bounds(Lower = 0.0, Upper = 1.0)]
-        [Units("0-1")]
+        [Units("")]
         [XmlIgnore]
         public double[] UreaHydrol_MoistureFactors
         {
@@ -675,78 +690,48 @@ namespace Models.Soils
             set { UreaHydrolysis_MoistureFactorData.yVals = value; }
         }
 
-        //// Parameters for calculating the potential urea hydrolysis
-
-        /// <summary>
-        /// Minimum potential hydrolysis rate for urea (/day)
-        /// </summary>
-        [Bounds(Lower = 0.0, Upper = 1.0)]
-        [Units("/day")]
-        [XmlIgnore]
-        public double UreaHydrol_MinRate = 0.25;
-
-        /// <summary>
-        /// Parameter A for potential urea hydrolysis function
-        /// </summary>
-        [Units("")]
-        [XmlIgnore]
-        public double UreaHydrol_parmA = -1.12;
-
-        /// <summary>
-        /// Parameter B for potential urea hydrolysis function
-        /// </summary>
-        [Units("")]
-        [XmlIgnore]
-        public double UreaHydrol_parmB = 1.31;
-
-        /// <summary>
-        /// Parameter C for potential urea hydrolysis function
-        /// </summary>
-        [Units("")]
-        [XmlIgnore]
-        public double UreaHydrol_parmC = 0.203;
-
-        /// <summary>
-        /// Parameter D for potential urea hydrolysis function
-        /// </summary>
-        [Units("")]
-        [XmlIgnore]
-        public double UreaHydrol_parmD = -0.155;
+        #endregion
 
         #endregion params for hydrolysis
 
         #region Parameters for nitrification process
 
         /// <summary>
-        /// maximum soil nitrification potential, Michaelis-Menten dynamics (ug NH4/g soil)
+        /// Maximum soil nitrification potential, Michaelis-Menten dynamics (ug NH4/g soil/day).
         /// </summary>
         /// <remarks>
-        /// This is the parameter M on Michaelis-Menten equation
-        /// r = MC/(k+C)
+        /// This is the parameter M on Michaelis-Menten equation, r = MC/(k+C)
         /// </remarks>
         [Units("ppm/day")]
         [XmlIgnore]
         public double NitrificationMaxPotential = 40.0;
 
         /// <summary>
-        /// NH4 concentration at half potential nitrification, Michaelis-Menten dynamics (ppm)
+        /// NH4 concentration at half potential nitrification, Michaelis-Menten dynamics (ppm).
         /// </summary>
         /// <remarks>
-        /// This is the parameter k on Michaelis-Menten equation
-        /// r = MC/(k+C)
+        /// This is the parameter k on Michaelis-Menten equation, r = MC/(k+C)
         /// </remarks>
         [Bounds(Lower = 0.0, Upper = 200.0)]
         [Units("ppm")]
         [XmlIgnore]
-        public double NitrificationNH4ForHalf = 90.0;
+        public double NitrificationNH4ForHalfRate = 90.0;
 
         /// <summary>
-        /// Parameters to calculate the temperature effect on nitrification
+        /// Fraction of nitrification lost as denitrification
+        /// </summary>
+        [Bounds(Lower = 0.0, Upper = 1.0)]
+        [Units("")]
+        [XmlIgnore]
+        public double Nitrification_DenitLossFactor = 0.0;
+
+        /// <summary>
+        /// Parameters to calculate the temperature effect on nitrification.
         /// </summary>
         private BentStickData Nitrification_TemperatureFactorData = new BentStickData();
 
         /// <summary>
-        /// Optimum temperature for nitrification (oC)
+        /// Optimum temperature for nitrification (oC).
         /// </summary>
         [Bounds(Lower = 5.0, Upper = 100.0)]
         [Units("oC")]
@@ -758,7 +743,7 @@ namespace Models.Soils
         }
 
         /// <summary>
-        /// Temperature factor for nitrification at zero degrees
+        /// Temperature factor for nitrification at zero degrees.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("")]
@@ -770,7 +755,7 @@ namespace Models.Soils
         }
 
         /// <summary>
-        /// Curve coefficient for calculating the temperature factor for nitrification
+        /// Curve coefficient for calculating the temperature factor for nitrification.
         /// </summary>
         [Units("")]
         [XmlIgnore]
@@ -781,18 +766,18 @@ namespace Models.Soils
         }
 
         /// <summary>
-        /// Parameters to calculate the soil moisture factor for nitrification
+        /// Parameters to calculate the soil moisture factor for nitrification.
         /// </summary>
         private BrokenStickData Nitrification_MoistureFactorData = new BrokenStickData();
 
         /// <summary>
-        /// Values of the modified normalised soil water content at which the moisture factor is given
+        /// Values of the modified normalised soil water content at which the moisture factor is given.
         /// </summary>
         /// <remarks>
         /// X values for the moisture factor function, with: 0=dry, 1=LL, 2=DUL, 3=SAT
         /// </remarks>
         [Bounds(Lower = 0.0, Upper = 3.0)]
-        [Units("0-3")]
+        [Units("")]
         [XmlIgnore]
         public double[] Nitrification_NormWaterContents
         {
@@ -801,10 +786,10 @@ namespace Models.Soils
         }
 
         /// <summary>
-        /// Values of the moisture factor at given values of the normalised water content
+        /// Values of the moisture factor at given values of the normalised water content.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
-        [Units("0-1")]
+        [Units("")]
         [XmlIgnore]
         public double[] Nitrification_MoistureFactors
         {
@@ -813,12 +798,12 @@ namespace Models.Soils
         }
 
         /// <summary>
-        /// Parameters to calculate the soil pH factor for nitrification
+        /// Parameters to calculate the soil pH factor for nitrification.
         /// </summary>
         private BrokenStickData Nitrification_pHFactorData = new BrokenStickData();
 
         /// <summary>
-        /// Values of pH at which the pH factor is given
+        /// Values of pH at which the pH factor is given.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 14.0)]
         [Units("")]
@@ -830,7 +815,7 @@ namespace Models.Soils
         }
 
         /// <summary>
-        /// Values of pH factor at given pH values
+        /// Values of pH factor at given pH values.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("")]
@@ -844,7 +829,7 @@ namespace Models.Soils
         #region Parameters for Nitritation + Nitration processes
 
         /// <summary>
-        /// Maximum soil potential nitritation rate (ug NH4/g soil/day)
+        /// Maximum soil potential nitritation rate (ug NH4/g soil/day).
         /// </summary>
         /// <remarks>
         /// This is the parameter M on Michaelis-Menten equation, r = MC/(k+C)
@@ -855,7 +840,7 @@ namespace Models.Soils
         public double NitritationMaxPotential = 40.0;
 
         /// <summary>
-        /// NH4 concentration when nitritation is half of potential, Michaelis-Menten dynamics (ppm)
+        /// NH4 concentration when nitritation is half of potential (ppm).
         /// </summary>
         /// <remarks>
         /// This is the parameter k on Michaelis-Menten equation, r = MC/(k+C)
@@ -863,10 +848,10 @@ namespace Models.Soils
         [Units("ppm")]
         [Bounds(Lower = 0.0, Upper = 200.0)]
         [XmlIgnore]
-        public double NH4AtHalfNitritationPot = 90.0;
+        public double NitritationNH4ForHalfRate = 90.0;
 
         /// <summary>
-        /// Maximum soil potential nitratation rate (ug NO2/g soil/day)
+        /// Maximum soil potential nitratation rate (ug NO2/g soil/day).
         /// </summary>
         /// <remarks>
         /// This is the parameter M on Michaelis-Menten equation, r = MC/(k+C)
@@ -877,7 +862,7 @@ namespace Models.Soils
         public double NitratationMaxPotential = 400.0;
 
         /// <summary>
-        /// NO2 concentration when nitratation is half of potential, Michaelis-Menten dynamics (ppm)
+        /// NO2 concentration when nitratation is half of potential (ppm).
         /// </summary>
         /// <remarks>
         /// This is the parameter k on Michaelis-Menten equation, r = MC/(k+C)
@@ -885,10 +870,10 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 500.0)]
         [Units("ppm")]
         [XmlIgnore]
-        public double NO2AtHalfNitratationPot = 90.0;
+        public double NitratationNH4ForHalfRate = 90.0;
 
         /// <summary>
-        /// Parameter to determine the base fraction of ammonia oxidate lost as N2O
+        /// Parameter to determine the base fraction of ammonia oxidate lost as N2O.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("")]
@@ -896,7 +881,7 @@ namespace Models.Soils
         public double AmmoxLossParam1 = 0.0025;
 
         /// <summary>
-        /// Parameter to determine the changes in fraction of ammonia oxidate lost as N2O
+        /// Parameter to determine the changes in fraction of ammonia oxidate lost as N2O.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("")]
@@ -904,128 +889,133 @@ namespace Models.Soils
         public double AmmoxLossParam2 = 0.45;
 
         /// <summary>
-        /// Parameters to calculate the temperature effect on nitrification (Nitrition + Nitration)
+        /// Parameters to calculate the temperature effect on nitrification (Nitrition + Nitration).
         /// </summary>
-        private BentStickData TemperatureFactorData_Nitrification2 = new BentStickData();
+        private BentStickData Nitrification2_TemperatureFactorData = new BentStickData();
 
         /// <summary>
-        /// Optimum temperature for nitrification (Nitrition + Nitration)
+        /// Optimum temperature for nitrification (Nitrition + Nitration).
         /// </summary>
         [Bounds(Lower = 5.0, Upper = 100.0)]
         [Units("oC")]
         [XmlIgnore]
-        public double[] TOptimunNitrification2
+        public double[] Nitrification2_TOptimum
         {
-            get { return TemperatureFactorData_Nitrification2.xValueForOptimum; }
-            set { TemperatureFactorData_Nitrification2.xValueForOptimum = value; }
+            get { return Nitrification2_TemperatureFactorData.xValueForOptimum; }
+            set { Nitrification2_TemperatureFactorData.xValueForOptimum = value; }
         }
 
         /// <summary>
-        /// Temperature factor for nitrification (Nitrition + Nitration) at zero degrees
+        /// Temperature factor for nitrification (Nitrition + Nitration) at zero degrees.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
+        [Units("")]
         [XmlIgnore]
-        public double[] FactorAtZeroNitrification2
+        public double[] Nitrification2_TFactorAtZero
         {
-            get { return TemperatureFactorData_Nitrification2.yValueAtZero; }
-            set { TemperatureFactorData_Nitrification2.yValueAtZero = value; }
+            get { return Nitrification2_TemperatureFactorData.yValueAtZero; }
+            set { Nitrification2_TemperatureFactorData.yValueAtZero = value; }
         }
 
         /// <summary>
-        /// Curve coefficient for calculating the temperature factor for nitrification (Nitrition + Nitration)
+        /// Curve coefficient for calculating the temperature factor for nitrification (Nitrition + Nitration).
         /// </summary>
         [Units("")]
         [XmlIgnore]
-        public double[] CurveCoeffNitrification2
+        public double[] Nitrification2_TCurveCoeff
         {
-            get { return TemperatureFactorData_Nitrification2.CurveExponent; }
-            set { TemperatureFactorData_Nitrification2.CurveExponent = value; }
+            get { return Nitrification2_TemperatureFactorData.CurveExponent; }
+            set { Nitrification2_TemperatureFactorData.CurveExponent = value; }
         }
 
         /// <summary>
-        /// Parameters to calculate the soil moisture factor for nitrification (Nitrition + Nitration)
+        /// Parameters to calculate the soil moisture factor for nitrification (Nitrition + Nitration).
         /// </summary>
-        private BrokenStickData MoistureFactorData_Nitrification2 = new BrokenStickData();
+        private BrokenStickData Nitrification2_MoistureFactorData = new BrokenStickData();
 
         /// <summary>
-        /// Values of the modified soil water content at which the moisture factor is given
+        /// Values of the modified soil water content at which the moisture factor is given.
         /// </summary>
         /// <remarks>
         /// X values for the moisture factor function, with: 0=dry, 1=LL, 2=DUL, 3=SAT
         /// </remarks>
         [Bounds(Lower = 0.0, Upper = 3.0)]
-        [Units("0-3")]
+        [Units("")]
         [XmlIgnore]
-        public double[] NormWaterContentsNitrification2
+        public double[] Nitrification2_NormWaterContents
         {
-            get { return MoistureFactorData_Nitrification2.xVals; }
-            set { MoistureFactorData_Nitrification2.xVals = value; }
+            get { return Nitrification2_MoistureFactorData.xVals; }
+            set { Nitrification2_MoistureFactorData.xVals = value; }
         }
 
         /// <summary>
-        /// Values of the moisture factor at given normalised water content values
+        /// Values of the moisture factor at given normalised water content values.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
-        [Units("0-1")]
+        [Units("")]
         [XmlIgnore]
-        public double[] MoistureFactorsNitrification2
+        public double[] Nitrification2_MoistureFactors
         {
-            get { return MoistureFactorData_Nitrification2.yVals; }
-            set { MoistureFactorData_Nitrification2.yVals = value; }
+            get { return Nitrification2_MoistureFactorData.yVals; }
+            set { Nitrification2_MoistureFactorData.yVals = value; }
         }
 
         /// <summary>
-        /// Parameters to calculate the soil pH factor for nitritation
+        /// Parameters to calculate the soil pH factor for nitritation.
         /// </summary>
-        private BrokenStickData pHFactorData_Nitritation = new BrokenStickData();
+        private BrokenStickData Nitritation_pHFactorData = new BrokenStickData();
 
         /// <summary>
-        /// Values of pH at which factors is known
+        /// Values of pH at which factors is given.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 14.0)]
+        [Units("")]
         [XmlIgnore]
         public double[] Nitritation_pHValues
         {
-            get { return pHFactorData_Nitritation.xVals; }
-            set { pHFactorData_Nitritation.xVals = value; }
+            get { return Nitritation_pHFactorData.xVals; }
+            set { Nitritation_pHFactorData.xVals = value; }
         }
 
         /// <summary>
-        /// Values of pH factor at given pH values
+        /// Values of pH factor at given pH values.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
+        [Units("")]
         [XmlIgnore]
         public double[] Nitritation_pHFactors
         {
-            get { return pHFactorData_Nitritation.yVals; }
-            set { pHFactorData_Nitritation.yVals = value; }
+            get { return Nitritation_pHFactorData.yVals; }
+            set { Nitritation_pHFactorData.yVals = value; }
         }
 
         /// <summary>
-        /// Parameters to calculate the soil pH factor for nitratation
+        /// Parameters to calculate the soil pH factor for nitratation.
         /// </summary>
-        private BrokenStickData pHFactorData_Nitratation = new BrokenStickData();
+        private BrokenStickData Nitratation_pHFactorData = new BrokenStickData();
 
         /// <summary>
-        /// Values of pH at which factors is known
+        /// Values of pH at which factors is given.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 14.0)]
+        [Units("")]
         [XmlIgnore]
         public double[] Nitratation_pHValues
         {
-            get { return pHFactorData_Nitratation.xVals; }
-            set { pHFactorData_Nitratation.xVals = value; }
+            get { return Nitratation_pHFactorData.xVals; }
+            set { Nitratation_pHFactorData.xVals = value; }
         }
 
         /// <summary>
-        /// Values of pH factor at given pH values
+        /// Values of pH factor at given pH values.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
+        [Units("")]
         [XmlIgnore]
         public double[] Nitratation_pHFactors
         {
-            get { return pHFactorData_Nitratation.yVals; }
-            set { pHFactorData_Nitratation.yVals = value; }
+            get { return Nitratation_pHFactorData.yVals; }
+            set { Nitratation_pHFactorData.yVals = value; }
         }
 
         #endregion params for nitritation+nitratation
@@ -1035,138 +1025,141 @@ namespace Models.Soils
         #region Parameters for codenitrification and N2O emission processes
 
         /// <summary>
-        /// Denitrification rate coefficient (kg soil/mg C per day)
+        /// Denitrification rate coefficient (kg soil/mg C/day).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
-        [Units("kgsoil/mgC/day")]
+        [Units("kg/mg/day")]
         [XmlIgnore]
-        public double CodenitRateCoefficient = 0.0006;
+        public double CodenitrificationRateCoefficient = 0.0006;
 
         /// <summary>
-        /// Parameters to calculate the temperature effect on codenitrification
+        /// Parameters to calculate the temperature effect on codenitrification.
         /// </summary>
-        private BentStickData TemperatureFactorData_Codenitrification = new BentStickData();
+        private BentStickData Codenitrification_TemperatureFactorData = new BentStickData();
 
         /// <summary>
-        /// Optimum temperature for codenitrification
+        /// Optimum temperature for codenitrification.
         /// </summary>
         [Bounds(Lower = 5.0, Upper = 100.0)]
         [Units("oC")]
         [XmlIgnore]
-        public double[] TOptmimunCodenitrififaction
+        public double[] Codenitrification_TOptmimun
         {
-            get { return TemperatureFactorData_Codenitrification.xValueForOptimum; }
-            set { TemperatureFactorData_Codenitrification.xValueForOptimum = value; }
+            get { return Codenitrification_TemperatureFactorData.xValueForOptimum; }
+            set { Codenitrification_TemperatureFactorData.xValueForOptimum = value; }
         }
 
         /// <summary>
-        /// Temperature factor for codenitrification at zero degrees
+        /// Temperature factor for codenitrification at zero degrees.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
-        [Units("0-1")]
+        [Units("")]
         [XmlIgnore]
-        public double[] FactorAtZeroCodenitrification
+        public double[] Codenitrification_TFactorAtZero
         {
-            get { return TemperatureFactorData_Codenitrification.yValueAtZero; }
-            set { TemperatureFactorData_Codenitrification.yValueAtZero = value; }
+            get { return Codenitrification_TemperatureFactorData.yValueAtZero; }
+            set { Codenitrification_TemperatureFactorData.yValueAtZero = value; }
         }
 
         /// <summary>
-        /// Curve coefficient for calculating the temperature factor for codenitrification
+        /// Curve coefficient for calculating the temperature factor for codenitrification.
         /// </summary>
         [Units("")]
         [XmlIgnore]
-        public double[] CurveCoeffCodenitrification
+        public double[] Codenitrification_TCurveCoeff
         {
-            get { return TemperatureFactorData_Codenitrification.CurveExponent; }
-            set { TemperatureFactorData_Codenitrification.CurveExponent = value; }
+            get { return Codenitrification_TemperatureFactorData.CurveExponent; }
+            set { Codenitrification_TemperatureFactorData.CurveExponent = value; }
         }
 
         /// <summary>
-        /// Parameters to calculate the soil moisture factor for codenitrification
+        /// Parameters to calculate the soil moisture factor for codenitrification.
         /// </summary>
-        private BrokenStickData MoistureFactorData_Codenitrification = new BrokenStickData();
+        private BrokenStickData Codenitrification_MoistureFactorData = new BrokenStickData();
 
         /// <summary>
-        /// Values of modified soil water content at which the moisture factor is known
+        /// Values of modified soil water content at which the moisture factor is given.
         /// </summary>
+        /// <remarks>
+        /// X values for the moisture factor function, with: 0=dry, 1=LL, 2=DUL, 3=SAT
+        /// </remarks>
         [Bounds(Lower = 0.0, Upper = 3.0)]
-        [Units("0-3")]
+        [Units("")]
         [XmlIgnore]
         public double[] Codenitrification_NormWaterContents
         {
-            get { return MoistureFactorData_Codenitrification.xVals; }
-            set { MoistureFactorData_Codenitrification.xVals = value; }
+            get { return Codenitrification_MoistureFactorData.xVals; }
+            set { Codenitrification_MoistureFactorData.xVals = value; }
         }
 
         /// <summary>
-        /// Values of the moisture factor at given water content values
+        /// Values of the moisture factor at given water content values.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
-        [Units("0-1")]
+        [Units("")]
         [XmlIgnore]
         public double[] Codenitrification_MoistureFactors
         {
-            get { return MoistureFactorData_Codenitrification.yVals; }
-            set { MoistureFactorData_Codenitrification.yVals = value; }
+            get { return Codenitrification_MoistureFactorData.yVals; }
+            set { Codenitrification_MoistureFactorData.yVals = value; }
         }
 
         /// <summary>
-        /// Parameters to calculate the soil moisture factor for codenitrification
+        /// Parameters to calculate the soil pH factor for codenitrification.
         /// </summary>
-        private BrokenStickData pHFactorData_Codenitrification = new BrokenStickData();
+        private BrokenStickData Codenitrification_pHFactorData = new BrokenStickData();
 
         /// <summary>
-        /// Values of soil pH at which the pH factor is known
+        /// Values of soil pH at which the pH factor is given.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 3.0)]
-        [Units("0-3")]
+        [Units("")]
         [XmlIgnore]
         public double[] Codenitrification_pHValues
         {
-            get { return pHFactorData_Codenitrification.xVals; }
-            set { pHFactorData_Codenitrification.xVals = value; }
+            get { return Codenitrification_pHFactorData.xVals; }
+            set { Codenitrification_pHFactorData.xVals = value; }
         }
 
         /// <summary>
-        /// Values of the pH factor at given pH values
+        /// Values of the pH factor at given pH values.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
-        [Units("0-1")]
+        [Units("")]
         [XmlIgnore]
         public double[] Codenitrification_pHFactors
         {
-            get { return pHFactorData_Codenitrification.yVals; }
-            set { pHFactorData_Codenitrification.yVals = value; }
+            get { return Codenitrification_pHFactorData.yVals; }
+            set { Codenitrification_pHFactorData.yVals = value; }
         }
 
         /// <summary>
-        /// Parameters to calculate the N2:N2O ratio during denitrification
+        /// Parameters to calculate the N2:N2O ratio during denitrification.
         /// </summary>
-        private BrokenStickData NH3NO2FactorData_Codenitrification = new BrokenStickData();
+        private BrokenStickData Codenitrification_NH3NO2FactorData = new BrokenStickData();
 
         /// <summary>
-        /// Values of soil NH3+NO2 at which the N2 fraction is known
+        /// Values of soil NH3+NO2 at which the N2 fraction is given.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 100.0)]
         [Units("ppm")]
         [XmlIgnore]
         public double[] Codenitrification_NHNOValues
         {
-            get { return NH3NO2FactorData_Codenitrification.xVals; }
-            set { NH3NO2FactorData_Codenitrification.xVals = value; }
+            get { return Codenitrification_NH3NO2FactorData.xVals; }
+            set { Codenitrification_NH3NO2FactorData.xVals = value; }
         }
 
         /// <summary>
-        /// Values of the N2 fraction at given NH3+NO2 values
+        /// Values of the N2 fraction at given NH3+NO2 values.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
-        [Units("0-1")]
+        [Units("")]
         [XmlIgnore]
         public double[] Codenitrification_NHNOFactors
         {
-            get { return NH3NO2FactorData_Codenitrification.yVals; }
-            set { NH3NO2FactorData_Codenitrification.yVals = value; }
+            get { return Codenitrification_NH3NO2FactorData.yVals; }
+            set { Codenitrification_NH3NO2FactorData.yVals = value; }
         }
 
         #endregion params for codenitrification
@@ -1174,7 +1167,7 @@ namespace Models.Soils
         #region Parameters for denitrification and N2O emission processes
 
         /// <summary>
-        /// Denitrification rate coefficient (kg/mg)
+        /// Denitrification rate coefficient (kg/mg).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("kg/mg")]
@@ -1182,86 +1175,68 @@ namespace Models.Soils
         public double DenitrificationRateCoefficient = 0.0006;
 
         /// <summary>
-        /// Fraction of nitrification lost as denitrification
+        /// Parameter A of linear function to compute soluble carbon.
         /// </summary>
-        [Bounds(Lower = 0.0, Upper = 1.0)]
-        [Units("")]
-        [XmlIgnore]
-        public double Denit_LossFactorNitrif = 0;
-
-        /// <summary>
-        /// Parameter k1 from Thorburn et al (2010) for N2O model
-        /// </summary>
-        [Bounds(Lower = 0.0, Upper = 100.0)]
-        [Units("")]
-        [XmlIgnore]
-        public double Denit_k1 = 25.1;
-
-        /// <summary>
-        /// Parameter A in the equation computing the N2:N2O ratio
-        /// </summary>
-        [XmlIgnore]
-        public double N2N2O_parmA = 0.16;
-
-        /// <summary>
-        /// Parameter B in the equation computing the N2:N2O ratio
-        /// </summary>
-        [XmlIgnore]
-        public double N2N2O_parmB = -0.80;
-
-        /// <summary>
-        /// Parameter A to compute active carbon
-        /// </summary>
+        [Units("g/g")]
         [XmlIgnore]
         public double actC_parmA = 24.5;
 
         /// <summary>
-        /// Parameter B to compute active carbon
+        /// Parameter B of linear function to compute soluble carbon.
         /// </summary>
+        [Units("")]
         [XmlIgnore]
         public double actC_parmB = 0.0031;
 
-        /// <summary>Parameter A of exponential function to compute active carbon</summary>
+        /// <summary>
+        /// Parameter A of exponential function to compute soluble carbon.
+        /// </summary>
+        [Units("g/g")]
         [XmlIgnore]
         public double actCExp_parmA = 0.011;
 
-        /// <summary>Parameter B of exponential function to compute active carbon</summary>
+        /// <summary>
+        /// Parameter B of exponential function to compute soluble carbon.
+        /// </summary>
+        [Units("")]
         [XmlIgnore]
         public double actCExp_parmB = 0.895;
 
         /// <summary>
-        /// Parameters to calculate the temperature effect on denitrification
+        /// Parameters to calculate the temperature effect on denitrification.
         /// </summary>
         private BentStickData Denitrification_TemperatureFactorData = new BentStickData();
 
         /// <summary>
-        /// Optimum temperature for denitrification (oC)
+        /// Optimum temperature for denitrification (oC).
         /// </summary>
         [Bounds(Lower = 5.0, Upper = 100.0)]
         [Units("oC")]
         [XmlIgnore]
-        public double[] Denit_TOptimum
+        public double[] Denitrification_TOptimum
         {
             get { return Denitrification_TemperatureFactorData.xValueForOptimum; }
             set { Denitrification_TemperatureFactorData.xValueForOptimum = value; }
         }
 
         /// <summary>
-        /// Temperature factor for denitrification at zero degrees
+        /// Temperature factor for denitrification at zero degrees.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
+        [Units("")]
         [XmlIgnore]
-        public double[] Denit_FactorAtZero
+        public double[] Denitrification_TFactorAtZero
         {
             get { return Denitrification_TemperatureFactorData.yValueAtZero; }
             set { Denitrification_TemperatureFactorData.yValueAtZero = value; }
         }
 
         /// <summary>
-        /// Curve coefficient for calculating the temperature factor for denitrification
+        /// Curve coefficient for calculating the temperature factor for denitrification.
         /// </summary>
+        [Units("")]
         [XmlIgnore]
-        public double[] Denit_CurveCoeff
+        public double[] Denitrification_TCurveCoeff
         {
             get { return Denitrification_TemperatureFactorData.CurveExponent; }
             set { Denitrification_TemperatureFactorData.CurveExponent = value; }
@@ -1273,37 +1248,63 @@ namespace Models.Soils
         private BrokenStickData Denitrification_MoistureFactorData = new BrokenStickData();
 
         /// <summary>
-        /// Values of modified soil water content at which the moisture factor is given
+        /// Values of modified normalised soil water content at which the moisture factor is given.
         /// </summary>
         /// <remarks>
         /// X values for the moisture factor function, with: 0=dry, 1=LL, 2=DUL, 3=SAT
         /// </remarks>
         [Bounds(Lower = 0.0, Upper = 3.0)]
+        [Units("")]
         [XmlIgnore]
-        public double[] Denit_NormWaterContents
+        public double[] Denitrification_NormWaterContents
         {
             get { return Denitrification_MoistureFactorData.xVals; }
             set { Denitrification_MoistureFactorData.xVals = value; }
         }
 
         /// <summary>
-        /// Values of the moisture factor at given normalised water content values
+        /// Values of the moisture factor at given normalised water content values.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
+        [Units("")]
         [XmlIgnore]
-        public double[] Denit_MoistureFactors
+        public double[] Denitrification_MoistureFactors
         {
             get { return Denitrification_MoistureFactorData.yVals; }
             set { Denitrification_MoistureFactorData.yVals = value; }
         }
 
+        #region Parameters for N2:N2O partition
+
         /// <summary>
-        /// Parameters to calculate the N2:N2O ratio during denitrification
+        /// Parameter k1 from Thorburn et al (2010) for N2O model.
+        /// </summary>
+        [Bounds(Lower = 0.0, Upper = 100.0)]
+        [Units("")]
+        [XmlIgnore]
+        public double Denit_k1 = 25.1;
+
+        /// <summary>
+        /// Parameter A in the function computing the N2:N2O ratio.
+        /// </summary>
+        [Units("")]
+        [XmlIgnore]
+        public double N2N2O_parmA = 0.16;
+
+        /// <summary>
+        /// Parameter B in the function computing the N2:N2O ratio.
+        /// </summary>
+        [Units("")]
+        [XmlIgnore]
+        public double N2N2O_parmB = -0.80;
+
+        /// <summary>
+        /// Parameters to calculate the effect of water filled pore space on N2:N2O ratio during denitrification.
         /// </summary>
         private BrokenStickData Denitrification_WFPSFactorData = new BrokenStickData();
 
         /// <summary>
-        /// Values of soil water filled pore sapce at which the WFPS factor is known
+        /// Values of soil water filled pore sapce at which the WFPS factor is given.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 100.0)]
         [Units("%")]
@@ -1315,10 +1316,10 @@ namespace Models.Soils
         }
 
         /// <summary>
-        /// Values of the WFPS factor at given water fille pore space values
+        /// Values of the WFPS factor at given water fille pore space values.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
-        [Units("0-1")]
+        [Units("")]
         [XmlIgnore]
         public double[] Denit_WFPSFactors
         {
@@ -1326,19 +1327,23 @@ namespace Models.Soils
             set { Denitrification_WFPSFactorData.yVals = value; }
         }
 
+        #endregion
+
         #endregion params for denitrification
 
         #region Parameters for handling soil loss process
 
         /// <summary>
-        /// coefficient A for erosion enrichment function
+        /// coefficient A for erosion enrichment function.
         /// </summary>
+        [Units("")]
         [XmlIgnore]
         public double enr_a_coeff = 7.4;
 
         /// <summary>
-        /// coefficient A for erosion enrichment function
+        /// coefficient A for erosion enrichment function.
         /// </summary>
+        [Units("")]
         [XmlIgnore]
         public double enr_b_coeff = 0.2;
 
@@ -1351,42 +1356,36 @@ namespace Models.Soils
         #region Parameter for handling patches
 
         /// <summary>
-        /// The approach used for partitioning the N between patches
+        /// The approach used for partitioning the N between patches.
         /// </summary>
         [XmlIgnore]
         public string NPartitionApproach
         {
-            get { return PatchNPartitionApproach; }
-            set { PatchNPartitionApproach = value.Trim(); }
+            get { return patchNPartitionApproach; }
+            set { patchNPartitionApproach = value.Trim(); }
         }
 
-        /// <summary>Layer thickness to consider if N partition between patches is BasedOnSoilConcentration (mm)</summary>
-        private double layerNPartition = -99;
         /// <summary>
-        /// Layer thickness to consider when N partiton is BasedOnSoilConcentration (mm)
+        /// Layer thickness to consider when N partition between patches is BasedOnSoilConcentration (mm).
         /// </summary>
         [Units("mm")]
         [XmlIgnore]
-        public double LayerNPartition
-        {
-            get { return layerNPartition; }
-            set { layerNPartition = value; }
-        }
+        public double LayerForNPartition = -99;
 
         /// <summary>
-        /// Minimum relative area (fraction of paddock) for any patch
+        /// Minimum relative area (fraction of paddock) for any patch.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("0-1")]
         [XmlIgnore]
         public double MininumRelativeAreaCNPatch
         {
-            get { return MinimumPatchArea; }
-            set { MinimumPatchArea = value; }
+            get { return minimumPatchArea; }
+            set { minimumPatchArea = value; }
         }
 
         /// <summary>
-        /// Maximum NH4 uptake rate for plants (ppm/day)
+        /// Maximum NH4 uptake rate for plants (ppm/day).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 10000.0)]
         [Units("ppm/day")]
@@ -1402,14 +1401,14 @@ namespace Models.Soils
                     for (int layer = 0; layer < nLayers; layer++)
                     {
                         // set maximum uptake rates for N forms (only really used for AgPasture when patches exist)
-                        MaximumNH4UptakeRate[layer] = reset_MaximumNH4Uptake / convFactor[layer];
+                        maximumNH4UptakeRate[layer] = reset_MaximumNH4Uptake / convFactor[layer];
                     }
                 }
             }
         }
 
         /// <summary>
-        /// Maximum NO3 uptake rate for plants (ppm/day)
+        /// Maximum NO3 uptake rate for plants (ppm/day).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 10000.0)]
         [Units("ppm/day")]
@@ -1425,14 +1424,14 @@ namespace Models.Soils
                     for (int layer = 0; layer < nLayers; layer++)
                     {
                         // set maximum uptake rates for N forms (only really used for AgPasture when patches exist)
-                        MaximumNO3UptakeRate[layer] = reset_MaximumNO3Uptake / convFactor[layer];
+                        maximumNO3UptakeRate[layer] = reset_MaximumNO3Uptake / convFactor[layer];
                     }
                 }
             }
         }
 
         /// <summary>
-        /// The maximum amount of N that is made available to plants in one day (kg/ha/day)
+        /// The maximum amount of N that is made available to plants in one day (kg/ha/day).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 10000.0)]
         [Units("kg/ha/day")]
@@ -1449,18 +1448,18 @@ namespace Models.Soils
         #region Parameter for amalgamating patches
 
         /// <summary>
-        /// whether auto amalgamation of CN patches is allowed (yes/no)
+        /// Flag for whether auto amalgamation of CN patches is allowed (yes/no).
         /// </summary>
         [Units("yes/no")]
         [XmlIgnore]
         public string AllowPatchAutoAmalgamation
         {
-            get { return (PatchAutoAmalgamationAllowed) ? "yes" : "no"; }
-            set { PatchAutoAmalgamationAllowed = value.ToLower().Contains("yes"); }
+            get { return (patchAutoAmalgamationAllowed) ? "yes" : "no"; }
+            set { patchAutoAmalgamationAllowed = value.ToLower().Contains("yes"); }
         }
 
         /// <summary>
-        /// Approach to use when comparing patches for AutoAmalagamation
+        /// Approach to use when comparing patches for AutoAmalagamation.
         /// </summary>
         /// <remarks>
         /// Options:
@@ -1471,12 +1470,12 @@ namespace Models.Soils
         [XmlIgnore]
         public string AutoAmalgamationApproach
         {
-            get { return PatchAmalgamationApproach; }
-            set { PatchAmalgamationApproach = value.Trim(); }
+            get { return patchAmalgamationApproach; }
+            set { patchAmalgamationApproach = value.Trim(); }
         }
 
         /// <summary>
-        /// Approach to use when defining the base patch
+        /// Approach to use when defining the base patch.
         /// </summary>
         /// <remarks>
         /// This is used to define the patch considered the 'base'. It is only used when comparing patches during
@@ -1488,27 +1487,24 @@ namespace Models.Soils
         [XmlIgnore]
         public string basePatchApproach
         {
-            get { return PatchbasePatchApproach; }
-            set { PatchbasePatchApproach = value.Trim(); }
+            get { return patchbasePatchApproach; }
+            set { patchbasePatchApproach = value.Trim(); }
         }
 
         /// <summary>
-        /// Should an age check be used to force amalgamation of patches? (yes/no)
+        /// Flag for whether an age check is used to force amalgamation of patches (yes/no).
         /// </summary>
         [Units("yes/no")]
         [XmlIgnore]
         public string AllowPatchAmalgamationByAge
         {
-            get { return (PatchAmalgamationByAgeAllowed) ? "yes" : "no"; }
-            set { PatchAmalgamationByAgeAllowed = value.ToLower().Contains("yes"); }
+            get { return (patchAmalgamationByAgeAllowed) ? "yes" : "no"; }
+            set { patchAmalgamationByAgeAllowed = value.ToLower().Contains("yes"); }
         }
 
         /// <summary>
-        /// Patch age for forced merging (years)
+        /// Age of patch at which merging is enforced (years).
         /// </summary>
-        /// <remarks>
-        /// Age in years after which to merge the patch back into the paddock base
-        /// </remarks>
         [Units("years")]
         [XmlIgnore]
         public double PatchAgeForForcedMerge
@@ -1518,165 +1514,167 @@ namespace Models.Soils
         }
 
         /// <summary>
-        /// Relative difference in total organic carbon (0-1)
+        /// Relative difference in total organic carbon (g/g).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
+        [Units("")]
         [XmlIgnore]
         public double relativeDiff_TotalOrgC = 0.02;
 
         /// <summary>
-        /// Relative difference in total organic nitrogen (0-1)
+        /// Relative difference in total organic nitrogen (g/g).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
+        [Units("")]
         [XmlIgnore]
         public double relativeDiff_TotalOrgN = 0.02;
 
         /// <summary>
-        /// Relative difference in total organic nitrogen (0-1)
+        /// Relative difference in total organic nitrogen (g/g).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
-        [Units("0-1")]
+        [Units("")]
         [XmlIgnore]
         public double relativeDiff_TotalBiomC = 0.02;
 
         /// <summary>
-        /// Relative difference in total urea N amount (0-1)
+        /// Relative difference in total urea N amount (g/g).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
-        [Units("0-1")]
+        [Units("")]
         [XmlIgnore]
         public double relativeDiff_TotalUrea = 0.02;
 
         /// <summary>
-        /// Relative difference in total NH4 N amount (0-1)
+        /// Relative difference in total NH4 N amount (g/g).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
-        [Units("0-1")]
+        [Units("")]
         [XmlIgnore]
         public double relativeDiff_TotalNH4 = 0.02;
 
         /// <summary>
-        /// Relative difference in total NO3 N amount (0-1)
+        /// Relative difference in total NO3 N amount (g/g).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
-        [Units("0-1")]
+        [Units("")]
         [XmlIgnore]
         public double relativeDiff_TotalNO3 = 0.02;
 
         /// <summary>
-        /// Relative difference in urea N amount at any layer (0-1)
+        /// Relative difference in urea N amount at any layer (g/g).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
-        [Units("0-1")]
+        [Units("")]
         [XmlIgnore]
         public double relativeDiff_LayerBiomC = 0.02;
 
         /// <summary>
-        /// Relative difference in urea N amount at any layer (0-1)
+        /// Relative difference in urea N amount at any layer (g/g).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
-        [Units("0-1")]
+        [Units("")]
         [XmlIgnore]
         public double relativeDiff_LayerUrea = 0.02;
 
         /// <summary>
-        /// Relative difference in NH4 N amount at any layer (0-1)
+        /// Relative difference in NH4 N amount at any layer (g/g).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
-        [Units("0-1")]
+        [Units("")]
         [XmlIgnore]
         public double relativeDiff_LayerNH4 = 0.02;
 
         /// <summary>
-        /// Relative difference in NO3 N amount at any layer (0-1)
+        /// Relative difference in NO3 N amount at any layer (g/g).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
-        [Units("0-1")]
+        [Units("")]
         [XmlIgnore]
         public double relativeDiff_LayerNO3 = 0.02;
 
         /// <summary>
-        /// Absolute difference in total organic carbon (kg/ha)
+        /// Absolute difference in total organic carbon (kg/ha).
         /// </summary>
         [Units("kg/ha")]
         [XmlIgnore]
         public double absoluteDiff_TotalOrgC = 500;
 
         /// <summary>
-        /// Absolute difference in total organic nitrogen (kg/ha)
+        /// Absolute difference in total organic nitrogen (kg/ha).
         /// </summary>
         [Units("kg/ha")]
         [XmlIgnore]
         public double absoluteDiff_TotalOrgN = 50;
 
         /// <summary>
-        /// Absolute difference in total organic nitrogen (kg/ha)
+        /// Absolute difference in total organic nitrogen (kg/ha).
         /// </summary>
         [Units("kg/ha")]
         [XmlIgnore]
         public double absoluteDiff_TotalBiomC = 50;
 
         /// <summary>
-        /// Absolute difference in total urea N amount (kg/ha)
+        /// Absolute difference in total urea N amount (kg/ha).
         /// </summary>
         [Units("kg/ha")]
         [XmlIgnore]
         public double absoluteDiff_TotalUrea = 2;
 
         /// <summary>
-        /// Absolute difference in total NH4 N amount (kg/ha)
+        /// Absolute difference in total NH4 N amount (kg/ha).
         /// </summary>
         [Units("kg/ha")]
         [XmlIgnore]
         public double absoluteDiff_TotalNH4 = 5;
 
         /// <summary>
-        /// Absolute difference in total NO3 N amount (kg/ha)
+        /// Absolute difference in total NO3 N amount (kg/ha).
         /// </summary>
         [Units("kg/ha")]
         [XmlIgnore]
         public double absoluteDiff_TotalNO3 = 5;
 
         /// <summary>
-        /// Absolute difference in urea N amount at any layer (kg/ha)
+        /// Absolute difference in urea N amount at any layer (kg/ha).
         /// </summary>
         [Units("kg/ha")]
         [XmlIgnore]
         public double absoluteDiff_LayerBiomC = 1;
 
         /// <summary>
-        /// Absolute difference in urea N amount at any layer (kg/ha)
+        /// Absolute difference in urea N amount at any layer (kg/ha).
         /// </summary>
         [Units("kg/ha")]
         [XmlIgnore]
         public double absoluteDiff_LayerUrea = 1;
 
         /// <summary>
-        /// Absolute difference in NH4 N amount at any layer (kg/ha)
+        /// Absolute difference in NH4 N amount at any layer (kg/ha).
         /// </summary>
         [Units("kg/ha")]
         [XmlIgnore]
         public double absoluteDiff_LayerNH4 = 1;
 
         /// <summary>
-        /// Absolute difference in NO3 N amount at any layer (kg/ha)
+        /// Absolute difference in NO3 N amount at any layer (kg/ha).
         /// </summary>
         [Units("kg/ha")]
         [XmlIgnore]
         public double absoluteDiff_LayerNO3 = 1;
 
         /// <summary>
-        /// Depth to consider when testing diffs by layer, if -ve soil depth is used (mm)
+        /// Depth to consider when testing diffs by layer, if -ve soil depth is used (mm).
         /// </summary>
         [Units("mm")]
         [XmlIgnore]
         public double DepthToTestByLayer = 99;
 
         /// <summary>
-        /// Factor to adjust the tests between patches other than base (0-1)
+        /// Factor to adjust the tests between patches other than base (0-1).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
-        [Units("0-1")]
+        [Units("")]
         [XmlIgnore]
         public double DiffAdjustFactor = 0.5;
 
@@ -1693,21 +1691,14 @@ namespace Models.Soils
         [XmlIgnore]
         public double[] sw_dep;
 
-        /// <summary>
-        /// Soil temperature (oC), as computed by an external module (SoilTemp)
-        /// </summary>
-        [Units("oC")]
-        [XmlIgnore]
-        public double[] ave_soil_temp;
-
         #endregion physiscs data
 
         #region Soil pH data
 
         /// <summary>
-        /// pH of soil (assumed equivalent to a 1:1 soil-water slurry)
+        /// pH of soil (assumed equivalent to a 1:1 soil-water slurry).
         /// </summary>
-        [Bounds(Lower = 3.5, Upper = 11.0)]
+        [Bounds(Lower = 3.0, Upper = 11.0)]
         [XmlIgnore]
         public double[] ph = { 6, 6 };
 
@@ -1716,7 +1707,7 @@ namespace Models.Soils
         #region Values for soil organic matter (som)
 
         /// <summary>
-        /// Total soil organic carbon content (%)
+        /// Total soil organic carbon content (%).
         /// </summary>
         [Units("%")]
         [XmlIgnore]
@@ -1760,7 +1751,7 @@ namespace Models.Soils
         #region Values for soil mineral N
 
         /// <summary>
-        /// Soil urea nitrogen content (ppm)
+        /// Soil urea nitrogen content (ppm).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 10000.0)]
         [Units("mg/kg")]
@@ -1791,7 +1782,7 @@ namespace Models.Soils
         }
 
         /// <summary>
-        /// Soil ammonium nitrogen content (ppm)
+        /// Soil ammonium nitrogen content (ppm).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 10000.0)]
         [Units("mg/kg")]
@@ -1822,7 +1813,7 @@ namespace Models.Soils
         }
 
         /// <summary>
-        /// Soil nitrate nitrogen content (ppm)
+        /// Soil nitrate nitrogen content (ppm).
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 10000.0)]
         [Units("mg/kg")]
@@ -1856,18 +1847,18 @@ namespace Models.Soils
 
         #region Soil loss data
 
-        // it is assumed any changes in soil profile are due to erosion
-        // this should be done via an event (RCichota)
+        //// NOTE: it is assumed any changes in soil profile are due to erosion
+        //// this should be done via an event
 
         /// <summary>
-        /// Define whether soil profile reduction is on
+        /// Define whether soil profile reduction is on.
         /// </summary>
         [Units("on/off")]
         public string n_reduction
-        { set { ProfileReductionAllowed = value.StartsWith("on"); } }
+        { set { profileReductionAllowed = value.StartsWith("on"); } }
 
         /// <summary>
-        /// Soil loss due to erosion (t/ha)
+        /// Soil loss due to erosion (t/ha).
         /// </summary>
         [Units("t/ha")]
         [XmlIgnore]
@@ -1878,7 +1869,7 @@ namespace Models.Soils
         #region Pond data
 
         /// <summary>
-        /// Indicates whether pond is active or not
+        /// Flag for whether pond is active or not (yes/no).
         /// </summary>
         /// <remarks>
         /// If there is a pond, the decomposition of surface OM will be done by that model
@@ -1889,14 +1880,14 @@ namespace Models.Soils
         { set { isPondActive = (value == "yes"); } }
 
         /// <summary>
-        /// Amount of C decomposed in pond that is added to soil m. biomass
+        /// Amount of C decomposed in pond that is added to soil m. biomass.
         /// </summary>
         [Units("kg/ha")]
         [XmlIgnore]
         public double pond_biom_C;
 
         /// <summary>
-        /// Amount of C decomposed in pond that is added to soil humus
+        /// Amount of C decomposed in pond that is added to soil humus.
         /// </summary>
         [Units("kg/ha")]
         [XmlIgnore]
@@ -1907,7 +1898,7 @@ namespace Models.Soils
         #region Inhibitors data
 
         /// <summary>
-        /// Factor reducing nitrification due to the presence of a inhibitor
+        /// Factor reducing nitrification due to the presence of a inhibitor.
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("0-1")]
@@ -1921,20 +1912,20 @@ namespace Models.Soils
                     {
                         if (layer < value.Length)
                         {
-                            InhibitionFactor_Nitrification[layer] = value[layer];
-                            if (InhibitionFactor_Nitrification[layer] < -epsilon)
+                            inhibitionFactor_Nitrification[layer] = value[layer];
+                            if (inhibitionFactor_Nitrification[layer] < -epsilon)
                             {
-                                InhibitionFactor_Nitrification[layer] = 0.0;
+                                inhibitionFactor_Nitrification[layer] = 0.0;
                                 mySummary.WriteWarning(this, "Value for nitrification inhibition is below lower limit, value will be adjusted to 0.0");
                             }
-                            else if (InhibitionFactor_Nitrification[layer] > 1.0)
+                            else if (inhibitionFactor_Nitrification[layer] > 1.0)
                             {
-                                InhibitionFactor_Nitrification[layer] = 1.0;
+                                inhibitionFactor_Nitrification[layer] = 1.0;
                                 mySummary.WriteWarning(this, "Value for nitrification inhibition is above upper limit, value will be adjusted to 1.0");
                             }
                         }
                         else
-                            InhibitionFactor_Nitrification[layer] = 0.0;
+                            inhibitionFactor_Nitrification[layer] = 0.0;
                     }
                 }
             }
@@ -1944,10 +1935,17 @@ namespace Models.Soils
 
         #region Plant data
 
-        private double rootDepth = 0.0;
         /// <summary>
-        /// Depth of root zone  (mm)
+        /// Current depth of root zone (mm).
         /// </summary>
+        private double rootDepth = 0.0;
+
+        /// <summary>
+        /// Depth of root zone (mm).
+        /// </summary>
+        /// <remarks>
+        /// This is used to compute plant available N when using patches
+        /// </remarks>
         [Units("mm")]
         [XmlIgnore]
         public double RootingDepth
@@ -5952,10 +5950,10 @@ namespace Models.Soils
         #region Useful constants
 
         /// <summary>
-        /// Value to evaluate precision against floating point variables
+        /// Value to evaluate precision against floating point variables.
         /// </summary>
         private readonly double epsilon = 0.000000000001;
-        //private double epsilon = Math.Pow(2, -24);
+        ////private double epsilon = Math.Pow(2, -24);
 
         #endregion constants
 
@@ -5964,7 +5962,7 @@ namespace Models.Soils
         #region Components
 
         /// <summary>
-        /// List of all existing patches (internal instances of C and N processes)
+        /// List of all existing patches (internal instances of C and N processes).
         /// </summary>
         [XmlIgnore]
         public List<soilCNPatch> Patch;
@@ -5974,26 +5972,30 @@ namespace Models.Soils
         #region Soil physics data
 
         /// <summary>
-        /// The soil layer thickness at the start of the simulation
+        /// The soil layer thickness at the start of the simulation.
         /// </summary>
         private double[] reset_dlayer;
 
-        /// <summary>Soil layers' thichness (mm)</summary>
+        /// <summary>
+        /// Soil layers' thichness (mm).
+        /// </summary>
         [Units("mm")]
         private double[] dlayer;
 
-        /// <summary>Number layers in the soil</summary>
+        /// <summary>
+        /// Number layers in the soil.
+        /// </summary>
         private int nLayers;
 
-        /// <summary>Soil water amount at saturation (mm)</summary>
+        /// <summary>Soil water amount at saturation (mm).</summary>
         [Units("mm")]
         private double[] sat_dep;
 
-        /// <summary>Soil water amount at drainage upper limit (mm)</summary>
+        /// <summary>Soil water amount at drainage upper limit (mm).</summary>
         [Units("mm")]
         private double[] dul_dep;
 
-        /// <summary>Soil water amount at drainage lower limit (mm)</summary>
+        /// <summary>Soil water amount at drainage lower limit (mm).</summary>
         [Units("mm")]
         private double[] ll15_dep;
 
@@ -6002,22 +6004,22 @@ namespace Models.Soils
         #region Initial C and N amounts
 
         /// <summary>
-        /// The initial OC content for each layer of the soil (%). Also used onReset
+        /// The initial OC content for each layer of the soil (%). Also used onReset.
         /// </summary>
         private double[] reset_oc = { 3, 1 };
 
         /// <summary>
-        /// Initial content of urea in each soil layer (ppm). Also used onReset
+        /// Initial content of urea in each soil layer (ppm). Also used onReset.
         /// </summary>
         private double[] reset_ureappm;
 
         /// <summary>
-        /// Initial content of NH4 in each soil layer (ppm). Also used onReset
+        /// Initial content of NH4 in each soil layer (ppm). Also used onReset.
         /// </summary>
         private double[] reset_nh4ppm = { 1, 0.5 };
 
         /// <summary>
-        /// Initial content of NO3 in each soil layer (ppm). Also used onReset
+        /// Initial content of NO3 in each soil layer (ppm). Also used onReset.
         /// </summary>
         private double[] reset_no3ppm = { 5, 2 };
 
@@ -6030,7 +6032,7 @@ namespace Models.Soils
         #region Deltas in mineral nitrogen
 
         /// <summary>
-        /// Variations in urea as given by another component
+        /// Variations in urea as given by another component.
         /// </summary>
         /// <remarks>
         /// This property checks changes in the amount of urea at each soil layer
@@ -6049,7 +6051,7 @@ namespace Models.Soils
         }
 
         /// <summary>
-        /// Variations in nh4 as given by another component
+        /// Variations in nh4 as given by another component.
         /// </summary>
         private double[] dlt_nh4
         {
@@ -6062,7 +6064,7 @@ namespace Models.Soils
         }
 
         /// <summary>
-        /// Variations in no3 as given by another component
+        /// Variations in no3 as given by another component.
         /// </summary>
         private double[] dlt_no3
         {
@@ -6079,49 +6081,49 @@ namespace Models.Soils
         #region Decision auxiliary variables
 
         /// <summary>
-        /// Marker for whether initialisation has been finished or not
+        /// Marker for whether initialisation has been finished or not.
         /// </summary>
         private bool initDone = false;
 
         /// <summary>
-        /// Indicates whether soil profile reduction is allowed (from erosion)
+        /// Indicates whether soil profile reduction is allowed (from erosion).
         /// </summary>
-        private bool ProfileReductionAllowed = false;
+        private bool profileReductionAllowed = false;
 
         /// <summary>
-        /// Indicates whether organic solutes are to be simulated
+        /// Indicates whether organic solutes are to be simulated.
         /// </summary>
         /// <remarks>
         /// It should always be false, as organic solutes are not implemented yet
         /// </remarks>
-        private bool useOrganicSolutes = false;
+        private bool organicSolutesAllowed = false;
 
         #endregion
 
         #region Residue decomposition information
 
         /// <summary>
-        /// Name of residues decomposing
+        /// Name of residues decomposing.
         /// </summary>
         private string[] residueName;
 
         /// <summary>
-        /// Type of decomposing residue
+        /// Type of decomposing residue.
         /// </summary>
         private string[] residueType;
 
         /// <summary>
-        /// Potential residue C decomposition (kg/ha)
+        /// Potential residue C decomposition (kg/ha).
         /// </summary>
         private double[] pot_c_decomp;
 
         /// <summary>
-        /// Potential residue N decomposition (kg/ha)
+        /// Potential residue N decomposition (kg/ha).
         /// </summary>
         private double[] pot_n_decomp;
 
         /// <summary>
-        /// Potential residue P decomposition (kg/ha)
+        /// Potential residue P decomposition (kg/ha).
         /// </summary>
         private double[] pot_p_decomp;
 
@@ -6130,19 +6132,19 @@ namespace Models.Soils
         #region Miscelaneous
 
         /// <summary>
-        /// Total C content at the beginning of the day
+        /// Total C content at the beginning of the day.
         /// </summary>
         [XmlIgnore]
         public double TodaysInitialC;
 
         /// <summary>
-        /// Total N content at the beginning of the day
+        /// Total N content at the beginning of the day.
         /// </summary>
         [XmlIgnore]
         public double TodaysInitialN;
 
         /// <summary>
-        /// The initial FOM distribution, a 0-1 fraction for each layer
+        /// The initial FOM distribution, a 0-1 fraction for each layer.
         /// </summary>
         private double[] FOMiniFraction;
 
@@ -6151,95 +6153,97 @@ namespace Models.Soils
         /// </summary>
         private int fom_type;
 
-        /// <summary>Number of surface residues whose decomposition is being calculated</summary>
+        /// <summary>
+        /// Number of surface residues whose decomposition is being calculated.
+        /// </summary>
         private int nResidues = 0;
 
         /// <summary>
-        /// The C:N ratio of each fom pool
+        /// The C:N ratio of each fom pool.
         /// </summary>
         private double[] fomPoolsCNratio;
 
         /// <summary>
-        /// Factor for converting kg/ha into ppm
+        /// Factor for converting kg/ha into ppm.
         /// </summary>
         private double[] convFactor;
 
         /// <summary>
-        /// Factor reducing nitrification due to the presence of a inhibitor
+        /// Factor reducing nitrification due to the presence of a inhibitor.
         /// </summary>
-        private double[] InhibitionFactor_Nitrification = null;
+        private double[] inhibitionFactor_Nitrification = null;
 
         #endregion
 
         #region CNpatch related variables
 
         /// <summary>
-        /// Minimum allowable relative area for a CNpatch (0-1)
+        /// Minimum allowable relative area for a CNpatch (0-1).
         /// </summary>
-        private double MinimumPatchArea = 0.000001;
+        private double minimumPatchArea = 0.000001;
 
         /// <summary>
-        /// Approach to use when partitioning dltN amongst patches
+        /// Approach to use when partitioning dltN amongst patches.
         /// </summary>
-        private string PatchNPartitionApproach = "BasedOnConcentrationAndDelta";
+        private string patchNPartitionApproach = "BasedOnConcentrationAndDelta";
 
         /// <summary>
-        /// Whether auto amalgamation of patches is allowed
+        /// Whether auto amalgamation of patches is allowed.
         /// </summary>
-        private bool PatchAutoAmalgamationAllowed = false;
+        private bool patchAutoAmalgamationAllowed = false;
 
         /// <summary>
-        /// Approach to use for AutoAmalagamation (CompareAll, CompareBase, CompareMerge)
+        /// Approach to use for AutoAmalagamation (CompareAll, CompareBase, CompareMerge).
         /// </summary>
-        private string PatchAmalgamationApproach = "CompareAll";
+        private string patchAmalgamationApproach = "CompareAll";
 
         /// <summary>
-        /// Should an age check be used to force amalgamation of patches?
+        /// indicates whether an age check is used to force amalgamation of patches.
         /// </summary>
-        private bool PatchAmalgamationByAgeAllowed = false;
+        private bool patchAmalgamationByAgeAllowed = false;
 
         /// <summary>
-        /// Age after which patches will be merged if AllowPatchAmalgamationByAge
+        /// Age after which patches will be merged if AllowPatchAmalgamationByAge.
         /// </summary>
         private double forcedMergePatchAge = 3;
 
         /// <summary>
-        /// Approach to use for defining the base patch (IDBased, AreaBased)
+        /// Approach to use for defining the base patch (IDBased, AreaBased).
         /// </summary>
-        private string PatchbasePatchApproach = "AreaBased";
+        private string patchbasePatchApproach = "AreaBased";
 
         /// <summary>
-        /// Layer down to which test for diffs are made (upon auto amalgamation)
+        /// Layer down to which test for diffs are made (upon auto amalgamation).
         /// </summary>
-        private int LayerDepthToTestDiffs;
+        private int layerDepthToTestDiffs;
 
         /// <summary>
-        /// A description of the module sending a change in soil nitrogen (used for partitioning)
+        /// A description of the module sending a change in soil nitrogen (used for partitioning).
         /// </summary>
         private string senderModule;
 
         /// <summary>
-        /// Maximum NH4 uptake rate for plants (ppm/day) (only used when dealing with patches)
+        /// Maximum NH4 uptake rate for plants (ppm/day) (only used when dealing with patches).
         /// </summary>
         private double reset_MaximumNH4Uptake = 9999.9;
 
         /// <summary>
-        /// Maximum NO3 uptake rate for plants (ppm/day) (only used when dealing with patches)
+        /// Maximum NO3 uptake rate for plants (ppm/day) (only used when dealing with patches).
         /// </summary>
         private double reset_MaximumNO3Uptake = 9999.9;
 
         /// <summary>
-        /// Maximum NH4 uptake rate for plants (only used when dealing with patches)
+        /// Maximum NH4 uptake rate for plants (only used when dealing with patches).
         /// </summary>
-        private double[] MaximumNH4UptakeRate;
+        private double[] maximumNH4UptakeRate;
 
         /// <summary>
-        /// Maximum NO3 uptake rate for plants (only used when dealing with patches)
+        /// Maximum NO3 uptake rate for plants (only used when dealing with patches).
         /// </summary>
-        private double[] MaximumNO3UptakeRate;
+        private double[] maximumNO3UptakeRate;
 
         /// <summary>
-        /// The maximum amount of N that is made available to plants in one day
+        /// The maximum amount of N that is made available to plants in one day.
         /// </summary>
         private double maxTotalNAvailableToPlants = 9999.9;
 

--- a/Models/Soils/SoilNitrogen.cs
+++ b/Models/Soils/SoilNitrogen.cs
@@ -120,80 +120,80 @@ namespace Models.Soils
 
             // get the initial values 
             oc = Soil.OC;
-            fbiom = Soil.FBiom;
-            finert = Soil.FInert;
-            soil_cn = SoilOrganicMatter.SoilCN;
-            root_wt = SoilOrganicMatter.RootWt;
-            root_cn = SoilOrganicMatter.RootCN;
-            enr_a_coeff = SoilOrganicMatter.EnrACoeff;
-            enr_b_coeff = SoilOrganicMatter.EnrBCoeff;
+            FBiom = Soil.FBiom;
+            FInert = Soil.FInert;
+            HumusCNr = Soil.SoilOrganicMatter.SoilCN;
+            InitialFOMWt = Soil.SoilOrganicMatter.RootWt;
+            InitialFOMCNr = Soil.SoilOrganicMatter.RootCN;
+            enr_a_coeff = Soil.SoilOrganicMatter.EnrACoeff;
+            enr_b_coeff = Soil.SoilOrganicMatter.EnrBCoeff;
             ph = Soil.PH;
             NO3ppm = Soil.InitialNO3N;
             NH4ppm = Soil.InitialNH4N;
             ureappm = new double[Soil.Thickness.Length];
 
             // This is needed to initialise values in ApsimX, (they were done in xml file before)
-            FOMDecomp_TOptimum = new double[] { 32, 32 };
-            FOMDecomp_FactorAtZero = new double[] { 0, 0 };
-            FMDecomp_CurveCoeff = new double[] { 2, 2 };
-            FOMDecomp_NormWaterContents = new double[] { 0, 1, 1.5, 2, 3 };
-            FOMDecomp_MoistureFactors = new double[] { 0, 0, 1, 1, 0.5 };
+            FOMDecomp_TOptimum = new double[] { 32.0, 32.0 };
+            FOMDecomp_TFactorAtZero = new double[] { 0.0, 0.0 };
+            FOMDecomp_TCurveCoeff = new double[] { 2.0, 2.0 };
+            FOMDecomp_NormWaterContents = new double[] { 0.0, 1.0, 1.5, 2.0, 3.0 };
+            FOMDecomp_MoistureFactors = new double[] { 0.0, 0.0, 1.0, 1.0, 0.5 };
 
-            SOMMiner_TOptimum = new double[] { 32, 32 };
-            SOMMiner_FactorAtZero = new double[] { 0, 0 };
-            SOMMiner_CurveCoeff = new double[] { 2, 2 };
-            SOMMiner_NormWaterContents = new double[] { 0, 1, 1.5, 2, 3 };
-            SOMMiner_MoistureFactors = new double[] { 0, 0, 1, 1, 0.5 };
+            SOMMiner_TOptimum = new double[] { 32.0, 32.0 };
+            SOMMiner_TFactorAtZero = new double[] { 0.0, 0.0 };
+            SOMMiner_TCurveCoeff = new double[] { 2.0, 2.0 };
+            SOMMiner_NormWaterContents = new double[] { 0.0, 1.0, 1.5, 2.0, 3.0 };
+            SOMMiner_MoistureFactors = new double[] { 0.0, 0.0, 1.0, 1.0, 0.5 };
 
-            UreaHydrol_TOptimum = new double[] { 32, 32 };
-            UreaHydrol_FactorAtZero = new double[] { 0.2, 0.2 };
-            UreaHydrol_CurveCoeff = new double[] { 1, 1 };
-            UreaHydrol_NormWaterContents = new double[] { 0, 1, 1.4, 2.4, 3 };
+            UreaHydrol_TOptimum = new double[] { 32.0, 32.0 };
+            UreaHydrol_TFactorAtZero = new double[] { 0.2, 0.2 };
+            UreaHydrol_TCurveCoeff = new double[] { 1.0, 1.0 };
+            UreaHydrol_NormWaterContents = new double[] { 0.0, 1.0, 1.4, 2.4, 3.0 };
             UreaHydrol_MoistureFactors = new double[] { 0.2, 0.2, 1.0, 1.0, 0.7 };
 
-            Nitrification_TOptimum = new double[] { 32, 32 };
-            Nitrification_FactorAtZero = new double[] { 0, 0 };
-            Nitrification_CurveCoeff = new double[] { 2, 2 };
-            Nitrification_NormWaterContents = new double[] { 0, 1, 1.25, 2, 3 };
-            Nitrification_MoistureFactors = new double[] { 0, 0, 1, 1, 0 };
-            Nitrification_pHValues = new double[] { 0, 4.5, 6, 8, 9, 14 };
-            Nitrification_pHFactors = new double[] { 0, 0, 1, 1, 0, 0 };
+            Nitrification_TOptimum = new double[] { 32.0, 32.0 };
+            Nitrification_FactorAtZero = new double[] { 0.0, 0.0 };
+            Nitrification_CurveCoeff = new double[] { 2.0, 2.0 };
+            Nitrification_NormWaterContents = new double[] { 0.0, 1.0, 1.25, 2.0, 3.0 };
+            Nitrification_MoistureFactors = new double[] { 0.0, 0.0, 1.0, 1.0, 0.0 };
+            Nitrification_pHValues = new double[] { 0.0, 4.5, 6.0, 8.0, 9.0, 14.0 };
+            Nitrification_pHFactors = new double[] { 0.0, 0.0, 1.0, 1.0, 0.0, 0.0 };
 
-            TOptimunNitrification2 = new double[] { 32, 32 };
-            FactorAtZeroNitrification2 = new double[] { 0, 0 };
-            CurveCoeffNitrification2 = new double[] { 2, 2 };
-            NormWaterContentsNitrification2 = new double[] { 0, 1, 1.25, 2, 3 };
-            MoistureFactorsNitrification2 = new double[] { 0, 0, 1, 1, 0 };
-            Nitritation_pHValues = new double[] { 0, 4.5, 6, 8, 9, 14 };
-            Nitritation_pHFactors = new double[] { 0, 0, 1, 1, 0, 0 };
+            Nitrification2_TOptimum = new double[] { 32.0, 32.0 };
+            Nitrification2_TFactorAtZero = new double[] { 0.0, 0.0 };
+            Nitrification2_TCurveCoeff = new double[] { 2.0, 2.0 };
+            Nitrification2_NormWaterContents = new double[] { 0.0, 1.0, 1.25, 2.0, 3.0 };
+            Nitrification2_MoistureFactors = new double[] { 0.0, 0.0, 1.0, 1.0, 0.0 };
+            Nitritation_pHValues = new double[] { 0.0, 4.5, 6.0, 8.0, 9.0, 14.0 };
+            Nitritation_pHFactors = new double[] { 0.0, 0.0, 1.0, 1.0, 0.0, 0.0 };
 
-            TOptmimunCodenitrififaction = new double[] { 50.0561976737836, 50.0561976737836 };
-            FactorAtZeroCodenitrification = new double[] { 0.1, 0.1 };
-            CurveCoeffCodenitrification = new double[] { 67108874, 67108874 };
-            Codenitrification_NormWaterContents = new double[] { 0, 2, 3 };
-            Codenitrification_MoistureFactors = new double[] { 0, 0, 1 };
-            Codenitrification_pHValues = new double[] { 0, 4.5, 6, 8, 9, 14 };
-            Codenitrification_pHFactors = new double[] { 0, 0, 1, 1, 0, 0 };
-            Codenitrification_NHNOValues = new double[] { 0, 4.5, 6, 8, 9, 14 };
-            Codenitrification_NHNOFactors = new double[] { 0, 0, 1, 1, 0, 0 };
+            Codenitrification_TOptmimun = new double[] { 50.05, 50.05 };
+            Codenitrification_TFactorAtZero = new double[] { 0.1, 0.1 };
+            Codenitrification_TCurveCoeff = new double[] { 1000, 1000 };
+            Codenitrification_NormWaterContents = new double[] { 0.0, 2.0, 3.0 };
+            Codenitrification_MoistureFactors = new double[] { 0.0, 0.0, 1.0 };
+            Codenitrification_pHValues = new double[] { 0.0, 4.5, 6.0, 8.0, 9.0, 14.0 };
+            Codenitrification_pHFactors = new double[] { 0.0, 0.0, 1.0, 1.0, 0.0, 0.0 };
+            Codenitrification_NHNOValues = new double[] { 0.0, 4.5, 6.0, 8.0, 9.0, 14.0 };
+            Codenitrification_NHNOFactors = new double[] { 0.0, 0.0, 1.0, 1.0, 0.0, 0.0 };
 
             //// NOTE: the values for Topt and CvExp given here reproduce best the original function (it was an exponential, now a power)
             ////  however, values like 50.06 and 1000, or even more sane 50 and 100 should be good enough
-            Denit_TOptimum = new double[] { 50.0561976737836, 50.0561976737836 };
-            Denit_FactorAtZero = new double[] { 0.1, 0.1 };
-            Denit_CurveCoeff = new double[] { 67108874, 67108874 };
-            Denit_NormWaterContents = new double[] { 0, 2, 3 };
-            Denit_MoistureFactors = new double[] { 0, 0, 1 };
-            Denit_WPFSValues = new double[] { 0, 28, 88, 100 };
-            Denit_WFPSFactors = new double[] { 0.1, 0.1, 1, 1.18 };
+            Denitrification_TOptimum = new double[] { 50.0561976737836, 50.0561976737836 };
+            Denitrification_TFactorAtZero = new double[] { 0.1, 0.1 };
+            Denitrification_TCurveCoeff = new double[] { 67108874, 67108874 };
+            Denitrification_NormWaterContents = new double[] { 0.0, 2.0, 3.0 };
+            Denitrification_MoistureFactors = new double[] { 0.0, 0.0, 1.0 };
+            Denit_WPFSValues = new double[] { 0.0, 28.0, 88.0, 100.0 };
+            Denit_WFPSFactors = new double[] { 0.1, 0.1, 1.0, 1.18 };
 
             // update few parameters if soil type is Sand (for compatibility with classic apsim)
             if (Soil.SoilType != null && Soil.SoilType.Equals("Sand", StringComparison.CurrentCultureIgnoreCase))
             {
                 SoilNParameterSet = "sand";
                 MBiomassTurnOverRate = new double[] { 0.0324, 0.015 };
-                SOMMiner_MoistureFactors = new double[] { 0.05, 0.05, 1, 1, 0.5 };
-                FOMDecomp_MoistureFactors = new double[] { 0.05, 0.05, 1, 1, 0.5 };
+                SOMMiner_MoistureFactors = new double[] { 0.05, 0.05, 1.0, 1.0, 0.5 };
+                FOMDecomp_MoistureFactors = new double[] { 0.05, 0.05, 1.0, 1.0, 0.5 };
             }
 
             // check whether ph was supplied, use a default if not - would it be better to throw an exception?
@@ -201,9 +201,9 @@ namespace Models.Soils
             {
                 ph = new double[nLayers];
                 for (int layer = 0; layer < nLayers; ++layer)
-                    ph[layer] = defaultInitialpH;
+                    ph[layer] = DefaultInitialpH;
                 mySummary.WriteWarning(this, "Soil pH was not supplied to SoilNitrogen, the default value (" 
-                    + defaultInitialpH.ToString("0.00") + ") will be used for all layers");
+                    + DefaultInitialpH.ToString("0.00") + ") will be used for all layers");
             }
             
             // Check whether C:N values have been supplied. If not use average C:N ratio in all pools
@@ -211,12 +211,12 @@ namespace Models.Soils
             {
                 fomPoolsCNratio = new double[3];
                 for (int i = 0; i < 3; i++)
-                    fomPoolsCNratio[i] = iniFomCNratio;
+                    fomPoolsCNratio[i] = InitialFOMCNr;
             }
 
             // Check if initial fom depth has been supplied, if not assume that initial fom is distributed over the whole profile
-            if (iniFomDepth <= epsilon)
-                iniFomDepth = SumDoubleArray(dlayer);
+            if (InitialFOMDepth <= epsilon)
+                InitialFOMDepth = SumDoubleArray(dlayer);
 
             // Check if initial root depth has been supplied, if not use whole profile (used to compute plant available N - patches)
             if (rootDepth <= epsilon)
@@ -229,9 +229,9 @@ namespace Models.Soils
 
             // Check parameters for patches
             if (DepthToTestByLayer <= epsilon)
-                LayerDepthToTestDiffs = nLayers - 1;
+                layerDepthToTestDiffs = nLayers - 1;
             else
-                LayerDepthToTestDiffs = getCumulativeIndex(DepthToTestByLayer, dlayer);
+                layerDepthToTestDiffs = getCumulativeIndex(DepthToTestByLayer, dlayer);
         }
 
         /// <summary>
@@ -286,14 +286,14 @@ namespace Models.Soils
             // compute initial FOM distribution in the soil (FOM fractions)
             FOMiniFraction = new double[nLayers];
             double totFOMfraction = 0.0;
-            int deepestLayer = getCumulativeIndex(iniFomDepth, dlayer);
+            int deepestLayer = getCumulativeIndex(InitialFOMDepth, dlayer);
             double cumDepth = 0.0;
             double FracLayer = 0.0;
             for (int layer = 0; layer <= deepestLayer; layer++)
             {
-                FracLayer = Math.Min(1.0, MathUtilities.Divide(iniFomDepth - cumDepth, dlayer[layer], 0.0));
+                FracLayer = Math.Min(1.0, MathUtilities.Divide(InitialFOMDepth - cumDepth, dlayer[layer], 0.0));
                 cumDepth += dlayer[layer];
-                FOMiniFraction[layer] = FracLayer * Math.Exp(-FOMDistributionCoefficient * Math.Min(1.0, MathUtilities.Divide(cumDepth, iniFomDepth, 0.0)));
+                FOMiniFraction[layer] = FracLayer * Math.Exp(-InitialFOMDistCoefficient * Math.Min(1.0, MathUtilities.Divide(cumDepth, InitialFOMDepth, 0.0)));
             }
 
             // get the actuall FOM distribution through layers (adds up to one)
@@ -326,22 +326,22 @@ namespace Models.Soils
                 Soil_OC = MathUtilities.Divide(Soil_OC, convFactor[layer], 0.0);  //Convert from ppm to kg/ha
 
                 // calculate inert soil C
-                double InertC = finert[layer] * Soil_OC;
-                double InertN = MathUtilities.Divide(InertC, hum_cn, 0.0);
+                double InertC = FInert[layer] * Soil_OC;
+                double InertN = MathUtilities.Divide(InertC, HumusCNr, 0.0);
 
                 // calculate microbial biomass C and N
-                double BiomassC = MathUtilities.Divide((Soil_OC - InertC) * fbiom[layer], 1.0 + fbiom[layer], 0.0);
+                double BiomassC = MathUtilities.Divide((Soil_OC - InertC) * FBiom[layer], 1.0 + FBiom[layer], 0.0);
                 double BiomassN = MathUtilities.Divide(BiomassC, MBiomassCNr, 0.0);
 
                 // calculate C and N values for humus
                 double HumusC = Soil_OC - BiomassC;
-                double HumusN = MathUtilities.Divide(HumusC, hum_cn, 0.0);
+                double HumusN = MathUtilities.Divide(HumusC, HumusCNr, 0.0);
 
                 // distribute C over fom pools
                 double[] fomPool = new double[3];
-                fomPool[0] = iniFomWt * FOMiniFraction[layer] * fract_carb[FOMtypeID_reset] * defaultCarbonInFOM;
-                fomPool[1] = iniFomWt * FOMiniFraction[layer] * fract_cell[FOMtypeID_reset] * defaultCarbonInFOM;
-                fomPool[2] = iniFomWt * FOMiniFraction[layer] * fract_lign[FOMtypeID_reset] * defaultCarbonInFOM;
+                fomPool[0] = InitialFOMWt * FOMiniFraction[layer] * fract_carb[FOMtypeID_reset] * DefaultCarbonInFOM;
+                fomPool[1] = InitialFOMWt * FOMiniFraction[layer] * fract_cell[FOMtypeID_reset] * DefaultCarbonInFOM;
+                fomPool[2] = InitialFOMWt * FOMiniFraction[layer] * fract_lign[FOMtypeID_reset] * DefaultCarbonInFOM;
 
                 // set the initial values across patches
                 for (int k = 0; k < Patch.Count; k++)
@@ -364,8 +364,8 @@ namespace Models.Soils
                 }
 
                 // set maximum uptake rates for N forms (only really used for AgPasture when patches exist)
-                MaximumNH4UptakeRate[layer] = reset_MaximumNH4Uptake / convFactor[layer];
-                MaximumNO3UptakeRate[layer] = reset_MaximumNO3Uptake / convFactor[layer];
+                maximumNH4UptakeRate[layer] = reset_MaximumNH4Uptake / convFactor[layer];
+                maximumNO3UptakeRate[layer] = reset_MaximumNO3Uptake / convFactor[layer];
             }
 
             for (int k = 0; k < Patch.Count; k++)
@@ -385,9 +385,9 @@ namespace Models.Soils
         /// <param name="nLayers">The number of layers</param>
         private void ResizeLayeredVariables(int nLayers)
         {
-            Array.Resize(ref InhibitionFactor_Nitrification, nLayers);
-            Array.Resize(ref MaximumNH4UptakeRate, nLayers);
-            Array.Resize(ref MaximumNO3UptakeRate, nLayers);
+            Array.Resize(ref inhibitionFactor_Nitrification, nLayers);
+            Array.Resize(ref maximumNH4UptakeRate, nLayers);
+            Array.Resize(ref maximumNO3UptakeRate, nLayers);
 
             for (int k = 0; k < Patch.Count; k++)
                 Patch[k].ResizeLayeredVariables(nLayers);
@@ -488,12 +488,12 @@ namespace Models.Soils
         private void OnDoUpdate(object sender, EventArgs e)
         {
             // Check whether patch auto amalgamation is allowed
-            if ((Patch.Count > 1) && (PatchAutoAmalgamationAllowed))
+            if ((Patch.Count > 1) && (patchAutoAmalgamationAllowed))
             {
-                if ((PatchAmalgamationApproach.ToLower() == "CompareAll".ToLower()) ||
-                    (PatchAmalgamationApproach.ToLower() == "CompareBase".ToLower()) ||
-                    (PatchAmalgamationApproach.ToLower() == "CompareAge".ToLower()) ||
-                    (PatchAmalgamationApproach.ToLower() == "CompareMerge".ToLower()))
+                if ((patchAmalgamationApproach.ToLower() == "CompareAll".ToLower()) ||
+                    (patchAmalgamationApproach.ToLower() == "CompareBase".ToLower()) ||
+                    (patchAmalgamationApproach.ToLower() == "CompareAge".ToLower()) ||
+                    (patchAmalgamationApproach.ToLower() == "CompareMerge".ToLower()))
                 {
                     CheckPatchAutoAmalgamation();
                 }
@@ -677,7 +677,7 @@ namespace Models.Soils
                 {
                     if (inFOMdata.Layer[layer].FOM.amount >= epsilon)
                     {
-                        inFOMdata.Layer[layer].FOM.C = inFOMdata.Layer[layer].FOM.amount * (float)defaultCarbonInFOM;
+                        inFOMdata.Layer[layer].FOM.C = inFOMdata.Layer[layer].FOM.amount * (float)DefaultCarbonInFOM;
                         if (inFOMdata.Layer[layer].CNR > epsilon)
                         {   // we have C:N info - note that this has precedence over N amount
                             totalCAmount += inFOMdata.Layer[layer].FOM.C;
@@ -736,9 +736,9 @@ namespace Models.Soils
                         {
                             myFOMPoolData.Layer[layer].nh4 = 0.0F;
                             myFOMPoolData.Layer[layer].no3 = 0.0F;
-                            myFOMPoolData.Layer[layer].Pool[0].C = inFOMdata.Layer[layer].FOM.amount * defaultCarbonInFOM * fract_carb[fom_type];
-                            myFOMPoolData.Layer[layer].Pool[1].C = inFOMdata.Layer[layer].FOM.amount * defaultCarbonInFOM * fract_cell[fom_type];
-                            myFOMPoolData.Layer[layer].Pool[2].C = inFOMdata.Layer[layer].FOM.amount * defaultCarbonInFOM * fract_lign[fom_type];
+                            myFOMPoolData.Layer[layer].Pool[0].C = inFOMdata.Layer[layer].FOM.amount * DefaultCarbonInFOM * fract_carb[fom_type];
+                            myFOMPoolData.Layer[layer].Pool[1].C = inFOMdata.Layer[layer].FOM.amount * DefaultCarbonInFOM * fract_cell[fom_type];
+                            myFOMPoolData.Layer[layer].Pool[2].C = inFOMdata.Layer[layer].FOM.amount * DefaultCarbonInFOM * fract_lign[fom_type];
 
                             myFOMPoolData.Layer[layer].Pool[0].N = inFOMdata.Layer[layer].FOM.N * fract_carb[fom_type];
                             myFOMPoolData.Layer[layer].Pool[1].N = inFOMdata.Layer[layer].FOM.N * fract_cell[fom_type];
@@ -893,7 +893,7 @@ namespace Models.Soils
                     reset_dlayer[layer] = dlayer[layer];
                 }
             }
-            else if (soil_loss > epsilon && ProfileReductionAllowed)
+            else if (soil_loss > epsilon && profileReductionAllowed)
             {
                 // check for variations in the soil profile. and update the C and N amounts appropriately
                 // Are these changes mainly (only) due to by erosion? what else??
@@ -966,7 +966,7 @@ namespace Models.Soils
                 if ((Patch.Count > 1) && ((senderModule == "WaterModule".ToLower()) || (senderModule == "Plant".ToLower())))
                 {
                     // the values come from a module that requires partition
-                    double[][] newDelta = partitionDelta(NitrogenChanges.DeltaUrea, "Urea", PatchNPartitionApproach.ToLower());
+                    double[][] newDelta = partitionDelta(NitrogenChanges.DeltaUrea, "Urea", patchNPartitionApproach.ToLower());
 
                     for (int k = 0; k < Patch.Count; k++)
                         Patch[k].dlt_urea = newDelta[k];
@@ -985,7 +985,7 @@ namespace Models.Soils
                 if ((Patch.Count > 1) && ((senderModule == "WaterModule".ToLower()) || (senderModule == "Plant".ToLower())))
                 {
                     // the values come from a module that requires partition
-                    double[][] newDelta = partitionDelta(NitrogenChanges.DeltaNH4, "NH4", PatchNPartitionApproach.ToLower());
+                    double[][] newDelta = partitionDelta(NitrogenChanges.DeltaNH4, "NH4", patchNPartitionApproach.ToLower());
 
                     for (int k = 0; k < Patch.Count; k++)
                         Patch[k].dlt_nh4 = newDelta[k];
@@ -1004,7 +1004,7 @@ namespace Models.Soils
                 if ((Patch.Count > 1) && ((senderModule == "WaterModule".ToLower()) || (senderModule == "Plant".ToLower())))
                 {
                     // the values come from a module that requires partition
-                    double[][] newDelta = partitionDelta(NitrogenChanges.DeltaNO3, "NO3", PatchNPartitionApproach.ToLower());
+                    double[][] newDelta = partitionDelta(NitrogenChanges.DeltaNO3, "NO3", patchNPartitionApproach.ToLower());
 
                     for (int k = 0; k < Patch.Count; k++)
                         Patch[k].dlt_no3 = newDelta[k];

--- a/Models/Soils/SoilNitrogen.cs
+++ b/Models/Soils/SoilNitrogen.cs
@@ -616,8 +616,8 @@ namespace Models.Soils
                 ActualSOMDecomp.Pool[residue].Name = Patch[0].SurfOMActualDecomposition.Pool[residue].Name;
                 ActualSOMDecomp.Pool[residue].OrganicMatterType = Patch[0].SurfOMActualDecomposition.Pool[residue].OrganicMatterType;
                 ActualSOMDecomp.Pool[residue].FOM.amount = 0.0F;
-                ActualSOMDecomp.Pool[residue].FOM.C = (float)c_summed;
-                ActualSOMDecomp.Pool[residue].FOM.N = (float)n_summed;
+                ActualSOMDecomp.Pool[residue].FOM.C = c_summed;
+                ActualSOMDecomp.Pool[residue].FOM.N = n_summed;
                 ActualSOMDecomp.Pool[residue].FOM.P = 0.0F;
                 ActualSOMDecomp.Pool[residue].FOM.AshAlk = 0.0F;
                 // Note: The values for 'amount', 'P', and 'AshAlk' will not be collected by SurfaceOrganicMatter, so send zero as default.
@@ -677,7 +677,7 @@ namespace Models.Soils
                 {
                     if (inFOMdata.Layer[layer].FOM.amount >= epsilon)
                     {
-                        inFOMdata.Layer[layer].FOM.C = inFOMdata.Layer[layer].FOM.amount * (float)DefaultCarbonInFOM;
+                        inFOMdata.Layer[layer].FOM.C = inFOMdata.Layer[layer].FOM.amount * DefaultCarbonInFOM;
                         if (inFOMdata.Layer[layer].CNR > epsilon)
                         {   // we have C:N info - note that this has precedence over N amount
                             totalCAmount += inFOMdata.Layer[layer].FOM.C;
@@ -1242,7 +1242,7 @@ namespace Models.Soils
                     dltC = 0.0;
                 massBalanceChange.FlowType = dltC >= 0 ? "gain" : "loss";
                 massBalanceChange.PoolClass = "soil";
-                massBalanceChange.N = (float)Math.Abs(dltC);
+                massBalanceChange.N = Math.Abs(dltC);
                 ExternalMassFlow.Invoke(massBalanceChange);
             }
         }
@@ -1259,7 +1259,7 @@ namespace Models.Soils
                 dltN = 0.0;
             massBalanceChange.FlowType = dltN >= epsilon ? "gain" : "loss";
             massBalanceChange.PoolClass = "soil";
-            massBalanceChange.N = (float)Math.Abs(dltN);
+            massBalanceChange.N = Math.Abs(dltN);
             if (ExternalMassFlow != null)
             {
                 ExternalMassFlow.Invoke(massBalanceChange);

--- a/Prototypes/Plantain/Plantain.apsimx
+++ b/Prototypes/Plantain/Plantain.apsimx
@@ -3728,30 +3728,30 @@ Where:
           <RegrStats>
             <Name>CumulativeHarvestedWt</Name>
             <n>670</n>
-            <Slope>0.97301754648021277</Slope>
-            <Intercept>-29.961824816562739</Intercept>
-            <SEslope>0.014653028607413462</SEslope>
-            <SEintercept>9.419281083382403</SEintercept>
-            <R2>0.86843845644490292</R2>
-            <RMSE>140.62292315289693</RMSE>
-            <NSE>0.83981341731037351</NSE>
-            <ME>-44.486578374831844</ME>
-            <MAE>102.12674385288416</MAE>
-            <RSR>0.39993436741276794</RSR>
+            <Slope>0.97297100094555822</Slope>
+            <Intercept>-30.027985099146633</Intercept>
+            <SEslope>0.014658532622330802</SEslope>
+            <SEintercept>9.4228191822275331</SEintercept>
+            <R2>0.86834167903379811</R2>
+            <RMSE>140.70019516286118</RMSE>
+            <NSE>0.83963732454025719</NSE>
+            <ME>-44.577794289201506</ME>
+            <MAE>102.23453557338856</MAE>
+            <RSR>0.40015413053339494</RSR>
           </RegrStats>
           <RegrStats>
             <Name>HarvestedWt</Name>
             <n>660</n>
-            <Slope>0.58675635139411075</Slope>
-            <Intercept>49.134411690069257</Intercept>
-            <SEslope>0.024025805404948825</SEslope>
-            <SEintercept>3.4312729842126357</SEintercept>
-            <R2>0.47545909298109168</R2>
-            <RMSE>59.160775796202778</RMSE>
-            <NSE>0.44940169519587736</NSE>
-            <ME>0.1694238194243792</ME>
-            <MAE>41.812448851673558</MAE>
-            <RSR>0.741460764267644</RSR>
+            <Slope>0.586986143326879</Slope>
+            <Intercept>49.096503376073059</Intercept>
+            <SEslope>0.024030122919750981</SEslope>
+            <SEintercept>3.4318895950462736</SEintercept>
+            <R2>0.47556477246878814</R2>
+            <RMSE>59.157880243843714</RMSE>
+            <NSE>0.44945559060829265</NSE>
+            <ME>0.15874341138288095</ME>
+            <MAE>41.803387445497663</MAE>
+            <RSR>0.74142447437055869</RSR>
           </RegrStats>
           <RegrStats>
             <Name>NRate</Name>
@@ -3770,30 +3770,30 @@ Where:
           <RegrStats>
             <Name>Plantain.AboveGround.Wt</Name>
             <n>786</n>
-            <Slope>0.6074168351064293</Slope>
-            <Intercept>55.897495540938678</Intercept>
-            <SEslope>0.024175776201930385</SEslope>
-            <SEintercept>3.7135612966671143</SEintercept>
-            <R2>0.4460407581708119</R2>
-            <RMSE>46.739189397848449</RMSE>
-            <NSE>0.38762312745577876</NSE>
-            <ME>0.33943571639926889</ME>
-            <MAE>32.325339938730181</MAE>
-            <RSR>0.78204716424804877</RSR>
+            <Slope>0.60701002511985513</Slope>
+            <Intercept>55.947889244078041</Intercept>
+            <SEslope>0.024175573155878875</SEslope>
+            <SEintercept>3.7135301074324012</SEintercept>
+            <R2>0.44571385229683158</R2>
+            <RMSE>46.751038397241771</RMSE>
+            <NSE>0.38731259691225706</NSE>
+            <ME>0.33225799113189819</ME>
+            <MAE>32.331877950796006</MAE>
+            <RSR>0.78224542349246673</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Plantain.AboveGroundLive.NConc</Name>
             <n>831</n>
-            <Slope>0.78258187954463976</Slope>
-            <Intercept>0.002165444985180183</Intercept>
-            <SEslope>0.0472048470883153</SEslope>
-            <SEintercept>0.0014495030440949944</SEintercept>
-            <R2>0.24898813530803921</R2>
-            <RMSE>0.010451920401836011</RMSE>
-            <NSE>-1.2891513544262807</NSE>
-            <ME>-0.004339597936351039</ME>
-            <MAE>0.0087104393557668278</MAE>
-            <RSR>1.5120835491650622</RSR>
+            <Slope>0.78113367912731291</Slope>
+            <Intercept>0.0022038721524908038</Intercept>
+            <SEslope>0.047162785136594589</SEslope>
+            <SEintercept>0.0014482114621744834</SEintercept>
+            <R2>0.24862898008416678</R2>
+            <RMSE>0.010447886541048756</RMSE>
+            <NSE>-1.2873847248306771</NSE>
+            <ME>-0.0043445002111952794</ME>
+            <MAE>0.0087058322100084535</MAE>
+            <RSR>1.511499968894497</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Plantain.Population</Name>

--- a/Prototypes/Plantain/Plantain.apsimx
+++ b/Prototypes/Plantain/Plantain.apsimx
@@ -3728,30 +3728,30 @@ Where:
           <RegrStats>
             <Name>CumulativeHarvestedWt</Name>
             <n>670</n>
-            <Slope>0.97263569898704016</Slope>
-            <Intercept>-29.850749109976277</Intercept>
-            <SEslope>0.014642539152171853</SEslope>
-            <SEintercept>9.4125382365635364</SEintercept>
-            <R2>0.86851238312953383</R2>
-            <RMSE>140.57184036782164</RMSE>
-            <NSE>0.83992977516087675</NSE>
-            <ME>-44.581052572411672</ME>
-            <MAE>102.08763310450753</MAE>
-            <RSR>0.39978908696434096</RSR>
+            <Slope>0.97301754648021277</Slope>
+            <Intercept>-29.961824816562739</Intercept>
+            <SEslope>0.014653028607413462</SEslope>
+            <SEintercept>9.419281083382403</SEintercept>
+            <R2>0.86843845644490292</R2>
+            <RMSE>140.62292315289693</RMSE>
+            <NSE>0.83981341731037351</NSE>
+            <ME>-44.486578374831844</ME>
+            <MAE>102.12674385288416</MAE>
+            <RSR>0.39993436741276794</RSR>
           </RegrStats>
           <RegrStats>
             <Name>HarvestedWt</Name>
             <n>660</n>
-            <Slope>0.58666543617089173</Slope>
-            <Intercept>49.1235910029763</Intercept>
-            <SEslope>0.024016648669865689</SEslope>
-            <SEintercept>3.4299652545784025</SEintercept>
-            <R2>0.47557193974502376</R2>
-            <RMSE>59.149202967143111</RMSE>
-            <NSE>0.44961708644941645</NSE>
-            <ME>0.14783064298488718</ME>
-            <MAE>41.795830500480371</MAE>
-            <RSR>0.74131572224336628</RSR>
+            <Slope>0.58675635139411075</Slope>
+            <Intercept>49.134411690069257</Intercept>
+            <SEslope>0.024025805404948825</SEslope>
+            <SEintercept>3.4312729842126357</SEintercept>
+            <R2>0.47545909298109168</R2>
+            <RMSE>59.160775796202778</RMSE>
+            <NSE>0.44940169519587736</NSE>
+            <ME>0.1694238194243792</ME>
+            <MAE>41.812448851673558</MAE>
+            <RSR>0.741460764267644</RSR>
           </RegrStats>
           <RegrStats>
             <Name>NRate</Name>
@@ -3770,30 +3770,30 @@ Where:
           <RegrStats>
             <Name>Plantain.AboveGround.Wt</Name>
             <n>786</n>
-            <Slope>0.60766610435356561</Slope>
-            <Intercept>55.886659751451234</Intercept>
-            <SEslope>0.024186567589407043</SEslope>
-            <SEintercept>3.7152189261279402</SEintercept>
-            <R2>0.44602297747566788</R2>
-            <RMSE>46.747520587257846</RMSE>
-            <NSE>0.38740479750708468</NSE>
-            <ME>0.363876314141972</ME>
-            <MAE>32.332655098789843</MAE>
-            <RSR>0.78218656296540723</RSR>
+            <Slope>0.6074168351064293</Slope>
+            <Intercept>55.897495540938678</Intercept>
+            <SEslope>0.024175776201930385</SEslope>
+            <SEintercept>3.7135612966671143</SEintercept>
+            <R2>0.4460407581708119</R2>
+            <RMSE>46.739189397848449</RMSE>
+            <NSE>0.38762312745577876</NSE>
+            <ME>0.33943571639926889</ME>
+            <MAE>32.325339938730181</MAE>
+            <RSR>0.78204716424804877</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Plantain.AboveGroundLive.NConc</Name>
             <n>831</n>
-            <Slope>0.78215234804982992</Slope>
-            <Intercept>0.0021820472221256992</Intercept>
-            <SEslope>0.0472087526432056</SEslope>
-            <SEintercept>0.0014496229706290594</SEintercept>
-            <R2>0.24875194521937127</R2>
-            <RMSE>0.010451488388894327</RMSE>
-            <NSE>-1.2889621217236962</NSE>
-            <ME>-0.0043358470698618484</ME>
-            <MAE>0.0087095523908045161</MAE>
-            <RSR>1.5120210496781705</RSR>
+            <Slope>0.78258187954463976</Slope>
+            <Intercept>0.002165444985180183</Intercept>
+            <SEslope>0.0472048470883153</SEslope>
+            <SEintercept>0.0014495030440949944</SEintercept>
+            <R2>0.24898813530803921</R2>
+            <RMSE>0.010451920401836011</RMSE>
+            <NSE>-1.2891513544262807</NSE>
+            <ME>-0.004339597936351039</ME>
+            <MAE>0.0087104393557668278</MAE>
+            <RSR>1.5120835491650622</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Plantain.Population</Name>

--- a/Prototypes/SugarCane/Validation/SugarcaneValidation.apsimx
+++ b/Prototypes/SugarCane/Validation/SugarcaneValidation.apsimx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Simulations xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="7">
+<Simulations xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="8">
   <Name>Simulations</Name>
   <Memo>
     <Name>Memo</Name>
@@ -264,14 +264,6 @@ However we have to report daily because we have observation data during the crop
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -4336,14 +4328,6 @@ nb. fertiliser amounts are in (kg/ha) and depths in (mm)
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -7606,14 +7590,6 @@ nb. irrigation amounts and depths are in (mm)
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -10881,14 +10857,6 @@ They are missing the word "tillage". This means these tillage events won't occur
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -14114,14 +14082,6 @@ Unfortunately solute in irrigations is not possible in ApsimX yet.
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -17387,14 +17347,6 @@ Unfortunately solute in irrigations is not possible in ApsimX yet.
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -20592,14 +20544,6 @@ However Automatic Irrigations are not possible in ApsimX yet.
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -23833,14 +23777,6 @@ All operation irrigations are Overhead, high pressure gun
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -27078,14 +27014,6 @@ All operation irrigations are Overhead, high pressure gun
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -30321,14 +30249,6 @@ All operation irrigations are Overhead, high pressure gun
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -33603,14 +33523,6 @@ All operation irrigations are subsurface trickle irrigation unless stated otherw
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -36853,14 +36765,6 @@ All operation irrigations are subsurface trickle irrigation unless stated otherw
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -40058,14 +39962,6 @@ All operation irrigations are subsurface trickle irrigation unless stated otherw
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -42913,14 +42809,6 @@ All operation irrigations are subsurface trickle irrigation unless stated otherw
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -45864,14 +45752,6 @@ All operation irrigations are subsurface trickle irrigation unless stated otherw
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -48799,14 +48679,6 @@ All operation irrigations are subsurface trickle irrigation unless stated otherw
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -51742,14 +51614,6 @@ All operation irrigations are subsurface trickle irrigation unless stated otherw
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -54605,14 +54469,6 @@ All operation irrigations are subsurface trickle irrigation unless stated otherw
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -58096,14 +57952,6 @@ Likewise fertiliser applications are subsurface fertigations except for the foll
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -61297,14 +61145,6 @@ However Automatic Irrigations are not possible in ApsimX yet.
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -64832,14 +64672,6 @@ Likewise fertiliser applications are subsurface fertigations except the followin
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -68238,14 +68070,6 @@ Unfortunately solute in irrigations is not possible in ApsimX yet.
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -71561,14 +71385,6 @@ All operation irrigations are subsurface trickle irrigation except for the follo
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -74914,14 +74730,6 @@ All operation irrigations are subsurface trickle irrigation except for the follo
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -78275,14 +78083,6 @@ All operation irrigations are subsurface trickle irrigation except for the follo
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -81733,14 +81533,6 @@ All operation irrigations are subsurface trickle irrigation unless stated below,
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -84766,14 +84558,6 @@ All operation irrigations are subsurface trickle irrigation unless stated below,
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -87699,14 +87483,6 @@ All operation irrigations are subsurface trickle irrigation unless stated below,
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -90700,14 +90476,6 @@ All operation irrigations are subsurface trickle irrigation unless stated below,
               <double>0.08</double>
               <double>0.9</double>
             </fract_lign>
-            <wfpsN2N2O_x>
-              <double>22</double>
-              <double>88</double>
-            </wfpsN2N2O_x>
-            <wfpsN2N2O_y>
-              <double>0.1</double>
-              <double>1</double>
-            </wfpsN2N2O_y>
           </SoilNitrogen>
           <SoilOrganicMatter>
             <Name>SoilOrganicMatter</Name>
@@ -93447,16 +93215,16 @@ All operation irrigations are subsurface trickle irrigation unless stated below,
           <RegrStats>
             <Name>biomass</Name>
             <n>189</n>
-            <Slope>0.98556804966410394</Slope>
-            <Intercept>16.911084264918372</Intercept>
-            <SEslope>0.027566863220185086</SEslope>
-            <SEintercept>116.7390126286445</SEintercept>
-            <R2>0.872372299568194</R2>
-            <RMSE>949.812485601906</RMSE>
-            <NSE>0.85752022913391812</NSE>
-            <ME>-32.245436500065523</ME>
-            <MAE>663.43422996742959</MAE>
-            <RSR>0.37646501782312813</RSR>
+            <Slope>0.98556788621734426</Slope>
+            <Intercept>16.892434630074149</Intercept>
+            <SEslope>0.027566758830621117</SEslope>
+            <SEintercept>116.73857056403494</SEintercept>
+            <R2>0.87237310586965267</R2>
+            <RMSE>949.80956623990016</RMSE>
+            <NSE>0.85752110498972489</NSE>
+            <ME>-32.264642849271894</ME>
+            <MAE>663.43491779811757</MAE>
+            <RSR>0.37646386071297616</RSR>
           </RegrStats>
           <RegrStats>
             <Name>cab_N</Name>
@@ -93475,58 +93243,58 @@ All operation irrigations are subsurface trickle irrigation unless stated below,
           <RegrStats>
             <Name>cane_dmc</Name>
             <n>188</n>
-            <Slope>-0.51962907190811281</Slope>
-            <Intercept>0.45137108021114469</Intercept>
-            <SEslope>0.10718209247977376</SEslope>
-            <SEintercept>0.023514956334943</SEintercept>
-            <R2>0.11218893560233345</R2>
-            <RMSE>0.28699384283207052</RMSE>
-            <NSE>-5.6144739562570756</NSE>
-            <ME>0.16432284839228456</ME>
-            <MAE>0.16489293776287012</MAE>
-            <RSR>2.5650127844027071</RSR>
+            <Slope>-0.51151074957704434</Slope>
+            <Intercept>0.44930232240914614</Intercept>
+            <SEslope>0.10782987797751058</SEslope>
+            <SEintercept>0.023657075669817576</SEintercept>
+            <R2>0.10792448337604688</R2>
+            <RMSE>0.28671590931788643</RMSE>
+            <NSE>-5.6016688465746505</NSE>
+            <ME>0.1637875898589877</ME>
+            <MAE>0.1643576868624749</MAE>
+            <RSR>2.56252874847336</RSR>
           </RegrStats>
           <RegrStats>
             <Name>cane_N</Name>
             <n>168</n>
-            <Slope>0.93112285741876433</Slope>
-            <Intercept>1.2889913593793594</Intercept>
-            <SEslope>0.04776048405716015</SEslope>
-            <SEintercept>0.51205284112760574</SEintercept>
-            <R2>0.69601597585823916</R2>
-            <RMSE>4.4975563370247471</RMSE>
-            <NSE>0.60594194607252827</NSE>
-            <ME>0.73964284894012022</ME>
-            <MAE>3.1805952205260595</MAE>
-            <RSR>0.62586937157296774</RSR>
+            <Slope>0.93112422081288515</Slope>
+            <Intercept>1.2889209614467037</Intercept>
+            <SEslope>0.047760831506886564</SEslope>
+            <SEintercept>0.51205656622845153</SEintercept>
+            <R2>0.69601351708062653</R2>
+            <RMSE>4.4975769169389181</RMSE>
+            <NSE>0.60593833980331246</NSE>
+            <ME>0.73958332513059644</ME>
+            <MAE>3.180654744335583</MAE>
+            <RSR>0.62587223542546533</RSR>
           </RegrStats>
           <RegrStats>
             <Name>cane_wt</Name>
             <n>196</n>
-            <Slope>1.0516341698483056</Slope>
-            <Intercept>6.3243254330809577</Intercept>
-            <SEslope>0.030960850006655303</SEslope>
-            <SEintercept>98.107485251786642</SEintercept>
-            <R2>0.85605409565905455</R2>
-            <RMSE>891.48999447339622</RMSE>
-            <NSE>0.80714522414124823</NSE>
-            <ME>131.95607462201713</ME>
-            <MAE>605.51913310615419</MAE>
-            <RSR>0.43803061870227394</RSR>
+            <Slope>1.0516316746376304</Slope>
+            <Intercept>6.3167230922240378</Intercept>
+            <SEslope>0.030961255600747278</SEslope>
+            <SEintercept>98.108770481888143</SEintercept>
+            <R2>0.85605028232071867</R2>
+            <RMSE>891.49863654346768</RMSE>
+            <NSE>0.807141485069413</NSE>
+            <ME>131.9424011526294</ME>
+            <MAE>605.52474535105216</MAE>
+            <RSR>0.43803486495441785</RSR>
           </RegrStats>
           <RegrStats>
             <Name>canefw</Name>
             <n>188</n>
-            <Slope>0.86705661987838978</Slope>
-            <Intercept>-5.4662443762979223</Intercept>
-            <SEslope>0.0323561925155714</SEslope>
-            <SEintercept>4.0250303264983733</SEintercept>
-            <R2>0.79426872742341725</R2>
-            <RMSE>38.349235308205131</RMSE>
-            <NSE>0.71930321577486134</NSE>
-            <ME>-18.91615442902679</ME>
-            <MAE>28.819294594242738</MAE>
-            <RSR>0.52839730906197957</RSR>
+            <Slope>0.86705371674375453</Slope>
+            <Intercept>-5.4663409795408029</Intercept>
+            <SEslope>0.03235667371312044</SEslope>
+            <SEintercept>4.02509018628339</SEintercept>
+            <R2>0.79426277283378788</R2>
+            <RMSE>38.349876215878922</RMSE>
+            <NSE>0.71929383346385256</NSE>
+            <ME>-18.916544743018434</ME>
+            <MAE>28.819934325137972</MAE>
+            <RSR>0.52840613984797735</RSR>
           </RegrStats>
           <RegrStats>
             <Name>das</Name>
@@ -93545,44 +93313,44 @@ All operation irrigations are subsurface trickle irrigation unless stated below,
           <RegrStats>
             <Name>green_biomass</Name>
             <n>182</n>
-            <Slope>1.0165407880148518</Slope>
-            <Intercept>-47.220441781173122</Intercept>
-            <SEslope>0.031086172308144477</SEslope>
-            <SEintercept>116.36960845569696</SEintercept>
-            <R2>0.855923730734</R2>
-            <RMSE>905.47586941683437</RMSE>
-            <NSE>0.82578114914340606</NSE>
-            <ME>3.2421487552508386</ME>
-            <MAE>649.83873003236522</MAE>
-            <RSR>0.41624704734486212</RSR>
+            <Slope>1.0165365569402205</Slope>
+            <Intercept>-47.224511652315414</Intercept>
+            <SEslope>0.031086147730726547</SEslope>
+            <SEintercept>116.36951645130115</SEintercept>
+            <R2>0.85592289916854358</R2>
+            <RMSE>905.47473033670133</RMSE>
+            <NSE>0.82578158747448416</NSE>
+            <ME>3.2251707332728121</ME>
+            <MAE>649.836916845552</MAE>
+            <RSR>0.41624652370998894</RSR>
           </RegrStats>
           <RegrStats>
             <Name>green_biomass_n</Name>
             <n>166</n>
-            <Slope>0.81997764097852821</Slope>
-            <Intercept>1.5805287958497498</Intercept>
-            <SEslope>0.04545335185192103</SEslope>
-            <SEintercept>0.86133151717108836</SEintercept>
-            <R2>0.66492382377931</R2>
-            <RMSE>6.22478830554513</RMSE>
-            <NSE>0.61131739105350924</NSE>
-            <ME>-1.3189156550743502</ME>
+            <Slope>0.81994659557454319</Slope>
+            <Intercept>1.5807878500187531</Intercept>
+            <SEslope>0.045453118731167919</SEslope>
+            <SEintercept>0.86132709958154252</SEintercept>
+            <R2>0.66490923770214749</R2>
+            <RMSE>6.2249010484679443</RMSE>
+            <NSE>0.61130331134249838</NSE>
+            <ME>-1.3191566189297721</ME>
             <MAE>4.6512048478945172</MAE>
-            <RSR>0.62156347016761937</RSR>
+            <RSR>0.62157472788095869</RSR>
           </RegrStats>
           <RegrStats>
             <Name>lai</Name>
             <n>185</n>
-            <Slope>0.77313690302697935</Slope>
-            <Intercept>0.76590173820833884</Intercept>
-            <SEslope>0.044156067081608</SEslope>
-            <SEintercept>0.20714137642027816</SEintercept>
-            <R2>0.62620387077942574</R2>
-            <RMSE>1.2936015801820378</RMSE>
-            <NSE>0.5820676656698992</NSE>
-            <ME>-0.19666611986268573</ME>
-            <MAE>0.97852384862153141</MAE>
-            <RSR>0.64472726065447183</RSR>
+            <Slope>0.77312922151953023</Slope>
+            <Intercept>0.765894210540925</Intercept>
+            <SEslope>0.044156185668522349</SEslope>
+            <SEintercept>0.20714193272563522</SEintercept>
+            <R2>0.62619796221411206</R2>
+            <RMSE>1.2936160401773056</RMSE>
+            <NSE>0.58205832224693865</NSE>
+            <ME>-0.19670623975100188</ME>
+            <MAE>0.97853957631964517</MAE>
+            <RSR>0.64473446747400642</RSR>
           </RegrStats>
           <RegrStats>
             <Name>leaf_N</Name>
@@ -93601,44 +93369,44 @@ All operation irrigations are subsurface trickle irrigation unless stated below,
           <RegrStats>
             <Name>scmst</Name>
             <n>143</n>
-            <Slope>0.94627158466987238</Slope>
-            <Intercept>-0.011837222942572112</Intercept>
-            <SEslope>0.044884375808657284</SEslope>
-            <SEintercept>0.016853855890294447</SEintercept>
-            <R2>0.75916732808933562</R2>
-            <RMSE>0.10561920301088912</RMSE>
-            <NSE>0.68920814978737943</NSE>
-            <ME>-0.02925574979485673</ME>
-            <MAE>0.071054475457585489</MAE>
-            <RSR>0.5555344099429973</RSR>
+            <Slope>0.94627501781070744</Slope>
+            <Intercept>-0.011836889830566688</Intercept>
+            <SEslope>0.044884499418051678</SEslope>
+            <SEintercept>0.016853902304996272</SEintercept>
+            <R2>0.75916764772285028</R2>
+            <RMSE>0.10561900562344827</RMSE>
+            <NSE>0.68920931143883823</NSE>
+            <ME>-0.029254303672995079</ME>
+            <MAE>0.071053588846279964</MAE>
+            <RSR>0.55553337172729067</RSR>
           </RegrStats>
           <RegrStats>
             <Name>scmstf</Name>
             <n>143</n>
-            <Slope>0.9959368889277358</Slope>
-            <Intercept>0.010715408830899831</Intercept>
-            <SEslope>0.047934061269220646</SEslope>
-            <SEintercept>0.0048633191341844228</SEintercept>
-            <R2>0.75379486644073634</R2>
-            <RMSE>0.034143562864894485</RMSE>
-            <NSE>0.64305482297093941</NSE>
-            <ME>0.010374789420936878</ME>
-            <MAE>0.02347176148048909</MAE>
-            <RSR>0.59535624369781859</RSR>
+            <Slope>0.99593929560875694</Slope>
+            <Intercept>0.010715620226671066</Intercept>
+            <SEslope>0.04793424924559031</SEslope>
+            <SEintercept>0.0048633382059895475</SEintercept>
+            <R2>0.75379430779869461</R2>
+            <RMSE>0.034143808998766928</RMSE>
+            <NSE>0.64304967666469759</NSE>
+            <ME>0.010375202573995815</ME>
+            <MAE>0.023472047383682557</MAE>
+            <RSR>0.59536053549766155</RSR>
           </RegrStats>
           <RegrStats>
             <Name>sucrose_wt</Name>
             <n>152</n>
-            <Slope>1.0899021964076132</Slope>
-            <Intercept>-111.01132675322788</Intercept>
-            <SEslope>0.048715489466992862</SEslope>
-            <SEintercept>78.47834822866362</SEintercept>
-            <R2>0.76942319429084183</R2>
-            <RMSE>604.00424356261544</RMSE>
-            <NSE>0.63593171144890881</NSE>
-            <ME>2.4615105478376318</ME>
-            <MAE>394.32335464076039</MAE>
-            <RSR>0.60139263583968372</RSR>
+            <Slope>1.0899003217667658</Slope>
+            <Intercept>-111.01297377520655</Intercept>
+            <SEslope>0.048715846051869259</SEslope>
+            <SEintercept>78.47892267002527</SEintercept>
+            <R2>0.76941998677888357</R2>
+            <RMSE>604.00827055280979</RMSE>
+            <NSE>0.63592685683296524</NSE>
+            <ME>2.4574973899428705</ME>
+            <MAE>394.32684148286552</MAE>
+            <RSR>0.6013966454178834</RSR>
           </RegrStats>
         </AcceptedStats>
         <AcceptedStatsName>Name n Slope Intercept SEslope SEintercept R2 RMSE NSE ME MAE RSR</AcceptedStatsName>

--- a/Prototypes/SugarCane/Validation/SugarcaneValidation.apsimx
+++ b/Prototypes/SugarCane/Validation/SugarcaneValidation.apsimx
@@ -93215,16 +93215,16 @@ All operation irrigations are subsurface trickle irrigation unless stated below,
           <RegrStats>
             <Name>biomass</Name>
             <n>189</n>
-            <Slope>0.98556788621734426</Slope>
-            <Intercept>16.892434630074149</Intercept>
-            <SEslope>0.027566758830621117</SEslope>
-            <SEintercept>116.73857056403494</SEintercept>
-            <R2>0.87237310586965267</R2>
-            <RMSE>949.80956623990016</RMSE>
-            <NSE>0.85752110498972489</NSE>
-            <ME>-32.264642849271894</ME>
-            <MAE>663.43491779811757</MAE>
-            <RSR>0.37646386071297616</RSR>
+            <Slope>0.9855649186447758</Slope>
+            <Intercept>16.89603451262019</Intercept>
+            <SEslope>0.027566965493812511</SEslope>
+            <SEintercept>116.73944573277348</SEintercept>
+            <R2>0.8723707660040263</R2>
+            <RMSE>949.81717479795191</RMSE>
+            <NSE>0.857518822293647</NSE>
+            <ME>-32.271150785779817</ME>
+            <MAE>663.43973261293252</MAE>
+            <RSR>0.37646687641974563</RSR>
           </RegrStats>
           <RegrStats>
             <Name>cab_N</Name>
@@ -93243,58 +93243,58 @@ All operation irrigations are subsurface trickle irrigation unless stated below,
           <RegrStats>
             <Name>cane_dmc</Name>
             <n>188</n>
-            <Slope>-0.51151074957704434</Slope>
-            <Intercept>0.44930232240914614</Intercept>
-            <SEslope>0.10782987797751058</SEslope>
-            <SEintercept>0.023657075669817576</SEintercept>
-            <R2>0.10792448337604688</R2>
-            <RMSE>0.28671590931788643</RMSE>
-            <NSE>-5.6016688465746505</NSE>
-            <ME>0.1637875898589877</ME>
-            <MAE>0.1643576868624749</MAE>
-            <RSR>2.56252874847336</RSR>
+            <Slope>-0.52035652721823722</Slope>
+            <Intercept>0.45155640776732836</Intercept>
+            <SEslope>0.10713428683549177</SEslope>
+            <SEintercept>0.023504468131066342</SEintercept>
+            <R2>0.11255701423923337</R2>
+            <RMSE>0.28702791361646113</RMSE>
+            <NSE>-5.616044538334684</NSE>
+            <ME>0.16437076428376771</ME>
+            <MAE>0.16494086518982179</MAE>
+            <RSR>2.5653172926690662</RSR>
           </RegrStats>
           <RegrStats>
             <Name>cane_N</Name>
             <n>168</n>
-            <Slope>0.93112422081288515</Slope>
-            <Intercept>1.2889209614467037</Intercept>
-            <SEslope>0.047760831506886564</SEslope>
-            <SEintercept>0.51205656622845153</SEintercept>
-            <R2>0.69601351708062653</R2>
-            <RMSE>4.4975769169389181</RMSE>
-            <NSE>0.60593833980331246</NSE>
-            <ME>0.73958332513059644</ME>
-            <MAE>3.180654744335583</MAE>
-            <RSR>0.62587223542546533</RSR>
+            <Slope>0.93111607571721333</Slope>
+            <Intercept>1.2889264010779815</Intercept>
+            <SEslope>0.0477612308939832</SEslope>
+            <SEintercept>0.512060848163645</SEintercept>
+            <R2>0.69600627688209293</R2>
+            <RMSE>4.4976096725526249</RMSE>
+            <NSE>0.60593259992214554</NSE>
+            <ME>0.73952380132107254</ME>
+            <MAE>3.180714268145107</MAE>
+            <RSR>0.62587679361970017</RSR>
           </RegrStats>
           <RegrStats>
             <Name>cane_wt</Name>
             <n>196</n>
-            <Slope>1.0516316746376304</Slope>
-            <Intercept>6.3167230922240378</Intercept>
-            <SEslope>0.030961255600747278</SEslope>
-            <SEintercept>98.108770481888143</SEintercept>
-            <R2>0.85605028232071867</R2>
-            <RMSE>891.49863654346768</RMSE>
-            <NSE>0.807141485069413</NSE>
-            <ME>131.9424011526294</ME>
-            <MAE>605.52474535105216</MAE>
-            <RSR>0.43803486495441785</RSR>
+            <Slope>1.0516292508195617</Slope>
+            <Intercept>6.3182837798108267</Intercept>
+            <SEslope>0.030961345281556429</SEslope>
+            <SEintercept>98.109054658797348</SEintercept>
+            <R2>0.85604900040644183</R2>
+            <RMSE>891.499906251009</RMSE>
+            <NSE>0.80714093571560541</NSE>
+            <ME>131.93806441793552</ME>
+            <MAE>605.52581677962348</MAE>
+            <RSR>0.43803548882095961</RSR>
           </RegrStats>
           <RegrStats>
             <Name>canefw</Name>
             <n>188</n>
-            <Slope>0.86705371674375453</Slope>
-            <Intercept>-5.4663409795408029</Intercept>
-            <SEslope>0.03235667371312044</SEslope>
-            <SEintercept>4.02509018628339</SEintercept>
-            <R2>0.79426277283378788</R2>
-            <RMSE>38.349876215878922</RMSE>
-            <NSE>0.71929383346385256</NSE>
-            <ME>-18.916544743018434</ME>
-            <MAE>28.819934325137972</MAE>
-            <RSR>0.52840613984797735</RSR>
+            <Slope>0.867051597389933</Slope>
+            <Intercept>-5.4662740354886523</Intercept>
+            <SEslope>0.0323567145372808</SEslope>
+            <SEintercept>4.0250952647079732</SEintercept>
+            <R2>0.79426156163694339</R2>
+            <RMSE>38.350021018679961</RMSE>
+            <NSE>0.7192917136595699</NSE>
+            <ME>-18.916692214443326</ME>
+            <MAE>28.820011062021205</MAE>
+            <RSR>0.52840813502232176</RSR>
           </RegrStats>
           <RegrStats>
             <Name>das</Name>
@@ -93313,16 +93313,16 @@ All operation irrigations are subsurface trickle irrigation unless stated below,
           <RegrStats>
             <Name>green_biomass</Name>
             <n>182</n>
-            <Slope>1.0165365569402205</Slope>
-            <Intercept>-47.224511652315414</Intercept>
-            <SEslope>0.031086147730726547</SEslope>
-            <SEintercept>116.36951645130115</SEintercept>
-            <R2>0.85592289916854358</R2>
-            <RMSE>905.47473033670133</RMSE>
-            <NSE>0.82578158747448416</NSE>
-            <ME>3.2251707332728121</ME>
-            <MAE>649.836916845552</MAE>
-            <RSR>0.41624652370998894</RSR>
+            <Slope>1.0165353980971104</Slope>
+            <Intercept>-47.225316916286829</Intercept>
+            <SEslope>0.031086333924071608</SEslope>
+            <SEintercept>116.37021345723829</SEintercept>
+            <R2>0.8559211407391939</R2>
+            <RMSE>905.48003013492166</RMSE>
+            <NSE>0.8257795480467589</NSE>
+            <ME>3.2208300739322078</ME>
+            <MAE>649.83949926313414</MAE>
+            <RSR>0.4162489600260027</RSR>
           </RegrStats>
           <RegrStats>
             <Name>green_biomass_n</Name>
@@ -93341,16 +93341,16 @@ All operation irrigations are subsurface trickle irrigation unless stated below,
           <RegrStats>
             <Name>lai</Name>
             <n>185</n>
-            <Slope>0.77312922151953023</Slope>
-            <Intercept>0.765894210540925</Intercept>
-            <SEslope>0.044156185668522349</SEslope>
-            <SEintercept>0.20714193272563522</SEintercept>
-            <R2>0.62619796221411206</R2>
-            <RMSE>1.2936160401773056</RMSE>
-            <NSE>0.58205832224693865</NSE>
-            <ME>-0.19670623975100188</ME>
-            <MAE>0.97853957631964517</MAE>
-            <RSR>0.64473446747400642</RSR>
+            <Slope>0.77312632086516675</Slope>
+            <Intercept>0.7659034762439596</Intercept>
+            <SEslope>0.044156271637813313</SEslope>
+            <SEintercept>0.20714233601783122</SEintercept>
+            <R2>0.62619529433786469</R2>
+            <RMSE>1.2936206897522609</RMSE>
+            <NSE>0.58205531787069487</NSE>
+            <ME>-0.19670928136764812</ME>
+            <MAE>0.97854213838989812</MAE>
+            <RSR>0.64473678480862484</RSR>
           </RegrStats>
           <RegrStats>
             <Name>leaf_N</Name>
@@ -93369,44 +93369,44 @@ All operation irrigations are subsurface trickle irrigation unless stated below,
           <RegrStats>
             <Name>scmst</Name>
             <n>143</n>
-            <Slope>0.94627501781070744</Slope>
-            <Intercept>-0.011836889830566688</Intercept>
-            <SEslope>0.044884499418051678</SEslope>
-            <SEintercept>0.016853902304996272</SEintercept>
-            <R2>0.75916764772285028</R2>
-            <RMSE>0.10561900562344827</RMSE>
-            <NSE>0.68920931143883823</NSE>
-            <ME>-0.029254303672995079</ME>
-            <MAE>0.071053588846279964</MAE>
-            <RSR>0.55553337172729067</RSR>
+            <Slope>0.94627797480072717</Slope>
+            <Intercept>-0.011837156729178566</Intercept>
+            <SEslope>0.044884686757991545</SEslope>
+            <SEintercept>0.016853972650195292</SEintercept>
+            <R2>0.75916726416094282</R2>
+            <RMSE>0.10561916296134358</RMSE>
+            <NSE>0.68920838548448082</NSE>
+            <ME>-0.029253611927847378</ME>
+            <MAE>0.07105362614064388</MAE>
+            <RSR>0.5555341992909566</RSR>
           </RegrStats>
           <RegrStats>
             <Name>scmstf</Name>
             <n>143</n>
-            <Slope>0.99593929560875694</Slope>
-            <Intercept>0.010715620226671066</Intercept>
-            <SEslope>0.04793424924559031</SEslope>
-            <SEintercept>0.0048633382059895475</SEintercept>
-            <R2>0.75379430779869461</R2>
-            <RMSE>0.034143808998766928</RMSE>
-            <NSE>0.64304967666469759</NSE>
-            <ME>0.010375202573995815</ME>
-            <MAE>0.023472047383682557</MAE>
-            <RSR>0.59536053549766155</RSR>
+            <Slope>0.99594294071134437</Slope>
+            <Intercept>0.010715539837644394</Intercept>
+            <SEslope>0.047934375988202819</SEslope>
+            <SEintercept>0.0048633510651080163</SEintercept>
+            <R2>0.75379468486539258</R2>
+            <RMSE>0.034143957950635281</RMSE>
+            <NSE>0.64304656227675427</NSE>
+            <ME>0.010375427761821522</ME>
+            <MAE>0.023472197218018361</MAE>
+            <RSR>0.59536313274930708</RSR>
           </RegrStats>
           <RegrStats>
             <Name>sucrose_wt</Name>
             <n>152</n>
-            <Slope>1.0899003217667658</Slope>
-            <Intercept>-111.01297377520655</Intercept>
-            <SEslope>0.048715846051869259</SEslope>
-            <SEintercept>78.47892267002527</SEintercept>
-            <R2>0.76941998677888357</R2>
-            <RMSE>604.00827055280979</RMSE>
-            <NSE>0.63592685683296524</NSE>
-            <ME>2.4574973899428705</ME>
-            <MAE>394.32684148286552</MAE>
-            <RSR>0.6013966454178834</RSR>
+            <Slope>1.0899013689037786</Slope>
+            <Intercept>-111.01396650419997</Intercept>
+            <SEslope>0.048715926968029177</SEslope>
+            <SEintercept>78.4790530221298</SEintercept>
+            <R2>0.76941973832363075</R2>
+            <RMSE>604.00940902897526</RMSE>
+            <NSE>0.63592548437167</NSE>
+            <ME>2.4578263373112867</ME>
+            <MAE>394.32782832497071</MAE>
+            <RSR>0.60139777897147884</RSR>
           </RegrStats>
         </AcceptedStats>
         <AcceptedStatsName>Name n Slope Intercept SEslope SEintercept R2 RMSE NSE ME MAE RSR</AcceptedStatsName>

--- a/Prototypes/SugarCane/Validation/SugarcaneValidation.apsimx
+++ b/Prototypes/SugarCane/Validation/SugarcaneValidation.apsimx
@@ -93243,16 +93243,16 @@ All operation irrigations are subsurface trickle irrigation unless stated below,
           <RegrStats>
             <Name>cane_dmc</Name>
             <n>188</n>
-            <Slope>-0.52035652721823722</Slope>
-            <Intercept>0.45155640776732836</Intercept>
-            <SEslope>0.10713428683549177</SEslope>
-            <SEintercept>0.023504468131066342</SEintercept>
-            <R2>0.11255701423923337</R2>
-            <RMSE>0.28702791361646113</RMSE>
-            <NSE>-5.616044538334684</NSE>
-            <ME>0.16437076428376771</ME>
-            <MAE>0.16494086518982179</MAE>
-            <RSR>2.5653172926690662</RSR>
+            <Slope>-0.517471191848017</Slope>
+            <Intercept>0.4508211782953272</Intercept>
+            <SEslope>0.10733395815738113</SEslope>
+            <SEintercept>0.023548274538526197</SEintercept>
+            <R2>0.11108271160992322</R2>
+            <RMSE>0.28690166903331848</RMSE>
+            <NSE>-5.6102258979737361</NSE>
+            <ME>0.16418055624596808</ME>
+            <MAE>0.16475065715202758</MAE>
+            <RSR>2.5641889793696344</RSR>
           </RegrStats>
           <RegrStats>
             <Name>cane_N</Name>
@@ -93285,16 +93285,16 @@ All operation irrigations are subsurface trickle irrigation unless stated below,
           <RegrStats>
             <Name>canefw</Name>
             <n>188</n>
-            <Slope>0.867051597389933</Slope>
-            <Intercept>-5.4662740354886523</Intercept>
-            <SEslope>0.0323567145372808</SEslope>
-            <SEintercept>4.0250952647079732</SEintercept>
-            <R2>0.79426156163694339</R2>
-            <RMSE>38.350021018679961</RMSE>
-            <NSE>0.7192917136595699</NSE>
-            <ME>-18.916692214443326</ME>
-            <MAE>28.820011062021205</MAE>
-            <RSR>0.52840813502232176</RSR>
+            <Slope>0.86705159740448723</Slope>
+            <Intercept>-5.4662740372798027</Intercept>
+            <SEslope>0.032356714537322737</SEslope>
+            <SEintercept>4.02509526471319</SEintercept>
+            <R2>0.79426156164200579</R2>
+            <RMSE>38.350021018607265</RMSE>
+            <NSE>0.719291713660634</NSE>
+            <ME>-18.916692214761969</ME>
+            <MAE>28.820011062014171</MAE>
+            <RSR>0.52840813502132011</RSR>
           </RegrStats>
           <RegrStats>
             <Name>das</Name>
@@ -93341,16 +93341,16 @@ All operation irrigations are subsurface trickle irrigation unless stated below,
           <RegrStats>
             <Name>lai</Name>
             <n>185</n>
-            <Slope>0.77312632086516675</Slope>
-            <Intercept>0.7659034762439596</Intercept>
-            <SEslope>0.044156271637813313</SEslope>
-            <SEintercept>0.20714233601783122</SEintercept>
-            <R2>0.62619529433786469</R2>
-            <RMSE>1.2936206897522609</RMSE>
-            <NSE>0.58205531787069487</NSE>
-            <ME>-0.19670928136764812</ME>
-            <MAE>0.97854213838989812</MAE>
-            <RSR>0.64473678480862484</RSR>
+            <Slope>0.77312632087349131</Slope>
+            <Intercept>0.765903476177701</Intercept>
+            <SEslope>0.044156271638122212</SEslope>
+            <SEintercept>0.20714233601928028</SEintercept>
+            <R2>0.6261952943396305</R2>
+            <RMSE>1.2936206897588354</RMSE>
+            <NSE>0.58205531786644671</NSE>
+            <ME>-0.19670928139858676</ME>
+            <MAE>0.97854213840227222</MAE>
+            <RSR>0.64473678481190155</RSR>
           </RegrStats>
           <RegrStats>
             <Name>leaf_N</Name>
@@ -93369,30 +93369,30 @@ All operation irrigations are subsurface trickle irrigation unless stated below,
           <RegrStats>
             <Name>scmst</Name>
             <n>143</n>
-            <Slope>0.94627797480072717</Slope>
-            <Intercept>-0.011837156729178566</Intercept>
-            <SEslope>0.044884686757991545</SEslope>
-            <SEintercept>0.016853972650195292</SEintercept>
-            <R2>0.75916726416094282</R2>
-            <RMSE>0.10561916296134358</RMSE>
-            <NSE>0.68920838548448082</NSE>
-            <ME>-0.029253611927847378</ME>
-            <MAE>0.07105362614064388</MAE>
-            <RSR>0.5555341992909566</RSR>
+            <Slope>0.94627797480083375</Slope>
+            <Intercept>-0.011837156728847442</Intercept>
+            <SEslope>0.044884686758221416</SEslope>
+            <SEintercept>0.016853972650281608</SEintercept>
+            <R2>0.75916726415911118</R2>
+            <RMSE>0.10561916296173471</RMSE>
+            <NSE>0.68920838548217889</NSE>
+            <ME>-0.029253611927481906</ME>
+            <MAE>0.0710536261404617</MAE>
+            <RSR>0.55553419929301384</RSR>
           </RegrStats>
           <RegrStats>
             <Name>scmstf</Name>
             <n>143</n>
-            <Slope>0.99594294071134437</Slope>
-            <Intercept>0.010715539837644394</Intercept>
-            <SEslope>0.047934375988202819</SEslope>
-            <SEintercept>0.0048633510651080163</SEintercept>
-            <R2>0.75379468486539258</R2>
-            <RMSE>0.034143957950635281</RMSE>
-            <NSE>0.64304656227675427</NSE>
-            <ME>0.010375427761821522</ME>
-            <MAE>0.023472197218018361</MAE>
-            <RSR>0.59536313274930708</RSR>
+            <Slope>0.99594294071273826</Slope>
+            <Intercept>0.010715539837622773</Intercept>
+            <SEslope>0.047934375988121967</SEslope>
+            <SEintercept>0.0048633510650998128</SEintercept>
+            <R2>0.75379468486653822</R2>
+            <RMSE>0.034143957950611273</RMSE>
+            <NSE>0.64304656227725632</NSE>
+            <ME>0.010375427761916812</ME>
+            <MAE>0.023472197217930483</MAE>
+            <RSR>0.59536313274888852</RSR>
           </RegrStats>
           <RegrStats>
             <Name>sucrose_wt</Name>

--- a/Prototypes/Wheat/WheatValidation.apsimx
+++ b/Prototypes/Wheat/WheatValidation.apsimx
@@ -4397,198 +4397,198 @@ namespace Models
           <RegrStats>
             <Name>ET</Name>
             <n>123</n>
-            <Slope>1.1427758415997269</Slope>
-            <Intercept>-0.42429687449016384</Intercept>
-            <SEslope>0.045001497628507608</SEslope>
-            <SEintercept>0.17456342924956211</SEintercept>
-            <R2>0.84200851337795657</R2>
-            <RMSE>0.78583255312266886</RMSE>
-            <NSE>0.73139585581509525</NSE>
-            <ME>0.08547583469875282</ME>
-            <MAE>0.575791989944872</MAE>
-            <RSR>0.51615924931647417</RSR>
+            <Slope>1.143000350651757</Slope>
+            <Intercept>-0.425979288408322</Intercept>
+            <SEslope>0.044922084716058658</SEslope>
+            <SEintercept>0.174255381938821</SEintercept>
+            <R2>0.84253000171711012</R2>
+            <RMSE>0.78456609972867342</RMSE>
+            <NSE>0.73226092691644751</NSE>
+            <ME>0.084595017089944088</ME>
+            <MAE>0.57506558499215565</MAE>
+            <RSR>0.51532740335827176</RSR>
           </RegrStats>
           <RegrStats>
             <Name>ProfileWater</Name>
             <n>1333</n>
-            <Slope>0.84435498107973128</Slope>
-            <Intercept>79.393092837041991</Intercept>
-            <SEslope>0.014271611794532841</SEslope>
-            <SEintercept>5.8504910353974307</SEintercept>
-            <R2>0.72450425110050154</R2>
-            <RMSE>60.439062010292</RMSE>
-            <NSE>0.67673118765556062</NSE>
-            <ME>17.770596776492567</ME>
-            <MAE>37.724247321932616</MAE>
-            <RSR>0.56835402708797778</RSR>
+            <Slope>0.84435584726382151</Slope>
+            <Intercept>79.392859155957126</Intercept>
+            <SEslope>0.014271614090530783</SEslope>
+            <SEintercept>5.850491976616655</SEintercept>
+            <R2>0.72450459639417986</R2>
+            <RMSE>60.439077082785943</RMSE>
+            <NSE>0.67673102641984118</NSE>
+            <ME>17.770706032342662</ME>
+            <MAE>37.724279206289836</MAE>
+            <RSR>0.568354168825992</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Soil.SoilWater.SW(1)</Name>
             <n>1306</n>
-            <Slope>0.00040371806345410423</Slope>
-            <Intercept>0.19440828850249231</Intercept>
-            <SEslope>0.00012449119432170986</SEslope>
-            <SEintercept>0.0023649633761797821</SEintercept>
-            <R2>0.0080004237633715114</R2>
-            <RMSE>18.935258324305867</RMSE>
-            <NSE>-0.080629211142026147</NSE>
-            <ME>-5.197428177096679</ME>
-            <MAE>5.2541292120242753</MAE>
-            <RSR>1.0391351099978667</RSR>
+            <Slope>0.00040371787318510441</Slope>
+            <Intercept>0.19440830166756959</Intercept>
+            <SEslope>0.00012449119634518659</SEslope>
+            <SEintercept>0.0023649634146198375</SEintercept>
+            <R2>0.0080004160246410772</R2>
+            <RMSE>18.93525832431235</RMSE>
+            <NSE>-0.080629211142766</NSE>
+            <ME>-5.197428164957909</ME>
+            <MAE>5.254129221882061</MAE>
+            <RSR>1.0391351099982227</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Soil.SoilWater.SW(10)</Name>
             <n>8</n>
-            <Slope>-0.41115848334404043</Slope>
-            <Intercept>0.6123562985832659</Intercept>
-            <SEslope>0.20411122606150267</SEslope>
-            <SEintercept>0.0874615728168134</SEintercept>
-            <R2>0.40344479499019636</R2>
-            <RMSE>0.011381118279938245</RMSE>
-            <NSE>-3.1577342304620579</NSE>
-            <ME>0.00772679490146401</ME>
-            <MAE>0.0091949905439057539</MAE>
-            <RSR>1.9073587632258124</RSR>
+            <Slope>-0.41115848334314947</Slope>
+            <Intercept>0.61235629858288432</Intercept>
+            <SEslope>0.20411122606180177</SEslope>
+            <SEintercept>0.087461572816941557</SEintercept>
+            <R2>0.403444794988448</R2>
+            <RMSE>0.011381118279938372</RMSE>
+            <NSE>-3.1577342304621503</NSE>
+            <ME>0.0077267949014641346</ME>
+            <MAE>0.0091949905439058788</MAE>
+            <RSR>1.9073587632258335</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Soil.SoilWater.SW(2)</Name>
             <n>1329</n>
-            <Slope>0.00013839980614595895</Slope>
-            <Intercept>0.21710341243207848</Intercept>
-            <SEslope>8.0050981877331144E-05</SEslope>
-            <SEintercept>0.0018770158480832574</SEintercept>
-            <R2>0.0022474475330012122</R2>
-            <RMSE>23.383093040076798</RMSE>
-            <NSE>-0.084150718235887156</NSE>
-            <ME>-6.524950415788811</ME>
-            <MAE>6.5710639972123532</MAE>
-            <RSR>1.0408337782582406</RSR>
+            <Slope>0.00013839963959111915</Slope>
+            <Intercept>0.21710342640364433</Intercept>
+            <SEslope>8.0050997938133368E-05</SEslope>
+            <SEintercept>0.0018770162246730207</SEintercept>
+            <R2>0.0022474412360667939</R2>
+            <RMSE>23.383093040120087</RMSE>
+            <NSE>-0.084150718239901279</NSE>
+            <ME>-6.5249504029403278</ME>
+            <MAE>6.5710640114778833</MAE>
+            <RSR>1.0408337782601675</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Soil.SoilWater.SW(3)</Name>
             <n>1329</n>
-            <Slope>0.00023103454851384122</Slope>
-            <Intercept>0.20874830511025838</Intercept>
-            <SEslope>6.915417212252585E-05</SEslope>
-            <SEintercept>0.0020165149414131975</SEintercept>
-            <R2>0.0083408171146107657</R2>
-            <RMSE>29.093804483328405</RMSE>
-            <NSE>-0.084909618535444764</NSE>
-            <ME>-8.161019047294495</ME>
-            <MAE>8.1927897422907616</MAE>
-            <RSR>1.0411980038550817</RSR>
+            <Slope>0.00023103421718526304</Slope>
+            <Intercept>0.20874833971681908</Intercept>
+            <SEslope>6.91542010665584E-05</SEslope>
+            <SEintercept>0.0020165157854125158</SEintercept>
+            <R2>0.00834078646716463</R2>
+            <RMSE>29.093804483353438</RMSE>
+            <NSE>-0.084909618537311937</NSE>
+            <ME>-8.1610190154617186</ME>
+            <MAE>8.1927897588216787</MAE>
+            <RSR>1.0411980038559774</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Soil.SoilWater.SW(4)</Name>
             <n>1329</n>
-            <Slope>0.0002729228296524703</Slope>
-            <Intercept>0.21515836962585891</Intercept>
-            <SEslope>6.08949581353294E-05</SEslope>
-            <SEintercept>0.0019443053773163898</SEintercept>
-            <R2>0.014911501748020695</R2>
-            <RMSE>31.85925896112267</RMSE>
-            <NSE>-0.084563814173235441</NSE>
-            <ME>-8.9245185581755653</ME>
-            <MAE>8.9444410829155938</MAE>
-            <RSR>1.0410320547747389</RSR>
+            <Slope>0.0002729223342361464</Slope>
+            <Intercept>0.21515842647749059</Intercept>
+            <SEslope>6.0894980591313447E-05</SEslope>
+            <SEintercept>0.0019443060943099121</SEintercept>
+            <R2>0.014911437586177523</R2>
+            <RMSE>31.859258961068193</RMSE>
+            <NSE>-0.084563814169526186</NSE>
+            <ME>-8.92451850585311</ME>
+            <MAE>8.9444410366137941</MAE>
+            <RSR>1.0410320547729588</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Soil.SoilWater.SW(5)</Name>
             <n>1329</n>
-            <Slope>0.00048621016706542469</Slope>
-            <Intercept>0.2083953465542677</Intercept>
-            <SEslope>4.8539287880711081E-05</SEslope>
-            <SEintercept>0.0016063771442246569</SEintercept>
-            <R2>0.070296667301121274</R2>
-            <RMSE>33.01915652792745</RMSE>
-            <NSE>-0.084698155185066737</NSE>
-            <ME>-9.279377491305782</ME>
-            <MAE>9.29313194597565</MAE>
-            <RSR>1.041096527223131</RSR>
+            <Slope>0.00048620778857247295</Slope>
+            <Intercept>0.20839562848057996</Intercept>
+            <SEslope>4.8539401339547917E-05</SEslope>
+            <SEintercept>0.0016063808990733634</SEintercept>
+            <R2>0.070295722354570822</R2>
+            <RMSE>33.019156527633328</RMSE>
+            <NSE>-0.084698155165742417</NSE>
+            <ME>-9.27937723195706</ME>
+            <MAE>9.2931316864700246</MAE>
+            <RSR>1.0410965272138573</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Soil.SoilWater.SW(6)</Name>
             <n>1224</n>
-            <Slope>0.93113838035729168</Slope>
-            <Intercept>0.014578973657505545</Intercept>
-            <SEslope>0.0081827908160917121</SEslope>
-            <SEintercept>0.002066983535417673</SEintercept>
-            <R2>0.91376561700764</R2>
-            <RMSE>0.019033122629814707</RMSE>
-            <NSE>0.91221544352756279</NSE>
-            <ME>-0.0022436708022983824</ME>
-            <MAE>0.011682335641751354</MAE>
-            <RSR>0.29616353094794523</RSR>
+            <Slope>0.9311384462780653</Slope>
+            <Intercept>0.01457896774954498</Intercept>
+            <SEslope>0.0081827915508363974</SEslope>
+            <SEintercept>0.0020669837210151296</SEintercept>
+            <R2>0.91376561401401524</R2>
+            <RMSE>0.01903312203660568</RMSE>
+            <NSE>0.91221544899955931</NSE>
+            <ME>-0.0022436606060533587</ME>
+            <MAE>0.011682329501051175</MAE>
+            <RSR>0.296163521717359</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Soil.SoilWater.SW(7)</Name>
             <n>1200</n>
-            <Slope>0.95177964005015347</Slope>
-            <Intercept>0.0085443371830195569</Intercept>
-            <SEslope>0.0050950292486288736</SEslope>
-            <SEintercept>0.0014763811212378914</SEintercept>
-            <R2>0.96680916938693</R2>
-            <RMSE>0.015914845854599839</RMSE>
-            <NSE>0.96316272230530353</NSE>
-            <ME>-0.004844115016478104</ME>
-            <MAE>0.010723076019498734</MAE>
-            <RSR>0.19185041038080739</RSR>
+            <Slope>0.95177964004990723</Slope>
+            <Intercept>0.008544337183077455</Intercept>
+            <SEslope>0.0050950292486274893</SEslope>
+            <SEintercept>0.00147638112123749</SEintercept>
+            <R2>0.96680916938693084</R2>
+            <RMSE>0.015914845854603742</RMSE>
+            <NSE>0.96316272230528543</NSE>
+            <ME>-0.0048441150164885262</ME>
+            <MAE>0.010723076019509158</MAE>
+            <RSR>0.19185041038085446</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Soil.SoilWater.SW(8)</Name>
             <n>426</n>
-            <Slope>0.95982928961505165</Slope>
-            <Intercept>0.0048953141516391574</Intercept>
-            <SEslope>0.014446086623644884</SEslope>
-            <SEintercept>0.0027571415421321931</SEintercept>
-            <R2>0.91237064911765176</R2>
-            <RMSE>0.021118462427683685</RMSE>
-            <NSE>0.90887875686954755</NSE>
-            <ME>-0.0022379068133980538</ME>
-            <MAE>0.0142557595291683</MAE>
-            <RSR>0.30150844681151284</RSR>
+            <Slope>0.95982928961327785</Slope>
+            <Intercept>0.00489531415192046</Intercept>
+            <SEslope>0.014446086623631315</SEslope>
+            <SEintercept>0.0027571415421296036</SEintercept>
+            <R2>0.91237064911750643</R2>
+            <RMSE>0.021118462427684444</RMSE>
+            <NSE>0.908878756869541</NSE>
+            <ME>-0.0022379068134317534</ME>
+            <MAE>0.014255759529201998</MAE>
+            <RSR>0.30150844681152367</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Soil.SoilWater.SW(9)</Name>
             <n>8</n>
-            <Slope>0.010719488468142894</Slope>
-            <Intercept>0.46820758696990311</Intercept>
-            <SEslope>0.0379268526959648</SEslope>
-            <SEintercept>0.017366398831367889</SEintercept>
-            <R2>0.013138908529808591</R2>
-            <RMSE>0.020139851613450742</RMSE>
-            <NSE>-1.3808390988321664</NSE>
-            <ME>0.015408124997090239</ME>
-            <MAE>0.01801160573560974</MAE>
-            <RSR>1.4433413357477662</RSR>
+            <Slope>0.010719488467491224</Slope>
+            <Intercept>0.46820758697021053</Intercept>
+            <SEslope>0.037926852695995494</SEslope>
+            <SEintercept>0.017366398831381948</SEintercept>
+            <R2>0.013138908528211202</R2>
+            <RMSE>0.02013985161346327</RMSE>
+            <NSE>-1.3808390988351285</NSE>
+            <ME>0.015408124997099364</ME>
+            <MAE>0.018011605735618864</MAE>
+            <RSR>1.4433413357486642</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Wheat.AboveGround.N</Name>
             <n>429</n>
-            <Slope>0.80767248720744611</Slope>
-            <Intercept>1.6861424674042862</Intercept>
-            <SEslope>0.037744129751310404</SEslope>
-            <SEintercept>0.51677392923857735</SEintercept>
-            <R2>0.51746023346981262</R2>
-            <RMSE>5.6768036809740234</RMSE>
-            <NSE>0.34804568256362955</NSE>
-            <ME>-0.57341773499068</ME>
-            <MAE>3.4527512032440932</MAE>
-            <RSR>0.80649526371995461</RSR>
+            <Slope>0.80767277513091651</Slope>
+            <Intercept>1.686136856247499</Intercept>
+            <SEslope>0.037744127084766155</SEslope>
+            <SEintercept>0.5167738927295743</SEintercept>
+            <R2>0.51746044677602021</R2>
+            <RMSE>5.676803049692472</RMSE>
+            <NSE>0.34804582756308122</NSE>
+            <ME>-0.57341996347794422</ME>
+            <MAE>3.4527486128450011</MAE>
+            <RSR>0.80649517403470039</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Wheat.AboveGround.Wt</Name>
             <n>947</n>
-            <Slope>0.55186402019685366</Slope>
-            <Intercept>205.56388289224174</Intercept>
-            <SEslope>0.024117343292781378</SEslope>
-            <SEintercept>29.554730263941273</SEintercept>
-            <R2>0.35653298270872347</R2>
-            <RMSE>655.286787793378</RMSE>
-            <NSE>0.12795700484171046</NSE>
-            <ME>-244.65853535371173</ME>
-            <MAE>335.89913265528554</MAE>
-            <RSR>0.93333924551715741</RSR>
+            <Slope>0.551864015133095</Slope>
+            <Intercept>205.56388270430637</Intercept>
+            <SEslope>0.024117343031285751</SEslope>
+            <SEintercept>29.554729943490027</SEintercept>
+            <R2>0.35653298347355555</R2>
+            <RMSE>655.28678698980025</RMSE>
+            <NSE>0.12795700698048196</NSE>
+            <ME>-244.6585406289816</ME>
+            <MAE>335.89912791500348</MAE>
+            <RSR>0.93333924437260407</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Wheat.Ear.N</Name>
@@ -4621,100 +4621,100 @@ namespace Models
           <RegrStats>
             <Name>Wheat.Ear.Wt</Name>
             <n>435</n>
-            <Slope>0.24923477905266178</Slope>
-            <Intercept>185.92579075306074</Intercept>
-            <SEslope>0.033587868126059947</SEslope>
-            <SEintercept>20.25596389009706</SEintercept>
-            <R2>0.11281773278660146</R2>
-            <RMSE>427.69280076768729</RMSE>
-            <NSE>-0.22842326132861168</NSE>
-            <ME>-162.0203006773281</ME>
-            <MAE>220.96278598476849</MAE>
-            <RSR>1.107067884010875</RSR>
+            <Slope>0.24923473676961372</Slope>
+            <Intercept>185.9258039401584</Intercept>
+            <SEslope>0.033587868570804882</SEslope>
+            <SEintercept>20.255964158311084</SEintercept>
+            <R2>0.11281769617518</R2>
+            <RMSE>427.6928164999739</RMSE>
+            <NSE>-0.22842335170145489</NSE>
+            <ME>-162.02030708653152</ME>
+            <MAE>220.9627887352685</MAE>
+            <RSR>1.1070679247333495</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Wheat.Grain.N</Name>
             <n>98</n>
-            <Slope>0.21356150158576245</Slope>
-            <Intercept>2.4742327408928575</Intercept>
-            <SEslope>0.12147373970806479</SEslope>
-            <SEintercept>1.3055089748045008</SEintercept>
-            <R2>0.031192305385412289</R2>
-            <RMSE>7.9127634298940936</RMSE>
-            <NSE>-2.7382031620425882</NSE>
-            <ME>-5.3410139753209291</ME>
-            <MAE>5.7129284222576091</MAE>
-            <RSR>1.9235535427478137</RSR>
+            <Slope>0.21356081181827927</Slope>
+            <Intercept>2.4742424127113445</Intercept>
+            <SEslope>0.12147378119209087</SEslope>
+            <SEintercept>1.3055094206438114</SEintercept>
+            <R2>0.031192089538903955</R2>
+            <RMSE>7.9127637005330964</RMSE>
+            <NSE>-2.7382034177569419</NSE>
+            <ME>-5.3410111580792066</ME>
+            <MAE>5.7129288722853255</MAE>
+            <RSR>1.9235536085388127</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Wheat.Grain.Number</Name>
             <n>146</n>
-            <Slope>0.83339704512738866</Slope>
-            <Intercept>1931.1683019974644</Intercept>
-            <SEslope>0.028151517288312583</SEslope>
-            <SEintercept>451.14357228585288</SEintercept>
-            <R2>0.8588782931944281</R2>
-            <RMSE>2460.1441237584522</RMSE>
-            <NSE>0.85154954293364837</NSE>
-            <ME>-517.65932080680921</ME>
-            <MAE>1850.2957567301417</MAE>
-            <RSR>0.38397092743310968</RSR>
+            <Slope>0.83366881687997807</Slope>
+            <Intercept>1929.8301956242322</Intercept>
+            <SEslope>0.028158389419022874</SEslope>
+            <SEintercept>451.25370196611505</SEintercept>
+            <R2>0.85889816151559861</R2>
+            <RMSE>2459.2984131495205</RMSE>
+            <NSE>0.85165158943252517</NSE>
+            <ME>-515.00276708924559</ME>
+            <MAE>1847.6400300721903</MAE>
+            <RSR>0.38383893179768513</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Wheat.Grain.Wt</Name>
             <n>466</n>
-            <Slope>0.25212736072154507</Slope>
-            <Intercept>46.594069678456989</Intercept>
-            <SEslope>0.02697972750840261</SEslope>
-            <SEintercept>11.840544508946074</SEintercept>
-            <R2>0.15839920381131456</R2>
-            <RMSE>349.2098117928623</RMSE>
-            <NSE>-0.23358115479668595</NSE>
-            <ME>-182.39278091241798</ME>
-            <MAE>196.12562791466692</MAE>
-            <RSR>1.1094746436654637</RSR>
+            <Slope>0.25212735387070234</Slope>
+            <Intercept>46.594080021988461</Intercept>
+            <SEslope>0.026979728376246643</SEslope>
+            <SEintercept>11.840544889815226</SEintercept>
+            <R2>0.15839918799056896</R2>
+            <RMSE>349.20981201192137</RMSE>
+            <NSE>-0.23358115634433507</NSE>
+            <ME>-182.392772666507</ME>
+            <MAE>196.12561966451804</MAE>
+            <RSR>1.1094746443614363</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Wheat.Leaf.CoverTotal</Name>
             <n>568</n>
-            <Slope>0.88390434179787891</Slope>
-            <Intercept>0.14668031887488353</Intercept>
-            <SEslope>0.026394278483112196</SEslope>
-            <SEintercept>0.018214126102884753</SEintercept>
-            <R2>0.66458831567527654</R2>
-            <RMSE>0.19817782369567208</RMSE>
-            <NSE>0.52640448562375841</NSE>
-            <ME>0.073874345760528967</ME>
-            <MAE>0.1342703691966057</MAE>
-            <RSR>0.6875767007807676</RSR>
+            <Slope>0.883904307242095</Slope>
+            <Intercept>0.14668021770866857</Intercept>
+            <SEslope>0.02639428895196878</SEslope>
+            <SEintercept>0.0182141333272184</SEintercept>
+            <R2>0.66458812141840973</R2>
+            <RMSE>0.19817784502928934</RMSE>
+            <NSE>0.5264043836597162</NSE>
+            <ME>0.073874222923672031</ME>
+            <MAE>0.13427038510101982</MAE>
+            <RSR>0.68757677479761725</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Wheat.Leaf.Dead.N</Name>
             <n>119</n>
-            <Slope>-0.11226578751738266</Slope>
-            <Intercept>0.59944290735041439</Intercept>
-            <SEslope>0.1309048564433527</SEslope>
-            <SEintercept>0.080170285859877038</SEintercept>
-            <R2>0.0062470632085950273</R2>
-            <RMSE>1.0224829142235707</RMSE>
-            <NSE>-2.5221147727621505</NSE>
-            <ME>0.28832237543199279</ME>
-            <MAE>0.60459261644541307</MAE>
-            <RSR>1.8688277527984476</RSR>
+            <Slope>-0.11226576078062295</Slope>
+            <Intercept>0.59944291004015937</Intercept>
+            <SEslope>0.13090485564178922</SEslope>
+            <SEintercept>0.080170285368974137</SEintercept>
+            <R2>0.0062470603276605363</R2>
+            <RMSE>1.0224829048937922</RMSE>
+            <NSE>-2.522114708486161</NSE>
+            <ME>0.28832238560048529</ME>
+            <MAE>0.60459260627692069</MAE>
+            <RSR>1.8688277357460854</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Wheat.Leaf.Dead.Wt</Name>
             <n>261</n>
-            <Slope>-0.015171483864838711</Slope>
-            <Intercept>61.754940826097751</Intercept>
-            <SEslope>0.010000180131470157</SEslope>
-            <SEintercept>3.9225531738166244</SEintercept>
-            <R2>0.0088084260094550837</R2>
-            <RMSE>393.29475976495189</RMSE>
-            <NSE>-0.063106372483051842</NSE>
-            <ME>-31.064316796431754</ME>
-            <MAE>100.35496820914474</MAE>
-            <RSR>1.0290933718525155</RSR>
+            <Slope>-0.01517148508928886</Slope>
+            <Intercept>61.754946880005484</Intercept>
+            <SEslope>0.010000179555537678</SEslope>
+            <SEintercept>3.9225529479081165</SEintercept>
+            <R2>0.0088084284243972188</R2>
+            <RMSE>393.29475920363444</RMSE>
+            <NSE>-0.063106369448482358</NSE>
+            <ME>-31.064310854478077</ME>
+            <MAE>100.35496621329369</MAE>
+            <RSR>1.0290933703837746</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Wheat.Leaf.DeadCohortNo</Name>
@@ -4747,58 +4747,58 @@ namespace Models
           <RegrStats>
             <Name>Wheat.Leaf.LAI</Name>
             <n>685</n>
-            <Slope>0.86681980662313907</Slope>
-            <Intercept>1.1223956286347789</Intercept>
-            <SEslope>0.019465561525759827</SEslope>
-            <SEintercept>0.077091106124686434</SEintercept>
-            <R2>0.74381142028824465</R2>
-            <RMSE>1.4095712976400239</RMSE>
-            <NSE>0.63431710093465765</NSE>
-            <ME>0.69598450005839163</ME>
-            <MAE>1.0222756725831612</MAE>
-            <RSR>0.604275645229122</RSR>
+            <Slope>0.8668198287619675</Slope>
+            <Intercept>1.122395367989864</Intercept>
+            <SEslope>0.019465563271916633</SEslope>
+            <SEintercept>0.077091113040138617</SEintercept>
+            <R2>0.7438113958343322</R2>
+            <RMSE>1.4095712820644826</RMSE>
+            <NSE>0.63431710901613469</NSE>
+            <ME>0.69598431029671093</ME>
+            <MAE>1.0222755686156648</MAE>
+            <RSR>0.60427563855197119</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Wheat.Leaf.Live.N</Name>
             <n>311</n>
-            <Slope>0.87571911115081247</Slope>
-            <Intercept>1.3344345348659426</Intercept>
-            <SEslope>0.041900893690554948</SEslope>
-            <SEintercept>0.18983828113678863</SEintercept>
-            <R2>0.58568006030322162</R2>
-            <RMSE>2.2764790793931686</RMSE>
-            <NSE>0.34080726247102844</NSE>
-            <ME>0.89214266874105008</ME>
-            <MAE>1.5371062567087377</MAE>
-            <RSR>0.81060048527807982</RSR>
+            <Slope>0.87571944570253779</Slope>
+            <Intercept>1.3344307350417264</Intercept>
+            <SEslope>0.0419009343602738</SEslope>
+            <SEintercept>0.18983846539704757</SEintercept>
+            <R2>0.58567977465203369</R2>
+            <RMSE>2.276479731727262</RMSE>
+            <NSE>0.3408068846823965</NSE>
+            <ME>0.89214005952230913</ME>
+            <MAE>1.5371090107806638</MAE>
+            <RSR>0.81060071755885832</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Wheat.Leaf.Live.Wt</Name>
             <n>496</n>
-            <Slope>0.76245272829038724</Slope>
-            <Intercept>78.665596073489922</Intercept>
-            <SEslope>0.023347507534064418</SEslope>
-            <SEintercept>4.0254485251786294</SEintercept>
-            <R2>0.68342679459960687</R2>
-            <RMSE>76.9543859054043</RMSE>
-            <NSE>0.485614772118222</NSE>
-            <ME>46.606370276056886</ME>
-            <MAE>58.755752973161819</MAE>
-            <RSR>0.71648318953767554</RSR>
+            <Slope>0.762452699664976</Slope>
+            <Intercept>78.665599827694493</Intercept>
+            <SEslope>0.023347508137213202</SEslope>
+            <SEintercept>4.0254486291702181</SEintercept>
+            <R2>0.68342676717562445</R2>
+            <RMSE>76.954387897373579</RMSE>
+            <NSE>0.48561474548843164</NSE>
+            <ME>46.606370166994516</ME>
+            <MAE>58.755757738120444</MAE>
+            <RSR>0.71648320808388954</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Wheat.Leaf.SpecificArea</Name>
             <n>171</n>
-            <Slope>0.00011438576398530964</Slope>
-            <Intercept>23094.359329962983</Intercept>
-            <SEslope>0.00868408694128728</SEslope>
-            <SEintercept>123.38237742616344</SEintercept>
-            <R2>1.0266170633599359E-06</R2>
-            <RMSE>16847.141842506306</RMSE>
-            <NSE>-1.6830509649958634</NSE>
-            <ME>13293.506223205955</ME>
-            <MAE>13643.204642424531</MAE>
-            <RSR>1.6332056234520564</RSR>
+            <Slope>0.00011434844967771956</Slope>
+            <Intercept>23094.359375845168</Intercept>
+            <SEslope>0.0086840838071596919</SEslope>
+            <SEintercept>123.38233289688643</SEintercept>
+            <R2>1.0259481189045516E-06</R2>
+            <RMSE>16847.141795498021</RMSE>
+            <NSE>-1.6830509500229236</NSE>
+            <ME>13293.505903334253</ME>
+            <MAE>13643.204322552825</MAE>
+            <RSR>1.6332056188949513</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Wheat.Phenology.Zadok.Stage</Name>
@@ -4831,44 +4831,44 @@ namespace Models
           <RegrStats>
             <Name>Wheat.Spike.Wt</Name>
             <n>216</n>
-            <Slope>0.31615188378857267</Slope>
-            <Intercept>75.816328256901883</Intercept>
-            <SEslope>0.063307044858629716</SEslope>
-            <SEintercept>14.068049947634856</SEintercept>
-            <R2>0.10437573421341628</R2>
-            <RMSE>149.10452541877123</RMSE>
-            <NSE>-0.503923343122977</NSE>
-            <ME>-51.384315235161431</ME>
-            <MAE>99.8888602482018</MAE>
-            <RSR>1.223503467527969</RSR>
+            <Slope>0.31615192401769848</Slope>
+            <Intercept>75.816315616469552</Intercept>
+            <SEslope>0.063307043609198449</SEslope>
+            <SEintercept>14.06804966998706</SEintercept>
+            <R2>0.1043757616936436</R2>
+            <RMSE>149.10452279045302</RMSE>
+            <NSE>-0.50392329010260051</NSE>
+            <ME>-51.38432039268843</ME>
+            <MAE>99.888859105197142</MAE>
+            <RSR>1.2235034459608405</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Wheat.Stem.N</Name>
             <n>355</n>
-            <Slope>0.95885832314876662</Slope>
-            <Intercept>0.22930024786579795</Intercept>
-            <SEslope>0.036308448962505666</SEslope>
-            <SEintercept>0.16253666947500903</SEintercept>
-            <R2>0.663943480423821</R2>
-            <RMSE>1.7910621949756156</RMSE>
-            <NSE>0.53201464726680059</NSE>
-            <ME>0.079911140285951726</ME>
-            <MAE>1.2914333451193467</MAE>
-            <RSR>0.68313035661866994</RSR>
+            <Slope>0.95885881015061114</Slope>
+            <Intercept>0.22929738973775837</Intercept>
+            <SEslope>0.036308440575392759</SEslope>
+            <SEintercept>0.16253663192965973</SEintercept>
+            <R2>0.66394381015140269</R2>
+            <RMSE>1.7910616582639249</RMSE>
+            <NSE>0.53201492774078174</NSE>
+            <ME>0.079910050505158328</ME>
+            <MAE>1.2914323979930142</MAE>
+            <RSR>0.683130151911067</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Wheat.Stem.Wt</Name>
             <n>579</n>
-            <Slope>0.69429209355171539</Slope>
-            <Intercept>57.558102631288932</Intercept>
-            <SEslope>0.02372713644002622</SEslope>
-            <SEintercept>15.811551159415256</SEintercept>
-            <R2>0.59741468848773327</R2>
-            <RMSE>266.18901171902354</RMSE>
-            <NSE>0.49357805580014036</NSE>
-            <ME>-111.04220712143858</ME>
-            <MAE>172.16843312398834</MAE>
-            <RSR>0.7110184912509121</RSR>
+            <Slope>0.69429210270414476</Slope>
+            <Intercept>57.5580821522521</Intercept>
+            <SEslope>0.023727135200568735</SEslope>
+            <SEintercept>15.811550333451891</SEintercept>
+            <R2>0.59741471995628559</R2>
+            <RMSE>266.18900776633757</RMSE>
+            <NSE>0.49357807084003169</NSE>
+            <ME>-111.04222255283867</ME>
+            <MAE>172.16842136693569</MAE>
+            <RSR>0.71101848069287743</RSR>
           </RegrStats>
           <RegrStats>
             <Name>Wheat.Structure.HaunStage.Value()</Name>
@@ -4901,16 +4901,16 @@ namespace Models
           <RegrStats>
             <Name>Wheat.Structure.TotalStemPopn</Name>
             <n>496</n>
-            <Slope>0.37365732313229022</Slope>
-            <Intercept>269.99831065061409</Intercept>
-            <SEslope>0.037646446408677044</SEslope>
-            <SEintercept>24.206693082466845</SEintercept>
-            <R2>0.16626476659580602</R2>
-            <RMSE>270.57805602165814</RMSE>
-            <NSE>-0.28126432150559233</NSE>
-            <ME>-103.87588251664069</ME>
-            <MAE>194.27027945280409</MAE>
-            <RSR>1.1307878347899789</RSR>
+            <Slope>0.37365732439804633</Slope>
+            <Intercept>269.99830950307921</Intercept>
+            <SEslope>0.037646446330296277</SEslope>
+            <SEintercept>24.206693032067957</SEintercept>
+            <R2>0.16626476811217927</R2>
+            <RMSE>270.57805569688662</RMSE>
+            <NSE>-0.28126431842982091</NSE>
+            <ME>-103.87588290862487</ME>
+            <MAE>194.27027910614331</MAE>
+            <RSR>1.1307878334327079</RSR>
           </RegrStats>
         </AcceptedStats>
         <AcceptedStatsName>Name n Slope Intercept SEslope SEintercept R2 RMSE NSE ME MAE RSR</AcceptedStatsName>
@@ -6533,8 +6533,8 @@ Simulation results for the combined datasets from the various countries are show
               <Name>ApplyFertiliser</Name>
               <IncludeInDocumentation>false</IncludeInDocumentation>
               <Script>
-                <FertDayOfYear>186</FertDayOfYear>
                 <Amount>160</Amount>
+                <FertDayOfYear>186</FertDayOfYear>
               </Script>
               <Code><![CDATA[using System;
 using Models.Core;
@@ -14071,8 +14071,8 @@ namespace Models
               <Name>1</Name>
               <IncludeInDocumentation>false</IncludeInDocumentation>
               <Script>
-                <SowDate>29-Apr</SowDate>
                 <CultivarName>Hartog</CultivarName>
+                <SowDate>29-Apr</SowDate>
                 <SowingDepth>40</SowingDepth>
                 <RowSpacing>250</RowSpacing>
                 <Population>100</Population>
@@ -14130,8 +14130,8 @@ namespace Models
               <Name>2</Name>
               <IncludeInDocumentation>false</IncludeInDocumentation>
               <Script>
-                <SowDate>20-May</SowDate>
                 <CultivarName>Hartog</CultivarName>
+                <SowDate>20-May</SowDate>
                 <SowingDepth>40</SowingDepth>
                 <RowSpacing>250</RowSpacing>
                 <Population>100</Population>
@@ -14189,8 +14189,8 @@ namespace Models
               <Name>3</Name>
               <IncludeInDocumentation>false</IncludeInDocumentation>
               <Script>
-                <SowDate>10-Jun</SowDate>
                 <CultivarName>Hartog</CultivarName>
+                <SowDate>10-Jun</SowDate>
                 <SowingDepth>40</SowingDepth>
                 <RowSpacing>250</RowSpacing>
                 <Population>100</Population>
@@ -14248,8 +14248,8 @@ namespace Models
               <Name>4</Name>
               <IncludeInDocumentation>false</IncludeInDocumentation>
               <Script>
-                <SowDate>4-Jul</SowDate>
                 <CultivarName>Hartog</CultivarName>
+                <SowDate>4-Jul</SowDate>
                 <SowingDepth>40</SowingDepth>
                 <RowSpacing>250</RowSpacing>
                 <Population>100</Population>
@@ -14307,8 +14307,8 @@ namespace Models
               <Name>5</Name>
               <IncludeInDocumentation>false</IncludeInDocumentation>
               <Script>
-                <SowDate>22-Jul</SowDate>
                 <CultivarName>Hartog</CultivarName>
+                <SowDate>22-Jul</SowDate>
                 <SowingDepth>40</SowingDepth>
                 <RowSpacing>250</RowSpacing>
                 <Population>100</Population>
@@ -14366,8 +14366,8 @@ namespace Models
               <Name>6</Name>
               <IncludeInDocumentation>false</IncludeInDocumentation>
               <Script>
-                <SowDate>15-Aug</SowDate>
                 <CultivarName>Hartog</CultivarName>
+                <SowDate>15-Aug</SowDate>
                 <SowingDepth>40</SowingDepth>
                 <RowSpacing>250</RowSpacing>
                 <Population>100</Population>
@@ -14880,8 +14880,8 @@ namespace Models
               <Name>Sowing</Name>
               <IncludeInDocumentation>false</IncludeInDocumentation>
               <Script>
-                <SowDate>25-May</SowDate>
                 <CultivarName>Hartog</CultivarName>
+                <SowDate>25-May</SowDate>
                 <SowingDepth>40</SowingDepth>
                 <RowSpacing>250</RowSpacing>
                 <Population>100</Population>
@@ -17830,8 +17830,8 @@ namespace Models
                 <Name>Sowing</Name>
                 <IncludeInDocumentation>false</IncludeInDocumentation>
                 <Script>
-                  <SowDate>25-May</SowDate>
                   <CultivarName>Hartog</CultivarName>
+                  <SowDate>25-May</SowDate>
                   <SowingDepth>40</SowingDepth>
                   <RowSpacing>250</RowSpacing>
                   <Population>100</Population>
@@ -18574,8 +18574,8 @@ namespace Models
                 <Name>Sowing</Name>
                 <IncludeInDocumentation>false</IncludeInDocumentation>
                 <Script>
-                  <SowDate>25-May</SowDate>
                   <CultivarName>Hartog</CultivarName>
+                  <SowDate>25-May</SowDate>
                   <SowingDepth>40</SowingDepth>
                   <RowSpacing>250</RowSpacing>
                   <Population>100</Population>
@@ -19318,8 +19318,8 @@ namespace Models
                 <Name>Sowing</Name>
                 <IncludeInDocumentation>false</IncludeInDocumentation>
                 <Script>
-                  <SowDate>25-May</SowDate>
                   <CultivarName>Hartog</CultivarName>
+                  <SowDate>25-May</SowDate>
                   <SowingDepth>40</SowingDepth>
                   <RowSpacing>250</RowSpacing>
                   <Population>100</Population>
@@ -21085,18 +21085,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <oc>
-                  <double>1.2032986082022734</double>
-                  <double>0.79228456241895961</double>
-                  <double>0.29900863410282752</double>
-                  <double>0.05138058238638081</double>
-                  <double>0.051000528535209769</double>
-                  <double>0.050675681811826238</double>
-                  <double>0.050496873720279</double>
-                  <double>0.050120340898946514</double>
-                  <double>0.050058806023859134</double>
-                  <double>0.0500199904435238</double>
-                </oc>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -22649,25 +22637,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <oc>
-                  <double>0.72352640308603</double>
-                  <double>0.72301158556202039</double>
-                  <double>0.45528010944098596</double>
-                  <double>0.387092498436611</double>
-                  <double>0.29950113221038871</double>
-                  <double>0.21999754370504637</double>
-                  <double>0.19001057362088997</double>
-                  <double>0.18998552523739173</double>
-                  <double>0.099964977125739443</double>
-                  <double>0.099968106112963959</double>
-                  <double>0.099990261202082154</double>
-                  <double>0.10001425103904392</double>
-                  <double>0.10000482680173992</double>
-                  <double>0.10000034929500608</double>
-                  <double>0.10000004452705698</double>
-                  <double>0.10000011874242137</double>
-                  <double>0.099999927332399569</double>
-                </oc>
               </SoilNitrogen>
               <CERESSoilTemperature>
                 <Name>CERESSoilTemperature</Name>
@@ -23908,28 +23877,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <oc>
-                  <double>0.83098748905480757</double>
-                  <double>0.34912902535987167</double>
-                  <double>0.32945480931770033</double>
-                  <double>0.22033899225619674</double>
-                  <double>0.2204410407712849</double>
-                  <double>0.22033460534939428</double>
-                  <double>0.19066689182381227</double>
-                  <double>0.1705041939872736</double>
-                  <double>0.15047673339339734</double>
-                  <double>0.12054425206968533</double>
-                  <double>0.11047609227916679</double>
-                  <double>0.10041248749368043</double>
-                  <double>0.10035647768752969</double>
-                  <double>0.10031196392041249</double>
-                  <double>0.10024878738421951</double>
-                  <double>0.10021556360251731</double>
-                  <double>0.10017719304680695</double>
-                  <double>0.10012934933941822</double>
-                  <double>0.10009356434438876</double>
-                  <double>0.10004261693966804</double>
-                </oc>
               </SoilNitrogen>
               <CERESSoilTemperature>
                 <Name>CERESSoilTemperature</Name>
@@ -24361,28 +24308,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <oc>
-                  <double>0.83098748905480757</double>
-                  <double>0.34912902535987167</double>
-                  <double>0.32945480931770033</double>
-                  <double>0.22033899225619674</double>
-                  <double>0.2204410407712849</double>
-                  <double>0.22033460534939428</double>
-                  <double>0.19066689182381227</double>
-                  <double>0.1705041939872736</double>
-                  <double>0.15047673339339734</double>
-                  <double>0.12054425206968533</double>
-                  <double>0.11047609227916679</double>
-                  <double>0.10041248749368043</double>
-                  <double>0.10035647768752969</double>
-                  <double>0.10031196392041249</double>
-                  <double>0.10024878738421951</double>
-                  <double>0.10021556360251731</double>
-                  <double>0.10017719304680695</double>
-                  <double>0.10012934933941822</double>
-                  <double>0.10009356434438876</double>
-                  <double>0.10004261693966804</double>
-                </oc>
               </SoilNitrogen>
               <CERESSoilTemperature>
                 <Name>CERESSoilTemperature</Name>
@@ -25018,28 +24943,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <oc>
-                  <double>0.83535399008509137</double>
-                  <double>0.35072954829126568</double>
-                  <double>0.33072754319948056</double>
-                  <double>0.22133781089563034</double>
-                  <double>0.22119319780710267</double>
-                  <double>0.22068541649937309</double>
-                  <double>0.19107119682585652</double>
-                  <double>0.17089752635119607</double>
-                  <double>0.15078591418887777</double>
-                  <double>0.12077803225132484</double>
-                  <double>0.11061891255588494</double>
-                  <double>0.10052766716623916</double>
-                  <double>0.1004109273020362</double>
-                  <double>0.10032282547806296</double>
-                  <double>0.10027223505883373</double>
-                  <double>0.10023288106617885</double>
-                  <double>0.1001990217304492</double>
-                  <double>0.10016997933270549</double>
-                  <double>0.10014443726659265</double>
-                  <double>0.10012193846548656</double>
-                </oc>
               </SoilNitrogen>
               <CERESSoilTemperature>
                 <Name>CERESSoilTemperature</Name>
@@ -30290,16 +30193,6 @@ Irrigation was applied at weekly intervals through and assemply of low rate drip
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <oc>
-                  <double>0.36030177375113792</double>
-                  <double>0.27080607825510783</double>
-                  <double>0.241057083027954</double>
-                  <double>0.1614100773132848</double>
-                  <double>0.16039591661358196</double>
-                  <double>0.29923549966041468</double>
-                  <double>0.099634477132654622</double>
-                  <double>0.099656769505334544</double>
-                </oc>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -32502,15 +32395,15 @@ Emergence was recorded as the 28th of May for the first planting.  The model was
                 <Name>Fertilise</Name>
                 <IncludeInDocumentation>false</IncludeInDocumentation>
                 <Script>
-                  <FertDate1>05-Aug</FertDate1>
-                  <FertDate2>01-Oct</FertDate2>
-                  <FertDate3>20-Oct</FertDate3>
-                  <FertDate4>25-Nov</FertDate4>
+                  <SDSwitch>0</SDSwitch>
                   <Amount1>0</Amount1>
                   <Amount2>0</Amount2>
                   <Amount3>0</Amount3>
                   <Amount4>0</Amount4>
-                  <SDSwitch>0</SDSwitch>
+                  <FertDate1>05-Aug</FertDate1>
+                  <FertDate2>01-Oct</FertDate2>
+                  <FertDate3>20-Oct</FertDate3>
+                  <FertDate4>25-Nov</FertDate4>
                 </Script>
                 <Code><![CDATA[using System;
 using Models.Core;
@@ -32754,16 +32647,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <oc>
-                  <double>0.36030177375113792</double>
-                  <double>0.27080607825510783</double>
-                  <double>0.241057083027954</double>
-                  <double>0.1614100773132848</double>
-                  <double>0.16039591661358196</double>
-                  <double>0.29923549966041468</double>
-                  <double>0.099634477132654622</double>
-                  <double>0.099656769505334544</double>
-                </oc>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -36017,15 +35900,15 @@ namespace Models
                 <Name>Fertilise</Name>
                 <IncludeInDocumentation>false</IncludeInDocumentation>
                 <Script>
-                  <FertDate1>05-Aug</FertDate1>
-                  <FertDate2>01-Oct</FertDate2>
-                  <FertDate3>20-Oct</FertDate3>
-                  <FertDate4>25-Nov</FertDate4>
+                  <SDSwitch>0</SDSwitch>
                   <Amount1>0</Amount1>
                   <Amount2>0</Amount2>
                   <Amount3>0</Amount3>
                   <Amount4>0</Amount4>
-                  <SDSwitch>0</SDSwitch>
+                  <FertDate1>05-Aug</FertDate1>
+                  <FertDate2>01-Oct</FertDate2>
+                  <FertDate3>20-Oct</FertDate3>
+                  <FertDate4>25-Nov</FertDate4>
                 </Script>
                 <Code><![CDATA[using System;
 using Models.Core;
@@ -36447,14 +36330,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <oc>
-                  <double>1.8356606676098439</double>
-                  <double>1.4633385968844384</double>
-                  <double>1.1988393325681357</double>
-                  <double>1.0301002994895852</double>
-                  <double>0.4703383219429832</double>
-                  <double>0.47013790451920212</double>
-                </oc>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -45285,8 +45160,8 @@ namespace Models
               <Name>StateFactors</Name>
               <IncludeInDocumentation>false</IncludeInDocumentation>
               <Script>
-                <IrrFactor>False</IrrFactor>
                 <NitFactor>0</NitFactor>
+                <IrrFactor>False</IrrFactor>
               </Script>
               <Code><![CDATA[using System;
 using Models.Core;
@@ -49278,10 +49153,10 @@ Considerable canopy decay was observed during the winter for the early sown trea
                 <IncludeInDocumentation>false</IncludeInDocumentation>
                 <Script>
                   <SowDate>24-Jul</SowDate>
+                  <Population>150</Population>
                   <CultivarName>Wakanui</CultivarName>
                   <SowingDepth>50</SowingDepth>
                   <RowSpacing>150</RowSpacing>
-                  <Population>150</Population>
                 </Script>
                 <Code><![CDATA[using System;
 using Models.Core;
@@ -49521,16 +49396,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <oc>
-                  <double>0.36030177375113792</double>
-                  <double>0.27080607825510783</double>
-                  <double>0.241057083027954</double>
-                  <double>0.1614100773132848</double>
-                  <double>0.16039591661358196</double>
-                  <double>0.29923549966041468</double>
-                  <double>0.099634477132654622</double>
-                  <double>0.099656769505334544</double>
-                </oc>
               </SoilNitrogen>
               <SoilOrganicMatter>
                 <Name>SoilOrganicMatter</Name>
@@ -52021,16 +51886,6 @@ namespace Models
                     <double>0.08</double>
                     <double>0.9</double>
                   </fract_lign>
-                  <oc>
-                    <double>0.36030177375113792</double>
-                    <double>0.27080607825510783</double>
-                    <double>0.241057083027954</double>
-                    <double>0.1614100773132848</double>
-                    <double>0.16039591661358196</double>
-                    <double>0.29923549966041468</double>
-                    <double>0.099634477132654622</double>
-                    <double>0.099656769505334544</double>
-                  </oc>
                 </SoilNitrogen>
                 <SoilOrganicMatter>
                   <Name>SoilOrganicMatter</Name>
@@ -52635,16 +52490,6 @@ namespace Models
                     <double>0.08</double>
                     <double>0.9</double>
                   </fract_lign>
-                  <oc>
-                    <double>0.36030177375113792</double>
-                    <double>0.27080607825510783</double>
-                    <double>0.241057083027954</double>
-                    <double>0.1614100773132848</double>
-                    <double>0.16039591661358196</double>
-                    <double>0.29923549966041468</double>
-                    <double>0.099634477132654622</double>
-                    <double>0.099656769505334544</double>
-                  </oc>
                 </SoilNitrogen>
                 <SoilOrganicMatter>
                   <Name>SoilOrganicMatter</Name>
@@ -53195,16 +53040,6 @@ namespace Models
                     <double>0.08</double>
                     <double>0.9</double>
                   </fract_lign>
-                  <oc>
-                    <double>0.36030177375113792</double>
-                    <double>0.27080607825510783</double>
-                    <double>0.241057083027954</double>
-                    <double>0.1614100773132848</double>
-                    <double>0.16039591661358196</double>
-                    <double>0.29923549966041468</double>
-                    <double>0.099634477132654622</double>
-                    <double>0.099656769505334544</double>
-                  </oc>
                 </SoilNitrogen>
                 <SoilOrganicMatter>
                   <Name>SoilOrganicMatter</Name>
@@ -54129,16 +53964,6 @@ namespace Models
                     <double>0.08</double>
                     <double>0.9</double>
                   </fract_lign>
-                  <oc>
-                    <double>0.36030177375113792</double>
-                    <double>0.27080607825510783</double>
-                    <double>0.241057083027954</double>
-                    <double>0.1614100773132848</double>
-                    <double>0.16039591661358196</double>
-                    <double>0.29923549966041468</double>
-                    <double>0.099634477132654622</double>
-                    <double>0.099656769505334544</double>
-                  </oc>
                 </SoilNitrogen>
                 <SoilOrganicMatter>
                   <Name>SoilOrganicMatter</Name>
@@ -54689,16 +54514,6 @@ namespace Models
                     <double>0.08</double>
                     <double>0.9</double>
                   </fract_lign>
-                  <oc>
-                    <double>0.36030177375113792</double>
-                    <double>0.27080607825510783</double>
-                    <double>0.241057083027954</double>
-                    <double>0.1614100773132848</double>
-                    <double>0.16039591661358196</double>
-                    <double>0.29923549966041468</double>
-                    <double>0.099634477132654622</double>
-                    <double>0.099656769505334544</double>
-                  </oc>
                 </SoilNitrogen>
                 <SoilOrganicMatter>
                   <Name>SoilOrganicMatter</Name>
@@ -55355,16 +55170,6 @@ namespace Models
                     <double>0.08</double>
                     <double>0.9</double>
                   </fract_lign>
-                  <oc>
-                    <double>0.36030177375113792</double>
-                    <double>0.27080607825510783</double>
-                    <double>0.241057083027954</double>
-                    <double>0.1614100773132848</double>
-                    <double>0.16039591661358196</double>
-                    <double>0.29923549966041468</double>
-                    <double>0.099634477132654622</double>
-                    <double>0.099656769505334544</double>
-                  </oc>
                 </SoilNitrogen>
                 <SoilOrganicMatter>
                   <Name>SoilOrganicMatter</Name>
@@ -55915,16 +55720,6 @@ namespace Models
                     <double>0.08</double>
                     <double>0.9</double>
                   </fract_lign>
-                  <oc>
-                    <double>0.36030177375113792</double>
-                    <double>0.27080607825510783</double>
-                    <double>0.241057083027954</double>
-                    <double>0.1614100773132848</double>
-                    <double>0.16039591661358196</double>
-                    <double>0.29923549966041468</double>
-                    <double>0.099634477132654622</double>
-                    <double>0.099656769505334544</double>
-                  </oc>
                 </SoilNitrogen>
                 <SoilOrganicMatter>
                   <Name>SoilOrganicMatter</Name>
@@ -56475,16 +56270,6 @@ namespace Models
                     <double>0.08</double>
                     <double>0.9</double>
                   </fract_lign>
-                  <oc>
-                    <double>0.36030177375113792</double>
-                    <double>0.27080607825510783</double>
-                    <double>0.241057083027954</double>
-                    <double>0.1614100773132848</double>
-                    <double>0.16039591661358196</double>
-                    <double>0.29923549966041468</double>
-                    <double>0.099634477132654622</double>
-                    <double>0.099656769505334544</double>
-                  </oc>
                 </SoilNitrogen>
                 <SoilOrganicMatter>
                   <Name>SoilOrganicMatter</Name>
@@ -57035,16 +56820,6 @@ namespace Models
                     <double>0.08</double>
                     <double>0.9</double>
                   </fract_lign>
-                  <oc>
-                    <double>0.36030177375113792</double>
-                    <double>0.27080607825510783</double>
-                    <double>0.241057083027954</double>
-                    <double>0.1614100773132848</double>
-                    <double>0.16039591661358196</double>
-                    <double>0.29923549966041468</double>
-                    <double>0.099634477132654622</double>
-                    <double>0.099656769505334544</double>
-                  </oc>
                 </SoilNitrogen>
                 <SoilOrganicMatter>
                   <Name>SoilOrganicMatter</Name>
@@ -57595,16 +57370,6 @@ namespace Models
                     <double>0.08</double>
                     <double>0.9</double>
                   </fract_lign>
-                  <oc>
-                    <double>0.36030177375113792</double>
-                    <double>0.27080607825510783</double>
-                    <double>0.241057083027954</double>
-                    <double>0.1614100773132848</double>
-                    <double>0.16039591661358196</double>
-                    <double>0.29923549966041468</double>
-                    <double>0.099634477132654622</double>
-                    <double>0.099656769505334544</double>
-                  </oc>
                 </SoilNitrogen>
                 <SoilOrganicMatter>
                   <Name>SoilOrganicMatter</Name>
@@ -58155,16 +57920,6 @@ namespace Models
                     <double>0.08</double>
                     <double>0.9</double>
                   </fract_lign>
-                  <oc>
-                    <double>0.36030177375113792</double>
-                    <double>0.27080607825510783</double>
-                    <double>0.241057083027954</double>
-                    <double>0.1614100773132848</double>
-                    <double>0.16039591661358196</double>
-                    <double>0.29923549966041468</double>
-                    <double>0.099634477132654622</double>
-                    <double>0.099656769505334544</double>
-                  </oc>
                 </SoilNitrogen>
                 <SoilOrganicMatter>
                   <Name>SoilOrganicMatter</Name>
@@ -58715,16 +58470,6 @@ namespace Models
                     <double>0.08</double>
                     <double>0.9</double>
                   </fract_lign>
-                  <oc>
-                    <double>0.36030177375113792</double>
-                    <double>0.27080607825510783</double>
-                    <double>0.241057083027954</double>
-                    <double>0.1614100773132848</double>
-                    <double>0.16039591661358196</double>
-                    <double>0.29923549966041468</double>
-                    <double>0.099634477132654622</double>
-                    <double>0.099656769505334544</double>
-                  </oc>
                 </SoilNitrogen>
                 <SoilOrganicMatter>
                   <Name>SoilOrganicMatter</Name>
@@ -59275,16 +59020,6 @@ namespace Models
                     <double>0.08</double>
                     <double>0.9</double>
                   </fract_lign>
-                  <oc>
-                    <double>0.36030177375113792</double>
-                    <double>0.27080607825510783</double>
-                    <double>0.241057083027954</double>
-                    <double>0.1614100773132848</double>
-                    <double>0.16039591661358196</double>
-                    <double>0.29923549966041468</double>
-                    <double>0.099634477132654622</double>
-                    <double>0.099656769505334544</double>
-                  </oc>
                 </SoilNitrogen>
                 <SoilOrganicMatter>
                   <Name>SoilOrganicMatter</Name>
@@ -61969,28 +61704,6 @@ namespace Models
                     <double>0.08</double>
                     <double>0.9</double>
                   </fract_lign>
-                  <oc>
-                    <double>0.83098748905480757</double>
-                    <double>0.34912902535987167</double>
-                    <double>0.32945480931770033</double>
-                    <double>0.22033899225619674</double>
-                    <double>0.2204410407712849</double>
-                    <double>0.22033460534939428</double>
-                    <double>0.19066689182381227</double>
-                    <double>0.1705041939872736</double>
-                    <double>0.15047673339339734</double>
-                    <double>0.12054425206968533</double>
-                    <double>0.11047609227916679</double>
-                    <double>0.10041248749368043</double>
-                    <double>0.10035647768752969</double>
-                    <double>0.10031196392041249</double>
-                    <double>0.10024878738421951</double>
-                    <double>0.10021556360251731</double>
-                    <double>0.10017719304680695</double>
-                    <double>0.10012934933941822</double>
-                    <double>0.10009356434438876</double>
-                    <double>0.10004261693966804</double>
-                  </oc>
                 </SoilNitrogen>
                 <CERESSoilTemperature>
                   <Name>CERESSoilTemperature</Name>
@@ -67284,28 +66997,6 @@ namespace Models
                   <double>0.08</double>
                   <double>0.9</double>
                 </fract_lign>
-                <oc>
-                  <double>0.83098748905480757</double>
-                  <double>0.34912902535987167</double>
-                  <double>0.32945480931770033</double>
-                  <double>0.22033899225619674</double>
-                  <double>0.2204410407712849</double>
-                  <double>0.22033460534939428</double>
-                  <double>0.19066689182381227</double>
-                  <double>0.1705041939872736</double>
-                  <double>0.15047673339339734</double>
-                  <double>0.12054425206968533</double>
-                  <double>0.11047609227916679</double>
-                  <double>0.10041248749368043</double>
-                  <double>0.10035647768752969</double>
-                  <double>0.10031196392041249</double>
-                  <double>0.10024878738421951</double>
-                  <double>0.10021556360251731</double>
-                  <double>0.10017719304680695</double>
-                  <double>0.10012934933941822</double>
-                  <double>0.10009356434438876</double>
-                  <double>0.10004261693966804</double>
-                </oc>
               </SoilNitrogen>
               <CERESSoilTemperature>
                 <Name>CERESSoilTemperature</Name>
@@ -67452,8 +67143,8 @@ namespace Models
               <Name>MouseActivity</Name>
               <IncludeInDocumentation>false</IncludeInDocumentation>
               <Script>
-                <NibblingDate>2002-10-31</NibblingDate>
                 <ProportionNibbled>0.5</ProportionNibbled>
+                <NibblingDate>2002-10-31</NibblingDate>
               </Script>
               <Code><![CDATA[
 using System;
@@ -68583,8 +68274,8 @@ namespace Models
               <Name>Sowing</Name>
               <IncludeInDocumentation>false</IncludeInDocumentation>
               <Script>
-                <SowDate>25-May</SowDate>
                 <CultivarName>Hartog</CultivarName>
+                <SowDate>25-May</SowDate>
                 <SowingDepth>40</SowingDepth>
                 <RowSpacing>250</RowSpacing>
                 <Population>100</Population>
@@ -69367,8 +69058,8 @@ namespace Models
               <Name>Sowing</Name>
               <IncludeInDocumentation>false</IncludeInDocumentation>
               <Script>
-                <SowDate>25-May</SowDate>
                 <CultivarName>Hartog</CultivarName>
+                <SowDate>25-May</SowDate>
                 <SowingDepth>40</SowingDepth>
                 <RowSpacing>250</RowSpacing>
                 <Population>100</Population>
@@ -70111,8 +69802,8 @@ namespace Models
               <Name>Sowing</Name>
               <IncludeInDocumentation>false</IncludeInDocumentation>
               <Script>
-                <SowDate>25-May</SowDate>
                 <CultivarName>Hartog</CultivarName>
+                <SowDate>25-May</SowDate>
                 <SowingDepth>40</SowingDepth>
                 <RowSpacing>250</RowSpacing>
                 <Population>100</Population>
@@ -70855,8 +70546,8 @@ namespace Models
               <Name>Sowing</Name>
               <IncludeInDocumentation>false</IncludeInDocumentation>
               <Script>
-                <SowDate>25-May</SowDate>
                 <CultivarName>Hartog</CultivarName>
+                <SowDate>25-May</SowDate>
                 <SowingDepth>40</SowingDepth>
                 <RowSpacing>250</RowSpacing>
                 <Population>100</Population>


### PR DESCRIPTION
Working on #1798 
Changed how OC is defined in the calculation of urea hydrolysis, previously it used resetOC (which is the OC at initialisation), now it used current OC values