### PR TITLE
Don't assume full link resolution has occurred when generating documentation.

### DIFF
--- a/Models/Plant/Organs/GenericOrgan.cs
+++ b/Models/Plant/Organs/GenericOrgan.cs
@@ -588,10 +588,10 @@ namespace Models.PMF.Organs
                 IModel DMReallocFac = Apsim.Child(this, "DMReallocationFactor");
                 if (DMReallocFac.GetType() == typeof(Constant))
                 {
-                    if (dmReallocationFactor.Value() == 0)
+                    if ((DMReallocFac as Constant).Value() == 0)
                         tags.Add(new AutoDocumentation.Paragraph(Name + " does not reallocate DM when senescence of the organ occurs.", indent));
                     else
-                        tags.Add(new AutoDocumentation.Paragraph(Name + " will reallocate " + dmReallocationFactor.Value() * 100 + "% of DM that senesces each day.", indent));
+                        tags.Add(new AutoDocumentation.Paragraph(Name + " will reallocate " + (DMReallocFac as Constant).Value() * 100 + "% of DM that senesces each day.", indent));
                 }
                 else
                 {
@@ -601,10 +601,10 @@ namespace Models.PMF.Organs
                 IModel DMRetransFac = Apsim.Child(this, "DMRetranslocationFactor");
                 if (DMRetransFac.GetType() == typeof(Constant))
                 {
-                    if (dmRetranslocationFactor.Value() == 0)
+                    if ((DMRetransFac as Constant).Value() == 0)
                         tags.Add(new AutoDocumentation.Paragraph(Name + " does not retranslocate non-structural DM.", indent));
                     else
-                        tags.Add(new AutoDocumentation.Paragraph(Name + " will retranslocate " + dmRetranslocationFactor.Value() * 100 + "% of non-structural DM each day.", indent));
+                        tags.Add(new AutoDocumentation.Paragraph(Name + " will retranslocate " + (DMRetransFac as Constant).Value() * 100 + "% of non-structural DM each day.", indent));
                 }
                 else
                 {
@@ -617,10 +617,10 @@ namespace Models.PMF.Organs
                 IModel NReallocFac = Apsim.Child(this, "NReallocationFactor");
                 if (NReallocFac.GetType() == typeof(Constant))
                 {
-                    if (nReallocationFactor.Value() == 0)
+                    if ((NReallocFac as Constant).Value() == 0)
                         tags.Add(new AutoDocumentation.Paragraph(Name + " does not reallocate N when senescence of the organ occurs.", indent));
                     else
-                        tags.Add(new AutoDocumentation.Paragraph(Name + " will reallocate " + nReallocationFactor.Value() * 100 + "% of N that senesces each day.", indent));
+                        tags.Add(new AutoDocumentation.Paragraph(Name + " will reallocate " + (NReallocFac as Constant).Value() * 100 + "% of N that senesces each day.", indent));
                 }
                 else
                 {
@@ -630,10 +630,10 @@ namespace Models.PMF.Organs
                 IModel NRetransFac = Apsim.Child(this, "NRetranslocationFactor");
                 if (NRetransFac.GetType() == typeof(Constant))
                 {
-                    if (nRetranslocationFactor.Value() == 0)
+                    if ((NRetransFac as Constant).Value() == 0)
                         tags.Add(new AutoDocumentation.Paragraph(Name + " does not retranslocate non-structural N.", indent));
                     else
-                        tags.Add(new AutoDocumentation.Paragraph(Name + " will retranslocate " + nRetranslocationFactor.Value() * 100 + "% of non-structural N each day.", indent));
+                        tags.Add(new AutoDocumentation.Paragraph(Name + " will retranslocate " + (NRetransFac as Constant).Value() * 100 + "% of non-structural N each day.", indent));
                 }
                 else
                 {
@@ -646,10 +646,10 @@ namespace Models.PMF.Organs
                 IModel SenRate = Apsim.Child(this, "SenescenceRate");
                 if (SenRate.GetType() == typeof(Constant))
                 {
-                    if (senescenceRate.Value() == 0)
+                    if ((SenRate as Constant).Value() == 0)
                         tags.Add(new AutoDocumentation.Paragraph(Name + " has senescence parameterised to zero so all biomass in this organ will remain alive.", indent));
                     else
-                        tags.Add(new AutoDocumentation.Paragraph(Name + " senesces " + senescenceRate.Value() * 100 + "% of its live biomass each day, moving the corresponding amount of biomass from the live to the dead biomass pool.", indent));
+                        tags.Add(new AutoDocumentation.Paragraph(Name + " senesces " + (SenRate as Constant).Value() * 100 + "% of its live biomass each day, moving the corresponding amount of biomass from the live to the dead biomass pool.", indent));
                 }
                 else
                 {
@@ -660,10 +660,10 @@ namespace Models.PMF.Organs
                 IModel DetRate = Apsim.Child(this, "DetachmentRateFunction");
                 if (DetRate.GetType() == typeof(Constant))
                 {
-                    if (detachmentRateFunction.Value() == 0)
+                    if ((DetRate as Constant).Value() == 0)
                         tags.Add(new AutoDocumentation.Paragraph(Name + " has detachment parameterised to zero so all biomass in this organ will remain with the plant until a defoliation or harvest event occurs.", indent));
                     else
-                        tags.Add(new AutoDocumentation.Paragraph(Name + " detaches " + detachmentRateFunction.Value() * 100 + "% of its live biomass each day, passing it to the surface organic matter model for decomposition.", indent));
+                        tags.Add(new AutoDocumentation.Paragraph(Name + " detaches " + (DetRate as Constant).Value() * 100 + "% of its live biomass each day, passing it to the surface organic matter model for decomposition.", indent));
                 }
                 else
                 {

--- a/Models/Plant/Organs/GenericOrgan.cs
+++ b/Models/Plant/Organs/GenericOrgan.cs
@@ -568,7 +568,7 @@ namespace Models.PMF.Organs
                 IModel NDemSwitch = Apsim.Child(this, "NitrogenDemandSwitch");
                 if (NDemSwitch.GetType() == typeof(Constant))
                 {
-                    if (nitrogenDemandSwitch.Value() == 1.0)
+                    if ((NDemSwitch as Constant).Value() == 1.0)
                     {
                         //Don't bother documenting as is does nothing
                     }


### PR DESCRIPTION
Working on #3186 

This provides a resolution of the immediate problem, but I'm not sure it's the "right" way to fix it. When GenericOrgan was generating its documentation, it was assuming that child links to things like DMReallocationFactor had been resolved. I've modified things so that the documentation generation for this unit now works without full link resolution, but perhaps it would be better to somehow ensure that links have been resolved before generating the documentation for a simulation. I'm not quite sure how all that stuff is meant to work, though.