### PR TITLE
Tests for simulations lacking predicted/observed data

### DIFF
--- a/ApsimNG/Commands/RunCommand.cs
+++ b/ApsimNG/Commands/RunCommand.cs
@@ -52,7 +52,7 @@
             this.jobName = model.Name;
             this.explorerPresenter = presenter;
             this.explorerPresenter.MainPresenter.AddStopHandler(OnStopSimulation);
-            jobManager = Runner.ForSimulations(explorerPresenter.ApsimXFile, model, false);
+            jobManager = Runner.ForSimulations(explorerPresenter.ApsimXFile, model, true);
 
             if (multiProcess)
                 jobRunner = new JobRunnerMultiProcess(false);

--- a/Docs/content/Usage/Tests.md
+++ b/Docs/content/Usage/Tests.md
@@ -1,0 +1,31 @@
+---
+title: "Test Results"
+draft: false
+---
+
+To test your data, you can add something like this to a manager script:
+
+```csharp
+using System;
+using Models.Core;
+namespace Models
+{
+    public class Script : Model, ITest
+    {
+        public void Run()
+        {
+            bool testHasFailed = true;
+            if (testHasFailed)
+                throw new Exception("oh dear");
+        }
+    }
+}
+```
+
+Things to note:
+
+ * Any failures should be handled by throwing an exception.
+ * Whenever Apsim finishes running simulations, it will run all `IModel`s which implement the `ITest` interface. Therefore, the script must inherit from `Model`
+ * `ITest` is defined in the `Models.Core` namespace
+ * By default, Apsim will not run these tests when run from the command line, unless the `/RunTests` command line switch is provided. If you don't know what the command line is, this will not affect you.
+ * [Jenkins](http://www.apsim.info:8080/jenkins) will run these tests whenever a pull request is run. Therefore, all files under the Examples, Prototypes, and Tests directories are guaranteed to be tested.

--- a/Docs/content/Usage/_index.md
+++ b/Docs/content/Usage/_index.md
@@ -9,3 +9,4 @@ weight: 10
 * [Using an Excel file for weather data](/usage/usingexcelforweatherdata)
 * [Graph filters](/usage/graphfilters)
 * [Cloud Services](/usage/cloud)
+* [Test Results](/usage/tests)

--- a/Jenkins/runTests.bat
+++ b/Jenkins/runTests.bat
@@ -77,5 +77,5 @@ echo Deleting temp directory...
 del %TEMP%\ApsimX /S /Q 1>nul 2>nul
 
 echo Commencing simulations...
-models.exe %testdir%\*.apsimx /Recurse
+models.exe %testdir%\*.apsimx /Recurse /RunTests
 endlocal

--- a/Models/Core/ITest.cs
+++ b/Models/Core/ITest.cs
@@ -6,9 +6,8 @@
     public interface ITest : IModel
     {
         /// <summary>
-        /// Runs the test. Returns true iff successful.
+        /// Runs the test. Throws an exception on failure.
         /// </summary>
-        /// <returns>True iff successful.</returns>
-        bool Run();
+        void Run();
     }
 }

--- a/Models/Core/ITest.cs
+++ b/Models/Core/ITest.cs
@@ -1,0 +1,14 @@
+﻿namespace Models.Core
+{
+    /// <summary>
+    /// An interface for a model which is a test.
+    /// </summary>
+    public interface ITest : IModel
+    {
+        /// <summary>
+        /// Runs the test. Returns true iff successful.
+        /// </summary>
+        /// <returns>True iff successful.</returns>
+        bool Run();
+    }
+}

--- a/Models/Core/Runners/JobRunnerMultiProcess.cs
+++ b/Models/Core/Runners/JobRunnerMultiProcess.cs
@@ -87,6 +87,23 @@ namespace Models.Core.Runners
             if (wait)
                 while (!t.IsCompleted)
                     Thread.Sleep(200);
+
+            try
+            {
+                jobs.Completed();
+            }
+            catch (Exception err)
+            {
+                errors += Environment.NewLine + err.ToString();
+            }
+
+            if (AllJobsCompleted != null)
+            {
+                AllCompletedArgs args = new AllCompletedArgs();
+                if (errors != null)
+                    args.exceptionThrown = new Exception(errors);
+                AllJobsCompleted.Invoke(this, args);
+            }
         }
 
         /// <summary>Stop all jobs currently running</summary>
@@ -101,23 +118,6 @@ namespace Models.Core.Runners
                     server = null;
                     DeleteRunners();
                     runningJobs.Clear();
