### PR TITLE
Adding private variables to store water demand

### DIFF
--- a/Models/Plant/Organs/Leaf.cs
+++ b/Models/Plant/Organs/Leaf.cs
@@ -178,9 +178,14 @@ namespace Models.PMF.Organs
             }
         }
 
+        private double _WaterDemand;
         /// <summary>Sets the actual water demand.</summary>
         [Units("mm")]
-        public double WaterDemand { get; set; }
+        public double WaterDemand
+        {
+            get { return _WaterDemand; }
+            set { _WaterDemand = value; }
+        }
 
         /// <summary>Sets the light profile. Set by MICROCLIMATE.</summary>
         public CanopyEnergyBalanceInterceptionlayerType[] LightProfile { get; set; }

--- a/Models/Plant/Organs/PerennialLeaf.cs
+++ b/Models/Plant/Organs/PerennialLeaf.cs
@@ -217,9 +217,14 @@ namespace Models.PMF.Organs
             }
         }
 
+        private double _WaterDemand;
         /// <summary>Sets the actual water demand.</summary>
         [Units("mm")]
-        public double WaterDemand { get; set; }
+        public double WaterDemand
+        {
+            get { return _WaterDemand; }
+            set { _WaterDemand = value; }
+        }
 
         /// <summary>
         /// Flag to test if Microclimate is present

--- a/Models/Plant/Organs/SimpleLeaf.cs
+++ b/Models/Plant/Organs/SimpleLeaf.cs
@@ -163,9 +163,14 @@ namespace Models.PMF.Organs
             }
         }
 
+        private double _WaterDemand;
         /// <summary>Sets the actual water demand.</summary>
         [Units("mm")]
-        public double WaterDemand { get; set; }
+        public double WaterDemand
+        {
+            get { return _WaterDemand; }
+            set { _WaterDemand = value; }
+        }
 
         /// <summary>
         /// Flag to test if Microclimate is present


### PR DESCRIPTION
Resolves #3276

I seems necessary (I am not quite sure) to have private fields to store water demand, just like **PotentialEP**, especially when multiple simulations (e.g. factorial experiments) are being run simultaneously. If it is, it must be done in other models as well. I just made changes to those models that call **WaterDemand** (as I added this variable to **ICanopy** weeks ago).