### PR TITLE
removing slnDemandFunction as it has been made unnecessary.

### DIFF
--- a/Models/Core/ApsimFile/Converter.cs
+++ b/Models/Core/ApsimFile/Converter.cs
@@ -16,7 +16,7 @@
     public class Converter
     {
         /// <summary>Gets the latest .apsimx file format version.</summary>
-        public static int LatestVersion { get { return 45; } }
+        public static int LatestVersion { get { return 46; } }
 
         /// <summary>Converts to file to the latest version.</summary>
         /// <param name="fileName">Name of the file.</param>
@@ -1129,6 +1129,19 @@
             ConverterUtilities.AddVariableReferenceFuntionIfNotExists(Storage, "MaxNconc", "[" + organNode.FirstChild.InnerText + "].maximumNconc.Value()");
             NDemands.AppendChild(Storage);
         }
+
+        /// <summary>Remove slnDemandFunction in SimpleLeaf as it has been made redundant</summary>
+        private static void UpgradeToVersion46(XmlNode node, string fileName)
+        {
+            List<XmlNode> nodeList = XmlUtilities.FindAllRecursivelyByType(node, "SimpleLeaf");
+
+            foreach (XmlNode organ in nodeList)
+            {
+                foreach (XmlNode childToDelete in ConverterUtilities.FindModelNodes(organ, "Constant", "slnDemandFunction"))
+                    childToDelete.ParentNode.RemoveChild(childToDelete);
+            }
+        }
+
     }
 }
 

--- a/Models/Plant/Organs/SimpleLeaf.cs
+++ b/Models/Plant/Organs/SimpleLeaf.cs
@@ -226,9 +226,6 @@ namespace Models.PMF.Organs
         [Description("The Stage that leaves are initialised on")]
         public string LeafInitialisationStage { get; set; } = "Emergence";
 
-        /// <summary>Method for calculating Nitrogen demands</summary>
-        public bool UseSLNCalculation { get; set; } = false;
-
         #endregion
 
         #region States and variables
@@ -464,11 +461,6 @@ namespace Models.PMF.Organs
         [Units("g/g")]
         private IFunction criticalNConc = null;
 
-        /// <summary>Calculate N using SLN</summary>
-        [ChildLinkByName]
-        [Units("g/g")]
-        private IFunction slnDemandFunction = null;
-
         /// <summary>The proportion of biomass respired each day</summary>
         [ChildLinkByName]
         [Units("/d")]
@@ -661,16 +653,9 @@ namespace Models.PMF.Organs
         [EventSubscribe("SetNDemand")]
         protected virtual void SetNDemand(object sender, EventArgs e)
         {
-            if(UseSLNCalculation)
-            {
-                NDemand.Structural = Math.Max(0.0, slnDemandFunction.Value());
-            }
-            else
-            {
             NDemand.Structural = nDemands.Structural.Value();
             NDemand.Metabolic = nDemands.Metabolic.Value();
             NDemand.Storage = nDemands.Storage.Value();
-            }
         }
 
         /// <summary>Sets the dry matter potential allocation.</summary>

--- a/Models/Resources/Chicory.xml
+++ b/Models/Resources/Chicory.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Plant xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="45">
+<Plant xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="46">
   <Name>Chicory</Name>
   <Memo>
     <Name>GeneralDescription</Name>
@@ -1043,10 +1043,6 @@ This model was developed with help from Russel McAuliffe and Brittany Paton orga
         </SubtractFunction>
       </StorageDMDemandFunction>
     </BiomassDemand>
-    <Constant>
-      <Name>slnDemandFunction</Name>
-      <FixedValue>0.0</FixedValue>
-    </Constant>
     <BiomassDemand name="NDemands">
       <Name>NDemands</Name>
       <MultiplyFunction name="Structural">

--- a/Models/Resources/Plantain.xml
+++ b/Models/Resources/Plantain.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Plant Version="45">
+<Plant Version="46">
   <Name>Plantain</Name>
   <Memo>
     <Name>GeneralDescription</Name>
@@ -1032,10 +1032,6 @@ The current model assumes generic responses to enviromental factors, such as tem
         </SubtractFunction>
       </StorageDMDemandFunction>
     </BiomassDemand>
-    <Constant>
-      <Name>slnDemandFunction</Name>
-      <FixedValue>0.0</FixedValue>
-    </Constant>
     <BiomassDemand name="NDemands">
       <Name>NDemands</Name>
       <MultiplyFunction name="Structural">

--- a/Models/Resources/SCRUM.xml
+++ b/Models/Resources/SCRUM.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Plant xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="45">
+<Plant xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="46">
   <Name>SCRUM</Name>
   <Memo>
     <Name>TitlePage</Name>
@@ -1232,10 +1232,6 @@ DM demand is based on a simple partitioning coefficients.  At harvest the biomas
         </SubtractFunction>
       </StorageDMDemandFunction>
     </BiomassDemand>
-    <Constant>
-      <Name>slnDemandFunction</Name>
-      <FixedValue>0.0</FixedValue>
-    </Constant>
     <BiomassDemand name="NDemands">
       <Name>NDemands</Name>
       <MultiplyFunction name="Structural">

--- a/Models/Resources/Slurp.xml
+++ b/Models/Resources/Slurp.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Plant xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="45">
+<Plant xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="46">
   <Name>Slurp</Name>
   <Memo>
     <Name>TitlePage</Name>
@@ -639,10 +639,6 @@ This is important in SLURP as it is set for each species to represent their diff
         </SubtractFunction>
       </StorageDMDemandFunction>
     </BiomassDemand>
-    <Constant>
-      <Name>slnDemandFunction</Name>
-      <FixedValue>0.0</FixedValue>
-    </Constant>
     <BiomassDemand name="NDemands">
       <Name>NDemands</Name>
       <MultiplyFunction name="Structural">


### PR DESCRIPTION
working on #572

Is it preferred to write an undo function in the converter, or manually update the resource files and remove the previous converter function - it added a constant function that nobody should have used in the couple of days it was in the code base.