### PR TITLE
Leaf live and dead biomass are updated after maintenance respiration is deducted

### DIFF
--- a/Examples/Wheat.apsimx
+++ b/Examples/Wheat.apsimx
@@ -1,32 +1,45 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Simulations xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="32">
+<?xml version="1.0" encoding="utf-8"?>
+<Simulations xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="46">
   <Name>Simulations</Name>
   <Simulation>
-    <Name>Wheat</Name>
+    <Name>Simulation</Name>
     <Clock>
       <Name>Clock</Name>
       <IncludeInDocumentation>true</IncludeInDocumentation>
+      <Enabled>true</Enabled>
+      <ReadOnly>false</ReadOnly>
       <StartDate>1900-01-01T00:00:00</StartDate>
       <EndDate>2000-12-31T00:00:00</EndDate>
     </Clock>
     <Summary>
       <Name>SummaryFile</Name>
       <IncludeInDocumentation>true</IncludeInDocumentation>
+      <Enabled>true</Enabled>
+      <ReadOnly>false</ReadOnly>
+      <CaptureErrors>true</CaptureErrors>
+      <CaptureWarnings>true</CaptureWarnings>
+      <CaptureSummaryText>true</CaptureSummaryText>
     </Summary>
     <Weather>
       <Name>Weather</Name>
       <IncludeInDocumentation>true</IncludeInDocumentation>
+      <Enabled>true</Enabled>
+      <ReadOnly>false</ReadOnly>
       <FileName>%root%\Examples\WeatherFiles\Dalby.met</FileName>
     </Weather>
     <SoilArbitrator>
       <Name>SoilArbitrator</Name>
       <IncludeInDocumentation>true</IncludeInDocumentation>
+      <Enabled>true</Enabled>
+      <ReadOnly>false</ReadOnly>
     </SoilArbitrator>
     <Zone>
       <Name>Field</Name>
       <Report>
         <Name>Report</Name>
         <IncludeInDocumentation>true</IncludeInDocumentation>
+        <Enabled>true</Enabled>
+        <ReadOnly>false</ReadOnly>
         <ExperimentFactorNames />
         <ExperimentFactorValues />
         <VariableNames>
@@ -50,6 +63,8 @@
       <Fertiliser>
         <Name>Fertiliser</Name>
         <IncludeInDocumentation>true</IncludeInDocumentation>
+        <Enabled>true</Enabled>
+        <ReadOnly>false</ReadOnly>
       </Fertiliser>
       <Soil>
         <Name>Soil</Name>
@@ -58,6 +73,8 @@
           <SoilCrop>
             <Name>WheatSoil</Name>
             <IncludeInDocumentation>true</IncludeInDocumentation>
+            <Enabled>true</Enabled>
+            <ReadOnly>false</ReadOnly>
             <LL>
               <double>0.261</double>
               <double>0.248</double>
@@ -87,6 +104,8 @@
             </XF>
           </SoilCrop>
           <IncludeInDocumentation>true</IncludeInDocumentation>
+          <Enabled>true</Enabled>
+          <ReadOnly>false</ReadOnly>
           <Thickness>
             <double>150</double>
             <double>150</double>
@@ -154,6 +173,8 @@
         <SoilWater>
           <Name>SoilWater</Name>
           <IncludeInDocumentation>true</IncludeInDocumentation>
+          <Enabled>true</Enabled>
+          <ReadOnly>false</ReadOnly>
           <SummerDate>1-Nov</SummerDate>
           <SummerU>5</SummerU>
           <SummerCona>5</SummerCona>
@@ -188,11 +209,13 @@
             <double>0.3</double>
             <double>0.3</double>
           </SWCON>
-          <residueinterception>0</residueinterception>
+          <ResidueInterception>0</ResidueInterception>
         </SoilWater>
         <SoilNitrogen>
           <Name>SoilNitrogen</Name>
           <IncludeInDocumentation>true</IncludeInDocumentation>
+          <Enabled>true</Enabled>
+          <ReadOnly>false</ReadOnly>
           <fom_type>
             <string>default</string>
             <string>manure</string>
@@ -229,6 +252,8 @@
         <SoilOrganicMatter>
           <Name>SoilOrganicMatter</Name>
           <IncludeInDocumentation>true</IncludeInDocumentation>
