### PR TITLE
Allow a double-click to initiate editing of the name of a node on the…

### DIFF
--- a/ApsimNG/Menus/ContextMenu.cs
+++ b/ApsimNG/Menus/ContextMenu.cs
@@ -504,7 +504,7 @@ namespace UserInterface.Presenters
         public bool IncludeInDocumentationChecked()
         {
             IModel model = Apsim.Get(explorerPresenter.ApsimXFile, explorerPresenter.CurrentNodePath) as IModel;
-            return model.IncludeInDocumentation;
+            return (model != null) ? model.IncludeInDocumentation : false;
         }
 
         /// <summary>
@@ -529,7 +529,7 @@ namespace UserInterface.Presenters
         public bool ShowPageOfGraphsChecked()
         {
             Folder folder = Apsim.Get(explorerPresenter.ApsimXFile, explorerPresenter.CurrentNodePath) as Folder;
-            return folder.ShowPageOfGraphs;
+            return (folder != null) ? folder.ShowPageOfGraphs : false;
         }
 
     }


### PR DESCRIPTION
… tree. That's standard behaviour on Windows, but I'm not so sure that it's really desirable. However, you ask for it - you get it. Resolves #1875 