### PR TITLE
suppress the maintenance respiration

### DIFF
--- a/Models/Plant/Organs/Root.cs
+++ b/Models/Plant/Organs/Root.cs
@@ -79,7 +79,7 @@ namespace Models.PMF.Organs
         /// <summary>The DM demand function</summary>
         [ChildLinkByName]
         [Units("g/m2/d")]
-        private IFunction DMDemandFunction = null;
+        private IFunction dmDemandFunction = null;
 
         /// <summary>Link to the KNO3 link</summary>
         [ChildLinkByName]
@@ -925,7 +925,7 @@ namespace Models.PMF.Organs
         {
             if (dmConversionEfficiency.Value() > 0.0)
             {
-                double demandedDM = DMDemandFunction.Value();
+                double demandedDM = dmDemandFunction.Value();
                 if (structuralFraction != null)
                     demandedDM *= structuralFraction.Value() / dmConversionEfficiency.Value();
                 else

--- a/Models/Plant/Organs/Root.cs
+++ b/Models/Plant/Organs/Root.cs
@@ -79,7 +79,7 @@ namespace Models.PMF.Organs
         /// <summary>The DM demand function</summary>
         [ChildLinkByName]
         [Units("g/m2/d")]
-        private IFunction dmDemandFunction = null;
+        private IFunction DMDemandFunction = null;
 
         /// <summary>Link to the KNO3 link</summary>
         [ChildLinkByName]
@@ -925,7 +925,7 @@ namespace Models.PMF.Organs
         {
             if (dmConversionEfficiency.Value() > 0.0)
             {
-                double demandedDM = dmDemandFunction.Value();
+                double demandedDM = DMDemandFunction.Value();
                 if (structuralFraction != null)
                     demandedDM *= structuralFraction.Value() / dmConversionEfficiency.Value();
                 else

--- a/Prototypes/Grapevine/grapevine.apsimx
+++ b/Prototypes/Grapevine/grapevine.apsimx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Simulations xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="27">
+<Simulations xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="30">
   <Name>Simulations</Name>
   <Memo>
     <Name>TitlePage</Name>
@@ -752,6 +752,7 @@ A function is used to capture the year of the current season as in the south hem
           <ReSetEvent>StartDormancy</ReSetEvent>
         </OnEventFunction>
         <IncludeInDocumentation>true</IncludeInDocumentation>
+        <FractionBiomassRemoved>0</FractionBiomassRemoved>
         <DaysAfterSowing>0</DaysAfterSowing>
       </Phenology>
       <Structure>
@@ -825,7 +826,7 @@ A function is used to capture the year of the current season as in the south hem
         <Constant>
           <Name>FinalLeafNumber</Name>
           <IncludeInDocumentation>true</IncludeInDocumentation>
-          <FixedValue>24</FixedValue>
+          <FixedValue>30</FixedValue>
           <Units>number</Units>
         </Constant>
         <MultiplyFunction>
@@ -1116,358 +1117,6 @@ A function is used to capture the year of the current season as in the south hem
             <Name>MaxArea</Name>
             <XYPairs>
               <Name>XYPairs</Name>
-              <Graph>
-                <Name>Graph</Name>
-                <Series>
-                  <Name>Series</Name>
-                  <IncludeInDocumentation>true</IncludeInDocumentation>
-                  <Type>Scatter</Type>
-                  <XAxis>Bottom</XAxis>
-                  <YAxis>Left</YAxis>
-                  <ColourArgb>-65536</ColourArgb>
-                  <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-                  <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-                  <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-                  <Marker>None</Marker>
-                  <MarkerSize>Normal</MarkerSize>
-                  <Line>Solid</Line>
-                  <LineThickness>Normal</LineThickness>
-                  <Checkpoint>Current</Checkpoint>
-                  <XFieldName>.Simulations.Replacements.Grapevine.Leaf.CohortParameters.MaxArea.XYPairs.X</XFieldName>
-                  <YFieldName>.Simulations.Replacements.Grapevine.Leaf.CohortParameters.MaxArea.XYPairs.Y</YFieldName>
-                  <ShowInLegend>false</ShowInLegend>
-                  <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-                  <Cumulative>false</Cumulative>
-                  <CumulativeX>false</CumulativeX>
-                </Series>
-                <IncludeInDocumentation>true</IncludeInDocumentation>
-                <Axis>
-                  <Type>Left</Type>
-                  <Title>Y</Title>
-                  <Inverted>false</Inverted>
-                  <Minimum>NaN</Minimum>
-                  <Maximum>NaN</Maximum>
-                  <Interval>NaN</Interval>
-                </Axis>
-                <Axis>
-                  <Type>Bottom</Type>
-                  <Title>X</Title>
-                  <Inverted>false</Inverted>
-                  <Minimum>NaN</Minimum>
-                  <Maximum>NaN</Maximum>
-                  <Interval>NaN</Interval>
-                </Axis>
-                <LegendPosition>BottomRight</LegendPosition>
-                <DisabledSeries />
-              </Graph>
-              <Graph>
-                <Name>Graph</Name>
-                <Series>
-                  <Name>Series</Name>
-                  <IncludeInDocumentation>true</IncludeInDocumentation>
-                  <Type>Scatter</Type>
-                  <XAxis>Bottom</XAxis>
-                  <YAxis>Left</YAxis>
-                  <ColourArgb>-65536</ColourArgb>
-                  <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-                  <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-                  <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-                  <Marker>None</Marker>
-                  <MarkerSize>Normal</MarkerSize>
-                  <Line>Solid</Line>
-                  <LineThickness>Normal</LineThickness>
-                  <Checkpoint>Current</Checkpoint>
-                  <XFieldName>.Simulations.Replacements.Grapevine.Leaf.CohortParameters.MaxArea.XYPairs.X</XFieldName>
-                  <YFieldName>.Simulations.Replacements.Grapevine.Leaf.CohortParameters.MaxArea.XYPairs.Y</YFieldName>
-                  <ShowInLegend>false</ShowInLegend>
-                  <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-                  <Cumulative>false</Cumulative>
-                  <CumulativeX>false</CumulativeX>
-                </Series>
-                <IncludeInDocumentation>true</IncludeInDocumentation>
-                <Axis>
-                  <Type>Left</Type>
-                  <Title>Y</Title>
-                  <Inverted>false</Inverted>
-                  <Minimum>NaN</Minimum>
-                  <Maximum>NaN</Maximum>
-                  <Interval>NaN</Interval>
-                </Axis>
-                <Axis>
-                  <Type>Bottom</Type>
-                  <Title>X</Title>
-                  <Inverted>false</Inverted>
-                  <Minimum>NaN</Minimum>
-                  <Maximum>NaN</Maximum>
-                  <Interval>NaN</Interval>
-                </Axis>
-                <LegendPosition>BottomRight</LegendPosition>
-                <DisabledSeries />
-              </Graph>
-              <Graph>
-                <Name>Graph</Name>
-                <Series>
-                  <Name>Series</Name>
-                  <IncludeInDocumentation>true</IncludeInDocumentation>
-                  <Type>Scatter</Type>
-                  <XAxis>Bottom</XAxis>
-                  <YAxis>Left</YAxis>
-                  <ColourArgb>-65536</ColourArgb>
-                  <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-                  <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-                  <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-                  <Marker>None</Marker>
-                  <MarkerSize>Normal</MarkerSize>
-                  <Line>Solid</Line>
-                  <LineThickness>Normal</LineThickness>
-                  <Checkpoint>Current</Checkpoint>
-                  <XFieldName>.Simulations.Replacements.Grapevine.Leaf.CohortParameters.MaxArea.XYPairs.X</XFieldName>
-                  <YFieldName>.Simulations.Replacements.Grapevine.Leaf.CohortParameters.MaxArea.XYPairs.Y</YFieldName>
-                  <ShowInLegend>false</ShowInLegend>
-                  <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-                  <Cumulative>false</Cumulative>
-                  <CumulativeX>false</CumulativeX>
-                </Series>
-                <IncludeInDocumentation>true</IncludeInDocumentation>
-                <Axis>
-                  <Type>Left</Type>
-                  <Title>Y</Title>
-                  <Inverted>false</Inverted>
-                  <Minimum>NaN</Minimum>
-                  <Maximum>NaN</Maximum>
-                  <Interval>NaN</Interval>
-                </Axis>
-                <Axis>
-                  <Type>Bottom</Type>
-                  <Title>X</Title>
-                  <Inverted>false</Inverted>
-                  <Minimum>NaN</Minimum>
-                  <Maximum>NaN</Maximum>
-                  <Interval>NaN</Interval>
-                </Axis>
-                <LegendPosition>BottomRight</LegendPosition>
-                <DisabledSeries />
-              </Graph>
-              <Graph>
-                <Name>Graph</Name>
-                <Series>
-                  <Name>Series</Name>
-                  <IncludeInDocumentation>true</IncludeInDocumentation>
-                  <Type>Scatter</Type>
-                  <XAxis>Bottom</XAxis>
-                  <YAxis>Left</YAxis>
-                  <ColourArgb>-65536</ColourArgb>
-                  <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-                  <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-                  <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-                  <Marker>None</Marker>
-                  <MarkerSize>Normal</MarkerSize>
-                  <Line>Solid</Line>
-                  <LineThickness>Normal</LineThickness>
-                  <Checkpoint>Current</Checkpoint>
-                  <XFieldName>.Simulations.Replacements.Grapevine.Leaf.CohortParameters.MaxArea.XYPairs.X</XFieldName>
-                  <YFieldName>.Simulations.Replacements.Grapevine.Leaf.CohortParameters.MaxArea.XYPairs.Y</YFieldName>
-                  <ShowInLegend>false</ShowInLegend>
-                  <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-                  <Cumulative>false</Cumulative>
-                  <CumulativeX>false</CumulativeX>
-                </Series>
-                <IncludeInDocumentation>true</IncludeInDocumentation>
-                <Axis>
-                  <Type>Left</Type>
-                  <Title>Y</Title>
-                  <Inverted>false</Inverted>
-                  <Minimum>NaN</Minimum>
-                  <Maximum>NaN</Maximum>
-                  <Interval>NaN</Interval>
-                </Axis>
-                <Axis>
-                  <Type>Bottom</Type>
-                  <Title>X</Title>
-                  <Inverted>false</Inverted>
-                  <Minimum>NaN</Minimum>
-                  <Maximum>NaN</Maximum>
-                  <Interval>NaN</Interval>
-                </Axis>
-                <LegendPosition>BottomRight</LegendPosition>
-                <DisabledSeries />
-              </Graph>
-              <Graph>
-                <Name>Graph</Name>
-                <Series>
-                  <Name>Series</Name>
-                  <IncludeInDocumentation>true</IncludeInDocumentation>
-                  <Type>Scatter</Type>
-                  <XAxis>Bottom</XAxis>
-                  <YAxis>Left</YAxis>
-                  <ColourArgb>-65536</ColourArgb>
-                  <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-                  <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-                  <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-                  <Marker>None</Marker>
-                  <MarkerSize>Normal</MarkerSize>
-                  <Line>Solid</Line>
-                  <LineThickness>Normal</LineThickness>
-                  <Checkpoint>Current</Checkpoint>
-                  <XFieldName>.Simulations.Replacements.Grapevine.Leaf.CohortParameters.MaxArea.XYPairs.X</XFieldName>
-                  <YFieldName>.Simulations.Replacements.Grapevine.Leaf.CohortParameters.MaxArea.XYPairs.Y</YFieldName>
-                  <ShowInLegend>false</ShowInLegend>
-                  <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-                  <Cumulative>false</Cumulative>
-                  <CumulativeX>false</CumulativeX>
-                </Series>
-                <IncludeInDocumentation>true</IncludeInDocumentation>
-                <Axis>
-                  <Type>Left</Type>
-                  <Title>Y</Title>
-                  <Inverted>false</Inverted>
-                  <Minimum>NaN</Minimum>
-                  <Maximum>NaN</Maximum>
-                  <Interval>NaN</Interval>
-                </Axis>
-                <Axis>
-                  <Type>Bottom</Type>
-                  <Title>X</Title>
-                  <Inverted>false</Inverted>
-                  <Minimum>NaN</Minimum>
-                  <Maximum>NaN</Maximum>
-                  <Interval>NaN</Interval>
-                </Axis>
-                <LegendPosition>BottomRight</LegendPosition>
-                <DisabledSeries />
-              </Graph>
-              <Graph>
-                <Name>Graph</Name>
-                <Series>
-                  <Name>Series</Name>
-                  <IncludeInDocumentation>true</IncludeInDocumentation>
-                  <Type>Scatter</Type>
-                  <XAxis>Bottom</XAxis>
-                  <YAxis>Left</YAxis>
-                  <ColourArgb>-65536</ColourArgb>
-                  <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-                  <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-                  <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-                  <Marker>None</Marker>
-                  <MarkerSize>Normal</MarkerSize>
-                  <Line>Solid</Line>
-                  <LineThickness>Normal</LineThickness>
-                  <Checkpoint>Current</Checkpoint>
-                  <XFieldName>.Simulations.Replacements.Grapevine.Leaf.CohortParameters.MaxArea.XYPairs.X</XFieldName>
-                  <YFieldName>.Simulations.Replacements.Grapevine.Leaf.CohortParameters.MaxArea.XYPairs.Y</YFieldName>
-                  <ShowInLegend>false</ShowInLegend>
-                  <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-                  <Cumulative>false</Cumulative>
-                  <CumulativeX>false</CumulativeX>
-                </Series>
-                <IncludeInDocumentation>true</IncludeInDocumentation>
-                <Axis>
-                  <Type>Left</Type>
-                  <Title>Y</Title>
-                  <Inverted>false</Inverted>
-                  <Minimum>NaN</Minimum>
-                  <Maximum>NaN</Maximum>
-                  <Interval>NaN</Interval>
-                </Axis>
-                <Axis>
-                  <Type>Bottom</Type>
-                  <Title>X</Title>
-                  <Inverted>false</Inverted>
-                  <Minimum>NaN</Minimum>
-                  <Maximum>NaN</Maximum>
-                  <Interval>NaN</Interval>
-                </Axis>
-                <LegendPosition>BottomRight</LegendPosition>
-                <DisabledSeries />
-              </Graph>
-              <Graph>
-                <Name>Graph</Name>
-                <Series>
-                  <Name>Series</Name>
-                  <IncludeInDocumentation>true</IncludeInDocumentation>
-                  <Type>Scatter</Type>
-                  <XAxis>Bottom</XAxis>
-                  <YAxis>Left</YAxis>
-                  <ColourArgb>-65536</ColourArgb>
-                  <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-                  <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-                  <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-                  <Marker>None</Marker>
-                  <MarkerSize>Normal</MarkerSize>
-                  <Line>Solid</Line>
-                  <LineThickness>Normal</LineThickness>
-                  <Checkpoint>Current</Checkpoint>
-                  <XFieldName>.Simulations.Replacements.Grapevine.Leaf.CohortParameters.MaxArea.XYPairs.X</XFieldName>
-                  <YFieldName>.Simulations.Replacements.Grapevine.Leaf.CohortParameters.MaxArea.XYPairs.Y</YFieldName>
-                  <ShowInLegend>false</ShowInLegend>
-                  <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-                  <Cumulative>false</Cumulative>
-                  <CumulativeX>false</CumulativeX>
-                </Series>
-                <IncludeInDocumentation>true</IncludeInDocumentation>
-                <Axis>
-                  <Type>Left</Type>
-                  <Title>Y</Title>
-                  <Inverted>false</Inverted>
-                  <Minimum>NaN</Minimum>
-                  <Maximum>NaN</Maximum>
-                  <Interval>NaN</Interval>
-                </Axis>
-                <Axis>
-                  <Type>Bottom</Type>
-                  <Title>X</Title>
-                  <Inverted>false</Inverted>
-                  <Minimum>NaN</Minimum>
-                  <Maximum>NaN</Maximum>
-                  <Interval>NaN</Interval>
-                </Axis>
-                <LegendPosition>BottomRight</LegendPosition>
-                <DisabledSeries />
-              </Graph>
-              <Graph>
-                <Name>Graph</Name>
-                <Series>
-                  <Name>Series</Name>
-                  <IncludeInDocumentation>true</IncludeInDocumentation>
-                  <Type>Scatter</Type>
-                  <XAxis>Bottom</XAxis>
-                  <YAxis>Left</YAxis>
-                  <ColourArgb>-65536</ColourArgb>
-                  <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-                  <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-                  <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-                  <Marker>None</Marker>
-                  <MarkerSize>Normal</MarkerSize>
-                  <Line>Solid</Line>
-                  <LineThickness>Normal</LineThickness>
-                  <Checkpoint>Current</Checkpoint>
-                  <XFieldName>.Simulations.Replacements.Grapevine.Leaf.CohortParameters.MaxArea.XYPairs.X</XFieldName>
-                  <YFieldName>.Simulations.Replacements.Grapevine.Leaf.CohortParameters.MaxArea.XYPairs.Y</YFieldName>
-                  <ShowInLegend>false</ShowInLegend>
-                  <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-                  <Cumulative>false</Cumulative>
-                  <CumulativeX>false</CumulativeX>
-                </Series>
-                <IncludeInDocumentation>true</IncludeInDocumentation>
-                <Axis>
-                  <Type>Left</Type>
-                  <Title>Y</Title>
-                  <Inverted>false</Inverted>
-                  <Minimum>NaN</Minimum>
-                  <Maximum>NaN</Maximum>
-                  <Interval>NaN</Interval>
-                </Axis>
-                <Axis>
-                  <Type>Bottom</Type>
-                  <Title>X</Title>
-                  <Inverted>false</Inverted>
-                  <Minimum>NaN</Minimum>
-                  <Maximum>NaN</Maximum>
-                  <Interval>NaN</Interval>
-                </Axis>
-                <LegendPosition>BottomRight</LegendPosition>
-                <DisabledSeries />
-              </Graph>
               <IncludeInDocumentation>true</IncludeInDocumentation>
               <X>
                 <double>0</double>
@@ -1475,9 +1124,9 @@ A function is used to capture the year of the current season as in the south hem
                 <double>1</double>
               </X>
               <Y>
-                <double>8000</double>
+                <double>18000</double>
                 <double>25000</double>
-                <double>16000</double>
+                <double>22000</double>
               </Y>
             </XYPairs>
             <IncludeInDocumentation>true</IncludeInDocumentation>
@@ -1596,50 +1245,6 @@ A function is used to capture the year of the current season as in the south hem
             <Name>LagDuration</Name>
             <XYPairs>
               <Name>XYPairs</Name>
-              <Graph>
-                <Name>Graph</Name>
-                <Series>
-                  <Name>Series</Name>
-                  <IncludeInDocumentation>true</IncludeInDocumentation>
-                  <Type>Scatter</Type>
-                  <XAxis>Bottom</XAxis>
-                  <YAxis>Left</YAxis>
-                  <ColourArgb>-65536</ColourArgb>
-                  <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-                  <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-                  <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-                  <Marker>None</Marker>
-                  <MarkerSize>Normal</MarkerSize>
-                  <Line>Solid</Line>
-                  <LineThickness>Normal</LineThickness>
-                  <Checkpoint>Current</Checkpoint>
-                  <XFieldName>.Simulations.Replacements.Grapevine.Leaf.CohortParameters.LagDuration.XYPairs.X</XFieldName>
-                  <YFieldName>.Simulations.Replacements.Grapevine.Leaf.CohortParameters.LagDuration.XYPairs.Y</YFieldName>
-                  <ShowInLegend>false</ShowInLegend>
-                  <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-                  <Cumulative>false</Cumulative>
-                  <CumulativeX>false</CumulativeX>
-                </Series>
-                <IncludeInDocumentation>true</IncludeInDocumentation>
-                <Axis>
-                  <Type>Left</Type>
-                  <Title>Y</Title>
-                  <Inverted>false</Inverted>
-                  <Minimum>NaN</Minimum>
-                  <Maximum>NaN</Maximum>
-                  <Interval>NaN</Interval>
-                </Axis>
-                <Axis>
-                  <Type>Bottom</Type>
-                  <Title>X</Title>
-                  <Inverted>false</Inverted>
-                  <Minimum>NaN</Minimum>
-                  <Maximum>NaN</Maximum>
-                  <Interval>NaN</Interval>
-                </Axis>
-                <LegendPosition>BottomRight</LegendPosition>
-                <DisabledSeries />
-              </Graph>
               <IncludeInDocumentation>true</IncludeInDocumentation>
               <X>
                 <double>0</double>
@@ -1650,12 +1255,12 @@ A function is used to capture the year of the current season as in the south hem
                 <double>1</double>
               </X>
               <Y>
-                <double>600</double>
-                <double>800</double>
                 <double>1000</double>
-                <double>1000</double>
-                <double>1000</double>
-                <double>1000</double>
+                <double>1500</double>
+                <double>1800</double>
+                <double>1900</double>
+                <double>2000</double>
+                <double>2000</double>
               </Y>
             </XYPairs>
             <IncludeInDocumentation>true</IncludeInDocumentation>
@@ -1672,9 +1277,9 @@ A function is used to capture the year of the current season as in the south hem
                 <double>1</double>
               </X>
               <Y>
-                <double>400</double>
-                <double>600</double>
-                <double>800</double>
+                <double>1000</double>
+                <double>1000</double>
+                <double>1200</double>
               </Y>
             </XYPairs>
             <IncludeInDocumentation>true</IncludeInDocumentation>
@@ -1961,12 +1566,6 @@ A function is used to capture the year of the current season as in the south hem
             </PhaseLookupValue>
             <IncludeInDocumentation>true</IncludeInDocumentation>
           </PhaseLookup>
-          <Constant>
-            <Name>RUE1</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>1</FixedValue>
-            <Units>g/MJ</Units>
-          </Constant>
           <RUECO2Function>
             <Name>FCO2</Name>
             <IncludeInDocumentation>true</IncludeInDocumentation>
@@ -1983,7 +1582,7 @@ A function is used to capture the year of the current season as in the south hem
                 <double>1.5</double>
               </X>
               <Y>
-                <double>0</double>
+                <double>1</double>
                 <double>1</double>
                 <double>1</double>
               </Y>
@@ -2023,7 +1622,7 @@ A function is used to capture the year of the current season as in the south hem
                 <double>1.5</double>
               </X>
               <Y>
-                <double>0</double>
+                <double>1</double>
                 <double>1</double>
                 <double>1</double>
               </Y>
@@ -2092,6 +1691,7 @@ A function is used to capture the year of the current season as in the south hem
         <CompositeBiomass>
           <Name>Total</Name>
           <IncludeInDocumentation>true</IncludeInDocumentation>
+          <DMDOfStructural>0.6</DMDOfStructural>
           <Propertys>
             <string>[Leaf].Live</string>
             <string>[Leaf].Dead</string>
@@ -2136,8 +1736,8 @@ A function is used to capture the year of the current season as in the south hem
             <IncludeInDocumentation>true</IncludeInDocumentation>
             <FractionLiveToRemove>0</FractionLiveToRemove>
             <FractionDeadToRemove>0</FractionDeadToRemove>
-            <FractionLiveToResidue>1</FractionLiveToResidue>
-            <FractionDeadToResidue>1</FractionDeadToResidue>
+            <FractionLiveToResidue>0.05</FractionLiveToResidue>
+            <FractionDeadToResidue>0.05</FractionDeadToResidue>
           </OrganBiomassRemovalType>
           <OrganBiomassRemovalType>
             <Name>Graze</Name>
@@ -2213,7 +1813,7 @@ A function is used to capture the year of the current season as in the south hem
         <PotentialEP>0</PotentialEP>
         <MicroClimatePresent>true</MicroClimatePresent>
         <KDead>0.03</KDead>
-        <MaximumMainStemLeafNumber>24</MaximumMainStemLeafNumber>
+        <MaximumMainStemLeafNumber>30</MaximumMainStemLeafNumber>
         <TipsAtEmergence>0</TipsAtEmergence>
         <CohortsAtInitialisation>0</CohortsAtInitialisation>
         <FractionDied>0</FractionDied>
@@ -2491,7 +2091,7 @@ A function is used to capture the year of the current season as in the south hem
         <Constant>
           <Name>MaintenanceRespirationFunction</Name>
           <IncludeInDocumentation>true</IncludeInDocumentation>
-          <FixedValue>0.001</FixedValue>
+          <FixedValue>0</FixedValue>
           <Units>0-1</Units>
         </Constant>
         <Constant>
@@ -2552,7 +2152,7 @@ A function is used to capture the year of the current season as in the south hem
         <Constant>
           <Name>DMRetranslocationFactor</Name>
           <IncludeInDocumentation>true</IncludeInDocumentation>
-          <FixedValue>0</FixedValue>
+          <FixedValue>0.1</FixedValue>
         </Constant>
         <LinearInterpolationFunction>
           <Name>MaximumNConc</Name>
@@ -2641,7 +2241,7 @@ A function is used to capture the year of the current season as in the south hem
         <Constant>
           <Name>MaintenanceRespirationFunction</Name>
           <IncludeInDocumentation>true</IncludeInDocumentation>
-          <FixedValue>0.001</FixedValue>
+          <FixedValue>0</FixedValue>
           <Units>0-1</Units>
         </Constant>
         <Constant>
@@ -4311,10 +3911,12 @@ Pollination alone results in the development of small, hard green berries (live 
         <Live>
           <Name>Biomass</Name>
           <IncludeInDocumentation>true</IncludeInDocumentation>
+          <DMDOfStructural>0.6</DMDOfStructural>
         </Live>
         <Dead>
           <Name>Biomass</Name>
           <IncludeInDocumentation>true</IncludeInDocumentation>
+          <DMDOfStructural>0.6</DMDOfStructural>
         </Dead>
       </ReproductiveOrgan>
       <Root>
@@ -4347,50 +3949,6 @@ Pollination alone results in the development of small, hard green berries (live 
           <Name>KLModifier</Name>
           <XYPairs>
             <Name>XYPairs</Name>
-            <Graph>
-              <Name>Graph</Name>
-              <Series>
-                <Name>Series</Name>
-                <IncludeInDocumentation>true</IncludeInDocumentation>
-                <Type>Scatter</Type>
-                <XAxis>Bottom</XAxis>
-                <YAxis>Left</YAxis>
-                <ColourArgb>-65536</ColourArgb>
-                <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-                <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-                <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-                <Marker>None</Marker>
-                <MarkerSize>Normal</MarkerSize>
-                <Line>Solid</Line>
-                <LineThickness>Normal</LineThickness>
-                <Checkpoint>Current</Checkpoint>
-                <XFieldName>.Simulations.Replacements.Grapevine.Root.KLModifier.XYPairs.X</XFieldName>
-                <YFieldName>.Simulations.Replacements.Grapevine.Root.KLModifier.XYPairs.Y</YFieldName>
-                <ShowInLegend>false</ShowInLegend>
-                <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-                <Cumulative>false</Cumulative>
-                <CumulativeX>false</CumulativeX>
-              </Series>
-              <IncludeInDocumentation>true</IncludeInDocumentation>
-              <Axis>
-                <Type>Left</Type>
-                <Title>Y</Title>
-                <Inverted>false</Inverted>
-                <Minimum>NaN</Minimum>
-                <Maximum>NaN</Maximum>
-                <Interval>NaN</Interval>
-              </Axis>
-              <Axis>
-                <Type>Bottom</Type>
-                <Title>X</Title>
-                <Inverted>false</Inverted>
-                <Minimum>NaN</Minimum>
-                <Maximum>NaN</Maximum>
-                <Interval>NaN</Interval>
-              </Axis>
-              <LegendPosition>BottomRight</LegendPosition>
-              <DisabledSeries />
-            </Graph>
             <Graph>
               <Name>Graph</Name>
               <Series>
@@ -4503,7 +4061,7 @@ Pollination alone results in the development of small, hard green berries (live 
             </X>
             <Y>
               <double>0</double>
-              <double>0.1</double>
+              <double>0.05</double>
             </Y>
           </XYPairs>
           <IncludeInDocumentation>true</IncludeInDocumentation>
@@ -4600,7 +4158,7 @@ Pollination alone results in the development of small, hard green berries (live 
           <Constant>
             <Name>PartitionFraction</Name>
             <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>0.35</FixedValue>
+            <FixedValue>0.2</FixedValue>
           </Constant>
           <IncludeInDocumentation>true</IncludeInDocumentation>
         </PartitionFractionDemandFunction>
@@ -4623,6 +4181,17 @@ Pollination alone results in the development of small, hard green berries (live 
           <Name>CarbonConcentration</Name>
           <IncludeInDocumentation>true</IncludeInDocumentation>
           <FixedValue>0.4</FixedValue>
+        </Constant>
+        <Constant>
+          <Name>DMRetranslocationFactor</Name>
+          <IncludeInDocumentation>true</IncludeInDocumentation>
+          <FixedValue>0.1</FixedValue>
+        </Constant>
+        <Constant>
+          <Name>StructuralFraction</Name>
+          <IncludeInDocumentation>true</IncludeInDocumentation>
+          <FixedValue>0.8</FixedValue>
+          <Units>g/g</Units>
         </Constant>
         <IncludeInDocumentation>true</IncludeInDocumentation>
         <GrowthRespiration>0</GrowthRespiration>
@@ -4686,7 +4255,7 @@ namespace Models
         <IncludeInDocumentation>true</IncludeInDocumentation>
         <Operation>
           <Date>2005-01-01</Date>
-          <Action>[Grapevine].Sow(population: 0.231481, cultivar: "SauvignonBlanc", depth: 1500, rowSpacing: 2400, budNumber:24);</Action>
+          <Action>[Grapevine].Sow(population: 0.231481, cultivar: "SauvignonBlanc", depth: 800, rowSpacing: 2400, budNumber:24);</Action>
         </Operation>
       </Operations>
       <Manager>
@@ -4766,6 +4335,7 @@ namespace Models
         <string>[Grapevine].Structure.MainStemPopn</string>
         <string>[Grapevine].Structure.LeafTipsAppeared</string>
         <string>[Grapevine].Leaf.LAI</string>
+        <string>[Grapevine].Leaf.Photosynthesis.Value</string>
         <string>[Grapevine].Leaf.InitialisedCohortNo</string>
         <string>[Grapevine].Leaf.DeadCohortNo</string>
         <string>[Grapevine].Leaf.AppearedCohortNo</string>
@@ -4777,7 +4347,9 @@ namespace Models
         <string>[Grapevine].Cordon.Live.Wt</string>
         <string>[Grapevine].Trunk.Live.Wt</string>
         <string>[Grapevine].Root.Live.Wt</string>
+        <string />
         <string>[Grapevine].Arbitrator.FDM</string>
+        <string>[Grapevine].Arbitrator.DM.TotalFixationSupply</string>
         <string />
         <string>[Berry].Live.Wt</string>
         <string>[Berry].BerryFreshWeight.Value()</string>
@@ -4888,24 +4460,24 @@ namespace Models
                 <double>0.13</double>
                 <double>0.1</double>
                 <double>0.15</double>
-                <double>0.3</double>
-                <double>0.3</double>
+                <double>0.15</double>
+                <double>0.15</double>
               </LL>
               <KL>
                 <double>0.1</double>
                 <double>0.06</double>
                 <double>0.04</double>
                 <double>0.01</double>
-                <double>0</double>
-                <double>0</double>
+                <double>0.0051</double>
+                <double>0.002</double>
               </KL>
               <XF>
                 <double>1</double>
                 <double>1</double>
                 <double>1</double>
                 <double>1</double>
-                <double>0</double>
-                <double>0</double>
+                <double>0.5</double>
+                <double>0.2</double>
               </XF>
             </SoilCrop>
             <IncludeInDocumentation>true</IncludeInDocumentation>
@@ -5300,7 +4872,7 @@ namespace Models
             <IncludeInDocumentation>true</IncludeInDocumentation>
             <Operation>
               <Date>2005-01-01</Date>
-              <Action>[Grapevine].Sow(population: 0.231481, cultivar: "SauvignonBlanc", depth: 150, rowSpacing: 2400, budNumber:24);</Action>
+              <Action>[Grapevine].Sow(population: 0.231481, cultivar: "SauvignonBlanc", depth: 80, rowSpacing: 2400, budNumber:24);</Action>
             </Operation>
           </Operations>
           <Manager>
@@ -6753,6 +6325,49 @@ namespace Models
       <LegendPosition>TopLeft</LegendPosition>
       <DisabledSeries />
     </Graph>
+    <Graph>
+      <Name>Photosynthesis</Name>
+      <Series>
+        <Name>Series</Name>
+        <IncludeInDocumentation>true</IncludeInDocumentation>
+        <Type>Scatter</Type>
+        <XAxis>Bottom</XAxis>
+        <YAxis>Left</YAxis>
+        <ColourArgb>-16777216</ColourArgb>
+        <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
+        <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
+        <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
+        <Marker>None</Marker>
+        <MarkerSize>Normal</MarkerSize>
+        <Line>Solid</Line>
+        <LineThickness>Normal</LineThickness>
+        <Checkpoint>Current</Checkpoint>
+        <TableName>Report</TableName>
+        <XFieldName>Clock.Today</XFieldName>
+        <YFieldName>Grapevine.Arbitrator.DM.TotalFixationSupply</YFieldName>
+        <ShowInLegend>false</ShowInLegend>
+        <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
+        <Cumulative>false</Cumulative>
+        <CumulativeX>false</CumulativeX>
+      </Series>
+      <IncludeInDocumentation>false</IncludeInDocumentation>
+      <Axis>
+        <Type>Bottom</Type>
+        <Inverted>false</Inverted>
+        <Minimum>NaN</Minimum>
+        <Maximum>NaN</Maximum>
+        <Interval>NaN</Interval>
+      </Axis>
+      <Axis>
+        <Type>Left</Type>
+        <Inverted>false</Inverted>
+        <Minimum>NaN</Minimum>
+        <Maximum>NaN</Maximum>
+        <Interval>NaN</Interval>
+      </Axis>
+      <LegendPosition>TopLeft</LegendPosition>
+      <DisabledSeries />
+    </Graph>
     <IncludeInDocumentation>true</IncludeInDocumentation>
     <ShowPageOfGraphs>true</ShowPageOfGraphs>
   </Folder>
@@ -6812,24 +6427,24 @@ namespace Models
                   <double>0.13</double>
                   <double>0.1</double>
                   <double>0.15</double>
-                  <double>0.3</double>
-                  <double>0.3</double>
+                  <double>0.15</double>
+                  <double>0.15</double>
                 </LL>
                 <KL>
                   <double>0.1</double>
                   <double>0.06</double>
                   <double>0.04</double>
                   <double>0.01</double>
-                  <double>0</double>
-                  <double>0</double>
+                  <double>0.0051</double>
+                  <double>0.002</double>
                 </KL>
                 <XF>
                   <double>1</double>
                   <double>1</double>
                   <double>1</double>
                   <double>1</double>
-                  <double>0</double>
-                  <double>0</double>
+                  <double>0.5</double>
+                  <double>0.2</double>
                 </XF>
               </SoilCrop>
               <IncludeInDocumentation>true</IncludeInDocumentation>
@@ -7224,7 +6839,7 @@ namespace Models
               <IncludeInDocumentation>true</IncludeInDocumentation>
               <Operation>
                 <Date>2005-01-01</Date>
-                <Action>[Grapevine].Sow(population: 0.231481, cultivar: "SauvignonBlanc", depth: 150, rowSpacing: 2400, budNumber:24);</Action>
+                <Action>[Grapevine].Sow(population: 0.231481, cultivar: "SauvignonBlanc", depth: 80, rowSpacing: 2400, budNumber:24);</Action>
               </Operation>
             </Operations>
             <Manager>
@@ -7489,11 +7104,6 @@ namespace Models
         </SoilArbitrator>
         <Zone>
           <Name>Vineyard</Name>
-          <Memo>
-            <Name>Memo</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <MemoText><![CDATA[Double Guyôt-trained vines, pruned each year to retain 24 nodes were monitored. Vines were trained using vertical shoot positioning (VSP), with an exposed leaf area height of 1.2 m, and trimmed to maintain a compact canopy. Vines were planted 1.8 m apart within the row, and 2.4 m apart between rows. Average flowering date was determined by monitoring all the inflorescences on one cane on a vine in each plot on a regular basis throughout flowering. Likewise, regular berry samples (at least weekly) were taken from before the date of véraison until harvest at a soluble solids concentration value of 21.5 oBrix. ]]></MemoText>
-          </Memo>
           <Soil>
             <Name>Soil</Name>
             <Water>
@@ -7506,24 +7116,24 @@ namespace Models
                   <double>0.13</double>
                   <double>0.1</double>
                   <double>0.15</double>
-                  <double>0.3</double>
-                  <double>0.3</double>
+                  <double>0.15</double>
+                  <double>0.15</double>
                 </LL>
                 <KL>
                   <double>0.1</double>
                   <double>0.06</double>
                   <double>0.04</double>
                   <double>0.01</double>
-                  <double>0</double>
-                  <double>0</double>
+                  <double>0.0051</double>
+                  <double>0.002</double>
                 </KL>
                 <XF>
                   <double>1</double>
                   <double>1</double>
                   <double>1</double>
                   <double>1</double>
-                  <double>0</double>
-                  <double>0</double>
+                  <double>0.5</double>
+                  <double>0.2</double>
                 </XF>
               </SoilCrop>
               <IncludeInDocumentation>true</IncludeInDocumentation>
@@ -7784,6 +7394,11 @@ namespace Models
             <Latitude>0</Latitude>
             <Longitude>0</Longitude>
           </Soil>
+          <Memo>
+            <Name>Memo</Name>
+            <IncludeInDocumentation>true</IncludeInDocumentation>
+            <MemoText><![CDATA[Double Guyôt-trained vines, pruned each year to retain 24 nodes were monitored. Vines were trained using vertical shoot positioning (VSP), with an exposed leaf area height of 1.2 m, and trimmed to maintain a compact canopy. Vines were planted 1.8 m apart within the row, and 2.4 m apart between rows. Average flowering date was determined by monitoring all the inflorescences on one cane on a vine in each plot on a regular basis throughout flowering. Likewise, regular berry samples (at least weekly) were taken from before the date of véraison until harvest at a soluble solids concentration value of 21.5 oBrix. ]]></MemoText>
+          </Memo>
           <SurfaceOrganicMatter>
             <Name>SurfaceOrganicMatter</Name>
             <IncludeInDocumentation>true</IncludeInDocumentation>
@@ -7879,8 +7494,8 @@ namespace Models
             <Name>ParameterTest</Name>
             <IncludeInDocumentation>true</IncludeInDocumentation>
             <Script>
-              <EndoTarget>0</EndoTarget>
               <BudBurstBase>0</BudBurstBase>
+              <EndoTarget>0</EndoTarget>
             </Script>
             <Code><![CDATA[
 using System;
@@ -7960,7 +7575,7 @@ namespace Models
               <IncludeInDocumentation>true</IncludeInDocumentation>
               <Operation>
                 <Date>2005-01-01</Date>
-                <Action>[Grapevine].Sow(population: 0.231481, cultivar: "SauvignonBlanc", depth: 150, rowSpacing: 2400, budNumber:24);</Action>
+                <Action>[Grapevine].Sow(population: 0.231481, cultivar: "SauvignonBlanc", depth: 80, rowSpacing: 2400, budNumber:24);</Action>
               </Operation>
             </Operations>
             <Manager>
@@ -8030,2978 +7645,6 @@ namespace Models
     <IncludeInDocumentation>true</IncludeInDocumentation>
     <ShowPageOfGraphs>true</ShowPageOfGraphs>
   </Folder>
-  <Simulation>
-    <Name>InterrowCompetition</Name>
-    <Memo>
-      <Name>Memo</Name>
-      <IncludeInDocumentation>true</IncludeInDocumentation>
-      <MemoText><![CDATA[Double Guyôt-trained vines, pruned each year to retain 24 nodes were monitored. Vines were trained using vertical shoot positioning (VSP), with an exposed leaf area height of 1.2 m, and trimmed to maintain a compact canopy. Vines were planted 1.8 m apart within the row, and 2.4 m apart between rows. Average flowering date was determined by monitoring all the inflorescences on one cane on a vine in each plot on a regular basis throughout flowering. Likewise, regular berry samples (at least weekly) were taken from before the date of véraison until harvest at a soluble solids concentration value of 21.5 oBrix. ]]></MemoText>
-    </Memo>
-    <Weather>
-      <Name>Weather</Name>
-      <IncludeInDocumentation>true</IncludeInDocumentation>
-      <FileName>Blenheim.met</FileName>
-      <ExcelWorkSheetName />
-    </Weather>
-    <Clock>
-      <Name>Clock</Name>
-      <IncludeInDocumentation>true</IncludeInDocumentation>
-      <StartDate>2005-01-01T00:00:00</StartDate>
-      <EndDate>2012-09-29T00:00:00</EndDate>
-    </Clock>
-    <Summary>
-      <Name>Summary</Name>
-      <IncludeInDocumentation>true</IncludeInDocumentation>
-    </Summary>
-    <SoilArbitrator>
-      <Name>Soil Arbitrator</Name>
-      <IncludeInDocumentation>true</IncludeInDocumentation>
-    </SoilArbitrator>
-    <RectangularZone>
-      <Name>TreeRow</Name>
-      <Soil>
-        <Name>Soil</Name>
-        <Water>
-          <Name>Water</Name>
-          <SoilCrop>
-            <Name>GrapevineSoil</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <LL>
-              <double>0.13</double>
-              <double>0.13</double>
-              <double>0.15</double>
-              <double>0.15</double>
-              <double>0.15</double>
-              <double>0.15</double>
-            </LL>
-            <KL>
-              <double>0.1</double>
-              <double>0.1</double>
-              <double>0.1</double>
-              <double>0.1</double>
-              <double>0.06</double>
-              <double>0.05</double>
-            </KL>
-            <XF>
-              <double>1</double>
-              <double>1</double>
-              <double>1</double>
-              <double>1</double>
-              <double>1</double>
-              <double>1</double>
-            </XF>
-          </SoilCrop>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Thickness>
-            <double>100</double>
-            <double>200</double>
-            <double>300</double>
-            <double>300</double>
-            <double>300</double>
-            <double>300</double>
-          </Thickness>
-          <BD>
-            <double>1.2</double>
-            <double>1.2</double>
-            <double>1.2</double>
-            <double>1.2</double>
-            <double>1.2</double>
-            <double>1.2</double>
-          </BD>
-          <AirDry>
-            <double>0.08</double>
-            <double>0.16</double>
-            <double>0.15</double>
-            <double>0.13</double>
-            <double>0.15</double>
-            <double>0.15</double>
-          </AirDry>
-          <LL15>
-            <double>0.16</double>
-            <double>0.16</double>
-            <double>0.15</double>
-            <double>0.13</double>
-            <double>0.15</double>
-            <double>0.15</double>
-          </LL15>
-          <DUL>
-            <double>0.33</double>
-            <double>0.33</double>
-            <double>0.31</double>
-            <double>0.27</double>
-            <double>0.3</double>
-            <double>0.3</double>
-          </DUL>
-          <SAT>
-            <double>0.5</double>
-            <double>0.5</double>
-            <double>0.44</double>
-            <double>0.46</double>
-            <double>0.44</double>
-            <double>0.44</double>
-          </SAT>
-        </Water>
-        <SoilWater>
-          <Name>SoilWater</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <SummerDate>1-Nov</SummerDate>
-          <SummerU>9</SummerU>
-          <SummerCona>4.4</SummerCona>
-          <WinterDate>1-Apr</WinterDate>
-          <WinterU>9</WinterU>
-          <WinterCona>4.4</WinterCona>
-          <DiffusConst>88</DiffusConst>
-          <DiffusSlope>35.4</DiffusSlope>
-          <Salb>0.18</Salb>
-          <CN2Bare>0</CN2Bare>
-          <CNRed>-9E-05</CNRed>
-          <CNCov>0</CNCov>
-          <slope>0</slope>
-          <discharge_width>0</discharge_width>
-          <catchment_area>0</catchment_area>
-          <max_pond>0</max_pond>
-          <Thickness>
-            <double>100</double>
-            <double>200</double>
-            <double>300</double>
-            <double>300</double>
-            <double>300</double>
-            <double>300</double>
-          </Thickness>
-          <SWCON>
-            <double>0.55</double>
-            <double>0.55</double>
-            <double>0.55</double>
-            <double>0.55</double>
-            <double>0.55</double>
-            <double>0.55</double>
-          </SWCON>
-          <KLAT>
-            <double>0</double>
-            <double>0</double>
-            <double>0</double>
-            <double>0</double>
-            <double>0</double>
-            <double>0</double>
-          </KLAT>
-          <residueinterception>0</residueinterception>
-        </SoilWater>
-        <SoilNitrogen>
-          <Name>SoilNitrogen</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <fom_type>
-            <string>default</string>
-            <string>manure</string>
-            <string>mucuna</string>
-            <string>lablab</string>
-            <string>shemp</string>
-            <string>stable</string>
-          </fom_type>
-          <fract_carb>
-            <double>0.2</double>
-            <double>0.3</double>
-            <double>0.54</double>
-            <double>0.57</double>
-            <double>0.45</double>
-            <double>0</double>
-          </fract_carb>
-          <fract_cell>
-            <double>0.7</double>
-            <double>0.3</double>
-            <double>0.37</double>
-            <double>0.37</double>
-            <double>0.47</double>
-            <double>0.1</double>
-          </fract_cell>
-          <fract_lign>
-            <double>0.1</double>
-            <double>0.4</double>
-            <double>0.09</double>
-            <double>0.06</double>
-            <double>0.08</double>
-            <double>0.9</double>
-          </fract_lign>
-        </SoilNitrogen>
-        <SoilOrganicMatter>
-          <Name>SoilOrganicMatter</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <RootCN>30</RootCN>
-          <RootWt>3000</RootWt>
-          <SoilCN>11.5</SoilCN>
-          <EnrACoeff>7.4</EnrACoeff>
-          <EnrBCoeff>0.2</EnrBCoeff>
-          <Thickness>
-            <double>100</double>
-            <double>200</double>
-            <double>300</double>
-            <double>300</double>
-            <double>300</double>
-            <double>300</double>
-          </Thickness>
-          <Depth>
-            <string>0-10</string>
-            <string>10-30</string>
-            <string>30-60</string>
-            <string>60-90</string>
-            <string>90-120</string>
-            <string>120-150</string>
-          </Depth>
-          <OC>
-            <double>3.5</double>
-            <double>2.5</double>
-            <double>1.2</double>
-            <double>1.03</double>
-            <double>0.47</double>
-            <double>0.47</double>
-          </OC>
-          <FBiom>
-            <double>0.025</double>
-            <double>0.025</double>
-            <double>0.015</double>
-            <double>0.01</double>
-            <double>0.01</double>
-            <double>0.01</double>
-          </FBiom>
-          <FInert>
-            <double>0.3</double>
-            <double>0.4</double>
-            <double>0.75</double>
-            <double>0.9</double>
-            <double>0.96</double>
-            <double>0.96</double>
-          </FInert>
-          <OCUnits>Total</OCUnits>
-        </SoilOrganicMatter>
-        <Analysis>
-          <Name>Analysis</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Thickness>
-            <double>100</double>
-            <double>200</double>
-            <double>300</double>
-            <double>300</double>
-            <double>300</double>
-            <double>300</double>
-          </Thickness>
-          <PH>
-            <double>6.6</double>
-            <double>6.2</double>
-            <double>5.7</double>
-            <double>5.5</double>
-            <double>5.5</double>
-            <double>5.5</double>
-          </PH>
-          <PHUnits>Water</PHUnits>
-          <BoronUnits>HotWater</BoronUnits>
-        </Analysis>
-        <InitialWater>
-          <Name>Initial water</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <PercentMethod>FilledFromTop</PercentMethod>
-          <FractionFull>1</FractionFull>
-          <DepthWetSoil>NaN</DepthWetSoil>
-          <RelativeTo>GrapevineSoil</RelativeTo>
-        </InitialWater>
-        <Sample>
-          <Name>Sample</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Thickness>
-            <double>100</double>
-            <double>200</double>
-            <double>300</double>
-            <double>300</double>
-            <double>300</double>
-            <double>300</double>
-          </Thickness>
-          <NO3>
-            <double>40</double>
-            <double>30</double>
-            <double>14</double>
-            <double>14</double>
-            <double>1.38</double>
-            <double>1.38</double>
-          </NO3>
-          <NH4>
-            <double>0.1</double>
-            <double>0.1</double>
-            <double>0.1</double>
-            <double>0.1</double>
-            <double>0.1</double>
-            <double>0.1</double>
-          </NH4>
-          <NO3Units>kgha</NO3Units>
-          <NH4Units>kgha</NH4Units>
-          <SWUnits>Volumetric</SWUnits>
-          <OCUnits>Total</OCUnits>
-          <PHUnits>Water</PHUnits>
-        </Sample>
-        <CERESSoilTemperature>
-          <Name>CERESSoilTemperature</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-        </CERESSoilTemperature>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <RecordNumber>0</RecordNumber>
-        <SoilType>Sedementary</SoilType>
-        <LocalName>Lincoln</LocalName>
-        <Site />
-        <NearestTown />
-        <Region />
-        <NaturalVegetation />
-        <Latitude>0</Latitude>
-        <Longitude>0</Longitude>
-      </Soil>
-      <MicroClimate>
-        <Name>MicroClimate</Name>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <a_interception>0.2</a_interception>
-        <b_interception>1</b_interception>
-        <c_interception>0</c_interception>
-        <d_interception>0</d_interception>
-        <soil_albedo>0.23</soil_albedo>
-        <sun_angle>15</sun_angle>
-        <soil_heat_flux_fraction>0.4</soil_heat_flux_fraction>
-        <night_interception_fraction>0.5</night_interception_fraction>
-        <refheight>2</refheight>
-        <albedo>0.15</albedo>
-        <emissivity>0.96</emissivity>
-        <RadIntTotal>0</RadIntTotal>
-      </MicroClimate>
-      <Fertiliser>
-        <Name>Fertiliser</Name>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-      </Fertiliser>
-      <SurfaceOrganicMatter>
-        <Name>SurfaceOrganicMatter</Name>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <ResidueTypes>
-          <Name>ResidueTypes</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <LoadFromResource>ResidueTypes</LoadFromResource>
-        </ResidueTypes>
-        <Pools>
-          <Pool>
-            <PoolName>wheat_stubble</PoolName>
-            <ResidueType>wheat</ResidueType>
-            <Mass>500</Mass>
-            <CNRatio>100</CNRatio>
-            <CPRatio>NaN</CPRatio>
-            <StandingFraction>0</StandingFraction>
-          </Pool>
-        </Pools>
-        <PoolName>wheat_stubble</PoolName>
-        <type>wheat</type>
-        <mass>500</mass>
-        <standing_fraction>0</standing_fraction>
-        <cpr />
-        <cnr>100</cnr>
-        <CriticalResidueWeight>2000</CriticalResidueWeight>
-        <OptimumDecompTemp>20</OptimumDecompTemp>
-        <MaxCumulativeEOS>20</MaxCumulativeEOS>
-        <CNRatioDecompCoeff>0.277</CNRatioDecompCoeff>
-        <CNRatioDecompThreshold>25</CNRatioDecompThreshold>
-        <TotalLeachRain>25</TotalLeachRain>
-        <MinRainToLeach>10</MinRainToLeach>
-        <CriticalMinimumOrganicC>0.004</CriticalMinimumOrganicC>
-        <DefaultCPRatio>0</DefaultCPRatio>
-        <DefaultStandingFraction>0</DefaultStandingFraction>
-        <StandingExtinctCoeff>0.5</StandingExtinctCoeff>
-        <FractionFaecesAdded>0.5</FractionFaecesAdded>
-      </SurfaceOrganicMatter>
-      <Manager>
-        <Name>SetupRootZones</Name>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Script />
-        <Code><![CDATA[using System;
-using Models.Core;
-using System.Collections.Generic;
-using System.Text;
-using Models.PMF;
-using Models;
-using System.Xml.Serialization;
-using APSIM.Shared.Utilities;
-
-namespace Models
-{
-    [Serializable] 
-    public class Script : Model
-    {
-        [Link] Plant Grapevine;
-        [Link] Clock Clock;
-        [Link] Zone zone;
-        
-        [EventSubscribe("Commencing")]
-        private void OnSimulationCommencing(object sender, EventArgs e)
-        {
-            
-            Grapevine.Root.ZoneNamesToGrowRootsIn.Add("Interrow");
-            Grapevine.Root.ZoneRootDepths.Add(1500);   
-            Grapevine.Root.ZoneInitialDM.Add(2000);  //g per plant
-
-        }
-    }
-}
-       
-]]></Code>
-      </Manager>
-      <Graph>
-        <Name>Debug</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Slurp.Leaf.Fw</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Left</Type>
-          <Title />
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <SoluteManager>
-        <Name>SoluteManager</Name>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-      </SoluteManager>
-      <Plant>
-        <Name>Grapevine</Name>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <ResourceName>Grapevine</ResourceName>
-        <CropType>Grapevine</CropType>
-      </Plant>
-      <Report>
-        <Name>Report</Name>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <ExperimentFactorNames />
-        <ExperimentFactorValues />
-        <VariableNames>
-          <string />
-        </VariableNames>
-        <EventNames>
-          <string />
-        </EventNames>
-      </Report>
-      <Report>
-        <Name>Report1</Name>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <ExperimentFactorNames />
-        <ExperimentFactorValues />
-        <VariableNames>
-          <string>[Clock].Today</string>
-          <string>[Clock].Today.Year</string>
-          <string>[Clock].Today.DayOfYear</string>
-          <string>[Grapevine].Root.Zones[1].LayerLive[1].Wt</string>
-          <string>[Grapevine].Root.Zones[1].LayerLive[2].Wt</string>
-          <string>[Grapevine].Root.Zones[1].LayerLive[3].Wt</string>
-          <string>[Grapevine].Root.Zones[1].LayerLive[4].Wt</string>
-          <string>[Grapevine].Root.Zones[1].LayerLive[5].Wt</string>
-          <string>[Grapevine].Root.Zones[1].LayerLive[6].Wt</string>
-          <string>[Grapevine].Root.Zones[2].LayerLive[1].Wt</string>
-          <string>[Grapevine].Root.Zones[2].LayerLive[2].Wt</string>
-          <string>[Grapevine].Root.Zones[2].LayerLive[3].Wt</string>
-          <string>[Grapevine].Root.Zones[2].LayerLive[4].Wt</string>
-          <string>[Grapevine].Root.Zones[2].LayerLive[5].Wt</string>
-          <string>[Grapevine].Root.Zones[2].LayerLive[6].Wt</string>
-          <string>[Soil].SoilWater.SWmm</string>
-          <string>[Root].Zones[1].Uptake</string>
-          <string>[Root].Zones[2].Uptake</string>
-        </VariableNames>
-        <EventNames>
-          <string>[Clock].DoReport</string>
-        </EventNames>
-      </Report>
-      <Folder>
-        <Name>Management</Name>
-        <Manager>
-          <Name>ExtraVariables</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Script>
-            <CordonDiameter>10</CordonDiameter>
-          </Script>
-          <Code><![CDATA[using System;
-using Models.Core;
-using Models.PMF;
-using Models;
-using System.Xml.Serialization;
-using APSIM.Shared.Utilities;
-
-namespace Models
-{
-    [Serializable] 
-    public class Script : Model
-    {
-        [Link] Clock Clock;
-        [Link] Plant Grapevine;
-        [Link] Zone zone;
-
-        [Description("CordonDiameter_mm")]         
-        public double CordonDiameter { get; set; }  //mm
-        
-
-        [EventSubscribe("PlantSowing")]
-        private void OnPlantSowing(object sender, EventArgs e)
-        {
-        	zone.Set("Grapevine.Cordon.CordonDiameter.FixedValue", CordonDiameter);      
-        }
-
-     }
-}
-]]></Code>
-        </Manager>
-        <Operations>
-          <Name>Operations</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Operation>
-            <Date>2005-01-01</Date>
-            <Action>[Grapevine].Sow(population: 0.231481, cultivar: "SauvignonBlanc", depth: 150, rowSpacing: 2400, budNumber:24);</Action>
-          </Operation>
-        </Operations>
-        <Manager>
-          <Name>Pruning</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Script>
-            <PruneDateString>1-May</PruneDateString>
-          </Script>
-          <Code><![CDATA[
-using System;
-using System.Collections.Generic;
-using Models.Core;
-using Models.PMF;
-using Models.PMF.Interfaces;
-using System.Xml.Serialization;
-
-namespace Models
-{
-    [Serializable] 
-    [System.Xml.Serialization.XmlInclude(typeof(Model))]
-    public class Script : Model
-    {
-        [Link] Plant Grapevine;
-        [Link] Clock Clock;
-
-        [Description("Prune Date")]
-        public string PruneDateString { get; set; }
-        [XmlIgnore] private DateTime PruneDate { get; set; }
-        [XmlIgnore] private RemovalFractions Remove { get; set; }
-        
-        [EventSubscribe("Commencing")]
-        private void OnSimulationCommencing(object sender, EventArgs e)
-        {
-            Remove = new RemovalFractions();
-        }
-        
-        [EventSubscribe("DoManagement")]
-        private void OnDoManagement(object sender, EventArgs e)
-        {
-            //Set up  array of remove fractions to send with Cut method.  Each member in the array corresponds to an organ in the same order they are set up in.
-            PruneDate = DateTime.Parse(PruneDateString);
-                        
-            if (PruneDate.Month == Clock.Today.Month && PruneDate.Day == Clock.Today.Day)
-            {
-                Remove.SetPhenologyStage = 1;
-                Grapevine.RemoveBiomass("Prune", Remove);
-            }
-        }
-    }
-}
-            
-                
-]]></Code>
-        </Manager>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <ShowPageOfGraphs>true</ShowPageOfGraphs>
-      </Folder>
-      <IncludeInDocumentation>true</IncludeInDocumentation>
-      <Area>0.001</Area>
-      <Slope>0</Slope>
-      <Length>20</Length>
-      <Width>0.5</Width>
-    </RectangularZone>
-    <RectangularZone>
-      <Name>Interrow</Name>
-      <Fertiliser>
-        <Name>Fertiliser</Name>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-      </Fertiliser>
-      <SurfaceOrganicMatter>
-        <Name>SurfaceOrganicMatter</Name>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <ResidueTypes>
-          <Name>ResidueTypes</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <LoadFromResource>ResidueTypes</LoadFromResource>
-        </ResidueTypes>
-        <Pools>
-          <Pool>
-            <PoolName>wheat_stubble</PoolName>
-            <ResidueType>wheat</ResidueType>
-            <Mass>500</Mass>
-            <CNRatio>100</CNRatio>
-            <CPRatio>NaN</CPRatio>
-            <StandingFraction>0</StandingFraction>
-          </Pool>
-        </Pools>
-        <PoolName>wheat_stubble</PoolName>
-        <type>wheat</type>
-        <mass>500</mass>
-        <standing_fraction>0</standing_fraction>
-        <cpr />
-        <cnr>100</cnr>
-        <CriticalResidueWeight>2000</CriticalResidueWeight>
-        <OptimumDecompTemp>20</OptimumDecompTemp>
-        <MaxCumulativeEOS>20</MaxCumulativeEOS>
-        <CNRatioDecompCoeff>0.277</CNRatioDecompCoeff>
-        <CNRatioDecompThreshold>25</CNRatioDecompThreshold>
-        <TotalLeachRain>25</TotalLeachRain>
-        <MinRainToLeach>10</MinRainToLeach>
-        <CriticalMinimumOrganicC>0.004</CriticalMinimumOrganicC>
-        <DefaultCPRatio>0</DefaultCPRatio>
-        <DefaultStandingFraction>0</DefaultStandingFraction>
-        <StandingExtinctCoeff>0.5</StandingExtinctCoeff>
-        <FractionFaecesAdded>0.5</FractionFaecesAdded>
-      </SurfaceOrganicMatter>
-      <SoluteManager>
-        <Name>SoluteManager</Name>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-      </SoluteManager>
-      <Soil>
-        <Name>Soil</Name>
-        <Water>
-          <Name>Water</Name>
-          <SoilCrop>
-            <Name>GrapevineSoil</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <LL>
-              <double>0.13</double>
-              <double>0.13</double>
-              <double>0.1</double>
-              <double>0.15</double>
-              <double>0.3</double>
-              <double>0.3</double>
-            </LL>
-            <KL>
-              <double>0.02</double>
-              <double>0.02</double>
-              <double>0.02</double>
-              <double>0.02</double>
-              <double>0.01</double>
-              <double>0.01</double>
-            </KL>
-            <XF>
-              <double>1</double>
-              <double>1</double>
-              <double>1</double>
-              <double>1</double>
-              <double>1</double>
-              <double>1</double>
-            </XF>
-          </SoilCrop>
-          <SoilCrop>
-            <Name>SlurpSoil</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <LL>
-              <double>0.13</double>
-              <double>0.13</double>
-              <double>0.1</double>
-              <double>0.08</double>
-              <double>0.11</double>
-              <double>0.11</double>
-            </LL>
-            <KL>
-              <double>0.01</double>
-              <double>0.01</double>
-              <double>0.002</double>
-              <double>0</double>
-              <double>0</double>
-              <double>0</double>
-            </KL>
-            <XF>
-              <double>1</double>
-              <double>1</double>
-              <double>1</double>
-              <double>0</double>
-              <double>0</double>
-              <double>0</double>
-            </XF>
-          </SoilCrop>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Thickness>
-            <double>100</double>
-            <double>200</double>
-            <double>300</double>
-            <double>300</double>
-            <double>300</double>
-            <double>300</double>
-          </Thickness>
-          <BD>
-            <double>1.2</double>
-            <double>1.2</double>
-            <double>1.2</double>
-            <double>1.2</double>
-            <double>1.2</double>
-            <double>1.2</double>
-          </BD>
-          <AirDry>
-            <double>0.08</double>
-            <double>0.16</double>
-            <double>0.15</double>
-            <double>0.13</double>
-            <double>0.15</double>
-            <double>0.15</double>
-          </AirDry>
-          <LL15>
-            <double>0.16</double>
-            <double>0.16</double>
-            <double>0.15</double>
-            <double>0.13</double>
-            <double>0.15</double>
-            <double>0.15</double>
-          </LL15>
-          <DUL>
-            <double>0.33</double>
-            <double>0.33</double>
-            <double>0.31</double>
-            <double>0.27</double>
-            <double>0.3</double>
-            <double>0.3</double>
-          </DUL>
-          <SAT>
-            <double>0.5</double>
-            <double>0.5</double>
-            <double>0.44</double>
-            <double>0.46</double>
-            <double>0.44</double>
-            <double>0.44</double>
-          </SAT>
-        </Water>
-        <SoilWater>
-          <Name>SoilWater</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <SummerDate>1-Nov</SummerDate>
-          <SummerU>9</SummerU>
-          <SummerCona>4.4</SummerCona>
-          <WinterDate>1-Apr</WinterDate>
-          <WinterU>9</WinterU>
-          <WinterCona>4.4</WinterCona>
-          <DiffusConst>88</DiffusConst>
-          <DiffusSlope>35.4</DiffusSlope>
-          <Salb>0.18</Salb>
-          <CN2Bare>0</CN2Bare>
-          <CNRed>-9E-05</CNRed>
-          <CNCov>0</CNCov>
-          <slope>0</slope>
-          <discharge_width>0</discharge_width>
-          <catchment_area>0</catchment_area>
-          <max_pond>0</max_pond>
-          <Thickness>
-            <double>100</double>
-            <double>200</double>
-            <double>300</double>
-            <double>300</double>
-            <double>300</double>
-            <double>300</double>
-          </Thickness>
-          <SWCON>
-            <double>0.55</double>
-            <double>0.55</double>
-            <double>0.55</double>
-            <double>0.55</double>
-            <double>0.55</double>
-            <double>0.55</double>
-          </SWCON>
-          <KLAT>
-            <double>0</double>
-            <double>0</double>
-            <double>0</double>
-            <double>0</double>
-            <double>0</double>
-            <double>0</double>
-          </KLAT>
-          <residueinterception>0</residueinterception>
-        </SoilWater>
-        <SoilNitrogen>
-          <Name>SoilNitrogen</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <fom_type>
-            <string>default</string>
-            <string>manure</string>
-            <string>mucuna</string>
-            <string>lablab</string>
-            <string>shemp</string>
-            <string>stable</string>
-          </fom_type>
-          <fract_carb>
-            <double>0.2</double>
-            <double>0.3</double>
-            <double>0.54</double>
-            <double>0.57</double>
-            <double>0.45</double>
-            <double>0</double>
-          </fract_carb>
-          <fract_cell>
-            <double>0.7</double>
-            <double>0.3</double>
-            <double>0.37</double>
-            <double>0.37</double>
-            <double>0.47</double>
-            <double>0.1</double>
-          </fract_cell>
-          <fract_lign>
-            <double>0.1</double>
-            <double>0.4</double>
-            <double>0.09</double>
-            <double>0.06</double>
-            <double>0.08</double>
-            <double>0.9</double>
-          </fract_lign>
-        </SoilNitrogen>
-        <SoilOrganicMatter>
-          <Name>SoilOrganicMatter</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <RootCN>30</RootCN>
-          <RootWt>3000</RootWt>
-          <SoilCN>11.5</SoilCN>
-          <EnrACoeff>7.4</EnrACoeff>
-          <EnrBCoeff>0.2</EnrBCoeff>
-          <Thickness>
-            <double>100</double>
-            <double>200</double>
-            <double>300</double>
-            <double>300</double>
-            <double>300</double>
-            <double>300</double>
-          </Thickness>
-          <Depth>
-            <string>0-10</string>
-            <string>10-30</string>
-            <string>30-60</string>
-            <string>60-90</string>
-            <string>90-120</string>
-            <string>120-150</string>
-          </Depth>
-          <OC>
-            <double>3.5</double>
-            <double>2.5</double>
-            <double>1.2</double>
-            <double>1.03</double>
-            <double>0.47</double>
-            <double>0.47</double>
-          </OC>
-          <FBiom>
-            <double>0.025</double>
-            <double>0.025</double>
-            <double>0.015</double>
-            <double>0.01</double>
-            <double>0.01</double>
-            <double>0.01</double>
-          </FBiom>
-          <FInert>
-            <double>0.3</double>
-            <double>0.4</double>
-            <double>0.75</double>
-            <double>0.9</double>
-            <double>0.96</double>
-            <double>0.96</double>
-          </FInert>
-          <OCUnits>Total</OCUnits>
-        </SoilOrganicMatter>
-        <Analysis>
-          <Name>Analysis</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Thickness>
-            <double>100</double>
-            <double>200</double>
-            <double>300</double>
-            <double>300</double>
-            <double>300</double>
-            <double>300</double>
-          </Thickness>
-          <PH>
-            <double>6.6</double>
-            <double>6.2</double>
-            <double>5.7</double>
-            <double>5.5</double>
-            <double>5.5</double>
-            <double>5.5</double>
-          </PH>
-          <PHUnits>Water</PHUnits>
-          <BoronUnits>HotWater</BoronUnits>
-        </Analysis>
-        <InitialWater>
-          <Name>Initial water</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <PercentMethod>EvenlyDistributed</PercentMethod>
-          <FractionFull>0.43</FractionFull>
-          <DepthWetSoil>NaN</DepthWetSoil>
-          <RelativeTo>GrapevineSoil</RelativeTo>
-        </InitialWater>
-        <Sample>
-          <Name>Sample</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Thickness>
-            <double>100</double>
-            <double>200</double>
-            <double>300</double>
-            <double>300</double>
-            <double>300</double>
-            <double>300</double>
-          </Thickness>
-          <NO3>
-            <double>40</double>
-            <double>30</double>
-            <double>14</double>
-            <double>14</double>
-            <double>1.38</double>
-            <double>1.38</double>
-          </NO3>
-          <NH4>
-            <double>0.1</double>
-            <double>0.1</double>
-            <double>0.1</double>
-            <double>0.1</double>
-            <double>0.1</double>
-            <double>0.1</double>
-          </NH4>
-          <NO3Units>kgha</NO3Units>
-          <NH4Units>kgha</NH4Units>
-          <SWUnits>Volumetric</SWUnits>
-          <OCUnits>Total</OCUnits>
-          <PHUnits>Water</PHUnits>
-        </Sample>
-        <CERESSoilTemperature>
-          <Name>CERESSoilTemperature</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-        </CERESSoilTemperature>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <RecordNumber>0</RecordNumber>
-        <SoilType>Sedementary</SoilType>
-        <LocalName>Lincoln</LocalName>
-        <Site />
-        <NearestTown />
-        <Region />
-        <NaturalVegetation />
-        <Latitude>0</Latitude>
-        <Longitude>0</Longitude>
-      </Soil>
-      <Report>
-        <Name>Report</Name>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <ExperimentFactorNames />
-        <ExperimentFactorValues />
-        <VariableNames>
-          <string />
-        </VariableNames>
-        <EventNames>
-          <string />
-        </EventNames>
-      </Report>
-      <Report>
-        <Name>Report1</Name>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <ExperimentFactorNames />
-        <ExperimentFactorValues />
-        <VariableNames>
-          <string>[Clock].Today</string>
-          <string>[Clock].Today.Year</string>
-          <string>[Clock].Today.DayOfYear</string>
-          <string>[Soil].SoilWater.SWmm</string>
-          <string>[Slurp].Root.WaterUptake</string>
-          <string>[Slurp].Root.Zones[1].Uptake</string>
-        </VariableNames>
-        <EventNames>
-          <string>[Clock].DoReport</string>
-        </EventNames>
-      </Report>
-      <Plant>
-        <Name>Slurp</Name>
-        <Memo>
-          <Name>TitlePage</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <MemoText><![CDATA[
-# SLURP: the Sound of a crop using water
-
-This model has been built using the Plant Modelling Framework (PMF) of [brown_plant_2014] to provide a simple representation of crops.  It is usefull for water and nitrogen balance studies where the focus is on soil processes and a very simple crop is adequate.  The model does not predict crop growth, development or yields.  It simply takes up water and nitrogen.   .  
-
-SLURP has no phenology so the behaviour of the SLURP is the same throughout its ontology (with the exception of root depth being able to increase).  SLURP consists of 2 organs:  
-   1. Leaf which ls represented with a Simpleleaf class and provides a Water uptake demand to the soil arbitrator.  
-   2. Root which extracts water and nitrogen from the soil for plant growth  
- 
-
-##Inclusion in APSIM simulations
-A Slurp crop is included in a simulation the same as any other APSIM crop  
- * The Slurp object needs to be dragged or copied from the Crop folder in the tool box into the field of your simulation.  
- * It is then planted with a sowing rule  
-<pre><code class='language-cs'>
-Slurp.Sow(cultivar: StaticCrop, population: 1, depth: 10, rowSpacing: 150);  
-</code></pre>
-  * Note that SLURP has no notion of population or rowSpacing but these parameters are required by the Sow method so filler values are provided  
-  * depth in the Sow arguement is the depth that the crop is sown at.  While this has no effect on emergence in SLURP it sets the depth that the root system is initialised at.  For static crops this depth should be set to the rooting depth that is expected as roots will not grow during the simulation
-
-##Altering Slurp properties during runs
-In some cases users will wish to change properties of Slurp while the simulation is running.  This can be done using a the set method in a manager script.
-
-<pre><code class='language-cs'>
-object LAIResetValue = leaflai;  
-zone.Set("Slurp.Leaf.LAIFunction.FixedValue", LAIResetValue);  
-object HeightResetValue = CoverToday * MaximumHeight;  
-zone.Set("Slurp.Leaf.HeightFunction.FixedValue", HeightResetValue);  
-</code></pre>]]></MemoText>
-        </Memo>
-        <OrganArbitrator>
-          <Name>Arbitrator</Name>
-          <RelativeAllocation>
-            <Name>NArbitrator</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-          </RelativeAllocation>
-          <RelativeAllocation>
-            <Name>DMArbitrator</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-          </RelativeAllocation>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-        </OrganArbitrator>
-        <Root>
-          <Name>Root</Name>
-          <MultiplyFunction>
-            <Name>RootFrontVelocity</Name>
-            <AirTemperatureFunction>
-              <Name>TemperatureEffect</Name>
-              <XYPairs>
-                <Name>XYPairs</Name>
-                <Graph>
-                  <Name>Graph</Name>
-                  <Series>
-                    <Name>Series</Name>
-                    <IncludeInDocumentation>true</IncludeInDocumentation>
-                    <Type>Scatter</Type>
-                    <XAxis>Bottom</XAxis>
-                    <YAxis>Left</YAxis>
-                    <ColourArgb>-65536</ColourArgb>
-                    <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-                    <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-                    <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-                    <Marker>None</Marker>
-                    <MarkerSize>Normal</MarkerSize>
-                    <Line>Solid</Line>
-                    <LineThickness>Normal</LineThickness>
-                    <Checkpoint>Current</Checkpoint>
-                    <XFieldName>.Simulations.InterrowCompetition.Interrow.Slurp.Root.RootFrontVelocity.TemperatureEffect.XYPairs.X</XFieldName>
-                    <YFieldName>.Simulations.InterrowCompetition.Interrow.Slurp.Root.RootFrontVelocity.TemperatureEffect.XYPairs.Y</YFieldName>
-                    <ShowInLegend>false</ShowInLegend>
-                    <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-                    <Cumulative>false</Cumulative>
-                    <CumulativeX>false</CumulativeX>
-                  </Series>
-                  <IncludeInDocumentation>true</IncludeInDocumentation>
-                  <Axis>
-                    <Type>Left</Type>
-                    <Title>Y</Title>
-                    <Inverted>false</Inverted>
-                    <Minimum>NaN</Minimum>
-                    <Maximum>NaN</Maximum>
-                    <Interval>NaN</Interval>
-                  </Axis>
-                  <Axis>
-                    <Type>Bottom</Type>
-                    <Title>X</Title>
-                    <Inverted>false</Inverted>
-                    <Minimum>NaN</Minimum>
-                    <Maximum>NaN</Maximum>
-                    <Interval>NaN</Interval>
-                  </Axis>
-                  <LegendPosition>BottomRight</LegendPosition>
-                  <DisabledSeries />
-                </Graph>
-                <IncludeInDocumentation>true</IncludeInDocumentation>
-                <X>
-                  <double>0</double>
-                  <double>26</double>
-                  <double>35</double>
-                </X>
-                <Y>
-                  <double>1</double>
-                  <double>1</double>
-                  <double>1</double>
-                </Y>
-              </XYPairs>
-              <IncludeInDocumentation>true</IncludeInDocumentation>
-            </AirTemperatureFunction>
-            <Constant>
-              <Name>Potential</Name>
-              <IncludeInDocumentation>true</IncludeInDocumentation>
-              <FixedValue>5</FixedValue>
-              <Units>mm/d</Units>
-            </Constant>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-          </MultiplyFunction>
-          <Constant>
-            <Name>MaxDailyNUptake</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>100</FixedValue>
-            <Units>g/m2</Units>
-          </Constant>
-          <Constant>
-            <Name>MaximumRootDepth</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>1000</FixedValue>
-            <Units>mm</Units>
-          </Constant>
-          <Constant>
-            <Name>NitrogenDemandSwitch</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>1</FixedValue>
-            <Units>0-1</Units>
-          </Constant>
-          <Constant>
-            <Name>MaximumNConc</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>0.01</FixedValue>
-          </Constant>
-          <Constant>
-            <Name>MinimumNConc</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>0.01</FixedValue>
-          </Constant>
-          <LinearInterpolationFunction>
-            <Name>KLModifier</Name>
-            <XYPairs>
-              <Name>XYPairs</Name>
-              <IncludeInDocumentation>true</IncludeInDocumentation>
-              <X>
-                <double>0</double>
-                <double>400</double>
-                <double>1500</double>
-              </X>
-              <Y>
-                <double>1</double>
-                <double>1</double>
-                <double>0</double>
-              </Y>
-            </XYPairs>
-            <Memo>
-              <Name>Description</Name>
-              <IncludeInDocumentation>true</IncludeInDocumentation>
-              <MemoText><![CDATA[
-This is important in SLURP as it is set for each species to represent their differences in rooting patterns between crop species
-]]></MemoText>
-            </Memo>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <XProperty>[Root].LayerMidPointDepth</XProperty>
-          </LinearInterpolationFunction>
-          <Constant>
-            <Name>InitialDM</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>50</FixedValue>
-            <Units>g/plant</Units>
-          </Constant>
-          <Constant>
-            <Name>SenescenceRate</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>0</FixedValue>
-            <Units>/d</Units>
-          </Constant>
-          <Constant>
-            <Name>SpecificRootLength</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>40</FixedValue>
-            <Units>m/g</Units>
-          </Constant>
-          <LinearInterpolationFunction>
-            <Name>KNO3</Name>
-            <XYPairs>
-              <Name>XYPairs</Name>
-              <IncludeInDocumentation>true</IncludeInDocumentation>
-              <X>
-                <double>0</double>
-                <double>0.003</double>
-              </X>
-              <Y>
-                <double>0.02</double>
-                <double>0.02</double>
-              </Y>
-            </XYPairs>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <XProperty>[Root].LengthDensity</XProperty>
-          </LinearInterpolationFunction>
-          <LinearInterpolationFunction>
-            <Name>KNH4</Name>
-            <XYPairs>
-              <Name>XYPairs</Name>
-              <IncludeInDocumentation>true</IncludeInDocumentation>
-              <X>
-                <double>0</double>
-                <double>0.003</double>
-              </X>
-              <Y>
-                <double>0</double>
-                <double>0</double>
-              </Y>
-            </XYPairs>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <XProperty>[Root].LengthDensity</XProperty>
-          </LinearInterpolationFunction>
-          <BiomassRemoval>
-            <Name>BiomassRemovalDefaults</Name>
-            <OrganBiomassRemovalType>
-              <Name>Harvest</Name>
-              <IncludeInDocumentation>true</IncludeInDocumentation>
-              <FractionLiveToRemove>0</FractionLiveToRemove>
-              <FractionDeadToRemove>0</FractionDeadToRemove>
-              <FractionLiveToResidue>0</FractionLiveToResidue>
-              <FractionDeadToResidue>0</FractionDeadToResidue>
-            </OrganBiomassRemovalType>
-            <OrganBiomassRemovalType>
-              <Name>Cut</Name>
-              <IncludeInDocumentation>true</IncludeInDocumentation>
-              <FractionLiveToRemove>0</FractionLiveToRemove>
-              <FractionDeadToRemove>0</FractionDeadToRemove>
-              <FractionLiveToResidue>0</FractionLiveToResidue>
-              <FractionDeadToResidue>0</FractionDeadToResidue>
-            </OrganBiomassRemovalType>
-            <OrganBiomassRemovalType>
-              <Name>Prune</Name>
-              <IncludeInDocumentation>true</IncludeInDocumentation>
-              <FractionLiveToRemove>0</FractionLiveToRemove>
-              <FractionDeadToRemove>0</FractionDeadToRemove>
-              <FractionLiveToResidue>0</FractionLiveToResidue>
-              <FractionDeadToResidue>0</FractionDeadToResidue>
-            </OrganBiomassRemovalType>
-            <OrganBiomassRemovalType>
-              <Name>Graze</Name>
-              <IncludeInDocumentation>true</IncludeInDocumentation>
-              <FractionLiveToRemove>0</FractionLiveToRemove>
-              <FractionDeadToRemove>0</FractionDeadToRemove>
-              <FractionLiveToResidue>0</FractionLiveToResidue>
-              <FractionDeadToResidue>0</FractionDeadToResidue>
-            </OrganBiomassRemovalType>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-          </BiomassRemoval>
-          <LinearInterpolationFunction>
-            <Name>NUptakeSWFactor</Name>
-            <XYPairs>
-              <Name>XYPairs</Name>
-              <IncludeInDocumentation>true</IncludeInDocumentation>
-              <X>
-                <double>0</double>
-                <double>1</double>
-              </X>
-              <Y>
-                <double>1</double>
-                <double>1</double>
-              </Y>
-            </XYPairs>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <XProperty>[Root].RWC</XProperty>
-          </LinearInterpolationFunction>
-          <PartitionFractionDemandFunction>
-            <Name>DMDemandFunction</Name>
-            <Constant>
-              <Name>PartitionFraction</Name>
-              <IncludeInDocumentation>true</IncludeInDocumentation>
-              <FixedValue>0.2</FixedValue>
-              <Units>0-1</Units>
-            </Constant>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-          </PartitionFractionDemandFunction>
-          <Constant>
-            <Name>DMConversionEfficiency</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>1</FixedValue>
-          </Constant>
-          <Constant>
-            <Name>MaintenanceRespirationFunction</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>1</FixedValue>
-          </Constant>
-          <Constant>
-            <Name>RemobilisationCost</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>0</FixedValue>
-          </Constant>
-          <Constant>
-            <Name>CarbonConcentration</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>0.4</FixedValue>
-          </Constant>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <GrowthRespiration>0</GrowthRespiration>
-          <MaintenanceRespiration>0</MaintenanceRespiration>
-        </Root>
-        <SimpleLeaf>
-          <Name>Leaf</Name>
-          <Constant>
-            <Name>DetachmentRateFunction</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>0</FixedValue>
-            <Units>/d</Units>
-          </Constant>
-          <MultiplyFunction>
-            <Name>InitialWtFunction</Name>
-            <Constant>
-              <Name>InitialPlantWt</Name>
-              <IncludeInDocumentation>true</IncludeInDocumentation>
-              <FixedValue>0</FixedValue>
-              <Units>g/plant</Units>
-            </Constant>
-            <VariableReference>
-              <Name>Population</Name>
-              <IncludeInDocumentation>true</IncludeInDocumentation>
-              <VariableName>[Plant].Population</VariableName>
-            </VariableReference>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-          </MultiplyFunction>
-          <Constant>
-            <Name>LaiDeadFunction</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>0</FixedValue>
-            <Units>m^2/m^2</Units>
-          </Constant>
-          <Constant>
-            <Name>Photosynthesis</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>5</FixedValue>
-            <Units>g/m2/d</Units>
-          </Constant>
-          <AirTemperatureFunction>
-            <Name>FRGRFunction</Name>
-            <XYPairs>
-              <Name>XYPairs</Name>
-              <Graph>
-                <Name>Graph</Name>
-                <Series>
-                  <Name>Series</Name>
-                  <IncludeInDocumentation>true</IncludeInDocumentation>
-                  <Type>Scatter</Type>
-                  <XAxis>Bottom</XAxis>
-                  <YAxis>Left</YAxis>
-                  <ColourArgb>-65536</ColourArgb>
-                  <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-                  <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-                  <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-                  <Marker>None</Marker>
-                  <MarkerSize>Normal</MarkerSize>
-                  <Line>Solid</Line>
-                  <LineThickness>Normal</LineThickness>
-                  <Checkpoint>Current</Checkpoint>
-                  <XFieldName>[XYPairs].X</XFieldName>
-                  <YFieldName>[XYPairs].Y</YFieldName>
-                  <ShowInLegend>true</ShowInLegend>
-                  <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-                  <Cumulative>false</Cumulative>
-                  <CumulativeX>false</CumulativeX>
-                </Series>
-                <IncludeInDocumentation>false</IncludeInDocumentation>
-                <Axis>
-                  <Type>Left</Type>
-                  <Title>Y</Title>
-                  <Inverted>false</Inverted>
-                  <Minimum>NaN</Minimum>
-                  <Maximum>NaN</Maximum>
-                  <Interval>NaN</Interval>
-                </Axis>
-                <Axis>
-                  <Type>Bottom</Type>
-                  <Title>X</Title>
-                  <Inverted>false</Inverted>
-                  <Minimum>NaN</Minimum>
-                  <Maximum>NaN</Maximum>
-                  <Interval>NaN</Interval>
-                </Axis>
-                <LegendPosition>BottomRight</LegendPosition>
-                <DisabledSeries />
-              </Graph>
-              <IncludeInDocumentation>true</IncludeInDocumentation>
-              <X>
-                <double>0</double>
-                <double>10</double>
-                <double>25</double>
-                <double>40</double>
-              </X>
-              <Y>
-                <double>0</double>
-                <double>1</double>
-                <double>1</double>
-                <double>0</double>
-              </Y>
-            </XYPairs>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-          </AirTemperatureFunction>
-          <PartitionFractionDemandFunction>
-            <Name>DMDemandFunction</Name>
-            <Constant>
-              <Name>PartitionFraction</Name>
-              <IncludeInDocumentation>true</IncludeInDocumentation>
-              <FixedValue>1</FixedValue>
-              <Units>0-1</Units>
-            </Constant>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-          </PartitionFractionDemandFunction>
-          <Constant>
-            <Name>MaximumNConc</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>0.05</FixedValue>
-            <Units>g/g</Units>
-          </Constant>
-          <Constant>
-            <Name>MinimumNConc</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>0.05</FixedValue>
-            <Units>g/g</Units>
-          </Constant>
-          <Constant>
-            <Name>LAIFunction</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>1</FixedValue>
-            <Units>m2/m2</Units>
-          </Constant>
-          <Constant>
-            <Name>ExtinctionCoefficientFunction</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>0.7</FixedValue>
-          </Constant>
-          <Constant>
-            <Name>StructuralFraction</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>0.5</FixedValue>
-            <Units>0-1</Units>
-          </Constant>
-          <Constant>
-            <Name>HeightFunction</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>100</FixedValue>
-            <Units>mm</Units>
-          </Constant>
-          <Constant>
-            <Name>NReallocationFactor</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>0</FixedValue>
-          </Constant>
-          <Constant>
-            <Name>SenescenceRate</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>0</FixedValue>
-          </Constant>
-          <BiomassRemoval>
-            <Name>BiomassRemovalDefaults</Name>
-            <OrganBiomassRemovalType>
-              <Name>Harvest</Name>
-              <IncludeInDocumentation>true</IncludeInDocumentation>
-              <FractionLiveToRemove>0</FractionLiveToRemove>
-              <FractionDeadToRemove>0</FractionDeadToRemove>
-              <FractionLiveToResidue>0</FractionLiveToResidue>
-              <FractionDeadToResidue>0</FractionDeadToResidue>
-            </OrganBiomassRemovalType>
-            <OrganBiomassRemovalType>
-              <Name>Cut</Name>
-              <IncludeInDocumentation>true</IncludeInDocumentation>
-              <FractionLiveToRemove>0</FractionLiveToRemove>
-              <FractionDeadToRemove>0</FractionDeadToRemove>
-              <FractionLiveToResidue>0</FractionLiveToResidue>
-              <FractionDeadToResidue>0</FractionDeadToResidue>
-            </OrganBiomassRemovalType>
-            <OrganBiomassRemovalType>
-              <Name>Prune</Name>
-              <IncludeInDocumentation>true</IncludeInDocumentation>
-              <FractionLiveToRemove>0</FractionLiveToRemove>
-              <FractionDeadToRemove>0</FractionDeadToRemove>
-              <FractionLiveToResidue>0</FractionLiveToResidue>
-              <FractionDeadToResidue>0</FractionDeadToResidue>
-            </OrganBiomassRemovalType>
-            <OrganBiomassRemovalType>
-              <Name>Graze</Name>
-              <IncludeInDocumentation>true</IncludeInDocumentation>
-              <FractionLiveToRemove>0</FractionLiveToRemove>
-              <FractionDeadToRemove>0</FractionDeadToRemove>
-              <FractionLiveToResidue>0</FractionLiveToResidue>
-              <FractionDeadToResidue>0</FractionDeadToResidue>
-            </OrganBiomassRemovalType>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-          </BiomassRemoval>
-          <Constant>
-            <Name>MaintenanceRespirationFunction</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>0</FixedValue>
-            <Units>0-1</Units>
-          </Constant>
-          <Constant>
-            <Name>DMConversionEfficiency</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>1</FixedValue>
-            <Units>0-1</Units>
-          </Constant>
-          <Constant>
-            <Name>NRetranslocationFactor</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>0</FixedValue>
-          </Constant>
-          <Constant>
-            <Name>NitrogenDemandSwitch</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>1</FixedValue>
-          </Constant>
-          <Constant>
-            <Name>DMReallocationFactor</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>0</FixedValue>
-          </Constant>
-          <Constant>
-            <Name>DMRetranslocationFactor</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>0</FixedValue>
-          </Constant>
-          <VariableReference>
-            <Name>CriticalNConc</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <VariableName>[Leaf].MinimumNConc.Value()</VariableName>
-          </VariableReference>
-          <Constant>
-            <Name>RemobilisationCost</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>0</FixedValue>
-          </Constant>
-          <Constant>
-            <Name>CarbonConcentration</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <FixedValue>0.4</FixedValue>
-          </Constant>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <ApicalCohortNo>0</ApicalCohortNo>
-          <InitialisedCohortNo>0</InitialisedCohortNo>
-          <CohortsInitialised>false</CohortsInitialised>
-          <TipsAtEmergence>0</TipsAtEmergence>
-          <CohortsAtInitialisation>0</CohortsAtInitialisation>
-          <AppearedCohortNo>0</AppearedCohortNo>
-          <PlantAppearedLeafNo>0</PlantAppearedLeafNo>
-          <Albedo>0.018</Albedo>
-          <Gsmax>0.01</Gsmax>
-          <R50>200</R50>
-          <LAI>0</LAI>
-          <Height>0</Height>
-          <FRGR>0</FRGR>
-          <PotentialEP>0</PotentialEP>
-          <MicroClimatePresent>true</MicroClimatePresent>
-          <KDead>0</KDead>
-          <LAIDead>0</LAIDead>
-        </SimpleLeaf>
-        <Cultivar>
-          <Name>StaticCrop</Name>
-          <Memo>
-            <Name>Description</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <MemoText><![CDATA[The static crop is the base crop and uses all the paramaters values specified above.
-]]></MemoText>
-          </Memo>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Command />
-        </Cultivar>
-        <Cultivar>
-          <Name>StaticTree</Name>
-          <Memo>
-            <Name>Description</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <MemoText><![CDATA[The static tree is similar to the static crop but is taller, has a deeper root system and a lower extinction coefficient
-]]></MemoText>
-          </Memo>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Command>[Root].MaximumRootDepth.FixedValue = 2600</Command>
-          <Command>[Leaf].ExtinctionCoefficientFunction.FixedValue = 0.65</Command>
-          <Command>[Leaf].HeightFunction.FixedValue = 5000</Command>
-          <Command>[Root].KLModifier.XYPairs.X = 0, 400, 500, 1000, 1500, 2000</Command>
-          <Command>[Root].KLModifier.XYPairs.Y = 1, 1, 0.9, 0.6, 0.3, 0.1</Command>
-        </Cultivar>
-        <Cultivar>
-          <Name>Pasture</Name>
-          <Memo>
-            <Name>Description</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <MemoText><![CDATA[The pasture differs from the base crop because its has a RootFrontVelocity of 15 (as opposed to zero) which means the roots grow downward from sowing untill the MaximumRootDepth is reached.  It ExtinctionCoefficient and MaximumRootDepth are different to the base StaticCrop and it has a different pattern of kl with depth.
-]]></MemoText>
-          </Memo>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Command>[Root].MaximumRootDepth.FixedValue = 800</Command>
-          <Command>[Root].RootFrontVelocity.Potential.FixedValue = 15</Command>
-          <Command>[Leaf].ExtinctionCoefficientFunction.FixedValue = 0.65</Command>
-          <Command>[Root].KLModifier.XYPairs.X = 0, 200, 500, 1000</Command>
-          <Command>[Root].KLModifier.XYPairs.Y = 1, 1, 0.7, 0.0</Command>
-        </Cultivar>
-        <Cultivar>
-          <Name>Lucerne</Name>
-          <Memo>
-            <Name>Description</Name>
-            <IncludeInDocumentation>true</IncludeInDocumentation>
-            <MemoText><![CDATA[Lucerne also grows root depth like pasture but has a greater root depth, different kl pattern and different extinction coefficient
-]]></MemoText>
-          </Memo>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Command>[Root].MaximumRootDepth.FixedValue = 2500</Command>
-          <Command>[Root].RootFrontVelocity.Potential.FixedValue = 15</Command>
-          <Command>[Leaf].ExtinctionCoefficientFunction.FixedValue = 0.8</Command>
-          <Command>[Root].KLModifier.XYPairs.X = 0, 200, 500, 1000, 1500, 2000</Command>
-          <Command>[Root].KLModifier.XYPairs.Y = 1, 1, 0.9, 0.6, 0.3, 0.1</Command>
-        </Cultivar>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <CropType>Slurp</CropType>
-      </Plant>
-      <Manager>
-        <Name>SlurpSowingRule</Name>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Script>
-          <CultivarName>StaticCrop</CultivarName>
-          <InitialRootDepth>200</InitialRootDepth>
-          <SowingDate>2005-01-01</SowingDate>
-        </Script>
-        <Code><![CDATA[
-using System;
-using Models.Core;
-using Models.PMF;
-using APSIM.Shared.Utilities;
-        
-namespace Models
-{
-    [Serializable] 
-    [System.Xml.Serialization.XmlInclude(typeof(Model))]
-    public class Script : Model
-    {
-        [Link] Plant Slurp;
-        [Link] Clock Clock;
-
-        [Description("Cultivar")]
-        public string CultivarName { get; set; }
-        [Description("Initial Root Depth")]
-        public double InitialRootDepth { get; set; }
-        [Description("Sowing Date")]
-        public DateTime SowingDate { get; set; }
-
-               
-        [EventSubscribe("DoManagement")]
-        private void OnDoManagement(object sender, EventArgs e)
-        {
-            if (Clock.Today.Date == SowingDate)
-                Slurp.Sow(cultivar: CultivarName, population: 1, depth: InitialRootDepth, rowSpacing: 50);
-            //Potato.Sow(... Contains the following arguements:
-            //Population  double  Optional  Seeds sowing/m2.  Default is zero
-            //Cultivar    string  Required  "NameOfCultivar"
-            //Depth       double  Optional  Depth (mm) seed sown.   Default is 100mm 
-            //MaxCover    double  Optional  Proportion (0-1) of the ground row crop will cover.   Default is 1.0
-            //BudNumber   double  Optional  Number of mainstems per seed sown.  Default is 1.0
-            //RowSpacing  double  Optional  Spaceing (mm) between drill rows when crop is sown.  Default is 150mm
-            //CropClass   string  Optional  Crop class to instantiate when crop is sown.  Default is "Plant"
-        }
-    }
-}
-                
-]]></Code>
-      </Manager>
-      <MicroClimate>
-        <Name>MicroClimate</Name>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <a_interception>0.2</a_interception>
-        <b_interception>1</b_interception>
-        <c_interception>0</c_interception>
-        <d_interception>0</d_interception>
-        <soil_albedo>0.23</soil_albedo>
-        <sun_angle>15</sun_angle>
-        <soil_heat_flux_fraction>0.4</soil_heat_flux_fraction>
-        <night_interception_fraction>0.5</night_interception_fraction>
-        <refheight>2</refheight>
-        <albedo>0.15</albedo>
-        <emissivity>0.96</emissivity>
-        <RadIntTotal>0</RadIntTotal>
-      </MicroClimate>
-      <IncludeInDocumentation>true</IncludeInDocumentation>
-      <Area>0.0038</Area>
-      <Slope>0</Slope>
-      <Length>20</Length>
-      <Width>1.9</Width>
-    </RectangularZone>
-    <Folder>
-      <Name>SoilWater</Name>
-      <Graph>
-        <Name>Soil water layer 1</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>0</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Soil.SoilWater.SWmm(1)</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Left</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <Graph>
-        <Name>Soil water layer 2</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>0</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Soil.SoilWater.SWmm(2)</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Left</Type>
-          <Title />
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <Graph>
-        <Name>Soil water layer 3</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>0</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Soil.SoilWater.SWmm(3)</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Left</Type>
-          <Title />
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <Graph>
-        <Name>Soil water layer 4</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>0</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Soil.SoilWater.SWmm(4)</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Left</Type>
-          <Title />
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <Graph>
-        <Name>Soil water layer 5</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>0</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Soil.SoilWater.SWmm(5)</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Left</Type>
-          <Title />
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <Graph>
-        <Name>Soil water layer 6</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>0</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Soil.SoilWater.SWmm(5)</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Left</Type>
-          <Title />
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <IncludeInDocumentation>true</IncludeInDocumentation>
-      <ShowPageOfGraphs>true</ShowPageOfGraphs>
-    </Folder>
-    <Folder>
-      <Name>RootMass</Name>
-      <Graph>
-        <Name>Root Mass layer 1</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Grapevine.Root.Zones1.LayerLive1.Wt</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <Series>
-          <Name>Series 11</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-1663232</ColourArgb>
-          <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Grapevine.Root.Zones2.LayerLive1.Wt</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Left</Type>
-          <Title />
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <Graph>
-        <Name>Root Mass layer 2</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Grapevine.Root.Zones1.LayerLive2.Wt</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <Series>
-          <Name>Series 11</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-1663232</ColourArgb>
-          <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Grapevine.Root.Zones2.LayerLive2.Wt</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Left</Type>
-          <Title />
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <Graph>
-        <Name>Root Mass layer 3</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Grapevine.Root.Zones1.LayerLive3.Wt</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <Series>
-          <Name>Series 11</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-1663232</ColourArgb>
-          <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Grapevine.Root.Zones2.LayerLive3.Wt</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Left</Type>
-          <Title />
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <Graph>
-        <Name>Root Mass layer 4</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Grapevine.Root.Zones1.LayerLive4.Wt</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <Series>
-          <Name>Series 11</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-1663232</ColourArgb>
-          <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Grapevine.Root.Zones2.LayerLive4.Wt</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Left</Type>
-          <Title />
-          <Inverted>false</Inverted>
-          <Minimum>0</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <Graph>
-        <Name>Root Mass layer 5</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Grapevine.Root.Zones1.LayerLive5.Wt</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <Series>
-          <Name>Series 11</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-1663232</ColourArgb>
-          <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Grapevine.Root.Zones2.LayerLive5.Wt</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Left</Type>
-          <Title />
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <Graph>
-        <Name>Root Mass layer 6</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Grapevine.Root.Zones1.LayerLive6.Wt</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <Series>
-          <Name>Series 11</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-1663232</ColourArgb>
-          <FactorIndexToVaryColours>-1</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Grapevine.Root.Zones2.LayerLive6.Wt</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Left</Type>
-          <Title />
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <IncludeInDocumentation>true</IncludeInDocumentation>
-      <ShowPageOfGraphs>true</ShowPageOfGraphs>
-    </Folder>
-    <Folder>
-      <Name>VineWaterUptakeZone1</Name>
-      <Graph>
-        <Name>Soil water layer 1</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>0</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Root.Zones1.Uptake(1)</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Left</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <Graph>
-        <Name>Soil water layer 2</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>0</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Root.Zones1.Uptake(2)</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Left</Type>
-          <Title />
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <Graph>
-        <Name>Soil water layer 3</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>0</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Root.Zones1.Uptake(3)</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Left</Type>
-          <Title />
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <Graph>
-        <Name>Soil water layer 4</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>0</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Root.Zones1.Uptake(4)</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Left</Type>
-          <Title />
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <Graph>
-        <Name>Soil water layer 5</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>0</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Root.Zones1.Uptake(5)</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Left</Type>
-          <Title />
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <Graph>
-        <Name>Soil water layer 6</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>0</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Root.Zones1.Uptake(6)</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Left</Type>
-          <Title />
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <IncludeInDocumentation>true</IncludeInDocumentation>
-      <ShowPageOfGraphs>true</ShowPageOfGraphs>
-    </Folder>
-    <Folder>
-      <Name>VineWaterUptakeZone2</Name>
-      <Graph>
-        <Name>Soil water layer 1</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>0</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Root.Zones2.Uptake(1)</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Left</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <Graph>
-        <Name>Soil water layer 2</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>0</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Root.Zones2.Uptake(2)</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Left</Type>
-          <Title />
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <Graph>
-        <Name>Soil water layer 3</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>0</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Root.Zones2.Uptake(3)</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Left</Type>
-          <Title />
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <Graph>
-        <Name>Soil water layer 4</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>0</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Root.Zones2.Uptake(4)</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Left</Type>
-          <Title />
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <Graph>
-        <Name>Soil water layer 5</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>0</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Root.Zones2.Uptake(5)</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Left</Type>
-          <Title />
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <Graph>
-        <Name>Soil water layer 6</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>0</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Root.Zones2.Uptake(6)</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Left</Type>
-          <Title />
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <IncludeInDocumentation>true</IncludeInDocumentation>
-      <ShowPageOfGraphs>true</ShowPageOfGraphs>
-    </Folder>
-    <Folder>
-      <Name>SlurpWaterUptakeZone2</Name>
-      <Graph>
-        <Name>Soil water layer 1</Name>
-        <Series>
-          <Name>Series 1</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <Type>Scatter</Type>
-          <XAxis>Bottom</XAxis>
-          <YAxis>Left</YAxis>
-          <ColourArgb>-16777216</ColourArgb>
-          <FactorIndexToVaryColours>0</FactorIndexToVaryColours>
-          <FactorIndexToVaryMarkers>-1</FactorIndexToVaryMarkers>
-          <FactorIndexToVaryLines>-1</FactorIndexToVaryLines>
-          <Marker>None</Marker>
-          <MarkerSize>Normal</MarkerSize>
-          <Line>Solid</Line>
-          <LineThickness>Normal</LineThickness>
-          <Checkpoint>Current</Checkpoint>
-          <TableName>Report1</TableName>
-          <XFieldName>Clock.Today</XFieldName>
-          <YFieldName>Slurp.Root.WaterUptake</YFieldName>
-          <ShowInLegend>true</ShowInLegend>
-          <IncludeSeriesNameInLegend>false</IncludeSeriesNameInLegend>
-          <Cumulative>false</Cumulative>
-          <CumulativeX>false</CumulativeX>
-        </Series>
-        <IncludeInDocumentation>true</IncludeInDocumentation>
-        <Axis>
-          <Type>Bottom</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <Axis>
-          <Type>Left</Type>
-          <Inverted>false</Inverted>
-          <Minimum>NaN</Minimum>
-          <Maximum>NaN</Maximum>
-          <Interval>NaN</Interval>
-        </Axis>
-        <LegendPosition>BottomLeft</LegendPosition>
-        <DisabledSeries />
-      </Graph>
-      <IncludeInDocumentation>true</IncludeInDocumentation>
-      <ShowPageOfGraphs>true</ShowPageOfGraphs>
-    </Folder>
-    <IncludeInDocumentation>true</IncludeInDocumentation>
-  </Simulation>
   <IncludeInDocumentation>true</IncludeInDocumentation>
   <ExplorerWidth>283</ExplorerWidth>
 </Simulations>


### PR DESCRIPTION
working on #1822 
suppress the maintenance respiration due to errors in respiration larger than storage supply and interrow competition due to an error in N allocation. 
Focus on the climate effects on yield components for the moment.

Signed-off-by: Junqi_zhu <junqi108@gmail.com>