### PR TITLE
Intellisense for column filter in DataStore and Series

### DIFF
--- a/ApsimNG/Presenters/DataStorePresenter.cs
+++ b/ApsimNG/Presenters/DataStorePresenter.cs
@@ -237,9 +237,15 @@ namespace UserInterface.Presenters
 
         private void OnInsertIntellisenseItem(object sender, IntellisenseItemSelectedArgs args)
         {
-            // (sender, e) => managerView.Editor.InsertCompletionOption(e.ItemSelected, e.TriggerWord)
-            this.view.ColumnFilter.InsertAtCursor(args.ItemSelected);
-            PopulateGrid();
+            try
+            {
+                view.ColumnFilter.InsertCompletionOption(args.ItemSelected, args.TriggerWord);
+                PopulateGrid();
+            }
+            catch (Exception err)
+            {
+                explorerPresenter.MainPresenter.ShowError(err);
+            }
         }
 
         /// <summary>The maximum number of records has changed.</summary>

--- a/ApsimNG/Presenters/DataStorePresenter.cs
+++ b/ApsimNG/Presenters/DataStorePresenter.cs
@@ -12,6 +12,7 @@ namespace UserInterface.Presenters
     using Models.Core;
     using Models.Factorial;
     using Views;
+    using EventArguments;
 
     /// <summary>A data store presenter connecting a data store model with a data store view</summary>
     public class DataStorePresenter : IPresenter
@@ -21,6 +22,11 @@ namespace UserInterface.Presenters
 
         /// <summary>The data store view to work with.</summary>
         private IDataStoreView view;
+
+        /// <summary>
+        /// The intellisense.
+        /// </summary>
+        private IntellisensePresenter intellisense;
 
         /// <summary>Parent explorer presenter.</summary>
         private ExplorerPresenter explorerPresenter;
@@ -40,6 +46,8 @@ namespace UserInterface.Presenters
             dataStore = model as IStorageReader;
             this.view = view as IDataStoreView;
             this.explorerPresenter = explorerPresenter;
+            this.intellisense = new IntellisensePresenter(this.view as ViewBase);
+            intellisense.ItemSelected += OnInsertIntellisenseItem;
 
             this.view.TableList.IsEditable = false;
             this.view.Grid.ReadOnly = true;
@@ -55,6 +63,7 @@ namespace UserInterface.Presenters
 
             this.view.TableList.Changed += this.OnTableSelected;
             this.view.ColumnFilter.Changed += OnColumnFilterChanged;
+            this.view.ColumnFilter.IntellisenseItemsNeeded += OnIntellisenseNeeded;
             this.view.MaximumNumberRecords.Changed += OnMaximumNumberRecordsChanged;
             PopulateGrid();
         }
@@ -205,6 +214,31 @@ namespace UserInterface.Presenters
         /// <param name="e">Event arguments</param>
         private void OnColumnFilterChanged(object sender, EventArgs e)
         {
+            PopulateGrid();
+        }
+
+        /// <summary>
+        /// The view is asking for items for the intellisense.
+        /// </summary>
+        /// <param name="sender">Sender object.</param>
+        /// <param name="args">Event arguments.</param>
+        private void OnIntellisenseNeeded(object sender, NeedContextItemsArgs args)
+        {
+            try
+            {
+                if (intellisense.GenerateSeriesCompletions(args.Code, args.Offset, view.TableList.SelectedValue, dataStore))
+                    intellisense.Show(args.Coordinates.Item1, args.Coordinates.Item2);
+            }
+            catch (Exception err)
+            {
+                explorerPresenter.MainPresenter.ShowError(err);
+            }
+        }
+
+        private void OnInsertIntellisenseItem(object sender, IntellisenseItemSelectedArgs args)
+        {
+            // (sender, e) => managerView.Editor.InsertCompletionOption(e.ItemSelected, e.TriggerWord)
+            this.view.ColumnFilter.InsertAtCursor(args.ItemSelected);
             PopulateGrid();
         }
 

