### PR TITLE
Rooting depth must be limited to the depth of the first impeding layer. 

### DIFF
--- a/Models/Plant/Organs/RootZoneState.cs
+++ b/Models/Plant/Organs/RootZoneState.cs
@@ -184,6 +184,8 @@ namespace Models.PMF.Organs
                 {
                     if (xf[i] > 0)
                         MaxDepth += soil.Thickness[i];
+                    else
+                        break;
                 }
                 else
                     MaxDepth += soil.Thickness[i];


### PR DESCRIPTION
Resolves #3149 

If there is an impeding layer in soil profile, rooting depth must be limited to the depth of that layer. Currently, the model ignores the impeding layer(s), but continues to increase rooting depth if there are more layers beyond that impeding layer.

            ```
// Limit root depth for impeded layers
            double MaxDepth = 0;
            for (int i = 0; i < soil.Thickness.Length; i++)
            {
                if (soil.Weirdo == null)
                {
                    if (xf[i] > 0)
                        MaxDepth += soil.Thickness[i];
                }
                else
                    MaxDepth += soil.Thickness[i];
            }
            // Limit root depth for the crop specific maximum depth
            MaxDepth = Math.Min(maximumRootDepth.Value(), MaxDepth);

            Depth = Math.Min(Depth, MaxDepth);
```