+          <Enabled>true</Enabled>
+          <ReadOnly>false</ReadOnly>
           <RootCN>40</RootCN>
           <RootWt>1000</RootWt>
           <SoilCN>12</SoilCN>
@@ -284,6 +309,8 @@
         <Analysis>
           <Name>Analysis</Name>
           <IncludeInDocumentation>true</IncludeInDocumentation>
+          <Enabled>true</Enabled>
+          <ReadOnly>false</ReadOnly>
           <Thickness>
             <double>150</double>
             <double>150</double>
@@ -308,6 +335,8 @@
         <InitialWater>
           <Name>InitialWater</Name>
           <IncludeInDocumentation>true</IncludeInDocumentation>
+          <Enabled>true</Enabled>
+          <ReadOnly>false</ReadOnly>
           <PercentMethod>EvenlyDistributed</PercentMethod>
           <FractionFull>1</FractionFull>
           <DepthWetSoil>NaN</DepthWetSoil>
@@ -315,6 +344,8 @@
         <Sample>
           <Name>InitialN</Name>
           <IncludeInDocumentation>true</IncludeInDocumentation>
+          <Enabled>true</Enabled>
+          <ReadOnly>false</ReadOnly>
           <Thickness>
             <double>150</double>
             <double>150</double>
@@ -405,8 +436,12 @@
         <CERESSoilTemperature>
           <Name>CERESSoilTemperature</Name>
           <IncludeInDocumentation>true</IncludeInDocumentation>
+          <Enabled>true</Enabled>
+          <ReadOnly>false</ReadOnly>
         </CERESSoilTemperature>
         <IncludeInDocumentation>true</IncludeInDocumentation>
+        <Enabled>true</Enabled>
+        <ReadOnly>false</ReadOnly>
         <RecordNumber>0</RecordNumber>
         <ASCOrder>Vertosol</ASCOrder>
         <ASCSubOrder>Black</ASCSubOrder>
@@ -428,65 +463,44 @@
       <SurfaceOrganicMatter>
         <Name>SurfaceOrganicMatter</Name>
         <IncludeInDocumentation>true</IncludeInDocumentation>
-        <ResidueTypes>
-          <Name>ResidueTypes</Name>
-          <IncludeInDocumentation>true</IncludeInDocumentation>
-          <LoadFromResource>ResidueTypes</LoadFromResource>
-        </ResidueTypes>
-        <Pools>
-          <Pool>
-            <PoolName>wheat_stubble</PoolName>
-            <ResidueType>wheat</ResidueType>
-            <Mass>500</Mass>
-            <CNRatio>100</CNRatio>
-            <CPRatio>NaN</CPRatio>
-            <StandingFraction>0</StandingFraction>
-          </Pool>
-        </Pools>
-        <PoolName>wheat_stubble</PoolName>
-        <type>wheat</type>
-        <mass>500</mass>
-        <standing_fraction>0</standing_fraction>
-        <cpr />
-        <cnr>100</cnr>
-        <CriticalResidueWeight>2000</CriticalResidueWeight>
-        <OptimumDecompTemp>20</OptimumDecompTemp>
-        <MaxCumulativeEOS>20</MaxCumulativeEOS>
-        <CNRatioDecompCoeff>0.277</CNRatioDecompCoeff>
-        <CNRatioDecompThreshold>25</CNRatioDecompThreshold>
-        <TotalLeachRain>25</TotalLeachRain>
-        <MinRainToLeach>10</MinRainToLeach>
-        <CriticalMinimumOrganicC>0.004</CriticalMinimumOrganicC>
-        <DefaultCPRatio>0</DefaultCPRatio>
-        <DefaultStandingFraction>0</DefaultStandingFraction>
-        <StandingExtinctCoeff>0.5</StandingExtinctCoeff>
+        <Enabled>true</Enabled>
+        <ReadOnly>false</ReadOnly>
+        <ResourceName>SurfaceOrganicMatter</ResourceName>
+        <InitialResidueName>wheat_stubble</InitialResidueName>
+        <InitialResidueType>wheat</InitialResidueType>
+        <InitialResidueMass>500</InitialResidueMass>
+        <InitialStandingFraction>0</InitialStandingFraction>
+        <InitialCPR>0</InitialCPR>
+        <InitialCNR>100</InitialCNR>
         <FractionFaecesAdded>0.5</FractionFaecesAdded>
       </SurfaceOrganicMatter>
       <Plant>
         <Name>Wheat</Name>
         <IncludeInDocumentation>true</IncludeInDocumentation>
