### PR TITLE
Added MathNet.Numerics to ApsimNG/Intellisense

### DIFF
--- a/ApsimNG/ApsimNG.csproj
+++ b/ApsimNG/ApsimNG.csproj
@@ -930,6 +930,10 @@
       <HintPath>..\packages\MarkdownDeep.NET.1.5\lib\.NetFramework 3.5\MarkdownDeep.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="MathNet.Numerics, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\Bin\MathNet.Numerics.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Azure.Batch, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Azure.Batch.8.0.1\lib\net452\Microsoft.Azure.Batch.dll</HintPath>
     </Reference>

--- a/ApsimNG/Classes/Intellisense/CSharpCompletion.cs
+++ b/ApsimNG/Classes/Intellisense/CSharpCompletion.cs
@@ -271,6 +271,7 @@ namespace UserInterface.Intellisense
 		            typeof(IProjectContent).Assembly,
                     typeof(Models.Core.IModel).Assembly, // Models.exe
                     typeof(APSIM.Shared.Utilities.StringUtilities).Assembly, // APSIM.Shared.dll
+                    typeof(MathNet.Numerics.Combinatorics).Assembly, // MathNet.Numerics
                 };
             assemblies = assemblies.Where(v => !v.IsDynamic).ToList();
 

--- a/ApsimNG/Presenters/MainPresenter.cs
+++ b/ApsimNG/Presenters/MainPresenter.cs
@@ -146,7 +146,7 @@
         /// <returns>Any exception message or null</returns>
         public void ProcessStartupScript(string code)
         {
-            Assembly compiledAssembly = ReflectionUtilities.CompileTextToAssembly(code, Path.GetTempFileName());
+            Assembly compiledAssembly = Manager.CompileTextToAssembly(code, Path.GetTempFileName());
 
             // Get the script 'Type' from the compiled assembly.
             Type scriptType = compiledAssembly.GetType("Script");

--- a/Models/Manager.cs
+++ b/Models/Manager.cs
@@ -331,7 +331,9 @@
                         Params.ReferencedAssemblies.Add(typeof(MathNet.Numerics.Fit).Assembly.Location); // MathNet.Numerics
                         Params.ReferencedAssemblies.Add(typeof(APSIM.Shared.Utilities.MathUtilities).Assembly.Location); // APSIM.Shared.dll
                         Params.ReferencedAssemblies.Add(typeof(IModel).Assembly.Location); // Models.exe
-                        
+
+                        if (!Params.ReferencedAssemblies.Contains(Assembly.GetCallingAssembly().Location))
+                            Params.ReferencedAssemblies.Add(Assembly.GetCallingAssembly().Location);
                         Params.TempFiles = new TempFileCollection(Path.GetTempPath());  // ensure that any temp files are in a writeable area
                         Params.TempFiles.KeepFiles = false;
                         CompilerResults results;


### PR DESCRIPTION
Resolves #3673 

Unfortunately, because the intellisense lives in ApsimNG, I've had to add a MathNet.Numerics reference to ApsimNG. Not Ideal, but it should keep Val happy for now. Might be worth moving a lot of the intellisense code into Models one day...and maybe making the intellisense/manager compilation code figure out for itself which assemblies it needs.