--- a/ApsimNG/Presenters/ExplorerPresenter.cs
+++ b/ApsimNG/Presenters/ExplorerPresenter.cs
@@ -677,33 +677,40 @@ namespace UserInterface.Presenters
         /// <summary>Display a view on the right hand panel in view.</summary>
         public void ShowRightHandPanel()
         {
-            if (this.view.Tree.SelectedNode != string.Empty)
+            try
             {
-                object model = Apsim.Get(this.ApsimXFile, this.view.Tree.SelectedNode);
-
-                if (model != null)
+                if (this.view.Tree.SelectedNode != string.Empty)
                 {
-                    ViewNameAttribute viewName = ReflectionUtilities.GetAttribute(model.GetType(), typeof(ViewNameAttribute), false) as ViewNameAttribute;
-                    PresenterNameAttribute presenterName = ReflectionUtilities.GetAttribute(model.GetType(), typeof(PresenterNameAttribute), false) as PresenterNameAttribute;
-                    DescriptionAttribute descriptionName = ReflectionUtilities.GetAttribute(model.GetType(), typeof(DescriptionAttribute), false) as DescriptionAttribute;
+                    object model = Apsim.Get(this.ApsimXFile, this.view.Tree.SelectedNode);
 
-                    if (descriptionName != null)
+                    if (model != null)
                     {
-                        viewName = new ViewNameAttribute("UserInterface.Views.ModelDetailsWrapperView");
-                        presenterName = new PresenterNameAttribute("UserInterface.Presenters.ModelDetailsWrapperPresenter");
-                    }
+                        ViewNameAttribute viewName = ReflectionUtilities.GetAttribute(model.GetType(), typeof(ViewNameAttribute), false) as ViewNameAttribute;
+                        PresenterNameAttribute presenterName = ReflectionUtilities.GetAttribute(model.GetType(), typeof(PresenterNameAttribute), false) as PresenterNameAttribute;
+                        DescriptionAttribute descriptionName = ReflectionUtilities.GetAttribute(model.GetType(), typeof(DescriptionAttribute), false) as DescriptionAttribute;
 
-                    if (viewName == null && presenterName == null)
-                    {
-                        viewName = new ViewNameAttribute("UserInterface.Views.HTMLView");
-                        presenterName = new PresenterNameAttribute("UserInterface.Presenters.GenericPresenter");
-                    }
+                        if (descriptionName != null)
+                        {
+                            viewName = new ViewNameAttribute("UserInterface.Views.ModelDetailsWrapperView");
+                            presenterName = new PresenterNameAttribute("UserInterface.Presenters.ModelDetailsWrapperPresenter");
+                        }
 
-                    if (viewName != null && presenterName != null)
-                    {
-                        this.ShowInRightHandPanel(model, viewName.ToString(), presenterName.ToString());
+                        if (viewName == null && presenterName == null)
+                        {
+                            viewName = new ViewNameAttribute("UserInterface.Views.HTMLView");
+                            presenterName = new PresenterNameAttribute("UserInterface.Presenters.GenericPresenter");
+                        }
+
+                        if (viewName != null && presenterName != null)
+                        {
+                            this.ShowInRightHandPanel(model, viewName.ToString(), presenterName.ToString());
+                        }
                     }
                 }
+            }
+            catch (Exception err)
+            {
+                MainPresenter.ShowError(err);
             }
         }
 

--- a/ApsimNG/Presenters/IntellisensePresenter.cs
+++ b/ApsimNG/Presenters/IntellisensePresenter.cs
@@ -245,16 +245,13 @@
 
         public bool GenerateSeriesCompletions(string text, int offset, string tableName, IStorageReader storage)
         {
-            string textSoFar = text?.Substring(0, offset);
-
-            if (textSoFar.LastOrDefault() == '[')
-                textSoFar = string.Empty;
-
+            triggerWord = text?.Substring(0, offset).Split(' ').Last().Replace("[", "").Replace("]", "");
+            
             List<string> columnNames = storage.ColumnNames(tableName).ToList();
             List<NeedContextItemsArgs.ContextItem> intellisenseOptions = new List<NeedContextItemsArgs.ContextItem>();
             foreach (string columnName in columnNames)
             {
-                if (string.IsNullOrEmpty(textSoFar) || string.IsNullOrEmpty(textSoFar.Replace("[", "").Replace("]", "")) || columnName.StartsWith(textSoFar.Substring(0, offset)))
+                if (string.IsNullOrEmpty(triggerWord) || string.IsNullOrEmpty(triggerWord.Replace("[", "").Replace("]", "")) || columnName.StartsWith(triggerWord.Replace("[", "").Replace("]", "")))
                 intellisenseOptions.Add(new NeedContextItemsArgs.ContextItem()
                 {
                     Name = columnName,

--- a/ApsimNG/Presenters/IntellisensePresenter.cs
+++ b/ApsimNG/Presenters/IntellisensePresenter.cs
@@ -243,6 +243,32 @@
             return completionList.Any();
         }
 
+        public bool GenerateSeriesCompletions(string text, int offset, string tableName, IStorageReader storage)
+        {
+            string textSoFar = text?.Substring(0, offset);
+
+            if (textSoFar.LastOrDefault() == '[')
+                textSoFar = string.Empty;
+
+            List<string> columnNames = storage.ColumnNames(tableName).ToList();
+            List<NeedContextItemsArgs.ContextItem> intellisenseOptions = new List<NeedContextItemsArgs.ContextItem>();
+            foreach (string columnName in columnNames)
+            {
+                if (string.IsNullOrEmpty(textSoFar) || string.IsNullOrEmpty(textSoFar.Replace("[", "").Replace("]", "")) || columnName.StartsWith(textSoFar.Substring(0, offset)))
+                intellisenseOptions.Add(new NeedContextItemsArgs.ContextItem()
+                {
+                    Name = columnName,
+                    Units = string.Empty,
+                    TypeName = string.Empty,
+                    Descr = string.Empty,
+                    ParamString = string.Empty
+                });
+            }
+            if (intellisenseOptions.Any())
+                view.Populate(intellisenseOptions);
+            return intellisenseOptions.Any();
+        }
+
         /// <summary>
         /// Generates the intellisense options.
         /// After calling this, call <see cref="Show(int, int, int)"/> to show the intellisense popup.

--- a/ApsimNG/Views/EditBoxView.cs
+++ b/ApsimNG/Views/EditBoxView.cs
@@ -154,6 +154,7 @@ namespace UserInterface.Views
                         Code = textentry1.Text,
                         Offset = Offset
                     };
+                    lastText = textentry1.Text;
                     IntellisenseItemsNeeded.Invoke(this, e);
                 }
             }

