### PR TITLE
Managers should always reset script's properties at start of simulation.

### DIFF
--- a/Models/Manager.cs
+++ b/Models/Manager.cs
@@ -87,6 +87,7 @@
         private void OnSimulationCommencing(object sender, EventArgs e)
         {
             RebuildScriptModel();
+            SetParametersInObject(Apsim.Child(this, "Script") as Model);
         }
 
         /// <summary>Rebuild the script model and return error message if script cannot be compiled.</summary>
@@ -170,7 +171,7 @@
                     if (property != null)
                     {
                         object value;
-                        if (parameter.Value.StartsWith(".Simulations."))
+                        if (parameter.Value.StartsWith("."))
                             value = Apsim.Get(this, parameter.Value);
                         else if (property.PropertyType == typeof(IPlant))
                             value = Apsim.Find(this, parameter.Value);


### PR DESCRIPTION
Resolves #2636 