### PR TITLE
Implemented a better way of detecting if a JToken should be a JArray …

### DIFF
--- a/Models/Core/ApsimFile/XmlToJson.cs
+++ b/Models/Core/ApsimFile/XmlToJson.cs
@@ -165,11 +165,13 @@ namespace Models.Core.ApsimFile
             else
             {
                 Type modelType = GetModelTypeName(name);
-
                 if (modelType == null || modelType.GetInterface("IModel") == null)
                 {
+                    modelType = GetModelTypeName(JsonUtilities.Type(newRoot));
+                    var property = modelType?.GetProperty(name);
                     var newObject = CreateObject(obj);
-                    if (arrayVariableNames.Contains(name))
+                    // If the new obejct is NOT a JArray, and this object is supposed to be an array...
+                    if (!(newObject is JArray) && (arrayVariableNames.Contains(name) || (property != null && property.PropertyType.IsArray)))
                     {
                         // Should be an array of objects.
                         if (newObject.First.First is JArray)
@@ -339,6 +341,9 @@ namespace Models.Core.ApsimFile
 
         private static Type GetModelTypeName(string modelNameToFind)
         {
+            if (modelNameToFind == null)
+                return null;
+
             string[] modelWords = modelNameToFind.Split(".".ToCharArray());
             string m = modelWords[modelWords.Length - 1];
 


### PR DESCRIPTION
…when converting XML to Json.

Resolves #3350 

@hol353 Would be good to get your input on this when (if?) you return from holiday...this whole xml to json conversion process is difficult to follow, but I think I've implemented a better way of checking if a property is supposed to be an array:

The problem that I'm trying to solve is that class Stock contains an array of type `StockGeno`, and this array is not being correctly converted from xml to json when it contains only one element. There seem to be several static arrays in the `XmlToJson` class which are used to check if objects should be arrays:

```csharp
private static string[] builtinTypeNames = new string[] { "string", "int", "double", "dateTime", "ArrayOfString" };
private static string[] arrayVariableNames = new string[] { "AcceptedStats", "Operation", "Parameters", "cultivars", "Nodes", "Stores", "PaddockList" };
private static string[] arrayVariables = new[] { "Command", "Alias", "Leaves", "ZoneNamesToGrowRootsIn", "ZoneRootDepths", "ZoneInitialDM" };
private static string[] propertiesToIgnore = new[] { "ParameterValues", "Nodes", "Arcs", "Weirdo" };
```

(As a side note, should `builtinTypeNames` contain another element "bool"?)

Class Stock contains many array properties, so I didn't really want to add all of these to arrayVariableNames. I'm not really sure how this xml to json conversion works though, so I'm not sure if this is the right thing to do here.