### PR TITLE
Allow properties to be tagged with a "Caption" attribute that provide…

### DIFF
--- a/ApsimNG/Presenters/ProfilePresenter.cs
+++ b/ApsimNG/Presenters/ProfilePresenter.cs
@@ -351,9 +351,11 @@ namespace UserInterface.Presenters
             foreach (VariableProperty property in this.propertiesInGrid)
             {
                 string columnName = property.Description;
+                string columnCaption = property.Caption;
                 if (property.UnitsLabel != null)
                 {
                     columnName += "\r\n" + property.UnitsLabel;
+                    columnCaption += "\r\n" + property.UnitsLabel;
                 }
 
                 // add a total to the column header if necessary.
@@ -361,6 +363,7 @@ namespace UserInterface.Presenters
                 if (!double.IsNaN(total))
                 {
                     columnName = columnName + "\r\n" + total.ToString("N1");
+                    columnCaption = columnCaption + "\r\n" + total.ToString("N1");
                 }
 
                 Array values = null;
@@ -374,7 +377,8 @@ namespace UserInterface.Presenters
 
                 if (table.Columns.IndexOf(columnName) == -1)
                 {
-                    table.Columns.Add(columnName, property.DataType.GetElementType());
+                    DataColumn newCol = table.Columns.Add(columnName, property.DataType.GetElementType());
+                    newCol.Caption = columnCaption;
                 }
                 else
                 {

--- a/ApsimNG/Views/GridView.cs
+++ b/ApsimNG/Views/GridView.cs
@@ -458,7 +458,7 @@ namespace UserInterface.Views
                 textRender.Xalign = ((i == 0) || (i == 1) && isPropertyMode) ? 0.0f : 1.0f; // For right alignment of text cell contents; left align the first column
 
                 TreeViewColumn column = new TreeViewColumn();
-                column.Title = this.DataSource.Columns[i].ColumnName;
+                column.Title = this.DataSource.Columns[i].Caption;
                 column.PackStart(textRender, true);     // 0
                 column.PackStart(toggleRender, true);   // 1
                 column.PackStart(comboRender, true);    // 2
@@ -521,6 +521,8 @@ namespace UserInterface.Views
                     (newLabel.Parent as Alignment).LeftPadding = 2;
                 newLabel.UseMarkup = true;
                 newLabel.Markup = "<b>" + System.Security.SecurityElement.Escape(gridview.Columns[i].Title) + "</b>";
+                if (this.DataSource.Columns[i].Caption != this.DataSource.Columns[i].ColumnName)
+                    newLabel.Parent.Parent.Parent.TooltipText = this.DataSource.Columns[i].ColumnName;
                 newLabel.Show();
             }
 

--- a/ApsimNG/Views/MainView.cs
+++ b/ApsimNG/Views/MainView.cs
@@ -314,6 +314,8 @@ namespace UserInterface.Views
         public void ShowWaitCursor(bool wait)
         {
             WaitCursor = wait;
+            while (GLib.MainContext.Iteration())
+                ;
         }
 
         /// <summary>Close the application.</summary>

--- a/Models/Core/Attributes/BriefLabelAttribute.cs
+++ b/Models/Core/Attributes/BriefLabelAttribute.cs
@@ -1,0 +1,41 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="DescriptionAttribute.cs" company="APSIM Initiative">
+//     Copyright (c) APSIM Initiative
+// </copyright>
+// -----------------------------------------------------------------------
+namespace Models.Core
+{
+    using System;
+
+    /// <summary>
+    /// Attribute to hold a short description string for a property
+    /// This is almost identical to the DescriptionAttribute, but is intended
+    /// to allow for a "brief" as well as a "lengthy" description. 
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class)]
+    public class CaptionAttribute : System.Attribute
+    {
+        /// <summary>
+        /// The name of the view class
+        /// </summary>
+        private string description;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CaptionAttribute" /> class.
+        /// </summary>
+        /// <param name="description">Description text</param>
+        public CaptionAttribute(string description)
+        {
+            this.description = description;
+        }
+
+        /// <summary>
+        /// Gets the description
+        /// </summary>
+        /// <returns>The description</returns>
+        public override string ToString()
+        {
+            return this.description;
+        }
+    } 
+}