--- a/ApsimNG/Views/EditBoxView.cs
+++ b/ApsimNG/Views/EditBoxView.cs
@@ -32,6 +32,14 @@ namespace UserInterface.Views
         /// </summary>
         /// <param name="text"></param>
         void InsertAtCursor(string text);
+
+        /// <summary>
+        /// Inserts a completion option, replacing the half-typed trigger word
+        /// for which we have generated completion options.
+        /// </summary>
+        /// <param name="text">Text to be inserted.</param>
+        /// <param name="triggerWord">Incomplete word to be replaced.</param>
+        void InsertCompletionOption(string text, string triggerWord);
     }
 
     /// <summary>A drop down view.</summary>
@@ -152,6 +160,43 @@ namespace UserInterface.Views
             else if ((args.Event.Key & Gdk.Key.Return) == Gdk.Key.Return)
             {
                 OnSelectionChanged(this, EventArgs.Empty);
+            }
+        }
+
+        /// <summary>
+        /// Inserts a completion option, replacing the half-typed trigger word
+        /// for which we have generated completion options.
+        /// </summary>
+        /// <param name="text">Text to be inserted.</param>
+        /// <param name="triggerWord">Incomplete word to be replaced.</param>
+        public void InsertCompletionOption(string text, string triggerWord)
+        {
+            if (string.IsNullOrEmpty(text))
+                return;
+            if (string.IsNullOrEmpty(triggerWord))
+            {
+                textentry1.Text = text;
+                textentry1.Position = text.Length;
+            }
+            else if (!textentry1.Text.Contains(triggerWord))
+                textentry1.Text += text;
+            else
+            {
+                string textBeforeCursor = textentry1.Text.Substring(0, Offset);
+                string textAfterCursor = textentry1.Text.Substring(Offset);
+                int index = textBeforeCursor.LastIndexOf(triggerWord);
+                if (index >= 0)
+                {
+                    string textBeforeWord = textBeforeCursor.Substring(0, index);
+                    string textAfterWord = textBeforeCursor.Substring(index + triggerWord.Length);
+                    textentry1.Text = textBeforeWord + text + textAfterWord + textAfterCursor;
+                    textentry1.Position = textBeforeWord.Length + text.Length;
+                }
+                else
+                {
+                    // I can't imagine how this could ever happen, but it doesn't hurt to be prepared.
+                    textentry1.Text = textBeforeCursor + text + textAfterCursor;
+                }
             }
         }
 


### PR DESCRIPTION
Resolves #948 
Resolves #2209 
Working on #2966 

I'm not sure what a typical use case is for the column filter, so I haven't been able to extensively test this feature. That said, it works for examples similar to the one Hamish provided in #948.

I'm marking #2209 as resolved, as we don't really need 2 issues describing the same bug. I'll leave #2966 open until we get a patch out allowing users to click on graphs for simulations not being run.