### PR TITLE
Generate model files

### DIFF
--- a/ApsimNG/Menus/ContextMenu.cs
+++ b/ApsimNG/Menus/ContextMenu.cs
@@ -466,14 +466,20 @@ namespace UserInterface.Presenters
                 children = Apsim.ChildrenRecursively(node, typeof(Experiment));
             }
 
-            //string outDir = Path.Combine(Path.GetDirectoryName(explorerPresenter.ApsimXFile.FileName), "ModelFiles");
             string outDir = ViewBase.AskUserForDirectory("Select a directory to save model files to.");
+            if (outDir == null)                
+                return;
             if (!Directory.Exists(outDir))
                 Directory.CreateDirectory(outDir);
             string err = "";
+            int i = 0;            
             children.ForEach(expt => 
             {
-                err += (expt as Experiment).GenerateApsimXFile(Path.Combine(outDir, expt.Name + ".apsimx"));
+                explorerPresenter.MainPresenter.ShowMessage("Generating simulation files: ", Simulation.ErrorLevel.Information);
+                explorerPresenter.MainPresenter.ShowProgress(100 * i / children.Count, false);                
+                while (GLib.MainContext.Iteration()) ;
+                err += (expt as Experiment).GenerateApsimXFile(outDir);
+                i++;
             });            
             if (err.Length < 1)
                 explorerPresenter.MainPresenter.ShowMessage("Successfully generated .apsimx files under " + outDir + ".", Simulation.ErrorLevel.Information);

--- a/ApsimNG/Menus/ContextMenu.cs
+++ b/ApsimNG/Menus/ContextMenu.cs
@@ -438,7 +438,49 @@ namespace UserInterface.Presenters
             }
             
         }
-        
+
+        /// <summary>
+        /// Event handler for generate .apsimx files option.
+        /// </summary>
+        /// <param name="sender">Sender of the event</param>
+        /// <param name="e">Event arguments</param>
+        [ContextMenu(MenuName = "Generate .apsimx files",
+             AppliesTo = new Type[] {   typeof(Folder),
+                                        typeof(Simulations),
+                                        typeof(Simulation),
+                                        typeof(Experiment),
+                                    }
+            )
+        ]
+        public void OnGenerateApsimXFiles(object sender, EventArgs e)
+        {
+            IModel node = Apsim.Get(explorerPresenter.ApsimXFile, explorerPresenter.CurrentNodePath) as IModel;
+
+            List<IModel> children;
+            if (node is Experiment)
+            {
+                children = new List<IModel> { node };
+            }
+            else
+            {
+                children = Apsim.ChildrenRecursively(node, typeof(Experiment));
+            }
+
+            //string outDir = Path.Combine(Path.GetDirectoryName(explorerPresenter.ApsimXFile.FileName), "ModelFiles");
+            string outDir = ViewBase.AskUserForDirectory("Select a directory to save model files to.");
+            if (!Directory.Exists(outDir))
+                Directory.CreateDirectory(outDir);
+            string err = "";
+            children.ForEach(expt => 
+            {
+                err += (expt as Experiment).GenerateApsimXFile(Path.Combine(outDir, expt.Name + ".apsimx"));
+            });            
+            if (err.Length < 1)
+                explorerPresenter.MainPresenter.ShowMessage("Successfully generated .apsimx files under " + outDir + ".", Simulation.ErrorLevel.Information);
+            else
+                explorerPresenter.MainPresenter.ShowMessage(err, Simulation.ErrorLevel.Error);
+        }
+
         /// <summary>
         /// Event handler for a Add model action
         /// </summary>

--- a/ApsimNG/Presenters/MainPresenter.cs
+++ b/ApsimNG/Presenters/MainPresenter.cs
@@ -178,9 +178,9 @@ namespace UserInterface.Presenters
         /// Show progress bar with the specified percent.
         /// </summary>
         /// <param name="percent">The progress</param>
-        public void ShowProgress(int percent)
+        public void ShowProgress(int percent, bool showStopButton = true)
         {
-            this.view.ShowProgress(percent);
+            this.view.ShowProgress(percent, showStopButton);
         }
 
         /// <summary>

--- a/ApsimNG/Views/MainView.cs
+++ b/ApsimNG/Views/MainView.cs
@@ -88,7 +88,7 @@ namespace UserInterface.Views
         /// Show progress bar with the specified percent.
         /// </summary>
         /// <param name="percent"></param>
-        void ShowProgress(int percent);
+        void ShowProgress(int percent, bool showStopButton = true);
 
         /// <summary>Set the wait cursor (or not)/</summary>
         /// <param name="wait">Shows wait cursor if true, normal cursor if false.</param>