+        <Enabled>true</Enabled>
+        <ReadOnly>false</ReadOnly>
         <ResourceName>Wheat</ResourceName>
         <CropType>Wheat</CropType>
       </Plant>
       <MicroClimate>
         <Name>MicroClimate</Name>
         <IncludeInDocumentation>true</IncludeInDocumentation>
+        <Enabled>true</Enabled>
+        <ReadOnly>false</ReadOnly>
         <a_interception>0</a_interception>
         <b_interception>1</b_interception>
         <c_interception>0</c_interception>
         <d_interception>0</d_interception>
         <soil_albedo>0.3</soil_albedo>
-        <sun_angle>15</sun_angle>
-        <soil_heat_flux_fraction>0.4</soil_heat_flux_fraction>
-        <night_interception_fraction>0.5</night_interception_fraction>
-        <refheight>2</refheight>
-        <albedo>0.15</albedo>
-        <emissivity>0.96</emissivity>
-        <RadIntTotal>0</RadIntTotal>
+        <SoilHeatFluxFraction>0.4</SoilHeatFluxFraction>
+        <NightInterceptionFraction>0.5</NightInterceptionFraction>
+        <ReferenceHeight>2</ReferenceHeight>
       </MicroClimate>
       <Manager>
         <Name>SowingFertiliser</Name>
         <IncludeInDocumentation>true</IncludeInDocumentation>
+        <Enabled>true</Enabled>
+        <ReadOnly>false</ReadOnly>
         <Script>
           <Amount>160</Amount>
           <CropName>wheat</CropName>
@@ -528,6 +542,8 @@ namespace Models
       <Manager>
         <Name>Harvest</Name>
         <IncludeInDocumentation>true</IncludeInDocumentation>
+        <Enabled>true</Enabled>
+        <ReadOnly>false</ReadOnly>
         <Script />
         <Code><![CDATA[using System;
 using Models.Core;
@@ -561,10 +577,14 @@ namespace Models
       <SoluteManager>
         <Name>SoluteManager</Name>
         <IncludeInDocumentation>true</IncludeInDocumentation>
+        <Enabled>true</Enabled>
+        <ReadOnly>false</ReadOnly>
       </SoluteManager>
       <Manager>
         <Name>SowingRule1</Name>
         <IncludeInDocumentation>true</IncludeInDocumentation>
+        <Enabled>true</Enabled>
+        <ReadOnly>false</ReadOnly>
         <Script>
           <StartDate>1-may</StartDate>
           <EndDate>10-jul</EndDate>
@@ -643,6 +663,8 @@ namespace Models
 ]]></Code>
       </Manager>
       <IncludeInDocumentation>true</IncludeInDocumentation>
+      <Enabled>true</Enabled>
+      <ReadOnly>false</ReadOnly>
       <Area>1</Area>
       <Slope>0</Slope>
     </Zone>
@@ -651,6 +673,8 @@ namespace Models
       <Series>
         <Name>Wheat Yield</Name>
         <IncludeInDocumentation>true</IncludeInDocumentation>
+        <Enabled>true</Enabled>
+        <ReadOnly>false</ReadOnly>
         <Type>Scatter</Type>
         <XAxis>Bottom</XAxis>
         <YAxis>Left</YAxis>
@@ -659,6 +683,7 @@ namespace Models
         <MarkerSize>Normal</MarkerSize>
         <Line>Solid</Line>
         <LineThickness>Normal</LineThickness>
+        <Checkpoint>Current</Checkpoint>
         <TableName>Report</TableName>
         <XFieldName>Clock.Today</XFieldName>
         <YFieldName>Yield</YFieldName>
@@ -668,6 +693,8 @@ namespace Models
         <CumulativeX>false</CumulativeX>
       </Series>
       <IncludeInDocumentation>true</IncludeInDocumentation>