--- a/Models/Core/IVariable.cs
+++ b/Models/Core/IVariable.cs
@@ -35,6 +35,11 @@ namespace Models.Core
         public abstract string Description { get; }
 
         /// <summary>
+        /// Gets the text to use as a label for the property.
+        /// </summary>
+        public abstract string Caption { get; }
+
+        /// <summary>
         /// Gets or sets the units of the property or null if not found.
         /// </summary>
         public abstract string Units { get; set;  }

--- a/Models/Core/Variable.cs
+++ b/Models/Core/Variable.cs
@@ -65,6 +65,18 @@
             }
         }
 
+
+        /// <summary>
+        /// Gets the text to use as a label for the property.
+        /// </summary>
+        public override string Caption
+        {
+            get
+            {
+                return null;
+            }
+        }
+
         /// <summary>
         /// Returns the units of the property (in brackets) or null if not found.
         /// </summary>
@@ -161,6 +173,25 @@
                 if (descriptionAttribute != null && descriptionAttribute.ToString() != "")
                     return descriptionAttribute.ToString();
                 return null;
+            }
+        }
+
+        /// <summary>
+        /// Gets the text to use as a label for the property.
+        /// </summary>
+        public override string Caption
+        {
+            get
+            {
+                CaptionAttribute labelAttribute = ReflectionUtilities.GetAttribute(FieldInfo, typeof(CaptionAttribute), false) as CaptionAttribute;
+                if (labelAttribute == null)
+                {
+                    return Description;
+                }
+                else
+                {
+                    return labelAttribute.ToString();
+                }
             }
         }
 

--- a/Models/Core/VariableComposite.cs
+++ b/Models/Core/VariableComposite.cs
@@ -114,6 +114,17 @@ namespace Models.Core
         }
 
         /// <summary>
+        /// Gets the text to use as a label for the property.
+        /// </summary>
+        public override string Caption
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Gets the units of the property or null if not found.
         /// </summary>
         public override string Units

--- a/Models/Core/VariableExpression.cs
+++ b/Models/Core/VariableExpression.cs
@@ -101,6 +101,17 @@ namespace Models.Core
         }
 
         /// <summary>
+        /// Gets the text to use as a label for the property.
+        /// </summary>
+        public override string Caption
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Gets the units of the property (in brackets) or null if not found.
         /// </summary>
         public override string Units

--- a/Models/Core/VariableMethod.cs
+++ b/Models/Core/VariableMethod.cs
@@ -61,6 +61,10 @@ namespace Models.Core
         public override string Description { get { return string.Empty; } }
 
         /// <summary>
+        /// Gets the text to use as a label for the property.
+        /// </summary>
+        public override string Caption { get { return string.Empty; } }
+        /// <summary>
         /// Gets the units of the method
         /// </summary>
         public override string Units { get { return string.Empty; } set { } }

--- a/Models/Core/VariableProperty.cs
+++ b/Models/Core/VariableProperty.cs
@@ -129,6 +129,27 @@ namespace Models.Core
         }
 
         /// <summary>
+        /// Gets the text to use as a label for the property.
+        /// This is derived from the BriefLabel attribute or,
+        /// if that does not exist, from the Description attribute
+        /// </summary>
+        public override string Caption
+        {
+            get
+            {
+                CaptionAttribute labelAttribute = ReflectionUtilities.GetAttribute(this.property, typeof(CaptionAttribute), false) as CaptionAttribute;
+                if (labelAttribute == null)
+                {
+                    return Description;
+                }
+                else
+                {
+                    return labelAttribute.ToString();
+                }
+            }
+        }
+
+        /// <summary>
         /// Gets the units of the property
         /// </summary>
         public override string Units

--- a/Models/Models.csproj
+++ b/Models/Models.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Core\APSIMFileConverter.cs" />
     <Compile Include="Core\APSIMFileReader.cs" />
     <Compile Include="Core\APSIMFileWriter.cs" />