@@ -619,7 +619,7 @@ namespace UserInterface.Views
         /// Show progress bar with the specified percent.
         /// </summary>
         /// <param name="percent"></param>
-        public void ShowProgress(int percent)
+        public void ShowProgress(int percent, bool showStopButton = true)
         {
             // We need to use "Invoke" if the timer is running in a
             // different thread. That means we can use either
@@ -629,7 +629,8 @@ namespace UserInterface.Views
             {
                 progressBar.Visible = true;
                 progressBar.Fraction = percent / 100.0;
-                stopButton.Visible = true;
+                if (showStopButton)
+                    stopButton.Visible = true;
             });
         }
 

--- a/ApsimNG/Views/ViewBase.cs
+++ b/ApsimNG/Views/ViewBase.cs
@@ -309,7 +309,7 @@ namespace UserInterface
         }
 
         /// <summary>
-        /// Ask the user for a directory.
+        /// Ask the user for a directory. Returns the path to that directory, or null if they did not choose a directory.
         /// </summary>
         /// <param name="prompt">String to use as dialog heading.</param>
         /// <param name="initialPath">Optional initial starting filename or directory.</param>
@@ -322,7 +322,7 @@ namespace UserInterface
                 return OsxDirectoryDialog(prompt, initialPath);
             else
             {
-                string path = "";
+                string path = null;
                 FileChooserDialog fc = new FileChooserDialog(
                     prompt,
                     null,
@@ -336,6 +336,9 @@ namespace UserInterface
                     {
                         response = fc.Run();
                     });
+                    // The issue here is that if this method is called from the main UI thread, the 
+                    // Application.Invoke delegate will not be called until the main thread is idle.
+                    while (GLib.MainContext.Iteration()) ;
                     if (response == (int)ResponseType.Accept)
                     {
                         path = fc.Filename;

--- a/Models/Factorial/Experiment.cs
+++ b/Models/Factorial/Experiment.cs
@@ -76,21 +76,30 @@
         }
 
         /// <summary>
-        /// Generates an .apsimx file for the specified simulation and returns an error message (if it fails).
+        /// Generates an .apsimx file for each simulation in the experiment and returns an error message (if it fails).
         /// </summary>
         /// <param name="path">Full path including filename and extension.</param>
         /// <returns>Empty string if successful, error message if it fails.</returns>
         public string GenerateApsimXFile(string path)
         {
+            if (allCombinations == null || allCombinations.Count < 1)
+                allCombinations = EnabledCombinations();
             string err = "";
-            string xml = Apsim.Serialise(this);
-            try
+            Simulation sim = NextSimulationToRun();
+            while (sim != null)
             {
-                File.WriteAllText(path, xml);
-            }
-            catch (Exception ex)
-            {
-                err += ex.ToString();
+                Simulations sims = Simulations.Create(new List<IModel> { sim, new Models.Storage.DataStore() });
+
+                string xml = Apsim.Serialise(sims);
+                try
+                {
+                    File.WriteAllText(Path.Combine(path, sim.Name + ".apsimx"), xml);
+                }
+                catch (Exception e)
+                {
+                    err += e.ToString();
+                }
+                sim = NextSimulationToRun();
             }
             return err;
         }

--- a/Models/Factorial/Experiment.cs
+++ b/Models/Factorial/Experiment.cs
@@ -75,6 +75,25 @@
             return newSimulation;
         }
 
+        /// <summary>
+        /// Generates an .apsimx file for the specified simulation and returns an error message (if it fails).
+        /// </summary>
+        /// <param name="path">Full path including filename and extension.</param>
+        /// <returns>Empty string if successful, error message if it fails.</returns>
+        public string GenerateApsimXFile(string path)
+        {
+            string err = "";
+            string xml = Apsim.Serialise(this);
+            try
+            {
+                File.WriteAllText(path, xml);
+            }
+            catch (Exception ex)
+            {
+                err += ex.ToString();
+            }
+            return err;
+        }
         /// <summary>Gets a list of simulation names</summary>
         public IEnumerable<string> GetSimulationNames(bool fullFactorial = true)
         {


### PR DESCRIPTION
Resolves #2286 

Added the ability to generate a set of .apsimx files for each simulation under the selected node. This option is accessible via the right-click context menu. 

I also added functionality to select a directory (rather than a file) to the ViewBase class. Similarly to the file choosing methods already existing in that class, it uses an API appropriate to the user's OS (e.g. Windows.Forms, MonoMac, etc.). 

If someone could test this code on OSX, that'd be great. All you would need to do is open an .apsimx file and right click on a node -> generate .apsimx files.