### PR TITLE
Altered moving average function and wheat.xml

### DIFF
--- a/Models/Core/APSIMFileConverter.cs
+++ b/Models/Core/APSIMFileConverter.cs
@@ -24,7 +24,7 @@ namespace Models.Core
     public class APSIMFileConverter
     {
         /// <summary>Gets the lastest .apsimx file format version.</summary>
-        public static int LastestVersion { get { return 21; } }
+        public static int LastestVersion { get { return 22; } }
 
         /// <summary>Converts to file to the latest version.</summary>
         /// <param name="fileName">Name of the file.</param>
@@ -180,7 +180,7 @@ namespace Models.Core
 
                 try
                 {
-                    double area = Convert.ToDouble(areaString, 
+                    double area = Convert.ToDouble(areaString,
                                                    System.Globalization.CultureInfo.InvariantCulture);
                     if (area <= 0)
                         XmlUtilities.SetValue(zoneNode, "Area", "1");
@@ -569,7 +569,7 @@ namespace Models.Core
             foreach (XmlNode n in XmlUtilities.FindAllRecursivelyByType(node, "Leaf"))
             {
                 XmlNode dmFunction = APSIMFileConverterUtilities.FindModelNode(n, "DMConversionEfficiencyFunction");
-                if (dmFunction!=null)
+                if (dmFunction != null)
                 {
                     XmlUtilities.SetValue(dmFunction, "Name", "DMConversionEfficiency");
                 }
@@ -654,6 +654,27 @@ namespace Models.Core
                 if (APSIMFileConverterUtilities.FindModelNode(n, "RemobilisationCost") == null)
                     n.AppendChild(DMnode);
             }
+
+        }
+        /// <summary>
+        /// Upgrades to version 22. Alter MovingAverage Function
+        /// XProperty values.
+        /// </summary>
+        /// <param name="node">The node to upgrade.</param>
+        /// <param name="fileName">The name of the .apsimx file</param>
+        private static void UpgradeToVersion22(XmlNode node, string fileName)
+        {
+            string StartStage = "";
+            foreach (XmlNode EmergePhase in XmlUtilities.FindAllRecursivelyByType(node, "EmergingPhase"))
+            {
+                StartStage = XmlUtilities.Value(EmergePhase, "End");
+            }
+            APSIMFileConverterUtilities.RenameVariable(node, "InitialValue", "StageToStartMovingAverage");
+            foreach (XmlNode MovingAverageFunction in XmlUtilities.FindAllRecursivelyByType(node, "MovingAverageFunction"))
+            {
+                XmlUtilities.SetValue(MovingAverageFunction, "StageToStartMovingAverage", StartStage);
+            }
+
         }
     }
 }

--- a/Models/Plant/Functions/MovingAverage.cs
+++ b/Models/Plant/Functions/MovingAverage.cs
@@ -21,12 +21,19 @@ namespace Models.PMF.Functions
         [Description("Number of Days")]
         public int NumberOfDays { get; set; }
 
-        /// <summary>Initial value of the moving average</summary>
-        [Description("Initial Value")]
-        public double InitialValue { get; set; }
+        /// <summary>The stage to start calculating moving average</summary>
+        [Description("The stage to start calculating moving average")]
+        public string StageToStartMovingAverage { get; set; }
+
 
         /// <summary>The accumulated value</summary>
         private List<double> AccumulatedValues = new List<double>();
+
+        /// <summary>Was the moving average array initialised today</summary>
+        private bool InitialisedToday { get; set; }
+
+        /// <summary>Was the moving average array initialised today</summary>
+        private bool Calculate { get; set; }
 
         /// <summary>The child functions</summary>
         private IFunction ChildFunction
@@ -47,23 +54,44 @@ namespace Models.PMF.Functions
         /// <summary>Called when [simulation commencing].</summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
-        [EventSubscribe("Commencing")]
-        private void OnSimulationCommencing(object sender, EventArgs e)
+        [EventSubscribe("PlantSowing")]
+        private void OnSowing(object sender, EventArgs e)
         {
-            for (int i = 0; i < NumberOfDays; i++)
-                AccumulatedValues.Add(InitialValue);
-         }
+            AccumulatedValues.Clear();
+            Calculate = false;
+            
+        }
 
