### PR TITLE
If the heading level for documenting a constant in invalid, just writ…

### DIFF
--- a/Models/Plant/Functions/Constant.cs
+++ b/Models/Plant/Functions/Constant.cs
@@ -41,12 +41,12 @@ namespace Models.PMF.Functions
                 units = " (" + units + ")";
 
             if (!(Parent is IFunction) && headingLevel > 0)
-            {
-                tags.Add(new AutoDocumentation.Heading(Name + " = " + FixedValue + units, headingLevel));
+                tags.Add(new AutoDocumentation.Heading(Name, headingLevel));
+
+            tags.Add(new AutoDocumentation.Paragraph("<i>" + Name + " = " + FixedValue + units + "</i>", indent));
+
+            if (!String.IsNullOrEmpty(description))
                 tags.Add(new AutoDocumentation.Paragraph(description, indent));
-            }
-            else
-                tags.Add(new AutoDocumentation.Paragraph("<i>" + Name + " = " + FixedValue + units + "</i>", indent));
 
             // write memos.
             foreach (IModel memo in Apsim.Children(this, typeof(Memo)))

--- a/Models/Plant/Functions/Constant.cs
+++ b/Models/Plant/Functions/Constant.cs
@@ -40,7 +40,7 @@ namespace Models.PMF.Functions
             if (units != string.Empty)
                 units = " (" + units + ")";
 
-            if (!(Parent is IFunction))
+            if (!(Parent is IFunction) && headingLevel > 0)
             {
                 tags.Add(new AutoDocumentation.Heading(Name + " = " + FixedValue + units, headingLevel));
                 tags.Add(new AutoDocumentation.Paragraph(description, indent));


### PR DESCRIPTION
…e it as a paragraph. Resolves #1861