### PR TITLE
When InitialResidueMass=0 and Organic Matter is to be reset, an exception is thrown

### DIFF
--- a/Models/Surface/SurfaceOrganicMatter.cs
+++ b/Models/Surface/SurfaceOrganicMatter.cs
@@ -438,7 +438,7 @@
             double totN = 0;  // total N in residue;
             double totP = 0;  // total P in residue;
 
-            if (InitialResidueMass > 0.0)
+            if (InitialResidueMass >= 0.0)
             {
                 // Normally the residue shouldn't already exist, and we
                 // will need to add it, and normally this should result in SOMNo == i


### PR DESCRIPTION
Resolves #3376 

When **InitialResidueMass**=0 and organic matter is to be reset, an exception is thrown. The reason is that if **InitialResidueMass**=0, the subroutine **ReadParam** does not fill the object **SurfOM**.

Can someone have a look at this change?