### PR TITLE
When generating auto-docs on Windows, keep the temporary window used …

### DIFF
--- a/ApsimNG/Commands/ExportNodeCommand.cs
+++ b/ApsimNG/Commands/ExportNodeCommand.cs
@@ -669,13 +669,17 @@ namespace UserInterface.Commands
                             ExplorerPresenter.ApsimXFile.Links.Resolve(presenter);
                             presenter.Attach(modelView.model, view, ExplorerPresenter);
 
-                            Gtk.Window popupWin = new Gtk.Window(Gtk.WindowType.Popup);
-                            popupWin.SetSizeRequest(800, 800);
-                            // Move the window offscreen; the user doesn't need to see it.
-                            // This works with IE, but not with WebKit
-                            // Not yet tested on OSX
-                            if (ProcessUtilities.CurrentOS.IsWindows)
-                                popupWin.Move(-10000, -10000);
+                            Gtk.Window popupWin;
+                            if (view is MapView)
+                            {
+                                popupWin = (view as MapView).GetPopupWin();
+                                popupWin.SetSizeRequest(500, 500);
+                            }
+                            else
+                            {
+                                popupWin = new Gtk.Window(Gtk.WindowType.Popup);
+                                popupWin.SetSizeRequest(800, 800);
+                            }
                             popupWin.Add(view.MainWidget);
                             popupWin.ShowAll();
                             while (Gtk.Application.EventsPending())
@@ -685,6 +689,7 @@ namespace UserInterface.Commands
                             section.AddImage(PNGFileName);
                             presenter.Detach();
                             view.MainWidget.Destroy();
+                            popupWin.Destroy();
                         }
                     }
                 }

--- a/ApsimNG/Commands/ExportNodeCommand.cs
+++ b/ApsimNG/Commands/ExportNodeCommand.cs
@@ -679,8 +679,8 @@ namespace UserInterface.Commands
                             {
                                 popupWin = new Gtk.Window(Gtk.WindowType.Popup);
                                 popupWin.SetSizeRequest(800, 800);
+                                popupWin.Add(view.MainWidget);
                             }
-                            popupWin.Add(view.MainWidget);
                             popupWin.ShowAll();
                             while (Gtk.Application.EventsPending())
                                 Gtk.Application.RunIteration();

--- a/ApsimNG/Views/HTMLView.cs
+++ b/ApsimNG/Views/HTMLView.cs
@@ -458,8 +458,8 @@ namespace UserInterface.Views
                 // Move the window offscreen; the user doesn't need to see it.
                 // This works with IE, but not with WebKit
                 // Not yet tested on OSX
-                if (ProcessUtilities.CurrentOS.IsWindows)
-                    popupWin.Move(-10000, -10000);
+                //if (ProcessUtilities.CurrentOS.IsWindows)
+                //    popupWin.Move(-10000, -10000);
                 popupWin.Add(MainWidget);
                 popupWin.ShowAll();
                 while (Gtk.Application.EventsPending())
@@ -490,7 +490,7 @@ namespace UserInterface.Views
                 if (vbox2.Toplevel is Window)
                     (vbox2.Toplevel as Window).SetFocus -= MainWindow_SetFocus;
                 frame1.Unrealized -= Frame1_Unrealized;
-                (browser as TWWebBrowserIE).socket.UnmapEvent += (browser as TWWebBrowserIE).Socket_UnmapEvent;
+                (browser as TWWebBrowserIE).socket.UnmapEvent -= (browser as TWWebBrowserIE).Socket_UnmapEvent;
             }
             if (browser != null)
                 browser.Dispose();
@@ -688,5 +688,6 @@ namespace UserInterface.Views
             if (browser is TWWebBrowserIE)
                 (browser as TWWebBrowserIE).wb.Parent.Enabled = state;
         }
+
     }
 }

--- a/ApsimNG/Views/MapView.cs
+++ b/ApsimNG/Views/MapView.cs
@@ -213,6 +213,12 @@ google.maps.event.addDomListener(window, 'load', initialize);
         }
 
         /// <summary>
+        /// Returns the Popup window used for exporting
+        /// </summary>
+        /// <returns></returns>
+        public Gtk.Window GetPopupWin() { return popupWin; }
+
+        /// <summary>
         /// Export the map to an image.
         /// </summary>
         public Image Export()


### PR DESCRIPTION
…for map generation on-screen. Resolves #2261 