-
-                    try
-                    {
-                        jobs.Completed();
-                    }
-                    catch (Exception err)
-                    {
-                        errors += Environment.NewLine + err.ToString();
-                    }
-
-                    if (AllJobsCompleted != null)
-                    {
-                        AllCompletedArgs args = new AllCompletedArgs();
-                        if (errors != null)
-                            args.exceptionThrown = new Exception(errors);
-                        AllJobsCompleted.Invoke(this, args);
-                    }
                 }
             }
         }

--- a/Models/Core/Runners/RunOrganiser.cs
+++ b/Models/Core/Runners/RunOrganiser.cs
@@ -112,6 +112,25 @@
             {
                 foreach (Tests test in Apsim.ChildrenRecursively(simulations, typeof(Tests)))
                     test.Test();
+                foreach (ITest test in Apsim.ChildrenRecursively(simulations, typeof(ITest)))
+                {
+                    // If we run into problems, we will want to include the name of the test in the 
+                    // exception's message. However, tests may be manager scripts, which always have
+                    // a name of 'Script'. Therefore, if the test's parent is a Manager, we use the
+                    // manager's name instead.
+                    string testName = test.Parent is Manager ? test.Parent.Name : test.Name;
+                    bool successful = false;
+                    try
+                    {
+                        successful = test.Run();
+                    }
+                    catch (Exception err)
+                    {
+                        throw new Exception("Encountered an error while running test " + testName, err);
+                    }
+                    if (!successful)
+                        throw new ApsimXException(test, "Failed test " + testName);
+                }
             }
         }
     }

--- a/Models/Core/Runners/RunOrganiser.cs
+++ b/Models/Core/Runners/RunOrganiser.cs
@@ -119,17 +119,14 @@
                     // a name of 'Script'. Therefore, if the test's parent is a Manager, we use the
                     // manager's name instead.
                     string testName = test.Parent is Manager ? test.Parent.Name : test.Name;
-                    bool successful = false;
                     try
                     {
-                        successful = test.Run();
+                        test.Run();
                     }
                     catch (Exception err)
                     {
                         throw new Exception("Encountered an error while running test " + testName, err);
                     }
-                    if (!successful)
-                        throw new ApsimXException(test, "Failed test " + testName);
                 }
             }
         }

--- a/Models/Models.csproj
+++ b/Models/Models.csproj
@@ -182,6 +182,7 @@
     <Compile Include="Core\ICustomDocumentation.cs" />
     <Compile Include="Core\Interfaces\IOptionallySerialiseChildren.cs" />
     <Compile Include="Core\Interfaces\ISimulationEngine.cs" />
+    <Compile Include="Core\ITest.cs" />
     <Compile Include="Core\SimulationGeneratorFactors.cs" />
     <Compile Include="Core\ISimulationGenerator.cs" />
     <Compile Include="Core\IStorageWriter.cs" />

--- a/Tests/UnitTests/TestTests.cs
+++ b/Tests/UnitTests/TestTests.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using APSIM.Shared.Utilities;
+using Models;
+using Models.Core;
+using NUnit.Framework;
+
+namespace UnitTests
+{
+    /// <summary>
+    /// Tests for ITest implementations.
+    /// </summary>
+    class TestTests
+    {
+        /// <summary>
+        /// Tests a simple implementation of ITest via a manager script.
+        /// </summary>
+        [Test]
+        public void ManagerScriptTest()
+        {
+            string managerCode = "using System; using Models.Core; namespace Models { public class Script : Model, ITest { public bool Run() { @action } } }";
+            Manager testManager = new Manager()
+            {
+                Name = "TestScript"
+            };
+
+            Folder testFolder = new Folder()
+            {
+                Name = "TestFolder"
+            };
+
+            testFolder.Children = new List<Model>() { testManager };
+            testManager.Parent = testFolder;
+
+            MockStorage storage = new MockStorage();
+
+            Simulations simToRun = Simulations.Create(new List<IModel>() { testFolder, storage });
+            IJobManager jobManager = Runner.ForSimulations(simToRun, simToRun, true);
+            IJobRunner jobRunner = new JobRunnerSync();
+
+            // Test should fail if it throws.
+            jobRunner.AllJobsCompleted += EnsureSimulationRanRed;
+            testManager.Code = managerCode.Replace("@action", "throw new Exception(\"Test has failed.\");");
+            jobRunner.Run(jobManager, true);
+
+            // Test should pass if it doesn't throw.
+            jobRunner.AllJobsCompleted -= EnsureSimulationRanRed;
+            jobRunner.AllJobsCompleted += EnsureSimulationRanGreen;
+            testManager.Code = managerCode.Replace("@action", "return true;");
+            jobRunner.Run(jobManager, true);
+        }
+
+        private void EnsureSimulationRanGreen(object sender, AllCompletedArgs args)
+        {
+            Assert.Null(args.exceptionThrown);
+        }
+
+        private void EnsureSimulationRanRed(object sender, AllCompletedArgs args)
+        {
+            Assert.NotNull(args.exceptionThrown);
+        }
+    }
+}

