### PR TITLE
Add MonoMac.dll to osx installer.

### DIFF
--- a/Setup/osx/BuildMacDist.sh
+++ b/Setup/osx/BuildMacDist.sh
@@ -19,6 +19,7 @@ do
 	rm -rf $apsimx/Bin/$(basename -- $f)
 done
 
+cp $apsimx/ApsimNG/Assemblies/MonoMac.dll $apsimx/Bin/
 export version=$(mono $apsimx/Bin/Models.exe /Version | grep -oP '(\d+\.){3}\d+')
 export short_version=$(echo $version | cut -d'.' -f 1,2)
 export issue_id=$(echo $version | cut -d'.' -f 4)


### PR DESCRIPTION
Working on #2916 

This should get the Mac installers working, but there are still some issues with the Linux installer which need to be ironed out.