### PR TITLE
Intellisense: return of the type column (and other bugfixes).

### DIFF
--- a/ApsimNG/Classes/Intellisense/EntityCompletionData.cs
+++ b/ApsimNG/Classes/Intellisense/EntityCompletionData.cs
@@ -77,7 +77,7 @@ namespace UserInterface.Intellisense
                     {
                         description += " (+" + OverloadedData.Count() + " overloads)";
                     }
-                    description += Environment.NewLine + XmlDocumentationToText(Entity.Documentation);
+                    description = /*.NewLine + */XmlDocumentationToText(Entity.Documentation);
                 }
                 return description;
             }

--- a/ApsimNG/EventArguments/NeedContextItemsArgs.cs
+++ b/ApsimNG/EventArguments/NeedContextItemsArgs.cs
@@ -7,6 +7,7 @@
 namespace UserInterface.EventArguments
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
@@ -281,7 +282,6 @@ namespace UserInterface.EventArguments
         /// <returns></returns>
         private static object GetNodeFromPath(Model relativeTo, string objectName)
         {
-            
             string modelNamePattern = @"\[([A-Za-z]+[A-Za-z0-9]*)\]";
             var matches = System.Text.RegularExpressions.Regex.Matches(objectName, modelNamePattern);
             if (matches.Count <= 0)
@@ -302,11 +302,22 @@ namespace UserInterface.EventArguments
 
             // Iterate over the 'child' models/properties.
             // childName is the next child we're looking for. e.g. in "[Wheat].Leaf", the first childName will be "Leaf".
-            foreach (string childName in APSIM.Shared.Utilities.StringUtilities.SplitStringHonouringBrackets(objectName, '.', '[', ']'))
+            string[] namePathBits = APSIM.Shared.Utilities.StringUtilities.SplitStringHonouringBrackets(objectName, '.', '[', ']');
+            for (int i = 0; i < namePathBits.Length; i++)
             {
                 if (node == null)
                     return null;
+                string childName = namePathBits[i];
 
+                int squareBracketIndex = childName.IndexOf('[');
+                if (squareBracketIndex == 0)
+                {
+                    // User has typed something like [Wheat].[...]
+                    throw new Exception("Unable to parse child or property " + childName);
+                }
+                if (squareBracketIndex > 0) // childName contains square brackets - it may be an IList element
+                    childName = childName.Substring(0, squareBracketIndex);
+                
                 // First, check the child models. 
                 if (node is IModel)
                     node = (node as IModel).Children.FirstOrDefault(c => c.Name == childName) ?? node;
@@ -326,13 +337,18 @@ namespace UserInterface.EventArguments
                         if (property == null)
                             return null;
 
-                        // This property has the correct name. If the property's type provides a parameterless constructor, we can use 
-                        // reflection to instantiate an object of that type and assign it to the node variable. 
-                        // Otherwise, we assign the type itself to node.
-                        if (property.PropertyType.GetConstructor(Type.EmptyTypes) == null)
-                            node = property.PropertyType;
-                        else
-                            node = Activator.CreateInstance(property.PropertyType);
+                        // Try to set node to the value of the property.
+                        node = ReflectionUtilities.GetValueOfFieldOrProperty(childName, node);
+                        if (node == null)
+                        {
+                            // This property has the correct name. If the property's type provides a parameterless constructor, we can use 
+                            // reflection to instantiate an object of that type and assign it to the node variable. 
+                            // Otherwise, we assign the type itself to node.
+                            if (property.PropertyType.GetConstructor(Type.EmptyTypes) == null)
+                                node = property.PropertyType;
+                            else
+                                node = Activator.CreateInstance(property.PropertyType);
+                        }
                     }
                     catch
                     {
@@ -343,6 +359,37 @@ namespace UserInterface.EventArguments
                         return null;
                     }
                 }
