### PR TITLE
Display more useful help information when running from the command line.

### DIFF
--- a/Models/Main.cs
+++ b/Models/Main.cs
@@ -46,7 +46,25 @@ namespace Models
                     fileName = args[0];
 
                 if (args.Length < 1 || args.Length > 4)
-                    throw new Exception("Usage: ApsimX ApsimXFileSpec [/Recurse] [/SingleThreaded] [/RunTests] [/Csv]");
+                {
+                    Console.WriteLine("Usage: Models ApsimXFileSpec [/Recurse] [/SingleThreaded] [/RunTests] [/Csv] [/?]");
+                    return 1;
+                }
+
+                if (args.Contains("/?"))
+                {
+                    string detailedHelpInfo =   "Usage: Models ApsimXFileSpec [/Recurse] [/SingleThreaded] [/RunTests] [/Csv] [/?]";
+                    detailedHelpInfo +=         Environment.NewLine + Environment.NewLine;
+                    detailedHelpInfo +=         "ApsimXFileSpec:          The path to an .apsimx file. May include wildcard.";
+                    detailedHelpInfo +=         Environment.NewLine + Environment.NewLine + "Options:" + Environment.NewLine;
+                    detailedHelpInfo +=         "    /Recurse             Recursively search subdirectories for files matching ApsimXFileSpec" + Environment.NewLine;
+                    detailedHelpInfo +=         "    /SingleThreaded      Run all simulations in a single thread." + Environment.NewLine;
+                    detailedHelpInfo +=         "    /RunTests            Run all tests." + Environment.NewLine;
+                    detailedHelpInfo +=         "    /Csv                 Export all reports to .csv files." + Environment.NewLine;
+                    detailedHelpInfo +=         "    /?                   Show detailed help information.";
+                    Console.WriteLine(detailedHelpInfo);
+                    return 1;
+                }
 
                 Stopwatch timer = new Stopwatch();
                 timer.Start();


### PR DESCRIPTION
Resolves #2528

Detailed help info is accessible via the `/?` switch - e.g. `Models /?`