### PR TITLE
Accounting for 'fraction' of water demand that is available in soil profiles

### DIFF
--- a/ApsimNG/ApsimNG.csproj
+++ b/ApsimNG/ApsimNG.csproj
@@ -934,7 +934,7 @@
     <Reference Include="MonoMac, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>Assemblies\MonoMac.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="OxyPlot, Version=2.0.0.0, Culture=neutral, PublicKeyToken=638079a8f0bd61e9, processorArchitecture=MSIL">
       <HintPath>..\packages\OxyPlot.Core.2.0.0-unstable0996\lib\net45\OxyPlot.dll</HintPath>

--- a/Models/Plant/Arbitrator/OrganArbitrator.cs
+++ b/Models/Plant/Arbitrator/OrganArbitrator.cs
@@ -212,11 +212,11 @@ namespace Models.PMF
 
             // Give the water uptake for each zone to Root so that it can perform the uptake
             // i.e. Root will do pass the uptake to the soil water balance.
-            fraction = Math.Max(0.0, Math.Min(1.0, WDemand / waterSupply));
-            foreach (ZoneWaterAndN Z in zones)
+            fraction = Math.Max(0.0, Math.Min(1.0, WDemand / waterSupply)); 
+            foreach (ZoneWaterAndN Z in zones) 
             {
-                double[] uptake = MathUtilities.Multiply_Value(Z.Water, fraction);
-                Plant.Root.DoWaterUptake(uptake, Z.Zone.Name);
+                double[] uptake = MathUtilities.Multiply_Value(Z.Water, fraction); 
+                Plant.Root.DoWaterUptake(uptake, Z.Zone.Name); 
             }
         }
 

--- a/Models/Plant/Arbitrator/OrganArbitrator.cs
+++ b/Models/Plant/Arbitrator/OrganArbitrator.cs
@@ -213,7 +213,10 @@ namespace Models.PMF
             // Give the water uptake for each zone to Root so that it can perform the uptake
             // i.e. Root will do pass the uptake to the soil water balance.
             foreach (ZoneWaterAndN Z in zones)
-                Plant.Root.DoWaterUptake(Z.Water, Z.Zone.Name);
+            {
+                double[] uptake = MathUtilities.Multiply_Value(Z.Water, fraction);
+                Plant.Root.DoWaterUptake(uptake, Z.Zone.Name);
+            }
         }
 
         /// <summary>

--- a/Models/Plant/Arbitrator/OrganArbitrator.cs
+++ b/Models/Plant/Arbitrator/OrganArbitrator.cs
@@ -212,6 +212,7 @@ namespace Models.PMF
 
             // Give the water uptake for each zone to Root so that it can perform the uptake
             // i.e. Root will do pass the uptake to the soil water balance.
+            fraction = Math.Max(0.0, Math.Min(1.0, WDemand / waterSupply));
             foreach (ZoneWaterAndN Z in zones)
             {
                 double[] uptake = MathUtilities.Multiply_Value(Z.Water, fraction);

--- a/Models/Plant/Arbitrator/OrganArbitrator.cs
+++ b/Models/Plant/Arbitrator/OrganArbitrator.cs
@@ -212,7 +212,8 @@ namespace Models.PMF
 
             // Give the water uptake for each zone to Root so that it can perform the uptake
             // i.e. Root will do pass the uptake to the soil water balance.
-            fraction = Math.Max(0.0, Math.Min(1.0, WDemand / waterSupply)); 
+            fraction = 1;
+            if (waterSupply > 0) fraction = Math.Max(0.0, Math.Min(1.0, WDemand / waterSupply)); 
             foreach (ZoneWaterAndN Z in zones) 
             {
                 double[] uptake = MathUtilities.Multiply_Value(Z.Water, fraction); 


### PR DESCRIPTION
Resolves #3086

Accounting for 'fraction' of water demand that is available in soil profiles when calculating the amount of water that needs to be deducted from soil profiles.