### PR TITLE
Allow user to initiate cell editing by clicking on a cell and typing.

### DIFF
--- a/ApsimNG/Views/GridView.cs
+++ b/ApsimNG/Views/GridView.cs
@@ -307,69 +307,72 @@ namespace UserInterface.Views
 
             if (keyName == "ISO_Left_Tab")
                 keyName = "Tab";
-            if ((keyName == "Return" || keyName == "Tab") && userEditingCell)
+            if (keyName == "Return" || keyName == "Tab")
             {
-                bool shifted = (args.Event.State & Gdk.ModifierType.ShiftMask) != 0;
-                int nextRow = iRow;
-                int nCols = DataSource != null ? this.DataSource.Columns.Count : 0;
-                int nextCol = iCol;
-                if (shifted) // Move backwards
+                if (userEditingCell)
                 {
-                    do
+                    bool shifted = (args.Event.State & Gdk.ModifierType.ShiftMask) != 0;
+                    int nextRow = iRow;
+                    int nCols = DataSource != null ? this.DataSource.Columns.Count : 0;
+                    int nextCol = iCol;
+                    if (shifted) // Move backwards
                     {
-                        if (keyName == "Tab") // Move horizontally
+                        do
                         {
-                            if (--nextCol < 0)
-                            {
-                                if (--nextRow < 0)
-                                    nextRow = RowCount - 1;
-                                nextCol = nCols - 1;
-                            }
-                        }
-                        else if (keyName == "Return") // Move vertically
-                        {
-                            if (--nextRow < 0)
+                            if (keyName == "Tab") // Move horizontally
                             {
                                 if (--nextCol < 0)
+                                {
+                                    if (--nextRow < 0)
+                                        nextRow = RowCount - 1;
                                     nextCol = nCols - 1;
-                                nextRow = RowCount - 1;
+                                }
                             }
-                        }
-                    }
-                    while (this.GetColumn(nextCol).ReadOnly || !(new GridCell(this, nextCol, nextRow).EditorType == EditorTypeEnum.TextBox));
-                }
-                else
-                {
-                    do
-                    {
-                        if (keyName == "Tab") // Move horizontally
-                        {
-                            if (++nextCol >= nCols)
+                            else if (keyName == "Return") // Move vertically
                             {
-                                if (++nextRow >= RowCount)
-                                    nextRow = 0;
-                                nextCol = 0;
+                                if (--nextRow < 0)
+                                {
+                                    if (--nextCol < 0)
+                                        nextCol = nCols - 1;
+                                    nextRow = RowCount - 1;
+                                }
                             }
                         }
-                        else if (keyName == "Return") // Move vertically
+                        while (this.GetColumn(nextCol).ReadOnly || !(new GridCell(this, nextCol, nextRow).EditorType == EditorTypeEnum.TextBox));
+                    }
+                    else
+                    {
+                        do
                         {
-                            if (++nextRow >= RowCount)
+                            if (keyName == "Tab") // Move horizontally
                             {
                                 if (++nextCol >= nCols)
+                                {
+                                    if (++nextRow >= RowCount)
+                                        nextRow = 0;
                                     nextCol = 0;
-                                nextRow = 0;
+                                }
+                            }
+                            else if (keyName == "Return") // Move vertically
+                            {
+                                if (++nextRow >= RowCount)
+                                {
+                                    if (++nextCol >= nCols)
+                                        nextCol = 0;
+                                    nextRow = 0;
+                                }
                             }
                         }
+                        while (this.GetColumn(nextCol).ReadOnly || !(new GridCell(this, nextCol, nextRow).EditorType == EditorTypeEnum.TextBox));
                     }
-                    while (this.GetColumn(nextCol).ReadOnly || !(new GridCell(this, nextCol, nextRow).EditorType == EditorTypeEnum.TextBox));
+
+                    EndEdit();
+                    while (GLib.MainContext.Iteration())
+                        ;
+                    if (nextRow != iRow || nextCol != iCol)
+                        gridview.SetCursor(new TreePath(new int[1] { nextRow }), gridview.GetColumn(nextCol), true);
+                    args.RetVal = true;
                 }
-                
-                EndEdit();
-                while (GLib.MainContext.Iteration())
-                    ;
-                if (nextRow != iRow || nextCol != iCol)
-                    gridview.SetCursor(new TreePath(new int[1] { nextRow }), gridview.GetColumn(nextCol), true);
-                args.RetVal = true;
             }
             else if (!userEditingCell && !GetColumn(iCol).ReadOnly) // Initiate cell editing when user starts typing.
             {

--- a/ApsimNG/Views/GridView.cs
+++ b/ApsimNG/Views/GridView.cs
@@ -305,13 +305,6 @@ namespace UserInterface.Views
             int iRow = cell.RowIndex;
             int iCol = cell.ColumnIndex;
 
-            if (keyName == "F2" && !userEditingCell) // Allow f2 to initiate cell editing
-            {
-                if (!this.GetColumn(iCol).ReadOnly)
-                {
-                    gridview.SetCursor(new TreePath(new int[1] { iRow }), gridview.GetColumn(iCol), true);
-                }
-            }
             if (keyName == "ISO_Left_Tab")
                 keyName = "Tab";
             if ((keyName == "Return" || keyName == "Tab") && userEditingCell)
@@ -377,6 +370,16 @@ namespace UserInterface.Views
                 if (nextRow != iRow || nextCol != iCol)
                     gridview.SetCursor(new TreePath(new int[1] { nextRow }), gridview.GetColumn(nextCol), true);
                 args.RetVal = true;
+            }
+            else if (!userEditingCell && !GetColumn(iCol).ReadOnly) // Initiate cell editing when user starts typing.
+            {
+                gridview.SetCursor(new TreePath(new int[1] { iRow }), gridview.GetColumn(iCol), true);
+                Entry editable = editControl as Entry;
+                editable.Text = "";
+                Gdk.EventHelper.Put(args.Event);
+                editable.Position = editable.Text.Length;
+                userEditingCell = true;
+                while (GLib.MainContext.Iteration()) ;
             }
             else if ((char)Gdk.Keyval.ToUnicode(args.Event.KeyValue) == '.')
             {


### PR DESCRIPTION
Resolves #1775
Working on #2399 

This should make data entry slightly easier. Just click on a cell and start typing. The cell won't appear to be selected/editable until you start typing, which is something I will try to address in the near future.