### PR TITLE
Bugfix for create macOS installation

### DIFF
--- a/Docker/CreateInstallation/Dockerfile
+++ b/Docker/CreateInstallation/Dockerfile
@@ -34,12 +34,12 @@ RUN Install-PackageProvider -Name Chocolatey -Force -RequiredVersion 2.8.5.130;	
 	Set-ExecutionPolicy Bypass -Scope Process -Force; iwr https://chocolatey.org/install.ps1 -UseBasicParsing | iex; 	\
     choco feature disable –name showDownloadProgress;                                        							\
 	choco feature enable -n allowGlobalConfirmation;                                         							\
-    choco install git;                                                                                                  \
-	choco install innosetup;																							\
-	choco install fciv;																									\
-	choco install cygwin;																								\
-	choco install 7zip;																									\
-	choco install curl;																									\
+    choco install --limit-output git																					\
+	choco install --limit-output innosetup;																				\
+	choco install --limit-output fciv;																					\
+	choco install --limit-output cygwin;																				\
+	choco install --limit-output 7zip;																					\
+	choco install --limit-output curl;																					\
 	mkdir C:\Utilities;																									\
 	Expand-Archive -Path C:\coreutils.zip -DestinationPath C:\coreutils -Force;											\
 	cp C:\coreutils\bin\* C:\Utilities\;																				\

--- a/Setup/osx/BuildMacDist.sh
+++ b/Setup/osx/BuildMacDist.sh
@@ -7,16 +7,18 @@ pushd $osx > /dev/null
 # Delete any .dmg files leftover from previous builds.
 find $setup -name "*.dmg" -exec rm "{}" \;
 
+if [ -f $apsimx/bin.zip ]; then
+	unzip $apsimx/bin.zip -d $apsimx/bin
+	rm -f $apsimx/bin.zip
+fi
+
 export version=$(mono $apsimx/Bin/Models.exe /Version | grep -oP '(\d\.){3}\d')
 export short_version=$(echo $version | cut -d'.' -f 1,2)
 export issue_id=$(echo $version | cut -d'.' -f 4)
 echo Apsim version: $version
 echo Short version: $short_version
 echo Issue number: 	$issue_id
-if [ -f $apsimx/bin.zip ]; then
-	unzip bin.zip -d $apsimx/bin
-	rm -f bin.zip
-fi
+
 
 if [ -d ./MacBundle ]; then
 	rm -rf ./MacBundle


### PR DESCRIPTION
Working on #2916 

I also reduced chocolatey's verbosity - the log file for the previous run had almost 40 000 lines of output.