### PR TITLE
Make use of the DeploymentSupport folder now in git, rather than stuf…

### DIFF
--- a/Setup/apsimx.iss
+++ b/Setup/apsimx.iss
@@ -18,7 +18,7 @@ AppVersion={#AppVerNo}
 AppID=APSIM{#AppVerNo}
 DefaultDirName={pf}\APSIM{#AppVerNo}
 DefaultGroupName=APSIM{#AppVerNo}
-UninstallDisplayIcon={app}\Bin\Userinterface.exe
+UninstallDisplayIcon={app}\Bin\ApsimNG.exe
 Compression=lzma/Max
 ChangesAssociations=true
 WizardSmallImageFile=apsim_logo32.bmp
@@ -129,9 +129,9 @@ Name: {localappdata}\VirtualStore\Apsim; Type: dirifempty
 [Files]
 Source: ..\Bin\*.exe; DestDir: {app}\Bin; Flags: ignoreversion; 
 Source: ..\Bin\*.dll; DestDir: {app}\Bin; Flags: ignoreversion; 
-Source: ..\..\..\..\DeploymentSupport\Windows\Assemblies\*.dll; DestDir: {app}\Bin; Flags: ignoreversion;
-Source: ..\..\..\..\DeploymentSupport\Windows\Bin\*.dll; DestDir: {app}\Bin; Flags: ignoreversion;
-Source: ..\..\..\..\DeploymentSupport\Windows\lib\gtk-2.0\2.10.0\engines\*.dll; DestDir: {app}\lib\gtk-2.0\2.10.0\engines; Flags: ignoreversion;
+;Source: ..\DeploymentSupport\Windows\Assemblies\*.dll; DestDir: {app}\Bin; Flags: ignoreversion;
+Source: ..\DeploymentSupport\Windows\Bin\*.dll; DestDir: {app}\Bin; Flags: ignoreversion;
+Source: ..\DeploymentSupport\Windows\lib\gtk-2.0\2.10.0\engines\*.dll; DestDir: {app}\lib\gtk-2.0\2.10.0\engines; Flags: ignoreversion;
 ;Source: ..\..\..\..\DeploymentSupport\Windows\etc\gtk-2.0\gtkrc; DestDir: {app}\etc\gtk-2.0; Flags: ignoreversion;
 Source: ..\Bin\.gtkrc; DestDir: {app}\Bin; Flags: ignoreversion;
 Source: ..\Bin\UserInterface.exe.config; DestDir: {app}\Bin; Flags: ignoreversion; 


### PR DESCRIPTION
…f not in git, when getting support DLLs for the Windows installer. Working on #1918