### PR TITLE
Avoid new syntax for out parameters, to allow compilation with older …

### DIFF
--- a/ApsimNG/Presenters/AzureJobDisplayPresenter.cs
+++ b/ApsimNG/Presenters/AzureJobDisplayPresenter.cs
@@ -445,9 +445,10 @@ namespace UserInterface.Presenters
             bool ignoreWarning = false;
 
             foreach (string id in jobsToDownload)
-            {                
-                // if the job id is invalid, skip downloading this job                
-                if (!Guid.TryParse(id, out Guid jobId)) continue;
+            {
+                // if the job id is invalid, skip downloading this job   
+                Guid jobId;             
+                if (!Guid.TryParse(id, out jobId)) continue;
                 currentlyDownloading.Add(jobId);
                 string jobName = GetJob(id).DisplayName;
 
@@ -726,7 +727,8 @@ namespace UserInterface.Presenters
             {
                 try
                 {
-                    if (!Guid.TryParse(id, out Guid parsedId)) continue;
+                    Guid parsedId;
+                    if (!Guid.TryParse(id, out parsedId)) continue;
                     // delete the job from Azure
                     CloudBlobContainer containerRef;
 

--- a/ApsimNG/Presenters/FactorControlPresenter.cs
+++ b/ApsimNG/Presenters/FactorControlPresenter.cs
@@ -100,12 +100,13 @@ namespace UserInterface.Presenters
         /// <param name="str">Max number of simulations allowed to be displayed.</param>
         public void SetMaxNumSims(string str)
         {
+            int n;
             if (str == null || str == "")
             {
                 maxSimsToDisplay = DEFAULT_MAX_SIMS;
                 UpdateView();
             }
-            else if (Int32.TryParse(str, out int n))
+            else if (Int32.TryParse(str, out n))
             {
                 if (n > 1000 && explorerPresenter.MainPresenter.AskQuestion("Displaying more than 1000 rows of data is not recommended! Are you sure you wish to do this?") != QuestionResponseEnum.Yes)
                 {                    
@@ -323,7 +324,8 @@ namespace UserInterface.Presenters
                         string name = data[0];
                         if (data.Count == headers.Count)
                         {
-                            if (!bool.TryParse(data[data.Count - 1], out bool enabled)) throw new Exception("Unable to parse " + data[data.Count - 1] + " to bool on line " + i + ".");
+                            bool enabled;
+                            if (!bool.TryParse(data[data.Count - 1], out enabled)) throw new Exception("Unable to parse " + data[data.Count - 1] + " to bool on line " + i + ".");
                             simulations.Add(new Tuple<string, List<string>, bool>(data[0], data.Skip(1).Take(data.Count - 2).ToList(), enabled));
                         }
                         else if (data.Count > headers.Count) throw new Exception("Too many elements in row " + i + ".");

--- a/ApsimNG/Views/AzureJobDisplayView.cs
+++ b/ApsimNG/Views/AzureJobDisplayView.cs
@@ -389,7 +389,8 @@ namespace UserInterface.Views
         /// <returns></returns>
         private int SortInts(TreeModel model, TreeIter a, TreeIter b, int n)
         {
-            if (!Int32.TryParse((string)model.GetValue(a, n), out int x) || !Int32.TryParse((string)model.GetValue(b, n), out int y)) return -1;
+            int x, y;
+            if (!Int32.TryParse((string)model.GetValue(a, n), out x) || !Int32.TryParse((string)model.GetValue(b, n), out y)) return -1;
             return x.CompareTo(y);
         }
         
@@ -529,8 +530,9 @@ namespace UserInterface.Views
             Application.Invoke(delegate
             {
                 // remember which column is being sorted. If the results are not sorted at all, order by start time ascending
-
-                if (!sort.GetSortColumnId(out int sortIndex, out SortType order))
+                int sortIndex;
+                SortType order;
+                if (!sort.GetSortColumnId(out sortIndex, out order))
                 {
                     sortIndex = Array.IndexOf(columnTitles, "Start Time");
                     order = SortType.Ascending;


### PR DESCRIPTION
…compilers (e.g., using VS 2015). Resolves #2276 