### PR TITLE
Fix date/time format when adding a build to the builds DB.

### DIFF
--- a/Docker/Deploy/deploy.bat
+++ b/Docker/Deploy/deploy.bat
@@ -1,8 +1,12 @@
 @echo off
-echo ########### Add a green build to the builds database...
+set HOUR=%time:~0,2%
+if "%HOUR:~0,1%" == " " set HOUR=0%HOUR:~1,1%
+set MIN=%time:~3,2%
+if "%MIN:~0,1%" == " " set MIN=0%MIN:~1,1%
 for /f "tokens=1-4 delims=/ " %%a in ('date /t') do (set DATE_STAMP=20%%c.%%b.%%c)
-for /f "tokens=1-2 delims=: " %%a in ("%TIME%") do (set TIME_STAMP=%%a:%%b)
-set DATETIMESTAMP=%DATE_STAMP%-%TIME_STAMP%
+set DATETIMESTAMP=%DATE_STAMP%-%HOUR%:%MIN%
+echo DateTime=%DATETIMESTAMP%
+echo ########### Add a green build to the builds database...
 curl https://www.apsim.info/APSIM.Builds.Service/Builds.svc/AddBuild?pullRequestNumber=%PULL_ID%^&issueID=%ISSUE_NUMBER%^&issueTitle=%ISSUE_TITLE%^&Released=%RELEASED%^&buildTimeStamp=%DATETIMESTAMP%^&ChangeDBPassword=%PASSWORD%
 if errorlevel 1 (
 	echo Errors encountered!


### PR DESCRIPTION
Resolves #2916 

~~Please don't merge this just yet, as there also appears to be a problem in APSIM.Builds.Service which I will need to fix before this works.~~

Edit: This is now safe to merge, once it runs green on Jenkins.