### PR TITLE
Managers should not remove all children after rebuilding script model.

### DIFF
--- a/Models/Manager.cs
+++ b/Models/Manager.cs
@@ -240,7 +240,7 @@ namespace Models
                             SetParametersInObject(Script, parameters);
 
                             // Add the new script model to our models collection.
-                            Children.Clear();
+                            Children.RemoveAll(x => x.GetType().Name == "Script");
                             Children.Add(Script);
                             Script.Parent = this;
                         }


### PR DESCRIPTION
Resolves #3230 

This fixes the memo not being saved, but not the crash, which I have not been able to reproduce.