### PR TITLE
Don't upload conference papers alongside model documentation

### DIFF
--- a/Docker/Documentation/doco.bat
+++ b/Docker/Documentation/doco.bat
@@ -20,8 +20,9 @@ if exist %apsimx%\results.7z (
 		echo Error unzipping %apsimx%\results.7z
 	)
 )
-
+dir %apsimx%\Bin
 cd %apsimx%\Documentation
+set FC_DEBUG=8191
 call GenerateDocumentation.bat
 cd %apsimx%
 for /r Documentation\PDF %%D in (*.pdf) do (

--- a/Docker/Documentation/doco.bat
+++ b/Docker/Documentation/doco.bat
@@ -24,8 +24,9 @@ if exist %apsimx%\results.7z (
 cd %apsimx%\Documentation
 call GenerateDocumentation.bat
 cd %apsimx%
-for /r Tests\Validation %%D in (*.pdf) do ( 
-	rename %%D %%~nD%ISSUE_NUMBER%%%~xD
-	echo Uploading %%~nD%ISSUE_NUMBER%%%~xD
-	@curl -u %APSIM_SITE_CREDS% -T "%%~dpnD%ISSUE_NUMBER%%%~xD" ftp://www.apsim.info/APSIM/ApsimXFiles/
+for /r Documentation\PDF %%D in (*.pdf) do (
+	set "NEW_NAME=%%~nD%ISSUE_NUMBER%%%~xD"
+	rename "%%D" "%NEW_NAME%"
+	echo Uploading %NEW_NAME%
+	@curl -u %APSIM_SITE_CREDS% -T "%NEW_NAME%" ftp://www.apsim.info/APSIM/ApsimXFiles/
 )


### PR DESCRIPTION
Working on #3001

Do these conference papers even belong in source control?

```
ApsimX\Tests\Validation\Maize\Ciampitti Maize Population N Dynamics.pdf
ApsimX\Tests\Validation\System\Hudson\SR08104.pdf
ApsimX\Tests\Validation\System\Tarlee Rotation Trial\EA9950865.pdf
ApsimX\Tests\Validation\System\Wagga\Chan et al 2002.pdf
ApsimX\Tests\Validation\System\Wagga\Heenan et al 1994.pdf
ApsimX\Tests\Validation\System\Wagga\Heenan et al 1995.pdf
```