### PR TITLE
Fix a typo that was causing problems for Output node in the tree of the GUI

### DIFF
--- a/UserInterface/Presenters/DataStorePresenter.cs
+++ b/UserInterface/Presenters/DataStorePresenter.cs
@@ -109,7 +109,7 @@ namespace UserInterface.Presenters
                     {
                         if (simulationId == 0 && data.Rows.Count > 0)
                         {
-                            simulationId = (int)data.Rows[0][1];
+                            simulationId = (int)data.Rows[0][i];
                         }
                         data.Columns.RemoveAt(i);
                         i--;


### PR DESCRIPTION
Fix a typo that was causing problems for Output node in the tree of the GUI. 

Only effects WindowsForms version of Output node not GTK.

resolves #1817 