+      <Enabled>true</Enabled>
+      <ReadOnly>false</ReadOnly>
       <Axis>
         <Type>Bottom</Type>
         <Title>Date</Title>
@@ -688,11 +715,17 @@ namespace Models
       <DisabledSeries />
     </Graph>
     <IncludeInDocumentation>true</IncludeInDocumentation>
+    <Enabled>true</Enabled>
+    <ReadOnly>false</ReadOnly>
   </Simulation>
   <DataStore>
     <Name>DataStore</Name>
     <IncludeInDocumentation>true</IncludeInDocumentation>
+    <Enabled>true</Enabled>
+    <ReadOnly>false</ReadOnly>
   </DataStore>
   <IncludeInDocumentation>true</IncludeInDocumentation>
+  <Enabled>true</Enabled>
+  <ReadOnly>false</ReadOnly>
   <ExplorerWidth>296</ExplorerWidth>
 </Simulations>

--- a/Models/Core/Model.cs
+++ b/Models/Core/Model.cs
@@ -206,6 +206,7 @@ namespace Models.Core
         [XmlElement(typeof(Models.Functions.DailyMeanVPD))]
         [XmlElement(typeof(Models.Functions.XYPairs))]
         [XmlElement(typeof(Models.Functions.SupplyFunctions.CanopyPhotosynthesis))]
+        [XmlElement(typeof(Models.Functions.SupplyFunctions.CanopyGrossPhotosynthesisHourly))]
         [XmlElement(typeof(Models.Functions.DemandFunctions.AllometricDemandFunction))]
         [XmlElement(typeof(Models.Functions.DemandFunctions.TEWaterDemandFunction))]
         [XmlElement(typeof(Models.Functions.DemandFunctions.InternodeDemandFunction))]

--- a/Models/Functions/SupplyFunctions/CanopyPhotosynthesis.cs
+++ b/Models/Functions/SupplyFunctions/CanopyPhotosynthesis.cs
@@ -48,30 +48,6 @@ namespace Models.Functions.SupplyFunctions
         /// <summary> The amount of DM that is fixed by photosynthesis </summary>
         public double GrossPhotosynthesis { get; set; }
 
-        /// <summary>Event from sequencer telling us to do our potential growth.</summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
-
-        [EventSubscribe("DoPotentialPlantGrowth")]
-
-        private void OnDoPotentialPlantGrowth(object sender, EventArgs e)
-        {
-            if (Plant.IsEmerged)
-            {
-                GrossPhotosynthesis = DailyCanopyGrossPhotosythesis(Canopy.LAI,
-                                                      Weather.Latitude,
-                                                      Clock.Today.DayOfYear,
-                                                      Weather.Radn,
-                                                      Weather.MaxT,
-                                                      Weather.MinT,
-                                                      Weather.CO2,
-                                                      Weather.DiffuseFraction,
-                                                      1.0) * 30/ 44 * 0.1;     
-                //30/44 converts CO2 to CH2O, 0.1 converts from kg/ha to g/m2                      
-
-            }
-        }
-
         ///<summary>%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
         ///float DLL DailyCanopyGrossPhotosythesis(LPSTR pCrop,float fLAI, float fLatitude,int nDay,
         ///                                        float fRad,float fTmpMax,float fTmpMin,float fCO2,
@@ -220,6 +196,20 @@ namespace Models.Functions.SupplyFunctions
         /// <returns>g dry matter/m2 soil/day</returns>
         public double Value(int arrayIndex = -1)
         {
+            if (Plant.IsEmerged)
+            {
+                GrossPhotosynthesis = DailyCanopyGrossPhotosythesis(Canopy.LAI,
+                                                      Weather.Latitude,
+                                                      Clock.Today.DayOfYear,
+                                                      Weather.Radn,
+                                                      Weather.MaxT,
+                                                      Weather.MinT,
+                                                      Weather.CO2,
+                                                      Weather.DiffuseFraction,
+                                                      1.0) * 30 / 44 * 0.1;
+                //30/44 converts CO2 to CH2O, 0.1 converts from kg/ha to g/m2                      
+
+            }
             return GrossPhotosynthesis;
         }
     }