-        /// <summary>Called by Plant.cs when phenology routines are complete.</summary>
+        /// <summary>Called when [phase changed].</summary>
+        /// <param name="phaseChange">The phase change.</param>
+        /// <param name="sender">Sender plant.</param>
+        [EventSubscribe("PhaseChanged")]
+        private void OnPhaseChanged(object sender, PhaseChangedType phaseChange)
+        {
+            //Put the first data member into the list on the day that moving average is to start being calculated
+            if (phaseChange.EventStageName == StageToStartMovingAverage)
+            {
+                AccumulatedValues.Add(ChildFunction.Value());
+                InitialisedToday = true;
+                Calculate = true;
+            }
+        }
+
+        /// <summary>Called by Plant.cs at the end of the day.</summary>
         /// <param name="sender">Plant.cs</param>
         /// <param name="e">Event arguments</param>
         [EventSubscribe("EndOfDay")]
         private void EndOfDay(object sender, EventArgs e)
         {
-            AccumulatedValues.RemoveAt(0);
-            AccumulatedValues.Add(ChildFunction.Value());
+            if (Calculate)
+            {
+                if (InitialisedToday == false)
+                    AccumulatedValues.Add(ChildFunction.Value());
+                if (AccumulatedValues.Count > NumberOfDays)
+                    AccumulatedValues.RemoveAt(0);
+                InitialisedToday = false;
+            }
         }
-
 
         /// <summary>Gets the value.</summary>
         /// <value>The value.</value>
@@ -71,7 +99,7 @@ namespace Models.PMF.Functions
         {
             if (NumberOfDays == 0)
                 throw new ApsimXException(this, "Number of days for moving average cannot be zero in function " + this.Name);
-            return MathUtilities.Sum(AccumulatedValues)/NumberOfDays;
+            return MathUtilities.Average(AccumulatedValues);
         }
 
         /// <summary>Writes documentation for this function by adding to the list of documentation tags.</summary>

--- a/Models/Plant/Phenology/NodeNumberPhase.cs
+++ b/Models/Plant/Phenology/NodeNumberPhase.cs
@@ -27,7 +27,7 @@ namespace Models.PMF.Phen
         private IFunction CompletionNodeNumber = null;
 
         /// <summary>The cohort no at start</summary>
-        private double CohortNoAtStart;
+        private double NodeNoAtStart;
         /// <summary>The first</summary>
         private bool First = true;
         /// <summary>The fraction complete yesterday</summary>
@@ -37,7 +37,7 @@ namespace Models.PMF.Phen
         public override void ResetPhase()
         {
             base.ResetPhase();
-            CohortNoAtStart = 0;
+            NodeNoAtStart = 0;
             FractionCompleteYesterday = 0;
             First = true;
         }
@@ -51,7 +51,7 @@ namespace Models.PMF.Phen
 
             if (First)
             {
-                CohortNoAtStart = Structure.LeafTipsAppeared;
+                NodeNoAtStart = Structure.LeafTipsAppeared;
                 First = false;
             }
 
@@ -72,7 +72,7 @@ namespace Models.PMF.Phen
             base.AddTT(PropOfDayToUse);
             if (First)
             {
-                CohortNoAtStart = Structure.LeafTipsAppeared;
+                NodeNoAtStart = Structure.LeafTipsAppeared;
                 First = false;
             }
 
@@ -91,7 +91,7 @@ namespace Models.PMF.Phen
         {
             get
             {
-                double F = (Structure.LeafTipsAppeared - CohortNoAtStart) / (CompletionNodeNumber.Value() - CohortNoAtStart);
+                double F = (Structure.LeafTipsAppeared - NodeNoAtStart) / (CompletionNodeNumber.Value() - NodeNoAtStart);
                 if (F < 0) F = 0;
                 if (F > 1) F = 1;
                 return Math.Max(F, FractionCompleteYesterday); //Set to maximum of FractionCompleteYesterday so on days where final leaf number increases phenological stage is not wound back.

--- a/Models/Resources/Wheat.xml
+++ b/Models/Resources/Wheat.xml
@@ -926,7 +926,7 @@ A function is used to provide maturity date as days after sowing(DAS).]]>
       </DivideFunction>
       <IncludeInDocumentation>true</IncludeInDocumentation>
       <NumberOfDays>5</NumberOfDays>
