### PR TITLE
Added a fallback for finding datastore from graph presenter.

### DIFF
--- a/ApsimNG/Presenters/CLEM/ModelDetailsWrapperPresenter.cs
+++ b/ApsimNG/Presenters/CLEM/ModelDetailsWrapperPresenter.cs
@@ -112,10 +112,10 @@
                 if (newView != null && this.currentLowerPresenter != null)
                 {
                     this.View.AddLowerView(newView);
-                    this.currentLowerPresenter.Attach(model, newView, ExplorerPresenter);
+
                     // Resolve links in presenter.
-                    // Not sure if this is needed AL
-                    // ApsimXFile.Links.Resolve(currentLowerPresenter);
+                    this.ExplorerPresenter.ApsimXFile.Links.Resolve(currentLowerPresenter);
+                    this.currentLowerPresenter.Attach(model, newView, ExplorerPresenter);
                 }
             }
             catch (Exception err)

--- a/ApsimNG/Presenters/GraphPresenter.cs
+++ b/ApsimNG/Presenters/GraphPresenter.cs
@@ -87,6 +87,8 @@ namespace UserInterface.Presenters
         public void DrawGraph()
         {
             graphView.Clear();
+            if (storage == null)
+                storage = Apsim.Find(graph, typeof(IDataStore)) as IDataStore;
             if (graph != null && graph.Series != null)
             {
                 // Get a list of series definitions.

--- a/ApsimNG/Presenters/XYPairsPresenter.cs
+++ b/ApsimNG/Presenters/XYPairsPresenter.cs
@@ -74,6 +74,7 @@ namespace UserInterface.Presenters
             (this.graph.Series[0] as Series).XFieldName = Apsim.FullPath(graph.Parent) + ".X";
             (this.graph.Series[0] as Series).YFieldName = Apsim.FullPath(graph.Parent) + ".Y";
             this.graphPresenter = new GraphPresenter();
+            this.presenter.ApsimXFile.Links.Resolve(graphPresenter);
             this.graphPresenter.Attach(this.graph, this.xYPairsView.Graph, this.presenter);
             string xAxisTitle = LookForXAxisTitle();
             if (xAxisTitle != null)

--- a/Jenkins/build.bat
+++ b/Jenkins/build.bat
@@ -40,7 +40,7 @@ if not exist "%solution_file%" (
 
 rem Copy DeploymentSupport files.
 echo Copying DeploymentSupport files...
-xcopy /e /i %apsimx%\DeploymentSupport\Windows\Bin64\lib %apsimx%\lib>nul
+xcopy /y /e /i %apsimx%\DeploymentSupport\Windows\Bin64\lib %apsimx%\lib>nul
 copy /y %apsimx%\DeploymentSupport\Windows\Bin64\* %apsimx%\Bin>nul
 echo Done.
 


### PR DESCRIPTION
Resolves #3651 
Resolves #3650 

The root cause was the same as in #3602 - whenever a presenter is instantiated from code, it needs to have its links resolved. I can't think of a simple way to enforce this.