### PR TITLE
Make ModelDetailsWrapperPresenter call its lower presenter's detach method.

### DIFF
--- a/ApsimNG/Presenters/ModelDetailsWrapperPresenter.cs
+++ b/ApsimNG/Presenters/ModelDetailsWrapperPresenter.cs
@@ -103,6 +103,8 @@
 
         public void Detach()
         {
+            if (currentLowerPresenter != null)
+                currentLowerPresenter.Detach();
             return;
         }
     }


### PR DESCRIPTION
Resolves #2441 

Certain presenters (e.g. XYPairsPresenter) were not being detached. 