### PR TITLE
 Remove released models' structure from XML when saving a file.

### DIFF
--- a/Models/Core/Apsim.cs
+++ b/Models/Core/Apsim.cs
@@ -98,6 +98,23 @@ namespace Models.Core
         }
 
         /// <summary>
+        /// Returns the closest ancestor to a node of the specified type.
+        /// Returns null if not found.
+        /// </summary>
+        /// <typeparam name="T">Type of model to search for.</typeparam>
+        /// <param name="model">The reference model.</param>
+        /// <returns></returns>
+        public static T Ancestor<T>(IModel model)
+        {
+            IModel obj = model == null ? null : model.Parent;
+            while (obj != null && !(obj is T))
+                obj = obj.Parent;
+            if (obj == null)
+                return default(T);
+            return (T)obj;
+        }
+
+        /// <summary>
         /// Locates and returns a model with the specified name that is in scope.
         /// </summary>
         /// <param name="model">The reference model</param>

--- a/Models/Core/ModelCollectionFromResource.cs
+++ b/Models/Core/ModelCollectionFromResource.cs
@@ -30,8 +30,15 @@ namespace Models.Core
         [EventSubscribe("Serialising")]
         protected void OnSerialising(bool xmlSerialisation)
         {
-            if (xmlSerialisation && ResourceName != null)
+            if (xmlSerialisation && Apsim.Ancestor<Replacements>(this) == null)
             {
+                if (string.IsNullOrEmpty(ResourceName))
+                {
+                    if (!string.IsNullOrEmpty(Properties.Resources.ResourceManager.GetString(Name)))
+                        ResourceName = Name;
+                    else
+                        return;
+                }
                 SetNotVisible(this);
                 allModels = new List<Model>();
                 allModels.AddRange(Children);

--- a/Tests/UnitTests/APITest.cs
+++ b/Tests/UnitTests/APITest.cs
@@ -132,7 +132,24 @@ namespace UnitTests
             Assert.AreEqual(Apsim.Parent(graph, typeof(Zone)).Name, "Field2");
         }
 
+        /// <summary>
+        /// A test for the Apsim.Ancestor method.
+        /// </summary>
+        [Test]
+        public void AncestorTest()
+        {
+            // Passing in null should return null.
+            Assert.Null(Apsim.Ancestor<IModel>(null));
 
+            // Passing in the top-level simulations object should return null.
+            Assert.Null(Apsim.Ancestor<IModel>(simulations));
+
+            // Passing in an object should never return that object
+            Assert.AreNotEqual(simulation, Apsim.Ancestor<Simulation>(simulation));
+
+            // Searching for any IModel ancestor should return the node's parent.
+            Assert.AreEqual(simulation.Parent, Apsim.Ancestor<IModel>(simulation));
+        }
 
         /// <summary>
         /// Tests for the get method


### PR DESCRIPTION
Resolves #3040 

Small change to make all `ModelCollectionFromResource` instances serialise to their released version, unless they are under a replacements node. Users can get around this by renaming the model in the simulations tree. 