### PR TITLE
Allow users to move text editor cursor via arrow keys while editing a grid cell.

### DIFF
--- a/ApsimNG/Views/GridView.cs
+++ b/ApsimNG/Views/GridView.cs
@@ -1080,7 +1080,7 @@
                 if (keyName == "ISO_Left_Tab")
                     keyName = "Tab";
                 bool shifted = (args.Event.State & Gdk.ModifierType.ShiftMask) != 0;
-                if (keyName == "Return" || keyName == "Tab" || IsArrowKey(key))
+                if (keyName == "Return" || keyName == "Tab" || (IsArrowKey(key) && !userEditingCell))
                 {
                     int nextRow = rowIdx;
                     int numCols = DataSource != null ? DataSource.Columns.Count : 0;

--- a/ApsimNG/Views/GridView.cs
+++ b/ApsimNG/Views/GridView.cs
@@ -1080,8 +1080,10 @@
                 if (keyName == "ISO_Left_Tab")
                     keyName = "Tab";
                 bool shifted = (args.Event.State & Gdk.ModifierType.ShiftMask) != 0;
-                if (keyName == "Return" || keyName == "Tab" || (IsArrowKey(key) && !userEditingCell))
+                if (keyName == "Return" || keyName == "Tab" || IsArrowKey(key))
                 {
+                    if (userEditingCell && (key == Gdk.Key.Left || key == Gdk.Key.Right))
+                        return;
                     int nextRow = rowIdx;
                     int numCols = DataSource != null ? DataSource.Columns.Count : 0;
                     int nextCol = colIdx;


### PR DESCRIPTION
Resolves #3561