+    <Compile Include="Core\Attributes\BriefLabelAttribute.cs" />
     <Compile Include="Core\Attributes\DoNotDocumentAttribute.cs" />
     <Compile Include="Core\Attributes\ScopedModelAttribute.cs" />
     <Compile Include="Core\Attributes\SoluteAttribute.cs" />

--- a/Models/Soils/LayerStructure.cs
+++ b/Models/Soils/LayerStructure.cs
@@ -20,8 +20,9 @@ namespace Models.Soils
         /// <summary>The depth boundaries of each layer</summary>
         /// <value>The thickness.</value>
         [XmlIgnore]
-        [Units("mm")]
-        [Description("Soil layer depth positions (cm)")]
+        [Units("cm")]
+        [Caption("Depth")]
+        [Description("Soil layer depth positions")]
         public string[] Depth
         {
             get
@@ -32,7 +33,8 @@ namespace Models.Soils
         /// <summary>Gets or sets the thickness.</summary>
         /// <value>The thickness.</value>
         [Units("mm")]
-        [Description("Soil layer thickness for each layer (mm)")]
+        [Caption("Thickness")]
+        [Description("Soil layer thickness for each layer")]
         public double[] Thickness { get; set; }       
     }
 }

--- a/Models/Soils/MultiPoreWater/WEIRDO.cs
+++ b/Models/Soils/MultiPoreWater/WEIRDO.cs
@@ -139,6 +139,7 @@ namespace Models.Soils
         public double Runoff { get; set; }
         ///<summary>Soil Albedo</summary>
         [Units("0-1")]
+        [Caption("Albedo")]
         [Description("The proportion of incoming radiation that is reflected by the soil surface")]
         public double Salb { get; set; }
         ///<summary> Who knows</summary>

--- a/Models/Soils/OutputLayers.cs
+++ b/Models/Soils/OutputLayers.cs
@@ -23,14 +23,16 @@ namespace Models.Soils
         /// <summary>The depth boundaries of each layer</summary>
         /// <value>The thickness.</value>
         [XmlIgnore]
-        [Units("mm")]
-        [Description("Soil layer depth positions (cm)")]
+        [Units("cm")]
+        [Caption("Depth")]
+        [Description("Soil layer depth positions")]
         public string[] Depth { get { return Soil.ToDepthStrings(Thickness); } }
             
         /// <summary>Gets or sets the thickness.</summary>
         /// <value>The thickness.</value>
         [Units("mm")]
-        [Description("Soil layer thickness for each layer (mm)")]
+        [Caption("Thickness")]
+        [Description("Soil layer thickness for each layer")]
         public double[] Thickness { get; set; }
 
         ///<summary> Soil water content (ml/ml) of each layer mapped onto specified layering to match observations </summary>

--- a/Models/Soils/SoilOrganicMatter.cs
+++ b/Models/Soils/SoilOrganicMatter.cs
@@ -26,7 +26,8 @@ namespace Models.Soils
         /// <summary>Gets or sets the root wt.</summary>
         /// <value>The root wt.</value>
         [Summary]
-        [Description("Root Weight (kg/ha)")]
+        [Units("kg/ha")]
+        [Description("Root Weight")]
         public double RootWt { get; set; }
 
         /// <summary>Gets or sets the soil cn.</summary>

--- a/Models/Soils/SoilWater.cs
+++ b/Models/Soils/SoilWater.cs
@@ -50,7 +50,8 @@ namespace Models.Soils
         /// The summer date.
         /// </value>
         [Units("dd-mmm")]
-        [Description("Start date for switch to summer parameters for soil water evaporation (dd-mmm)")]
+        [Caption("Summer date")]
+        [Description("Start date for switch to summer parameters for soil water evaporation")]
         public string SummerDate { get; set; }
 
         /// <summary>
@@ -61,7 +62,8 @@ namespace Models.Soils
         /// </value>
         [Bounds(Lower = 0.0, Upper = 40.0)]
         [Units("mm")]
-        [Description("Cummulative soil water evaporation to reach the end of stage 1 soil water evaporation in summer (a.k.a. U) (mm)")]
+        [Caption("Summer U")]
+        [Description("Cummulative soil water evaporation to reach the end of stage 1 soil water evaporation in summer (a.k.a. U)")]
         public double SummerU { get; set; }
 
         /// <summary>