--- a/Models/Plant/Arbitrator/OrganArbitrator.cs
+++ b/Models/Plant/Arbitrator/OrganArbitrator.cs
@@ -389,9 +389,11 @@ namespace Models.PMF
                 double remainRespiration = respiration - total;
                 for (int i = 0; i < Organs.ToArray().Length; i++)
                 {
-                    double organRespiration = remainRespiration *
-                        Organs[i].MaintenanceRespiration / respiration;
-                    Organs[i].RemoveMaintenanceRespiration(organRespiration);
+                    if ((Organs[i].Live.StorageWt + Organs[i].Live.MetabolicWt) > 0)
+                    {
+                        double organRespiration = remainRespiration * Organs[i].MaintenanceRespiration / respiration;
+                        Organs[i].RemoveMaintenanceRespiration(organRespiration);
+                    }
                 }
             }
         }

--- a/Models/Plant/Organs/GenericOrgan.cs
+++ b/Models/Plant/Organs/GenericOrgan.cs
@@ -505,8 +505,11 @@ namespace Models.PMF.Organs
 
                 // Do maintenance respiration
                 MaintenanceRespiration = 0;
-                MaintenanceRespiration += Live.MetabolicWt * maintenanceRespirationFunction.Value();
-                MaintenanceRespiration += Live.StorageWt * maintenanceRespirationFunction.Value();
+                if (maintenanceRespirationFunction != null && (Live.MetabolicWt + Live.StorageWt) > 0)
+                {
+                    MaintenanceRespiration += Live.MetabolicWt * maintenanceRespirationFunction.Value();
+                    MaintenanceRespiration += Live.StorageWt * maintenanceRespirationFunction.Value();
+                }
             }
         }
 

--- a/Models/Plant/Organs/Leaf.cs
+++ b/Models/Plant/Organs/Leaf.cs
@@ -1663,7 +1663,7 @@ namespace Models.PMF.Organs
             double ExtentOfError = Math.Abs(EndWt - CheckValue);
             double FloatingPointError = 0.00000001;
             if (ExtentOfError > FloatingPointError)
-                throw new Exception(Name + "Not all leaf DM allocation was used");
+                throw new Exception(Name + ": " + ExtentOfError.ToString() + " of DM allocation was not used");
         }
 
         /// <summary>Sets the n allocation.</summary>
@@ -1815,14 +1815,15 @@ namespace Models.PMF.Organs
             {
                 double totalBMLeafCohort = L.Live.MetabolicWt + L.Live.StorageWt;
                 double resLeafCohort = respiration * L.MaintenanceRespiration / totalResLeaf;
+
                 if (resLeafCohort > totalBMLeafCohort)
-                {
                     throw new Exception("Respiration is more than total biomass of metabolic and storage in live component.");
+
+                if (totalBMLeafCohort > 0 && (L.Live.MetabolicWt + L.Live.StorageWt) > 0)
+                {
+                    L.Live.MetabolicWt -= resLeafCohort * L.Live.MetabolicWt / totalBMLeafCohort;
+                    L.Live.StorageWt -= resLeafCohort * L.Live.StorageWt / totalBMLeafCohort;
                 }
-                L.Live.MetabolicWt = L.Live.MetabolicWt - 
-                    (resLeafCohort * L.Live.MetabolicWt / totalBMLeafCohort);
-                L.Live.StorageWt = L.Live.StorageWt - 
-                    (resLeafCohort * L.Live.StorageWt / totalBMLeafCohort);
             }
         }
 

--- a/Models/Plant/Organs/Leaf.cs
+++ b/Models/Plant/Organs/Leaf.cs
@@ -1819,10 +1819,11 @@ namespace Models.PMF.Organs
                 if (resLeafCohort > totalBMLeafCohort)
                     throw new Exception("Respiration is more than total biomass of metabolic and storage in live component.");
 