+
+                if (squareBracketIndex > 0)
+                {
+                    // We have found the node, but the node is an IList of some sort, and we are actually interested in a specific element.
+
+                    int closingBracketIndex = namePathBits[i].IndexOf(']');
+                    if (closingBracketIndex <= 0 || (closingBracketIndex - squareBracketIndex) < 1)
+                        return null;
+
+                    string textBetweenBrackets = namePathBits[i].Substring(squareBracketIndex + 1, closingBracketIndex - squareBracketIndex - 1);
+                    if (node is IList)
+                    {
+                        int index = -1;
+                        if (Int32.TryParse(textBetweenBrackets, out index))
+                        {
+                            IList nodeList = node as IList;
+                            if (index >= nodeList.Count)
+                                throw new Exception("Unable to access element " + index + " of list " + childName + ": " + childName + " only has " + childName.Count() + " items.");
+                            node = nodeList[index];
+                        }
+                        else
+                            throw new Exception("Unable to access element \"" + textBetweenBrackets + "\" of list \"" + namePathBits[i] + "\"");
+                    }
+                    else if (node is IDictionary)
+                    {
+                        node = (node as IDictionary)[textBetweenBrackets];
+                    }
+                    else
+                        throw new Exception("Unable to parse child or property name " + namePathBits[i]);
+                }
+                squareBracketIndex = -1;
             }
              return node;
         }

--- a/ApsimNG/EventArguments/NeedContextItemsArgs.cs
+++ b/ApsimNG/EventArguments/NeedContextItemsArgs.cs
@@ -376,7 +376,7 @@ namespace UserInterface.EventArguments
                         {
                             IList nodeList = node as IList;
                             if (index >= nodeList.Count)
-                                throw new Exception("Unable to access element " + index + " of list " + childName + ": " + childName + " only has " + childName.Count() + " items.");
+                                throw new Exception("Unable to access element " + index + " of list " + childName + ": " + childName + " only has " + nodeList.Count + " items.");
                             node = nodeList[index];
                         }
                         else

--- a/ApsimNG/Views/IntellisenseView.cs
+++ b/ApsimNG/Views/IntellisenseView.cs
@@ -100,12 +100,17 @@
                 WidthChars = 15,
                 Ellipsize = Pango.EllipsizeMode.End
             };
+            column = new TreeViewColumn("Type", textRender, "text", 3)
+            {
+                Resizable = true
+            };
+            completionView.AppendColumn(column);
 
             textRender = new CellRendererText()
             {
                 Editable = false,
             };
-            column = new TreeViewColumn("Descr", textRender, "text", 3)
+            column = new TreeViewColumn("Descr", textRender, "text", 4)
             {
                 Resizable = true
             };
@@ -288,11 +293,7 @@
             foreach (CompletionData item in items)
             {
                 System.Diagnostics.Debug.WriteLine(i);
-                // For now, we only display the first 2 lines of the item's description. It's not a great solution,
-                // but there are plenty of classes/methods with >10 line descriptions, and displaying a 10 line 
-                // description is not an option. Ultimately, the plan is to create a secondary popup which houses 
-                // the description, just like in visual studio.
-                completionModel.AppendValues(item.Image, item.DisplayText, item.Units, item.Description?.Split(Environment.NewLine.ToCharArray()).Select(x => x.Trim()).Where(x => !string.IsNullOrEmpty(x)).Take(2).Aggregate((x, y) => x + Environment.NewLine + y));
+                completionModel.AppendValues(item.Image, item.DisplayText, item.Units, item.ReturnType, item.Description?.Split(Environment.NewLine.ToCharArray()).Select(x => x.Trim()).Where(x => !string.IsNullOrEmpty(x)).Take(2).Aggregate((x, y) => x + Environment.NewLine + y), item.CompletionText);
                 i++;
             }
         }
@@ -312,7 +313,7 @@
             foreach (NeedContextItemsArgs.ContextItem item in items)
             {
                 pixbufToBeUsed = item.IsProperty ? propertyPixbuf : functionPixbuf;
-                completionModel.AppendValues(pixbufToBeUsed, item.Name, item.Units, item.Descr, item.ParamString);
+                completionModel.AppendValues(pixbufToBeUsed, item.Name, item.Units, item.TypeName, item.Descr, item.ParamString);
             }
         }
 

--- a/Models/Grazplan/GrazSupp.cs
+++ b/Models/Grazplan/GrazSupp.cs
@@ -98,6 +98,7 @@ namespace Models.GrazPlan
     /// <summary>
     /// Supplement information
     /// </summary>
+    [Serializable]
     public class SuppInfo
     {
         /// <summary>


### PR DESCRIPTION
Working on #2617 

Fixed a bug in which no completion options were generated for array/list elements. This fix should work for dictionaries as well, but I make to guarantees.

I also added the type column back in, and removed the declaration syntax from the description column in manager scripts.