### PR TITLE
If graph annotation has no colour, use default.

### DIFF
--- a/ApsimNG/Views/GraphView.cs
+++ b/ApsimNG/Views/GraphView.cs
@@ -518,8 +518,12 @@ namespace UserInterface.Views
             else
                 yPosition = (double)y;
             annotation.TextPosition = new DataPoint(xPosition, yPosition);
-            annotation.TextColor = OxyColor.FromArgb(colour.A, colour.R, colour.G, colour.B);
-            //annotation.Text += "\r\n\r\n";
+
+            if (colour == Color.Empty)
+                annotation.TextColor = ForegroundColour;
+            else
+                annotation.TextColor = Utility.Colour.ToOxy(colour);
+
             this.plot1.Model.Annotations.Add(annotation);
         }
         /// <summary>


### PR DESCRIPTION
Resolves #3762
Resolves #3779
This will fix the bug where regression equation doesn't show up.