-                if (totalBMLeafCohort > 0 && (L.Live.MetabolicWt + L.Live.StorageWt) > 0)
+                if (resLeafCohort > 0 && (L.Live.MetabolicWt + L.Live.StorageWt) > 0)
                 {
-                    L.Live.MetabolicWt -= resLeafCohort * L.Live.MetabolicWt / totalBMLeafCohort;
-                    L.Live.StorageWt -= resLeafCohort * L.Live.StorageWt / totalBMLeafCohort;
+                    L.Live.MetabolicWt -= (resLeafCohort * L.Live.MetabolicWt / totalBMLeafCohort);
+                    L.Live.StorageWt -= (resLeafCohort * L.Live.StorageWt / totalBMLeafCohort);
+                    needToRecalculateLiveDead = true;
                 }
             }
         }

--- a/Models/Plant/Organs/LeafCohort.cs
+++ b/Models/Plant/Organs/LeafCohort.cs
@@ -967,11 +967,14 @@ namespace Models.PMF.Organs
             Dead.StorageWt += Math.Max(0.0,
                 StorageWtSenescing - DMRetranslocated - StorageWtReallocated);
 
-            MaintenanceRespiration = 0;
             //Do Maintenance respiration
-            MaintenanceRespiration += Live.MetabolicWt*leafCohortParameters.MaintenanceRespirationFunction.Value();
-            MaintenanceRespiration += Live.StorageWt*leafCohortParameters.MaintenanceRespirationFunction.Value();
-            
+            MaintenanceRespiration = 0;
+            if (leafCohortParameters.MaintenanceRespirationFunction != null && (Live.MetabolicWt + Live.StorageWt) > 0)
+            {
+                MaintenanceRespiration += Live.MetabolicWt * leafCohortParameters.MaintenanceRespirationFunction.Value();
+                MaintenanceRespiration += Live.StorageWt * leafCohortParameters.MaintenanceRespirationFunction.Value();
+            }
+
             Age = Age + thermalTime;
 
             // Do Detachment of this Leaf Cohort

--- a/Models/Plant/Organs/Nodule.cs
+++ b/Models/Plant/Organs/Nodule.cs
@@ -545,8 +545,11 @@ namespace Models.PMF.Organs
 
                 // Do maintenance respiration
                 MaintenanceRespiration = 0;
-                MaintenanceRespiration += Live.MetabolicWt * maintenanceRespirationFunction.Value();
-                MaintenanceRespiration += Live.StorageWt * maintenanceRespirationFunction.Value();
+                if (maintenanceRespirationFunction != null && (Live.MetabolicWt + Live.StorageWt) > 0)
+                {
+                    MaintenanceRespiration += Live.MetabolicWt * maintenanceRespirationFunction.Value();
+                    MaintenanceRespiration += Live.StorageWt * maintenanceRespirationFunction.Value();
+                }
             }
         }
 

--- a/Models/Plant/Organs/PerennialLeaf.cs
+++ b/Models/Plant/Organs/PerennialLeaf.cs
@@ -794,13 +794,11 @@ namespace Models.PMF.Organs
 
                 MaintenanceRespiration = 0;
                 //Do Maintenance respiration
-                if (MaintenanceRespirationFunction != null)
+                if (MaintenanceRespirationFunction != null && (Live.MetabolicWt + Live.StorageWt) > 0)
                 {
                     MaintenanceRespiration += Live.MetabolicWt * MaintenanceRespirationFunction.Value();
                     RespireLeafFraction(MaintenanceRespirationFunction.Value());
-
                     MaintenanceRespiration += Live.StorageWt * MaintenanceRespirationFunction.Value();
-
                 }
 
                 if (DryMatterContent != null)

--- a/Models/Plant/Organs/ReproductiveOrgan.cs
+++ b/Models/Plant/Organs/ReproductiveOrgan.cs
@@ -345,16 +345,13 @@ namespace Models.PMF.Organs
             if (Phenology.OnStartDayOf(RipeStage))
                 _ReadyForHarvest = true;
 
-
-            MaintenanceRespiration = 0;
             //Do Maintenance respiration
-            if (MaintenanceRespirationFunction != null)
-
+            MaintenanceRespiration = 0;
+            if (MaintenanceRespirationFunction != null && (Live.MetabolicWt + Live.StorageWt) > 0)
             {
                 MaintenanceRespiration += Live.MetabolicWt * MaintenanceRespirationFunction.Value();
                 MaintenanceRespiration += Live.StorageWt * MaintenanceRespirationFunction.Value();
             }