-      <InitialValue>0</InitialValue>
+      <StageToStartMovingAverage>Emergence</StageToStartMovingAverage>
     </MovingAverageFunction>
     <MovingAverageFunction>
       <Name>MeanPhyllochron</Name>
@@ -937,7 +937,7 @@ A function is used to provide maturity date as days after sowing(DAS).]]>
       </VariableReference>
       <IncludeInDocumentation>true</IncludeInDocumentation>
       <NumberOfDays>300</NumberOfDays>
-      <InitialValue>80</InitialValue>
+      <StageToStartMovingAverage>Emergence</StageToStartMovingAverage>
     </MovingAverageFunction>
     <HoldFunction>
       <Name>FinalLeafNumber</Name>

--- a/Models/Resources/Wheat.xml
+++ b/Models/Resources/Wheat.xml
@@ -360,41 +360,22 @@ Where MinLeafNumber is the number of leaves that a wheat crop will produce when 
       <ShootLag>40</ShootLag>
       <ShootRate>1.5</ShootRate>
     </EmergingPhase>
-    <GenericPhase>
+    <NodeNumberPhase>
       <Name>Vegetative</Name>
-      <Memo>
-        <Name>Memo</Name>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <MemoText><![CDATA[The duration of the vegetative phase is set by a target Haun Stage for the occurence of Terminal Spikelet and the rate of leaf appearance.  ]]></MemoText>
-      </Memo>
       <VariableReference>
         <Name>ThermalTime</Name>
         <IncludeInDocumentation>true</IncludeInDocumentation>
         <VariableName>[Phenology].ThermalTime.Value()</VariableName>
       </VariableReference>
-      <MultiplyFunction>
-        <Name>Target</Name>
-        <VariableReference>
-          <Name>Phyllochron</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <VariableName>[Structure].MeanPhyllochron.Value()</VariableName>
-        </VariableReference>
-        <VariableReference>
-          <Name>HSTS</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <VariableName>[Structure].HaunStageTerminalSpikelet.Value()</VariableName>
-        </VariableReference>
+      <VariableReference>
+        <Name>CompletionNodeNumber</Name>
         <IncludeInDocumentation>true</IncludeInDocumentation>
-      </MultiplyFunction>
-      <Memo>
-        <Name>Memo1</Name>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <MemoText><![CDATA[HaunStageTerminalSpiklet decreases as vernalisation is accumulated and as photoperiod extends, capturing the effect of these responses on the duration of the Vegetative phase]]></MemoText>
-      </Memo>
+        <VariableName>[Structure].HaunStageTerminalSpikelet.Value()</VariableName>
+      </VariableReference>
       <IncludeInDocumentation>true</IncludeInDocumentation>
       <Start>Emergence</Start>
       <End>TerminalSpikelet</End>
-    </GenericPhase>
+    </NodeNumberPhase>
     <LeafAppearancePhase>
       <Name>StemElongation</Name>
       <Memo>


### PR DESCRIPTION
resolves #2189 

It seems the existing moving average function was causing some problems.  
- Initial value was assigned on the day of simulation commencing to all members in the array and then they were replaced 1 by 1 each day following.  In functions that wheat was using it for this could be placing zero values into the array before sowing.  I have modified the code so that it now has a StartMovingAverageStage on which it adds a single member to the array with the value for that day and keeps adding members each day until the array is at the size specified in the NumberOfDays parameter and then drops the last one off each day.
- Initial value for phyllochron should change with cultivar but it has not been set to do so.  Removing initialValue and having the function pick up the first days value should fix this.
- Array not reset between consecutive crops.  The array is now cleared on sow.

I expect some effect on stats and need to review and see if other changes are needed to compensate