@@ -71,6 +73,7 @@ namespace Models.Soils
         /// The summer cona.
         /// </value>
         [Bounds(Lower = 0.0, Upper = 10.0)]
+        [Caption("Summer ConA")]
         [Description("Drying coefficient for stage 2 soil water evaporation in summer (a.k.a. ConA)")]
         public double SummerCona { get; set; }
 
@@ -83,7 +86,8 @@ namespace Models.Soils
         /// The winter date.
         /// </value>
         [Units("dd-mmm")]
-        [Description("Start date for switch to winter parameters for soil water evaporation (dd-mmm)")]
+        [Caption("Winter date")]
+        [Description("Start date for switch to winter parameters for soil water evaporation")]
         public string WinterDate { get; set; }
 
         /// <summary>
@@ -94,7 +98,8 @@ namespace Models.Soils
         /// </value>
         [Bounds(Lower = 0.0, Upper = 10.0)]
         [Units("mm")]
-        [Description("Cummulative soil water evaporation to reach the end of stage 1 soil water evaporation in winter (a.k.a. U) (mm).")]
+        [Caption("Winter U")]
+        [Description("Cummulative soil water evaporation to reach the end of stage 1 soil water evaporation in winter (a.k.a. U).")]
         public double WinterU { get; set; }
 
         /// <summary>
@@ -104,6 +109,7 @@ namespace Models.Soils
         /// The winter cona.
         /// </value>
         [Bounds(Lower = 0.0, Upper = 10.0)]
+        [Caption("Winter ConA")]
         [Description("Drying coefficient for stage 2 soil water evaporation in winter (a.k.a. ConA)")]
         public double WinterCona { get; set; }
 
@@ -115,7 +121,8 @@ namespace Models.Soils
         /// </value>
         [Bounds(Lower = 0.0, Upper = 1000.0)]
         [Units("mm2/day")]
-        [Description("Constant in the soil water diffusivity calculation (mm2/day)")]
+        [Caption("Diffusivity constant")]
+        [Description("Constant in the soil water diffusivity calculation")]
         public double DiffusConst { get; set; }
 
         /// <summary>
@@ -126,7 +133,8 @@ namespace Models.Soils
         /// </value>
         [Bounds(Lower = 0.0, Upper = 100.0)]
         [Units("/mm")]
-        [Description("Effect of soil water storage above the lower limit on soil water diffusivity (/mm)")]
+        [Caption("Diffusivity slope")]
+        [Description("Effect of soil water storage above the lower limit on soil water diffusivity")]
         public double DiffusSlope { get; set; }
 
         /// <summary>
@@ -136,6 +144,7 @@ namespace Models.Soils
         /// The salb.
         /// </value>
         [Bounds(Lower = 0.0, Upper = 1.0)]
+        [Caption("Albedo")]
         [Description("Fraction of incoming radiation reflected from bare soil")]
         public double Salb { get; set; }
 
@@ -148,6 +157,7 @@ namespace Models.Soils
         /// The c n2 bare.
         /// </value>
         [Bounds(Lower = 1.0, Upper = 100.0)]
+        [Caption("CN bare")]
         [Description("Runoff Curve Number (CN) for bare soil with average moisture")]
         public double CN2Bare { get; set; }
 
@@ -158,6 +168,7 @@ namespace Models.Soils
         /// The cn red.
         /// </value>
         [Bounds(Lower = 1.0, Upper = 100.0)]
+        [Caption("CN reduction")]
         [Description("Maximum reduction in runoff Curve Number due to cover")]
         public double CNRed { get; set; }
 
@@ -168,6 +179,7 @@ namespace Models.Soils
         /// The cn cov.
         /// </value>
         [Bounds(Lower = 0.0, Upper = 1.0)]        
+        [Caption("CN cover")]
         [Description("Fractional cover at which maximum reduction of Curve Number occurs")]
         public double CNCov { get; set; }
 
@@ -184,7 +196,8 @@ namespace Models.Soils
         /// The slope.
         /// </value>
         [Bounds(Lower = 0.0, Upper = 1.0)]