--- a/Tests/UnitTests/TestTests.cs
+++ b/Tests/UnitTests/TestTests.cs
@@ -22,7 +22,7 @@ namespace UnitTests
         [Test]
         public void ManagerScriptTest()
         {
-            string managerCode = "using System; using Models.Core; namespace Models { public class Script : Model, ITest { public bool Run() { @action } } }";
+            string managerCode = "using System; using Models.Core; namespace Models { public class Script : Model, ITest { public void Run() { @action } } }";
             Manager testManager = new Manager()
             {
                 Name = "TestScript"
@@ -50,7 +50,7 @@ namespace UnitTests
             // Test should pass if it doesn't throw.
             jobRunner.AllJobsCompleted -= EnsureSimulationRanRed;
             jobRunner.AllJobsCompleted += EnsureSimulationRanGreen;
-            testManager.Code = managerCode.Replace("@action", "return true;");
+            testManager.Code = managerCode.Replace("@action", "return;");
             jobRunner.Run(jobManager, true);
         }
 

--- a/Tests/UnitTests/TestTests.cs
+++ b/Tests/UnitTests/TestTests.cs
@@ -1,9 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using APSIM.Shared.Utilities;
 using Models;
 using Models.Core;
@@ -23,15 +19,11 @@ namespace UnitTests
         public void ManagerScriptTest()
         {
             string managerCode = "using System; using Models.Core; namespace Models { public class Script : Model, ITest { public void Run() { @action } } }";
-            Manager testManager = new Manager()
-            {
-                Name = "TestScript"
-            };
+            Manager testManager = new Manager();
+            testManager.Name = "TestScript";
 
-            Folder testFolder = new Folder()
-            {
-                Name = "TestFolder"
-            };
+            Folder testFolder = new Folder();
+            testFolder.Name = "TestFolder";
 
             testFolder.Children = new List<Model>() { testManager };
             testManager.Parent = testFolder;
@@ -54,11 +46,23 @@ namespace UnitTests
             jobRunner.Run(jobManager, true);
         }
 
+        /// <summary>
+        /// Event handler for a job runner's <see cref="IJobRunner.AllJobsCompleted"/> event.
+        /// Asserts that the job ran successfully.
+        /// </summary>
+        /// <param name="sender">Sender object.</param>
+        /// <param name="args">Event arguments.</param>
         private void EnsureSimulationRanGreen(object sender, AllCompletedArgs args)
         {
             Assert.Null(args.exceptionThrown);
         }
 
+        /// <summary>
+        /// Event handler for a job runner's <see cref="IJobRunner.AllJobsCompleted"/> event.
+        /// Asserts that the job ran unsuccessfully.
+        /// </summary>
+        /// <param name="sender">Sender object.</param>
+        /// <param name="args">Event arguments.</param>
         private void EnsureSimulationRanRed(object sender, AllCompletedArgs args)
         {
             Assert.NotNull(args.exceptionThrown);

--- a/Tests/UnitTests/UnitTests.csproj
+++ b/Tests/UnitTests/UnitTests.csproj
@@ -104,6 +104,7 @@
   <ItemGroup>
     <Compile Include="StructureTests.cs" />
     <Compile Include="ImporterTests.cs" />
+    <Compile Include="TestTests.cs" />
     <Compile Include="XMLToJSONTests.cs" />
     <Compile Include="DocumentationTests.cs" />
     <Compile Include="ManagerConverterTests.cs" />


### PR DESCRIPTION
Resolves #3289 

@sno036 Once this has been merged, you can create a manager script to test your results. A test script should look something like this:

```csharp
using System;
using Models.Core;
namespace Models
{
    public class Script : Model, ITest
    {
        public void Run()
        {
            bool testHasFailed = true;
            if (testHasFailed)
                throw new Exception("oh dear");
        }
    }
}
```

Note that, for now, Apsim will run any such scripts, no matter which simulation they are in. I've also added some documentation to the website for this feature.