### PR TITLE
Add consideration for generic SoilFertility when computing N demand

### DIFF
--- a/Models/AgPasture/AgPasture.PastureSpecies.cs
+++ b/Models/AgPasture/AgPasture.PastureSpecies.cs
@@ -4758,7 +4758,7 @@ namespace Models.AgPasture
             {
                 // N demand is greater than fixation and remobilisation, N uptake is needed
                 senescedNRemobilised = RemobilisableSenescedN;
-                mySoilNDemand = demandLuxuryN - (fixedN + senescedNRemobilised);
+                mySoilNDemand = demandLuxuryN * GlfSoilFertility - (fixedN + senescedNRemobilised);
                 fracRemobilised = 1.0;
             }
 


### PR DESCRIPTION
Resolves #2025 
Added a correction for soil N demand so that N uptake is limited when using the generic GLFSoilFertility factor. This can still result in N concentration going above maximum, due to N fixation and remobilised from senesced tissues. This should be minor and rare, and a full fix would entail refactor these calcualtion which is a big job and may not be necessary...