### PR TITLE
Added the ability to copy/paste nodes to and from the clipboard.

### DIFF
--- a/ApsimNG/Interfaces/IExplorerView.cs
+++ b/ApsimNG/Interfaces/IExplorerView.cs
@@ -198,13 +198,13 @@ namespace UserInterface.Interfaces
         /// Get whatever text is currently on the clipboard
         /// </summary>
         /// <returns></returns>
-        string GetClipboardText();
+        string GetClipboardText(string clipboardName);
 
         /// <summary>
         /// Place text on the clipboard
         /// </summary>
         /// <param name="text"></param>
-        void SetClipboardText(string text);
+        void SetClipboardText(string text, string clipboardName);
 
         /// <summary>
         /// Gets or sets the width of the tree view.

--- a/ApsimNG/Presenters/ExplorerPresenter.cs
+++ b/ApsimNG/Presenters/ExplorerPresenter.cs
@@ -479,18 +479,18 @@ namespace UserInterface.Presenters
         /// Get whatever text is currently on the clipboard
         /// </summary>
         /// <returns>Clipboard text</returns>
-        public string GetClipboardText()
+        public string GetClipboardText(string clipboardName = "_APSIM_MODEL")
         {
-            return this.view.GetClipboardText();
+            return this.view.GetClipboardText(clipboardName);
         }
 
         /// <summary>
         /// Place text on the clipboard
         /// </summary>
         /// <param name="text">The text to be stored in the clipboard</param>
-        public void SetClipboardText(string text)
+        public void SetClipboardText(string text, string clipboardName = "_APSIM_MODEL")
         {
-            this.view.SetClipboardText(text);
+            this.view.SetClipboardText(text, clipboardName);
         }
 
         /// <summary>

--- a/ApsimNG/Views/ExplorerView.cs
+++ b/ApsimNG/Views/ExplorerView.cs
@@ -902,25 +902,28 @@ namespace UserInterface.Views
         }
 
         /// <summary>
-        /// Get whatever text is currently on the _APSIM_MODEL clipboard
+        /// Get whatever text is currently on a specific clipboard.
         /// </summary>
+        /// <param name="clipboardName">Name of the clipboard.</param>
         /// <returns></returns>
-        public string GetClipboardText()
+        public string GetClipboardText(string clipboardName)
         {
-            Gdk.Atom modelClipboard = Gdk.Atom.Intern("_APSIM_MODEL", false);
+            Gdk.Atom modelClipboard = Gdk.Atom.Intern(clipboardName, false);
             Clipboard cb = Clipboard.Get(modelClipboard);
+            
             return cb.WaitForText();
         }
 
         /// <summary>
-        /// Place text on the clipboard
+        /// Place text on a specific clipboard.
         /// </summary>
-        /// <param name="text"></param>
-        public void SetClipboardText(string text)
+        /// <param name="text">Text to place on the clipboard.</param>
+        /// <param name="clipboardName">Name of the clipboard.</param>
+        public void SetClipboardText(string text, string clipboardName)
         {
-            Gdk.Atom modelClipboard = Gdk.Atom.Intern("_APSIM_MODEL", false);
+            Gdk.Atom modelClipboard = Gdk.Atom.Intern(clipboardName, false);
             Clipboard cb = Clipboard.Get(modelClipboard);
-            cb.Text = text;
+            cb.Text = text;            
         }
 
         /*


### PR DESCRIPTION
Resolves #2237

Right clicking on a node and pressing copy will now serialise the node and put the XML onto the clipboard, which may then be pasted into a text editor.

After making any changes in the text editor, just copy the XML, right click on a node in the APSIM UI and click paste (or ctrl + v).