### PR TITLE
Convert .db path to short path on Windows if it contains non-ascii characters

### DIFF
--- a/Models/Storage/DataStore.cs
+++ b/Models/Storage/DataStore.cs
@@ -874,10 +874,6 @@
                     throw new Exception("Cannot find a filename for the DataStore database.");
             }
 
-            if (ProcessUtilities.CurrentOS.IsWindows && FileName.Any(c => c > 255))
-            {
-                FileName = PathUtilities.GetShortPath(FileName);
-            }
             Close();
 
             if (useFirebird)

--- a/Models/Storage/DataStore.cs
+++ b/Models/Storage/DataStore.cs
@@ -874,6 +874,10 @@
                     throw new Exception("Cannot find a filename for the DataStore database.");
             }
 
+            if (ProcessUtilities.CurrentOS.IsWindows && FileName.Any(c => c > 255))
+            {
+                FileName = PathUtilities.GetShortPath(FileName);
+            }
             Close();
 
             if (useFirebird)

--- a/Tests/UnitTests/StorageTests.cs
+++ b/Tests/UnitTests/StorageTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using NUnit.Framework;
+using System.IO;
+using Models.Storage;
+using Models.Core;
+
+namespace UnitTests
+{
+    /// <summary>
+    /// Unit tests for the storage component.
+    /// </summary>
+    class StorageTests
+    {
+        /// <summary>
+        /// Tests if we can open a database with foreign characters in the path.
+        /// </summary>
+        [Test]
+        public void ForeignCharacterTest()
+        {
+            string path = Path.Combine(Path.GetTempPath(), "文档.db");
+            DataStore storage = new DataStore();
+            storage.FileName = path;
+            Assert.DoesNotThrow(() => storage.Open(false));
+            try
+            {
+                storage.Close();
+                File.Delete(path);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/Tests/UnitTests/UnitTests.csproj
+++ b/Tests/UnitTests/UnitTests.csproj
@@ -104,6 +104,7 @@
   <ItemGroup>
     <Compile Include="APSIMFileReaderTests.cs" />
     <Compile Include="ManagerConverterTests.cs" />
+    <Compile Include="StorageTests.cs" />
     <Compile Include="TestIndexedDataTable.cs" />
     <Compile Include="TrackerFunctionTests.cs" />
     <Compile Include="RunnerTests.cs" />


### PR DESCRIPTION
Resolves #3219 