### PR TITLE
Issue/variables in new patches soil nitrogen#1823

### DIFF
--- a/Models/Soils/SoilNitrogen.CNPatch.Processes.cs
+++ b/Models/Soils/SoilNitrogen.CNPatch.Processes.cs
@@ -44,8 +44,8 @@ namespace Models.Soils
                 dlt_n_decomp = new double[g.nResidues][];
                 for (int residue = 0; residue < g.nResidues; residue++)
                 {
-                    dlt_c_decomp[residue] = new double[nLayers];
-                    dlt_n_decomp[residue] = new double[nLayers];
+                    dlt_c_decomp[residue] = new double[g.nLayers];
+                    dlt_n_decomp[residue] = new double[g.nLayers];
                 }
 
                 // 2. get the amounts of C decomposed
@@ -66,8 +66,8 @@ namespace Models.Soils
                     //{
                         // Surface OM sent some potential decomposition, here we verify the C-N balance over the immobilisation layer
 
-                        double[] no3_available = new double[nLayers];           // no3 available for mineralisation
-                        double[] nh4_available = new double[nLayers];           // nh4 available for mineralisation
+                        double[] no3_available = new double[g.nLayers];           // no3 available for mineralisation
+                        double[] nh4_available = new double[g.nLayers];           // nh4 available for mineralisation
                         double[] dltC_into_biom = new double[g.nResidues];      // C mineralized converted to biomass
                         double[] dltC_into_hum = new double[g.nResidues];       // C mineralized converted to humus
                         int ImmobilisationLayer = g.getCumulativeIndex(g.ResiduesDecompDepth, g.dlayer);  // soil layer down to which soil N is available for decemposition
@@ -84,7 +84,7 @@ namespace Models.Soils
                         // 2.2.1. get the available mineral N in the soil close to surface (mineralisation depth)
                         double MineralNAvailable = 0.0;
                         double cumDepth = 0.0;
