### PR TITLE
Be more thorough about cleaning up temp files.

### DIFF
--- a/ApsimNG/Commands/WriteDebugDoc.cs
+++ b/ApsimNG/Commands/WriteDebugDoc.cs
@@ -77,12 +77,14 @@ namespace UserInterface.Commands
                 }
 
                 // Apply the transform to the reader and write it to a temporary file.
-                string htmlFileName = Path.GetTempFileName() + ".html";
+                string tempFileName = Path.GetTempFileName();
+                File.Delete(tempFileName);
+                string htmlFileName = Path.ChangeExtension(tempFileName, ".html");
                 using (XmlReader reader = XmlReader.Create(new StringReader(rawXML.ToString())))
-                using (XmlWriter htmlWriter = XmlWriter.Create(htmlFileName))
-                {
-                    transform.Transform(reader, htmlWriter);
-                }
+                    using (XmlWriter htmlWriter = XmlWriter.Create(htmlFileName))
+                    {
+                        transform.Transform(reader, htmlWriter);
+                    }
                 Process.Start(htmlFileName);
             }
             finally

--- a/ApsimNG/Presenters/ManagerPresenter.cs
+++ b/ApsimNG/Presenters/ManagerPresenter.cs
@@ -235,9 +235,16 @@ namespace UserInterface.Presenters
         /// <param name="args">Event arguments.</param>
         private void OnIntellisenseItemSelected(object sender, IntellisenseItemSelectedArgs args)
         {
-            managerView.Editor.InsertCompletionOption(args.ItemSelected, args.TriggerWord);
-            if (args.IsMethod)
-                intellisense.ShowScriptMethodCompletion(manager, managerView.Editor.Text, managerView.Editor.Offset, managerView.Editor.GetPositionOfCursor());
+            try
+            {
+                managerView.Editor.InsertCompletionOption(args.ItemSelected, args.TriggerWord);
+                if (args.IsMethod)
+                    intellisense.ShowScriptMethodCompletion(manager, managerView.Editor.Text, managerView.Editor.Offset, managerView.Editor.GetPositionOfCursor());
+            }
+            catch (Exception err)
+            {
+                explorerPresenter.MainPresenter.ShowError(err);
+            }
         }
     }
 }

--- a/Models/Manager.cs
+++ b/Models/Manager.cs
@@ -217,16 +217,7 @@ namespace Models
                         try
                         {
                             compiledAssembly = ReflectionUtilities.CompileTextToAssembly(Code, GetAssemblyFileName());
-                            if (compiledAssembly.Location != assemblyPath)
-                            {
-                                if (!string.IsNullOrEmpty(assemblyPath))
-                                {
-                                    File.Delete(assemblyPath);
-                                    File.Delete(Path.ChangeExtension(assemblyPath, ".cs"));
-                                    File.Delete(Path.ChangeExtension(assemblyPath, ".pdb"));
-                                }
-                                assemblyPath = compiledAssembly.Location;
-                            }
+                            assemblyPath = compiledAssembly.Location;
                             // Get the script 'Type' from the compiled assembly.
                             if (compiledAssembly.GetType("Models.Script") == null)
                                 throw new ApsimXException(this, "Cannot find a public class called 'Script'");

--- a/Models/Utilities/R.cs
+++ b/Models/Utilities/R.cs
@@ -192,7 +192,9 @@ namespace Models.Utilities
             using (Stream s = Assembly.GetExecutingAssembly().GetManifestResourceStream("Models.Resources.GetPackage.R"))
                 using (StreamReader reader = new StreamReader(s))
                     script = reader.ReadToEnd();
-            string rFileName = Path.ChangeExtension(Path.GetTempFileName(), ".R");
+            string tempFileName = Path.GetTempFileName();
+            File.Delete(tempFileName);
+            string rFileName = Path.ChangeExtension(tempFileName, ".R");
             File.WriteAllText(rFileName, script);
 
             string arguments = packages.Aggregate((x, y) => x + " " + y);


### PR DESCRIPTION
Resolves #3165 

After modifying and recompiling a manager script, the old binary is still not deleted, because we cache the old binaries to speed up access if the user undoes a change. This shouldn't be a big problem, unless the user compiles more than 65, 536 assemblies in one session without restarting the UI. 