-
         }
         /// <summary>Sets the dry matter potential allocation.</summary>
         public void SetDryMatterPotentialAllocation(BiomassPoolType dryMatter)

--- a/Models/Plant/Organs/Root.cs
+++ b/Models/Plant/Organs/Root.cs
@@ -1034,19 +1034,19 @@ namespace Models.PMF.Organs
             {
                 foreach (ZoneState Z in Zones)
                     Z.GrowRootDepth();
+
                 // Do Root Senescence
                 RemoveBiomass(null, new OrganBiomassRemovalType() { FractionLiveToResidue = senescenceRate.Value() });
-            }
-            needToRecalculateLiveDead = false;
 
-            // Do maintenance respiration
-            MaintenanceRespiration = 0;
-            if (maintenanceRespirationFunction != null && (Live.MetabolicWt + Live.StorageWt) > 0)
-            {
-                MaintenanceRespiration += Live.MetabolicWt * maintenanceRespirationFunction.Value();
-                MaintenanceRespiration += Live.StorageWt * maintenanceRespirationFunction.Value();
+                // Do maintenance respiration
+                MaintenanceRespiration = 0;
+                if (maintenanceRespirationFunction != null && (Live.MetabolicWt + Live.StorageWt) > 0)
+                {
+                    MaintenanceRespiration += Live.MetabolicWt * maintenanceRespirationFunction.Value();
+                    MaintenanceRespiration += Live.StorageWt * maintenanceRespirationFunction.Value();
+                }
+                needToRecalculateLiveDead = true;
             }
-            needToRecalculateLiveDead = true;
         }
 
         /// <summary>Called when crop is ending</summary>

--- a/Models/Plant/Organs/Root.cs
+++ b/Models/Plant/Organs/Root.cs
@@ -1038,12 +1038,14 @@ namespace Models.PMF.Organs
                 RemoveBiomass(null, new OrganBiomassRemovalType() { FractionLiveToResidue = senescenceRate.Value() });
             }
             needToRecalculateLiveDead = false;
+
             // Do maintenance respiration
             MaintenanceRespiration = 0;
-            MaintenanceRespiration += Live.MetabolicWt * maintenanceRespirationFunction.Value();
-            // Live.MetabolicWt *= (1 - maintenanceRespirationFunction.Value());
-            MaintenanceRespiration += Live.StorageWt * maintenanceRespirationFunction.Value();
-            // Live.StorageWt *= (1 - maintenanceRespirationFunction.Value());
+            if (maintenanceRespirationFunction != null && (Live.MetabolicWt + Live.StorageWt) > 0)
+            {
+                MaintenanceRespiration += Live.MetabolicWt * maintenanceRespirationFunction.Value();
+                MaintenanceRespiration += Live.StorageWt * maintenanceRespirationFunction.Value();
+            }
             needToRecalculateLiveDead = true;
         }
 

--- a/Models/Plant/Organs/SimpleLeaf.cs
+++ b/Models/Plant/Organs/SimpleLeaf.cs
@@ -820,8 +820,11 @@ namespace Models.PMF.Organs
 
                 // Do maintenance respiration
                 MaintenanceRespiration = 0;
-                MaintenanceRespiration += Live.MetabolicWt * maintenanceRespirationFunction.Value();
-                MaintenanceRespiration += Live.StorageWt * maintenanceRespirationFunction.Value();
+                if (maintenanceRespirationFunction != null && (Live.MetabolicWt + Live.StorageWt) > 0)
+                {
+                    MaintenanceRespiration += Live.MetabolicWt * maintenanceRespirationFunction.Value();
+                    MaintenanceRespiration += Live.StorageWt * maintenanceRespirationFunction.Value();
+                }
             }
         }
 


### PR DESCRIPTION
Resolves #3243
Working on #2797


- The flag **needToRecalculateLiveDead** was missing/misplaced in a couple of organs. **Fixed**.

- When there is some maintenance respiration to be deducted from leaves, **needToRecalculateLiveDead** is now set TRUE to make sure **Leaf** live and dead biomass pools are up-to-date when final check is done.

- In all organs, some checking rules were added to make sure no **MaintenanceRespiration** is assigned to an organ with zero live storage and metabolic biomass. 