-        [Description("Slope of the catchment area for lateral flow calculations (0-1)")]
+        [Caption("Slope")]
+        [Description("Slope of the catchment area for lateral flow calculations")]
         public double slope { get; set; }
 
         /// <summary>
@@ -195,7 +208,8 @@ namespace Models.Soils
         /// </value>
         [Bounds(Lower = 0.0, Upper = 1.0e8F)]     //1.0e8F = 100000000
         [Units("m")]
-        [Description("Basal width of the downslope boundary of the catchment for lateral flow calculations (m)")]
+        [Caption("Basal width")]
+        [Description("Basal width of the downslope boundary of the catchment for lateral flow calculations")]
         public double discharge_width { get; set; }
 
         /// <summary>
@@ -206,7 +220,8 @@ namespace Models.Soils
         /// </value>
         [Bounds(Lower = 0.0, Upper = 1.0e8F)]     //1.0e8F = 100000000
         [Units("m2")]
-        [Description("Catchment area for later flow calculations (m2)")]
+        [Caption("Catchment")]
+        [Description("Catchment area for lateral flow calculations")]
         public double catchment_area { get; set; }
 
 
@@ -220,7 +235,8 @@ namespace Models.Soils
         /// </value>
         [Bounds(Lower = 0.0, Upper = 1000.0)]
         [Units("mm")]
-        [Description("Maximum ponding depth of water (e.g. of a rice paddy) (mm)")]
+        [Caption("Max pond")]
+        [Description("Maximum ponding depth of water (e.g. of a rice paddy)")]
         public double max_pond { get; set; }
 
 
@@ -270,7 +286,8 @@ namespace Models.Soils
         /// </value>
         [XmlIgnore]
         [Units("cm")]
-        [Description("Soil layer thickness for each layer (cm)")]
+        [Caption("Depth")]
+        [Description("Soil layer thickness for each layer")]
         public string[] Depth
             {
             get
@@ -297,7 +314,8 @@ namespace Models.Soils
         /// </value>
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("/d")]
-        [Description("Fractional amount of water above DUL that can drain under gravity per day (SWCON) (/d)")]
+        [Caption("SWCON")]
+        [Description("Fractional amount of water above DUL that can drain under gravity per day (SWCON)")]
         public double[] SWCON { get; set; }
 
 
@@ -314,7 +332,8 @@ namespace Models.Soils
         /// </value>
         [Bounds(Lower = 0, Upper = 1.0e3F)] //1.0e3F = 1000
         [Units("mm/d")]
-        [Description("Lateral saturated hydraulic conductivity (KLAT) (mm/d)")]
+        [Caption("Klat")]
+        [Description("Lateral saturated hydraulic conductivity (KLAT)")]
         public double[] KLAT { get; set; }
 
         #endregion

--- a/Models/Storage/DataStore.cs
+++ b/Models/Storage/DataStore.cs
@@ -245,7 +245,9 @@
             {
                 Table.Column column = table.Columns.Find(c => c.Name == columnHeading);
                 if (column != null)
-                    return "(" + column.Units + ")";
+                {
+                    return column.Units;
+                }
             }
             return null;
         }

--- a/Models/Storage/DataStore.cs
+++ b/Models/Storage/DataStore.cs
@@ -245,9 +245,7 @@
             {
                 Table.Column column = table.Columns.Find(c => c.Name == columnHeading);
                 if (column != null)
-                {
-                    return column.Units;
-                }
+                    return "(" + column.Units + ")";
             }
             return null;
         }

--- a/Models/SurfaceOrganicMatter.cs
+++ b/Models/SurfaceOrganicMatter.cs
@@ -365,7 +365,7 @@
         /// <summary>Gets or sets the Carbon:Phosphorus ratio.</summary>
         /// <value>The Carbon:Phosphorus ratio.</value>
         [Summary]
-        [Description("Carbon:Phosphorus ratio (g/g)")]
+        [Description("Carbon:Phosphorus ratio")]
         [Units("g/g")]
         public string cpr
         {


### PR DESCRIPTION
…s a short label in addition to the full description.

Removed redundant parentheses around units when displaying values from the datastore.
Removed redundant declarations of units from description attributes.
Working on #1726