-                        double[] fracLayer = new double[nLayers];
+                        double[] fracLayer = new double[g.nLayers];
                         for (int layer = 0; layer <= ImmobilisationLayer; layer++)
                         {
                             fracLayer[layer] = Math.Min(1.0, MathUtilities.Divide(g.ResiduesDecompDepth - cumDepth, g.dlayer[layer], 0.0));
@@ -175,7 +175,7 @@ namespace Models.Soils
                 // 4. Update variables - add/remove C and N in appropriate pools
                 if (g.SumDoubleArray(dlt_c_res_to_biom) + g.SumDoubleArray(dlt_c_res_to_hum) >= g.epsilon)
                 {
-                    for (int layer = 0; layer < nLayers; layer++)
+                    for (int layer = 0; layer < g.nLayers; layer++)
                     {
                         // organic C pools
                         biom_c[layer] += dlt_c_res_to_biom[layer];
@@ -204,54 +204,54 @@ namespace Models.Soils
                 if (g.SumDoubleArray(hum_c) >= g.epsilon)
                 {
                     poolsComputed += 1;
-                    for (int layer = 0; layer < nLayers; layer++)
+                    for (int layer = 0; layer < g.nLayers; layer++)
                         MineraliseHumus(layer);
                 }
                 else
                 {
-                    Array.Clear(dlt_c_hum_to_biom, 0, nLayers);
-                    Array.Clear(dlt_c_hum_to_atm, 0, nLayers);
-                    Array.Clear(dlt_n_hum_to_min, 0, nLayers);
+                    Array.Clear(dlt_c_hum_to_biom, 0, g.nLayers);
+                    Array.Clear(dlt_c_hum_to_atm, 0, g.nLayers);
+                    Array.Clear(dlt_n_hum_to_min, 0, g.nLayers);
                 }
 
                 // 2. get the mineralisation of m. biomass pool
                 if (g.SumDoubleArray(biom_c) >= g.epsilon)
                 {
                     poolsComputed += 1;
-                    for (int layer = 0; layer < nLayers; layer++)
+                    for (int layer = 0; layer < g.nLayers; layer++)
                         MineraliseMBiomass(layer);
                 }
                 else
                 {
-                    Array.Clear(dlt_c_biom_to_hum, 0, nLayers);
-                    Array.Clear(dlt_c_biom_to_atm, 0, nLayers);
-                    Array.Clear(dlt_n_biom_to_min, 0, nLayers);
+                    Array.Clear(dlt_c_biom_to_hum, 0, g.nLayers);
+                    Array.Clear(dlt_c_biom_to_atm, 0, g.nLayers);
+                    Array.Clear(dlt_n_biom_to_min, 0, g.nLayers);
                 }
 
                 // 3. get the decomposition of FOM pools
                 if ((g.SumDoubleArray(fom_c[0]) + g.SumDoubleArray(fom_c[1]) + g.SumDoubleArray(fom_c[2])) >= g.epsilon)
                 {
                     poolsComputed += 1;
-                    for (int layer = 0; layer < nLayers; layer++)
+                    for (int layer = 0; layer < g.nLayers; layer++)
                         DecomposeFOM(layer);
                 }
                 else
                 {
                     for (int pool = 0; pool < 3; pool++)
                     {
-                        Array.Clear(dlt_c_fom_to_biom[pool], 0, nLayers);
-                        Array.Clear(dlt_c_fom_to_hum[pool], 0, nLayers);
-                        Array.Clear(dlt_c_fom_to_atm[pool], 0, nLayers);
-                        Array.Clear(dlt_n_fom[pool], 0, nLayers);
+                        Array.Clear(dlt_c_fom_to_biom[pool], 0, g.nLayers);
+                        Array.Clear(dlt_c_fom_to_hum[pool], 0, g.nLayers);
+                        Array.Clear(dlt_c_fom_to_atm[pool], 0, g.nLayers);
+                        Array.Clear(dlt_n_fom[pool], 0, g.nLayers);
                     }
-                    Array.Clear(dlt_n_fom_to_min, 0, nLayers);
+                    Array.Clear(dlt_n_fom_to_min, 0, g.nLayers);
                 }
 
                 // 4. make changes effective
                 if (poolsComputed > 0)
                 {
                     // some of the OM pools has potentially changed
-                    for (int layer = 0; layer < nLayers; layer++)
+                    for (int layer = 0; layer < g.nLayers; layer++)
                     {
                         // 4.1. update SOM pools
                         biom_c[layer] += dlt_c_hum_to_biom[layer] - dlt_c_biom_to_hum[layer] - dlt_c_biom_to_atm[layer] +
@@ -484,7 +484,7 @@ namespace Models.Soils
                 if (g.SumDoubleArray(urea) >= g.epsilon)
                 {
                     // there is some urea in the soil
-                    for (int layer = 0; layer < nLayers; layer++)
+                    for (int layer = 0; layer < g.nLayers; layer++)
                     {
                         // get amount hydrolysed
                         dlt_urea_hydrolysis[layer] = UreaHydrolysis(layer);
@@ -494,7 +494,7 @@ namespace Models.Soils
                     }
                 }
                 else
-                    Array.Clear(dlt_urea_hydrolysis, 0, nLayers);
+                    Array.Clear(dlt_urea_hydrolysis, 0, g.nLayers);
             }
 
             /// <summary>
@@ -505,7 +505,7 @@ namespace Models.Soils
                 if (g.SumDoubleArray(nh4) >= g.epsilon)
                 {
                     // there is some ammonium in the soil
-                    for (int layer = 0; layer < nLayers; layer++)
+                    for (int layer = 0; layer < g.nLayers; layer++)
                     {
                         if (g.usingNewNitrification)
                         {
@@ -554,8 +554,8 @@ namespace Models.Soils
                 }
                 else
                 {
-                    Array.Clear(dlt_nitrification, 0, nLayers);
-                    Array.Clear(dlt_n2o_nitrif, 0, nLayers);
+                    Array.Clear(dlt_nitrification, 0, g.nLayers);
+                    Array.Clear(dlt_n2o_nitrif, 0, g.nLayers);
                 }
             }
 
@@ -567,7 +567,7 @@ namespace Models.Soils
                 if (g.SumDoubleArray(no3) >= g.epsilon)
                 {
                     // there is some nitrate in the soil
-                    for (int layer = 0; layer < nLayers; layer++)
+                    for (int layer = 0; layer < g.nLayers; layer++)
                     {
                         // get the denitrification amount
                         dlt_no3_dnit[layer] = Denitrification(layer);
@@ -580,8 +580,8 @@ namespace Models.Soils
                 }
                 else
                 {
-                    Array.Clear(dlt_no3_dnit, 0, nLayers);
-                    Array.Clear(dlt_n2o_dnit, 0, nLayers);
+                    Array.Clear(dlt_no3_dnit, 0, g.nLayers);
+                    Array.Clear(dlt_n2o_dnit, 0, g.nLayers);
                 }
             }
 

--- a/Models/Soils/SoilNitrogen.CNPatch.cs
+++ b/Models/Soils/SoilNitrogen.CNPatch.cs
@@ -156,7 +156,7 @@ namespace Models.Soils
             {
                 set
                 {
-                    for (int layer = 0; layer < Math.Min(value.Length, nLayers); ++layer)
+                    for (int layer = 0; layer < Math.Min(value.Length, g.nLayers); ++layer)
                     {
                         // update variable and check its value
                         urea[layer] += value[layer];
@@ -188,7 +188,7 @@ namespace Models.Soils
             {
                 set
                 {
-                    for (int layer = 0; layer < Math.Min(value.Length, nLayers); ++layer)
+                    for (int layer = 0; layer < Math.Min(value.Length, g.nLayers); ++layer)
                     {
                         // update variable and check its value
                         nh4[layer] += value[layer];
@@ -220,7 +220,7 @@ namespace Models.Soils
             {
                 set
                 {
-                    for (int layer = 0; layer < Math.Min(value.Length, nLayers); ++layer)
+                    for (int layer = 0; layer < Math.Min(value.Length, g.nLayers); ++layer)
                     {
                         // update variable and check its value
                         no3[layer] += value[layer];
@@ -253,7 +253,7 @@ namespace Models.Soils
                     int nPools = value.Length;
                     for (int pool = 0; pool < nPools; pool++)
                     {
-                        for (int layer = 0; layer < Math.Min(value[pool].Length, nLayers); ++layer)
+                        for (int layer = 0; layer < Math.Min(value[pool].Length, g.nLayers); ++layer)
                         {
                             fom_c[pool][layer] += value[pool][layer];
                             g.CheckNegativeValues(ref fom_c[pool][layer], layer, "FOM_C[" + (pool + 1).ToString() + "]", "Patch[" + this.PatchName + "].dltFOM");
@@ -272,7 +272,7 @@ namespace Models.Soils
                     int nPools = value.Length;
                     for (int pool = 0; pool < nPools; pool++)
                     {
-                        for (int layer = 0; layer < Math.Min(value[pool].Length, nLayers); ++layer)
+                        for (int layer = 0; layer < Math.Min(value[pool].Length, g.nLayers); ++layer)
                         {
                             fom_n[pool][layer] += value[pool][layer];
                             g.CheckNegativeValues(ref fom_n[pool][layer], layer, "FOM_N[" + (pool + 1).ToString() + "]", "Patch[" + this.PatchName + "].dltFOM");
@@ -301,8 +301,8 @@ namespace Models.Soils
                     double[] result = null;
                     if (g.dlayer != null)
                     {
-                        result = new double[nLayers];
-                        for (int layer = 0; layer < nLayers; ++layer)
+                        result = new double[g.nLayers];
+                        for (int layer = 0; layer < g.nLayers; ++layer)
                             result[layer] = fom_n[0][layer] +
                                             fom_n[1][layer] +
                                             fom_n[2][layer] +
@@ -324,10 +324,10 @@ namespace Models.Soils
                 get
                 {
                     double depthFromSurface = 0.0;
-                    double[] result = new double[nLayers];
+                    double[] result = new double[g.nLayers];
                     double fractionAvailable = Math.Min(1.0,
                            MathUtilities.Divide(g.maxTotalNAvailableToPlants, totalMineralNInRootZone, 0.0));
-                    for (int layer = 0; layer < nLayers; layer++)
+                    for (int layer = 0; layer < g.nLayers; layer++)
                     {
                         result[layer] = nh4[layer] * fractionAvailable;
                         depthFromSurface += g.dlayer[layer];
@@ -346,10 +346,10 @@ namespace Models.Soils
                 get
                 {
                     double depthFromSurface = 0.0;
-                    double[] result = new double[nLayers];
+                    double[] result = new double[g.nLayers];
                     double fractionAvailable = Math.Min(1.0,
                         MathUtilities.Divide(g.maxTotalNAvailableToPlants, totalMineralNInRootZone, 0.0));
-                    for (int layer = 0; layer < nLayers; layer++)
+                    for (int layer = 0; layer < g.nLayers; layer++)
                     {
                         result[layer] = no3[layer] * fractionAvailable;
                         depthFromSurface += g.dlayer[layer];
@@ -511,8 +511,8 @@ namespace Models.Soils
                     double[] result = null;
                     if (g.dlayer != null)
                     {
-                        result = new double[nLayers];
-                        for (int layer = 0; layer < nLayers; layer++)
+                        result = new double[g.nLayers];
+                        for (int layer = 0; layer < g.nLayers; layer++)
                             result[layer] += fom_c[0][layer] +
                                              fom_c[1][layer] +
                                              fom_c[2][layer] +
@@ -585,8 +585,8 @@ namespace Models.Soils
             {
                 get
                 {
-                    double[] result = new double[nLayers];
-                    for (int layer = 0; layer < nLayers; layer++)
+                    double[] result = new double[g.nLayers];
+                    for (int layer = 0; layer < g.nLayers; layer++)
                         result[layer] = dlt_c_fom_to_atm[0][layer] +
                                         dlt_c_fom_to_atm[1][layer] +
                                         dlt_c_fom_to_atm[2][layer] +
@@ -610,9 +610,6 @@ namespace Models.Soils
             #endregion
 
             #region Internal variables
-
-            /// <summary>Number layers in the soil</summary>
-            public int nLayers;
 
             #region Residue decomposition information
 
@@ -668,7 +665,7 @@ namespace Models.Soils
             {
                 totalMineralNInRootZone = 0.0;
                 double depthFromSurface = 0.0;
-                for (int layer = 0; layer < nLayers; layer++)
+                for (int layer = 0; layer < g.nLayers; layer++)
                 {
                     totalMineralNInRootZone += nh4[layer] + no3[layer];
                     depthFromSurface += g.dlayer[layer];
@@ -768,18 +765,18 @@ namespace Models.Soils
                 dlt_c_loss_in_sed = 0.0;
 
                 // variables to report changes by other modules after partitioning amongst patches
-                Array.Clear(urea_flow, 0, nLayers);
-                Array.Clear(nh4_flow, 0, nLayers);
-                Array.Clear(no3_flow, 0, nLayers);
-                Array.Clear(urea_uptake, 0, nLayers);
-                Array.Clear(nh4_uptake, 0, nLayers);
-                Array.Clear(no3_uptake, 0, nLayers);
-                Array.Clear(urea_fertiliser, 0, nLayers);
-                Array.Clear(nh4_fertiliser, 0, nLayers);
-                Array.Clear(no3_fertiliser, 0, nLayers);
-                Array.Clear(urea_ChangedOther, 0, nLayers);
-                Array.Clear(nh4_ChangedOther, 0, nLayers);
-                Array.Clear(no3_ChangedOther, 0, nLayers);
+                Array.Clear(urea_flow, 0, g.nLayers);
+                Array.Clear(nh4_flow, 0, g.nLayers);
+                Array.Clear(no3_flow, 0, g.nLayers);
+                Array.Clear(urea_uptake, 0, g.nLayers);
+                Array.Clear(nh4_uptake, 0, g.nLayers);
+                Array.Clear(no3_uptake, 0, g.nLayers);
+                Array.Clear(urea_fertiliser, 0, g.nLayers);
+                Array.Clear(nh4_fertiliser, 0, g.nLayers);
+                Array.Clear(no3_fertiliser, 0, g.nLayers);
+                Array.Clear(urea_ChangedOther, 0, g.nLayers);
+                Array.Clear(nh4_ChangedOther, 0, g.nLayers);
+                Array.Clear(no3_ChangedOther, 0, g.nLayers);
             }
 
             /// <summary>
@@ -790,7 +787,7 @@ namespace Models.Soils
                 TodaysInitialN = g.SumDoubleArray(nit_tot);
                 TodaysInitialC = g.SumDoubleArray(carbon_tot);
 
-                for (int layer = 0; layer < nLayers; layer++)
+                for (int layer = 0; layer < g.nLayers; layer++)
                 {
                     // store these values so they may be used to compute daily deltas
                     TodaysInitialNH4[layer] = nh4[layer];
@@ -806,7 +803,7 @@ namespace Models.Soils
             /// </remarks>
             private void PackActualResidueDecomposition()
             {
-                soilp_dlt_org_p = new double[nLayers];
+                soilp_dlt_org_p = new double[g.nLayers];
                 double soilp_cpr = MathUtilities.Divide(g.SumDoubleArray(g.pot_p_decomp), g.SumDoubleArray(g.pot_c_decomp), 0.0);
                 SurfOMActualDecomposition = new SurfaceOrganicMatterDecompType();
                 Array.Resize(ref SurfOMActualDecomposition.Pool, g.nResidues);
@@ -837,7 +834,7 @@ namespace Models.Soils
                 double act_c_decomp = 0.0;
                 double tot_pot_c_decomp = g.SumDoubleArray(g.pot_c_decomp);
                 double tot_pot_p_decomp = g.SumDoubleArray(g.pot_p_decomp);
-                for (int layer = 0; layer < nLayers; layer++)
+                for (int layer = 0; layer < g.nLayers; layer++)
                 {
                     act_c_decomp = dlt_c_res_to_biom[layer] + dlt_c_res_to_hum[layer] + dlt_c_res_to_atm[layer];
                     soilp_dlt_org_p[layer] = tot_pot_p_decomp * MathUtilities.Divide(act_c_decomp, tot_pot_c_decomp, 0.0);
@@ -893,8 +890,8 @@ namespace Models.Soils
             {
                 double layer_loss = 0.0;
                 double layer_gain = 0.0;
-                int lowest_layer = nLayers;
-                int lowestLayer = nLayers - 1;
+                int lowest_layer = g.nLayers;
+                int lowestLayer = g.nLayers - 1;
                 int new_lowest_layer = new_dlayer.Length;
 
                 double TodaysInitialAmount = g.SumDoubleArray(SoilProperty);
@@ -926,7 +923,7 @@ namespace Models.Soils
                     // soil profile has been increased (assume material has been added to the surface
                     AmountGainedBottom = 0.0;
                     // check for changes in layer structure
-                    if (nLayers < new_dlayer.Length)
+                    if (g.nLayers < new_dlayer.Length)
                     {
                         throw new Exception("Number of soil layers was increased, this option has not been coded in SoilNitrogen");
                     }
@@ -937,7 +934,7 @@ namespace Models.Soils
                     AmountGainedBottom = 0.0;
 
                     // check for changes in layer structure
-                    if (new_dlayer.Length < nLayers)
+                    if (new_dlayer.Length < g.nLayers)
                     {
                         // we have less layers than before.  The layer structure is kept, from top down, thus in fact the bottom layer merges with the second bottom etc.
 
@@ -990,7 +987,7 @@ namespace Models.Soils
             /// </summary>
             public void CheckVariables()
             {
-                for (int layer = 0; layer < nLayers; layer++)
+                for (int layer = 0; layer < g.nLayers; layer++)
                 {
                     // 1. Organic forms
                     for (int pool = 0; pool < 3; pool++)

--- a/Models/Soils/SoilNitrogen.CNPatch.cs
+++ b/Models/Soils/SoilNitrogen.CNPatch.cs
@@ -160,7 +160,7 @@ namespace Models.Soils
                     {
                         // update variable and check its value
                         urea[layer] += value[layer];
-                        g.CheckNegativeValues(ref urea[layer], layer, "urea", "Patch[" + this.PatchName + "].deltaUrea");
+                        g.CheckNegativeValues(ref urea[layer], layer, "urea", "Patch[" + PatchName + "].deltaUrea");
 
                         // record these values to use as outputs
                         if (g.senderModule == "WaterModule".ToLower())
@@ -192,7 +192,7 @@ namespace Models.Soils
                     {
                         // update variable and check its value
                         nh4[layer] += value[layer];
-                        g.CheckNegativeValues(ref nh4[layer], layer, "nh4", "Patch[" + this.PatchName + "].deltaNH4");
+                        g.CheckNegativeValues(ref nh4[layer], layer, "nh4", "Patch[" + PatchName + "].deltaNH4");
 
                         // record these values to use as outputs
                         if (g.senderModule == "WaterModule".ToLower())
@@ -224,7 +224,7 @@ namespace Models.Soils
                     {
                         // update variable and check its value
                         no3[layer] += value[layer];
-                        g.CheckNegativeValues(ref no3[layer], layer, "no3", "Patch[" + this.PatchName + "].deltaNO3");
+                        g.CheckNegativeValues(ref no3[layer], layer, "no3", "Patch[" + PatchName + "].deltaNO3");
 
                         // record these values to use as outputs
                         if (g.senderModule == "WaterModule".ToLower())
@@ -256,7 +256,7 @@ namespace Models.Soils
                         for (int layer = 0; layer < Math.Min(value[pool].Length, g.nLayers); ++layer)
                         {
                             fom_c[pool][layer] += value[pool][layer];
-                            g.CheckNegativeValues(ref fom_c[pool][layer], layer, "FOM_C[" + (pool + 1).ToString() + "]", "Patch[" + this.PatchName + "].dltFOM");
+                            g.CheckNegativeValues(ref fom_c[pool][layer], layer, "FOM_C[" + (pool + 1).ToString() + "]", "Patch[" + PatchName + "].dltFOM");
                         }
                     }
                 }
@@ -275,7 +275,7 @@ namespace Models.Soils
                         for (int layer = 0; layer < Math.Min(value[pool].Length, g.nLayers); ++layer)
                         {
                             fom_n[pool][layer] += value[pool][layer];
-                            g.CheckNegativeValues(ref fom_n[pool][layer], layer, "FOM_N[" + (pool + 1).ToString() + "]", "Patch[" + this.PatchName + "].dltFOM");
+                            g.CheckNegativeValues(ref fom_n[pool][layer], layer, "FOM_N[" + (pool + 1).ToString() + "]", "Patch[" + PatchName + "].dltFOM");
                         }
                     }
                 }
@@ -992,18 +992,18 @@ namespace Models.Soils
                     // 1. Organic forms
                     for (int pool = 0; pool < 3; pool++)
                     {
-                        g.CheckNegativeValues(ref fom_c[pool][layer], layer, "fom_c[" + (pool + 1).ToString() + "]", "Patch[" + this.PatchName + "].EvaluateProcesses");
-                        g.CheckNegativeValues(ref fom_n[pool][layer], layer, "fom_n[" + (pool + 1).ToString() + "]", "Patch[" + this.PatchName + "].EvaluateProcesses");
+                        g.CheckNegativeValues(ref fom_c[pool][layer], layer, "fom_c[" + (pool + 1).ToString() + "]", "Patch[" + PatchName + "].EvaluateProcesses");
+                        g.CheckNegativeValues(ref fom_n[pool][layer], layer, "fom_n[" + (pool + 1).ToString() + "]", "Patch[" + PatchName + "].EvaluateProcesses");
                     }
-                    g.CheckNegativeValues(ref biom_c[layer], layer, "biom_c", "Patch[" + this.PatchName + "].EvaluateProcesses");
-                    g.CheckNegativeValues(ref hum_c[layer], layer, "hum_c", "Patch[" + this.PatchName + "].EvaluateProcesses");
-                    g.CheckNegativeValues(ref biom_n[layer], layer, "biom_n", "Patch[" + this.PatchName + "].EvaluateProcesses");
-                    g.CheckNegativeValues(ref hum_n[layer], layer, "hum_n", "Patch[" + this.PatchName + "].EvaluateProcesses");
+                    g.CheckNegativeValues(ref biom_c[layer], layer, "biom_c", "Patch[" + PatchName + "].EvaluateProcesses");
+                    g.CheckNegativeValues(ref hum_c[layer], layer, "hum_c", "Patch[" + PatchName + "].EvaluateProcesses");
+                    g.CheckNegativeValues(ref biom_n[layer], layer, "biom_n", "Patch[" + PatchName + "].EvaluateProcesses");
+                    g.CheckNegativeValues(ref hum_n[layer], layer, "hum_n", "Patch[" + PatchName + "].EvaluateProcesses");
 
                     // 2. Mineral forms
-                    g.CheckNegativeValues(ref urea[layer], layer, "urea", "Patch[" + this.PatchName + "].EvaluateProcesses");
-                    g.CheckNegativeValues(ref nh4[layer], layer, "nh4", "Patch[" + this.PatchName + "].EvaluateProcesses");
-                    g.CheckNegativeValues(ref no3[layer], layer, "no3", "Patch[" + this.PatchName + "].EvaluateProcesses");
+                    g.CheckNegativeValues(ref urea[layer], layer, "urea", "Patch[" + PatchName + "].EvaluateProcesses");
+                    g.CheckNegativeValues(ref nh4[layer], layer, "nh4", "Patch[" + PatchName + "].EvaluateProcesses");
+                    g.CheckNegativeValues(ref no3[layer], layer, "no3", "Patch[" + PatchName + "].EvaluateProcesses");
                 }
             }
 

--- a/Models/Soils/SoilNitrogen.Variables.cs
+++ b/Models/Soils/SoilNitrogen.Variables.cs
@@ -2444,21 +2444,18 @@ namespace Models.Soils
 
                 return null;
             }
-            set
+            set  // should this be private?
             {
-                /*if (hasValues(value, EPSILON))
-                {
-                    double[] delta = MathUtilities.Subtract(value, urea);
-                    // 3.1- send incoming dlt to be partitioned amongst patches
-                    double[][] newDelta = partitionDelta(delta, "Urea", NPartitionApproach.ToLower());
-                    // 3.2- send dlt's to each patch
+                //double sumOld = MathUtilities.Sum(urea);
+
+                for (int layer = 0; layer < Math.Min(nLayers, value.Length); layer++)
                     for (int k = 0; k < Patch.Count; k++)
-                        Patch[k].dlt_urea = newDelta[k];
-                }*/
-                for (int k = 0; k < Patch.Count; k++)
-                    Patch[k].urea = value;
+                        Patch[k].urea[layer] = value[layer];
+
+                // SendExternalMassFlowN(MathUtilities.Sum(urea) - sumOld); //TODO:is this still needed?
             }
         }
+
         /// <summary>
         /// Soil ammonium nitrogen amount (kgN/ha)
         /// </summary>
@@ -2478,12 +2475,13 @@ namespace Models.Soils
             }
             set  // should this be private?
             {
-                double sumOld = MathUtilities.Sum(NH4);
+                //double sumOld = MathUtilities.Sum(NH4);
 
-                for (int k = 0; k < Patch.Count; k++)
-                    Patch[k].nh4 = value;
+                for (int layer = 0; layer < Math.Min(nLayers, value.Length); layer++)
+                    for (int k = 0; k < Patch.Count; k++)
+                        Patch[k].nh4[layer] = value[layer];
 
-                SendExternalMassFlowN(MathUtilities.Sum(NH4) - sumOld);
+                // SendExternalMassFlowN(MathUtilities.Sum(NH4) - sumOld); //TODO:is this still needed?
             }
         }
 
@@ -2509,19 +2507,15 @@ namespace Models.Soils
 
                 return null;
             }
-            set
+            set  // should this be private?
             {
-                /* if (hasValues(value, EPSILON))
-                 {
-                     double[] delta = MathUtilities.Subtract(value, NO3);
-                     // 3.1- send incoming dlt to be partitioned amongst patches
-                     double[][] newDelta = partitionDelta(delta, "NO3", NPartitionApproach.ToLower());
-                     // 3.2- send dlt's to each patch
-                     for (int k = 0; k < Patch.Count; k++)
-                         Patch[k].dlt_no3 = newDelta[k];
-                 } */
-                for (int k = 0; k < Patch.Count; k++)
-                    Patch[k].no3 = value;
+                //double sumOld = MathUtilities.Sum(NO3);
+
+                for (int layer = 0; layer < Math.Min(nLayers, value.Length); layer++)
+                    for (int k = 0; k < Patch.Count; k++)
+                        Patch[k].no3[layer] = value[layer];
+
+                // SendExternalMassFlowN(MathUtilities.Sum(NO3) - sumOld); //TODO:is this still needed?
             }
         }
 

--- a/Models/Soils/SoilNitrogen.cs
+++ b/Models/Soils/SoilNitrogen.cs
@@ -108,8 +108,6 @@ namespace Models.Soils
             // Get the layering info and set the layer count
             dlayer = Soil.Thickness;
             nLayers = dlayer.Length;
-            for (int k = 0; k < Patch.Count; k++)
-                Patch[k].nLayers = nLayers;
 
             // get the initial values 
             oc = Soil.OC;
@@ -919,8 +917,6 @@ namespace Models.Soils
 
             // and the layer count
             nLayers = dlayer.Length;
-            for (int k = 0; k < Patch.Count; k++)
-                Patch[k].nLayers = nLayers;
         }
 
         /// <summary>Gets the changes in mineral N made by other modules</summary>

--- a/Models/Soils/SoilNitrogen.cs
+++ b/Models/Soils/SoilNitrogen.cs
@@ -19,8 +19,8 @@ namespace Models.Soils
     /// Implements internal 'patches', which are replicates of state variables and processes used for simulating soil variability
     ///
     /// Based on a more-or-less direct port of the Fortran SoilN model  -  Ported by Eric Zurcher Sept/Oct 2010
-    /// Code tidied up by RCichota initially on Aug/Sep-2012 (updates in Feb-Mar/2014 and 2016)
-    /// Ported into ApsimX by Russel McAuliffe in 2017, tidied up by RCichota (July/2017)
+    /// Code tidied up by RCichota initially in Aug/Sep-2012 (updates in Feb-Apr/2014, Apr/2015, and Mar-Apr/2016)
+    /// Full patch capability ported into ApsimX by Russel McAuliffe in June/2017, tidied up by RCichota (July/2017)
     /// </remarks>
     [Serializable]
     [ValidParent(ParentType = typeof(Soil))]
@@ -857,17 +857,6 @@ namespace Models.Soils
         {
             // get the basic soil data info
             int nLayers = NewProfile.dlayer.Length;
-            //Array.Resize(ref SoilDensity, nLayers);
-            //Array.Resize(ref ll15_dep, nLayers);
-            //Array.Resize(ref dul_dep, nLayers);
-            //Array.Resize(ref sat_dep, nLayers);
-            //for (int layer = 0; layer < nLayers; layer++)
-            //{
-            //    SoilDensity[layer] = (double)NewProfile.bd[layer];
-            //    ll15_dep[layer] = (double)NewProfile.ll15_dep[layer];
-            //    dul_dep[layer] = (double)NewProfile.dul_dep[layer];
-            //    sat_dep[layer] = (double)NewProfile.sat_dep[layer];
-            //}
 
             // check the layer structure
             if (dlayer == null)


### PR DESCRIPTION
Resolves #1823 
When new patches were added to SoilNitrogen a few variables were not correctly handled. dlayer was not passed on to the new patches and the N variables (urea, nh4, and no3) were kept linked, so they changed in all patches whenever one was changed.
The variable nLayers (number of layers) in patches is now linked to that of SoilNitrogen, so there is no need to 'manually' pass it to each patch.  The problem with the N variables was the way there were set in their respective properties in SoilNitrogen. In there the array in each patch was simple pointed to the new array ('value'), and as this was done for all patches, they all pointed to the same object and were in fact 'linked'. I have added an extra loop to copy the values for each layer separately so no link is created... This arises form the fact that in .Net arrays are objects but their elements (as with fields) are not, so the result of "a = b" is different if the variables are array or fields...