### PR TITLE
Modifications to support Firebird databases.

### DIFF
--- a/APSIMRunner/StorageViaSockets.cs
+++ b/APSIMRunner/StorageViaSockets.cs
@@ -28,7 +28,7 @@
             var rowData = new JobRunnerMultiProcess.TransferReportData()
             {
                 key = jobKey,
-                data = data 
+                data = data
             };
 
             if (data.Rows.Count > 0)
@@ -130,6 +130,15 @@
         {
             throw new NotImplementedException();
         }
-    }
 
+        /// <summary>
+        /// Get the list of column names within a table
+        /// </summary>
+        /// <param name="tableName">Name of the table</param>
+        /// <returns></returns>
+        public IEnumerable<string> ColumnNames(string tableName)
+        {
+            throw new NotImplementedException();
+        }
+    }
 }

--- a/ApsimNG/Presenters/CLEM/MessagePresenter.cs
+++ b/ApsimNG/Presenters/CLEM/MessagePresenter.cs
@@ -168,7 +168,7 @@ namespace UserInterface.Presenters
                         {
                             type = "Ok";
                             title = "Success";
-                            DataTable dataRows2 = ds.Reader.GetDataUsingSql("Select * FROM _InitialConditions WHERE Name = 'Run on'"); // (simulationName: simulation.Name, tableName: "_InitialConditions");
+                            DataTable dataRows2 = ds.Reader.GetDataUsingSql("Select * FROM [_InitialConditions] WHERE [Name] = 'Run on'"); // (simulationName: simulation.Name, tableName: "_InitialConditions");
                             DateTime lastrun = DateTime.Parse(dataRows2.Rows[0][8].ToString());
                             msgStr = "Simulation successfully completed at [" + lastrun.ToShortTimeString() + "] on [" + lastrun.ToShortDateString() + "]";
                         }

--- a/ApsimNG/Presenters/CLEM/PropertyTablePresenter.cs
+++ b/ApsimNG/Presenters/CLEM/PropertyTablePresenter.cs
@@ -564,7 +564,10 @@ namespace UserInterface.Presenters
                         DataTable data = null;
                         if (storage.Reader.TableNames.Contains(tableName))
                         {
-                            data = this.storage.Reader.GetDataUsingSql("SELECT * FROM " + tableName + " LIMIT 1");
+                            if ((storage.Reader is DataStoreReader) && (storage.Reader as DataStoreReader).connection is Firebird)
+                                data = this.storage.Reader.GetDataUsingSql("SELECT FIRST 1 * FROM [" + tableName + "]");
+                            else
+                                data = this.storage.Reader.GetDataUsingSql("SELECT * FROM [" + tableName + "] LIMIT 1");
                         }
 
                         if (data != null)

--- a/ApsimNG/Presenters/CLEM/PropertyTablePresenter.cs
+++ b/ApsimNG/Presenters/CLEM/PropertyTablePresenter.cs
@@ -561,19 +561,8 @@ namespace UserInterface.Presenters
                     if (cell.Value != null && cell.Value.ToString() != string.Empty)
                     {
                         string tableName = cell.Value.ToString();
-                        DataTable data = null;
                         if (storage.Reader.TableNames.Contains(tableName))
-                        {
-                            if ((storage.Reader is DataStoreReader) && (storage.Reader as DataStoreReader).connection is Firebird)
-                                data = this.storage.Reader.GetDataUsingSql("SELECT FIRST 1 * FROM [" + tableName + "]");
-                            else
-                                data = this.storage.Reader.GetDataUsingSql("SELECT * FROM [" + tableName + "] LIMIT 1");
-                        }
-
-                        if (data != null)
-                        {
-                            fieldNames = DataTableUtilities.GetColumnNames(data);
-                        }
+                            fieldNames = storage.Reader.ColumnNames(tableName).ToArray<string>();
                     }
                 }
             }

--- a/ApsimNG/Presenters/DataStorePresenter.cs
+++ b/ApsimNG/Presenters/DataStorePresenter.cs
@@ -181,25 +181,7 @@ namespace UserInterface.Presenters
                         var names = ExperimentFilter.GenerateSimulationDescriptions().Select(s => s.Name);
                         string filter = "S.[Name] IN " + "(" + StringUtilities.Build(names, delimiter: ",", prefix: "'", suffix: "'") + ")";
                         if (!string.IsNullOrEmpty(view.RowFilter.Value))
-                        {
-                            // For Firebird, we need to convert column names to their short form to perform the query
-                            if (dataStore.Reader is DataStoreReader && (dataStore.Reader as DataStoreReader).connection is Firebird)
-                            {
-                                string rowFilter = view.RowFilter.Value;
-                                List<string> output = rowFilter.Split('[', ']').Where((item, index) => index % 2 != 0).ToList();
-                                foreach (string field in output)
-                                {
-                                    string shortName = ((dataStore.Reader as DataStoreReader).connection as Firebird).GetShortColumnName(view.TableList.SelectedValue, field);
-                                    if (!string.IsNullOrEmpty(shortName))
-                                    {
-                                        rowFilter = rowFilter.Replace("[" + field + "]", "[" + shortName + "]");
-                                    }
-                                }
-                                filter += " AND " + rowFilter;
-                            }
-                            else
-                                filter += " AND " + view.RowFilter.Value;
-                        }
+                            filter += " AND " + view.RowFilter.Value;
                         data = dataStore.Reader.GetData(tableName: view.TableList.SelectedValue, filter: filter, from: start, count: count);
                     }
                     else if (SimulationFilter != null)

--- a/ApsimNG/Presenters/DataStorePresenter.cs
+++ b/ApsimNG/Presenters/DataStorePresenter.cs
@@ -3,7 +3,6 @@
 namespace UserInterface.Presenters
 {
     using System;
-    using System.Collections.Generic;
     using System.Data;
     using System.Linq;
     using APSIM.Shared.Utilities;

--- a/ApsimNG/Presenters/DataStorePresenter.cs
+++ b/ApsimNG/Presenters/DataStorePresenter.cs
@@ -3,6 +3,7 @@
 namespace UserInterface.Presenters
 {
     using System;
+    using System.Collections.Generic;
     using System.Data;
     using System.Linq;
     using APSIM.Shared.Utilities;
@@ -178,9 +179,27 @@ namespace UserInterface.Presenters
                     if (ExperimentFilter != null)
                     {
                         var names = ExperimentFilter.GenerateSimulationDescriptions().Select(s => s.Name);
-                        string filter = "S.NAME IN " + "(" + StringUtilities.Build(names, delimiter: ",", prefix: "'", suffix: "'") + ")";
+                        string filter = "S.[Name] IN " + "(" + StringUtilities.Build(names, delimiter: ",", prefix: "'", suffix: "'") + ")";
                         if (!string.IsNullOrEmpty(view.RowFilter.Value))
-                            filter += " AND " + view.RowFilter.Value;
+                        {
+                            // For Firebird, we need to convert column names to their short form to perform the query
+                            if (dataStore.Reader is DataStoreReader && (dataStore.Reader as DataStoreReader).connection is Firebird)
+                            {
+                                string rowFilter = view.RowFilter.Value;
+                                List<string> output = rowFilter.Split('[', ']').Where((item, index) => index % 2 != 0).ToList();
+                                foreach (string field in output)
+                                {
+                                    string shortName = ((dataStore.Reader as DataStoreReader).connection as Firebird).GetShortColumnName(view.TableList.SelectedValue, field);
+                                    if (!string.IsNullOrEmpty(shortName))
+                                    {
+                                        rowFilter = rowFilter.Replace("[" + field + "]", "[" + shortName + "]");
+                                    }
+                                }
+                                filter += " AND " + rowFilter;
+                            }
+                            else
+                                filter += " AND " + view.RowFilter.Value;
+                        }
                         data = dataStore.Reader.GetData(tableName: view.TableList.SelectedValue, filter: filter, from: start, count: count);
                     }
                     else if (SimulationFilter != null)

--- a/ApsimNG/Presenters/GraphPresenter.cs
+++ b/ApsimNG/Presenters/GraphPresenter.cs
@@ -100,6 +100,10 @@ namespace UserInterface.Presenters
                 {
                     explorerPresenter.MainPresenter.ShowError(new Exception("Error obtaining data from database: ", e));
                 }
+                catch (FirebirdException e)
+                {
+                    explorerPresenter.MainPresenter.ShowError(new Exception("Error obtaining data from database: ", e));
+                }
 
                 foreach (SeriesDefinition definition in seriesDefinitions)
                 {

--- a/ApsimNG/Presenters/PropertyPresenter.cs
+++ b/ApsimNG/Presenters/PropertyPresenter.cs
@@ -591,17 +591,9 @@ namespace UserInterface.Presenters
                     if (cell.Value != null && cell.Value.ToString() != string.Empty)
                     {
                         string tableName = cell.Value.ToString();
-                        DataTable data = null;
                         if (storage.Reader.TableNames.Contains(tableName))
                         {
-                            if ((storage.Reader is DataStoreReader) && (storage.Reader as DataStoreReader).connection is Firebird)
-                                data = storage.Reader.GetDataUsingSql("SELECT FIRST 1 * FROM [" + tableName + "]");
-                            else
-                                data = storage.Reader.GetDataUsingSql("SELECT * FROM [" + tableName + "] LIMIT 1");
-                        }
-                        if (data != null)
-                        {
-                            fieldNames = DataTableUtilities.GetColumnNames(data).ToList();
+                            fieldNames = storage.Reader.ColumnNames(tableName).ToList();
                             if (fieldNames.Contains("SimulationID"))
                                 fieldNames.Add("SimulationName");
                         }

--- a/ApsimNG/Presenters/PropertyPresenter.cs
+++ b/ApsimNG/Presenters/PropertyPresenter.cs
@@ -593,7 +593,12 @@ namespace UserInterface.Presenters
                         string tableName = cell.Value.ToString();
                         DataTable data = null;
                         if (storage.Reader.TableNames.Contains(tableName))
-                            data = storage.Reader.GetDataUsingSql("SELECT * FROM " + tableName + " LIMIT 1");
+                        {
+                            if ((storage.Reader is DataStoreReader) && (storage.Reader as DataStoreReader).connection is Firebird)
+                                data = storage.Reader.GetDataUsingSql("SELECT FIRST 1 * FROM [" + tableName + "]");
+                            else
+                                data = storage.Reader.GetDataUsingSql("SELECT * FROM [" + tableName + "] LIMIT 1");
+                        }
                         if (data != null)
                         {
                             fieldNames = DataTableUtilities.GetColumnNames(data).ToList();

--- a/Models/Graph/Series.cs
+++ b/Models/Graph/Series.cs
@@ -726,25 +726,7 @@ namespace Models.Graph
                                    StringUtilities.Build(simulationNames, ",", "'", "'") +
                                    ")";
             if (Filter != null && Filter != string.Empty)
-            {
-                // For Firebird, we need to convert long column names into their short form.
-                if (reader is DataStoreReader && (reader as DataStoreReader).connection is Firebird)
-                {
-                    string filterCopy = Filter;
-                    List<string> output = filterCopy.Split('[', ']').Where((item, index) => index % 2 != 0).ToList();
-                    foreach (string field in output)
-                    {
-                        string shortName = ((reader as DataStoreReader).connection as Firebird).GetShortColumnName(TableName, field);
-                        if (!string.IsNullOrEmpty(shortName))
-                        {
-                            filterCopy = filterCopy.Replace("[" + field + "]", "[" + shortName + "]");
-                        }
-                    }
-                    filterToUse += " AND " + filterCopy;
-                }
-                else
-                    filterToUse += " AND " + Filter;
-            }
+               filterToUse += " AND " + Filter;
 
             // Checkpoints don't exist in observed files so don't pass a checkpoint name to 
             // GetData in this situation.

--- a/Models/PostSimulationTools/PredictedObserved.cs
+++ b/Models/PostSimulationTools/PredictedObserved.cs
@@ -78,9 +78,9 @@ namespace Models.PostSimulationTools
 
                 StringBuilder query = new StringBuilder("SELECT ");
 
-                if (dataStore.Reader is DataStoreReader && (dataStore.Reader as DataStoreReader).connection is Firebird)
+                if (dataStore.Reader is DataStoreReader && (dataStore.Reader as DataStoreReader).Connection is Firebird)
                 {
-                    Firebird fb = (dataStore.Reader as DataStoreReader).connection as Firebird;
+                    Firebird fb = (dataStore.Reader as DataStoreReader).Connection as Firebird;
                     foreach (string s in commonCols)
                     {
                         if (s == FieldNameUsedForMatch || s == FieldName2UsedForMatch || s == FieldName3UsedForMatch)
@@ -211,9 +211,9 @@ namespace Models.PostSimulationTools
                 if (predictedObservedData != null)
                 {
                     // If Firebird, first convert the short names (needed for querying) back into long ones
-                    if (dataStore.Reader is DataStoreReader && (dataStore.Reader as DataStoreReader).connection is Firebird)
+                    if (dataStore.Reader is DataStoreReader && (dataStore.Reader as DataStoreReader).Connection is Firebird)
                     {
-                        Firebird fb = (dataStore.Reader as DataStoreReader).connection as Firebird;
+                        Firebird fb = (dataStore.Reader as DataStoreReader).Connection as Firebird;
                         string match1 = fb.GetShortColumnName(ObservedTableName, FieldNameUsedForMatch);
                         string match2 = fb.GetShortColumnName(ObservedTableName, FieldName2UsedForMatch);
                         string match3 = fb.GetShortColumnName(ObservedTableName, FieldName3UsedForMatch);

--- a/Models/PostSimulationTools/PredictedObserved.cs
+++ b/Models/PostSimulationTools/PredictedObserved.cs
@@ -76,163 +76,80 @@ namespace Models.PostSimulationTools
                 // get the common columns between these lists of columns
                 IEnumerable<string> commonCols = predictedDataNames.Intersect(observedDataNames);
 
+                IStorageReader reader = dataStore.Reader;
+                string match1ObsShort = reader.BriefColumnName(ObservedTableName, FieldNameUsedForMatch);
+                string match2ObsShort = reader.BriefColumnName(ObservedTableName, FieldName2UsedForMatch);
+                string match3ObsShort = reader.BriefColumnName(ObservedTableName, FieldName3UsedForMatch);
+
+                string match1PredShort = reader.BriefColumnName(PredictedTableName, FieldNameUsedForMatch);
+                string match2PredShort = reader.BriefColumnName(PredictedTableName, FieldName2UsedForMatch);
+                string match3PredShort = reader.BriefColumnName(PredictedTableName, FieldName3UsedForMatch);
+
                 StringBuilder query = new StringBuilder("SELECT ");
-
-                if (dataStore.Reader is DataStoreReader && (dataStore.Reader as DataStoreReader).Connection is Firebird)
+                foreach (string s in commonCols)
                 {
-                    Firebird fb = (dataStore.Reader as DataStoreReader).Connection as Firebird;
-                    foreach (string s in commonCols)
-                    {
-                        if (s == FieldNameUsedForMatch || s == FieldName2UsedForMatch || s == FieldName3UsedForMatch)
-                            query.Append("O.[@fieldo], ");
-                        else
-                            query.Append("O.[@fieldo] AS [Observed.@fieldo], P.[@fieldp] AS [Predicted.@fieldp], ");
-
-                        string sObs = fb.GetShortColumnName(ObservedTableName, s);
-                        query.Replace("@fieldo", sObs);
-                        string sPred = fb.GetShortColumnName(PredictedTableName, s);
-                        query.Replace("@fieldp", sPred);
-                    }
-
-                    query.Append("FROM [" + ObservedTableName + "] O INNER JOIN [" + PredictedTableName + "] P USING ([SimulationID]) WHERE O.[@match1o] = P.[@match1p]");
-                    if (FieldName2UsedForMatch != null && FieldName2UsedForMatch != string.Empty)
-                        query.Append(" AND O.[@match2o] = P.[@match2p]");
-                    if (FieldName3UsedForMatch != null && FieldName3UsedForMatch != string.Empty)
-                        query.Append(" AND O.[@match3o] = P.[@match3p]");
-
-                    int checkpointID = dataStore.Writer.GetCheckpointID("Current");
-                    query.Append(" AND P.[CheckpointID] = " + checkpointID);
-
-                    query.Replace(", FROM", " FROM"); // get rid of the last comma
-                    query.Replace("O.[SimulationID] AS [Observed.SimulationID], P.[SimulationID] AS [Predicted.SimulationID]", "O.[SimulationID] AS [SimulationID]");
-
-                    string match;
-                    if (!string.IsNullOrEmpty(FieldNameUsedForMatch))
-                    {
-                        match = fb.GetShortColumnName(ObservedTableName, FieldNameUsedForMatch);
-                        query = query.Replace("@match1o", match);
-                        match = fb.GetShortColumnName(PredictedTableName, FieldNameUsedForMatch);
-                        query = query.Replace("@match1p", match);
-                    }
-                    if (!string.IsNullOrEmpty(FieldName2UsedForMatch))
-                    {
-                        match = fb.GetShortColumnName(ObservedTableName, FieldName2UsedForMatch);
-                        query = query.Replace("@match2o", match);
-                        match = fb.GetShortColumnName(PredictedTableName, FieldName2UsedForMatch);
-                        query = query.Replace("@match2p", match);
-                    }
-                    if (!string.IsNullOrEmpty(FieldName3UsedForMatch))
-                    {
-                        match = fb.GetShortColumnName(ObservedTableName, FieldName3UsedForMatch);
-                        query = query.Replace("@match3o", match);
-                        match = fb.GetShortColumnName(PredictedTableName, FieldName3UsedForMatch);
-                        query = query.Replace("@match3p", match);
-                    }
-
-                    if (Parent is Folder)
-                    {
-                        // Limit it to particular simulations in scope.
-                        List<string> simulationNames = new List<string>();
-                        foreach (Experiment experiment in Apsim.FindAll(this, typeof(Experiment)))
-                        {
-                            var names = experiment.GenerateSimulationDescriptions().Select(s => s.Name);
-                            simulationNames.AddRange(names);
-                        }
-
-                        foreach (Simulation simulation in Apsim.FindAll(this, typeof(Simulation)))
-                            if (!(simulation.Parent is Experiment))
-                                simulationNames.Add(simulation.Name);
-
-                        query.Append(" AND O.[SimulationID] in (");
-                        foreach (string simulationName in simulationNames)
-                        {
-                            if (simulationName != simulationNames[0])
-                                query.Append(',');
-                            query.Append(dataStore.Writer.GetSimulationID(simulationName));
-                        }
-                        query.Append(")");
-                    }
-
+                    string obsColShort = reader.BriefColumnName(ObservedTableName, s);
+                    string predColShort = reader.BriefColumnName(PredictedTableName, s);
+                    if (s == FieldNameUsedForMatch || s == FieldName2UsedForMatch || s == FieldName3UsedForMatch)
+                        query.Append("O.[" + obsColShort + "], ");
+                    else
+                        query.Append("O.[" + obsColShort + "] AS [Observed." + obsColShort + "], P.[" + predColShort + "] AS [Predicted." + predColShort +"], ");
                 }
-                else
+
+                query.Append("FROM [" + ObservedTableName + "] O INNER JOIN [" + PredictedTableName + "] P USING ([SimulationID]) WHERE O.[" + match1ObsShort + "] = P.[" + match1PredShort + "]");
+                if (FieldName2UsedForMatch != null && FieldName2UsedForMatch != string.Empty)
+                    query.Append(" AND O.[" + match2ObsShort + "] = P.[" + match2PredShort + "]");
+                if (FieldName3UsedForMatch != null && FieldName3UsedForMatch != string.Empty)
+                    query.Append(" AND O.[" + match3ObsShort + "] = P.[" + match3PredShort + "]");
+
+                int checkpointID = dataStore.Writer.GetCheckpointID("Current");
+                query.Append(" AND P.[CheckpointID] = " + checkpointID);
+                query.Replace(", FROM", " FROM"); // get rid of the last comma
+                query.Replace("O.[SimulationID] AS [Observed.SimulationID], P.[SimulationID] AS [Predicted.SimulationID]", "O.[SimulationID] AS [SimulationID]");
+
+                if (Parent is Folder)
                 {
-                    foreach (string s in commonCols)
+                    // Limit it to particular simulations in scope.
+                    List<string> simulationNames = new List<string>();
+                    foreach (Experiment experiment in Apsim.FindAll(this, typeof(Experiment)))
                     {
-                        if (s == FieldNameUsedForMatch || s == FieldName2UsedForMatch || s == FieldName3UsedForMatch)
-                            query.Append("O.[@field], ");
-                        else
-                            query.Append("O.[@field] AS [Observed.@field], P.[@field] AS [Predicted.@field], ");
-
-                        query.Replace("@field", s);
+                        var names = experiment.GenerateSimulationDescriptions().Select(s => s.Name);
+                        simulationNames.AddRange(names);
                     }
 
-                    query.Append("FROM [" + ObservedTableName + "] O INNER JOIN [" + PredictedTableName + "] P USING (SimulationID) WHERE O.[@match1] = P.[@match1]");
-                    if (FieldName2UsedForMatch != null && FieldName2UsedForMatch != string.Empty)
-                        query.Append(" AND O.[@match2] = P.[@match2]");
-                    if (FieldName3UsedForMatch != null && FieldName3UsedForMatch != string.Empty)
-                        query.Append(" AND O.[@match3] = P.[@match3]");
+                    foreach (Simulation simulation in Apsim.FindAll(this, typeof(Simulation)))
+                        if (!(simulation.Parent is Experiment))
+                            simulationNames.Add(simulation.Name);
 
-                    int checkpointID = dataStore.Writer.GetCheckpointID("Current");
-                    query.Append(" AND P.[CheckpointID] = " + checkpointID);
-
-                    query.Replace(", FROM", " FROM"); // get rid of the last comma
-                    query.Replace("O.[SimulationID] AS [Observed.SimulationID], P.[SimulationID] AS [Predicted.SimulationID]", "O.[SimulationID] AS [SimulationID]");
-
-                    query = query.Replace("@match1", FieldNameUsedForMatch);
-                    query = query.Replace("@match2", FieldName2UsedForMatch);
-                    query = query.Replace("@match3", FieldName3UsedForMatch);
-
-                    if (Parent is Folder)
+                    query.Append(" AND O.[SimulationID] in (");
+                    foreach (string simulationName in simulationNames)
                     {
-                        // Limit it to particular simulations in scope.
-                        List<string> simulationNames = new List<string>();
-                        foreach (Experiment experiment in Apsim.FindAll(this, typeof(Experiment)))
-                        {
-                            var names = experiment.GenerateSimulationDescriptions().Select(s => s.Name);
-                            simulationNames.AddRange(names);
-                        }
-
-                        foreach (Simulation simulation in Apsim.FindAll(this, typeof(Simulation)))
-                            if (!(simulation.Parent is Experiment))
-                                simulationNames.Add(simulation.Name);
-
-                        query.Append(" AND O.[SimulationID] in (");
-                        foreach (string simulationName in simulationNames)
-                        {
-                            if (simulationName != simulationNames[0])
-                                query.Append(',');
-                            query.Append(dataStore.Writer.GetSimulationID(simulationName));
-                        }
-                        query.Append(")");
+                        if (simulationName != simulationNames[0])
+                            query.Append(',');
+                        query.Append(dataStore.Writer.GetSimulationID(simulationName));
                     }
+                    query.Append(")");
                 }
-                DataTable predictedObservedData = dataStore.Reader.GetDataUsingSql(query.ToString());
+
+                DataTable predictedObservedData = reader.GetDataUsingSql(query.ToString());
 
                 if (predictedObservedData != null)
                 {
-                    // If Firebird, first convert the short names (needed for querying) back into long ones
-                    if (dataStore.Reader is DataStoreReader && (dataStore.Reader as DataStoreReader).Connection is Firebird)
+                    foreach (DataColumn column in predictedObservedData.Columns)
                     {
-                        Firebird fb = (dataStore.Reader as DataStoreReader).Connection as Firebird;
-                        string match1 = fb.GetShortColumnName(ObservedTableName, FieldNameUsedForMatch);
-                        string match2 = fb.GetShortColumnName(ObservedTableName, FieldName2UsedForMatch);
-                        string match3 = fb.GetShortColumnName(ObservedTableName, FieldName3UsedForMatch);
-                        foreach (DataColumn column in predictedObservedData.Columns)
+                        if (column.ColumnName.StartsWith("Predicted."))
                         {
-                            if (column.ColumnName.StartsWith("Predicted."))
-                            {
-                                string shortName = column.ColumnName.Substring("Predicted.".Length);
-                                column.ColumnName = "Predicted." + fb.GetLongColumnName(PredictedTableName, shortName);
-                            }
-                            else if (column.ColumnName.StartsWith("Observed."))
-                            {
-                                string shortName = column.ColumnName.Substring("Observed.".Length);
-                                column.ColumnName = "Observed." + fb.GetLongColumnName(ObservedTableName, shortName);
-                            }
-                            else if (column.ColumnName.Equals(match1) || column.ColumnName.Equals(match2) || column.ColumnName.Equals(match3))
-                            {
-                                column.ColumnName = fb.GetLongColumnName(ObservedTableName, column.ColumnName);
-                            }
+                            string shortName = column.ColumnName.Substring("Predicted.".Length);
+                            column.ColumnName = "Predicted." + reader.FullColumnName(PredictedTableName, shortName);
+                        }
+                        else if (column.ColumnName.StartsWith("Observed."))
+                        {
+                            string shortName = column.ColumnName.Substring("Observed.".Length);
+                            column.ColumnName = "Observed." + reader.FullColumnName(ObservedTableName, shortName);
+                        }
+                        else if (column.ColumnName.Equals(match1ObsShort) || column.ColumnName.Equals(match2ObsShort) || column.ColumnName.Equals(match3ObsShort))
+                        {
+                            column.ColumnName = reader.FullColumnName(ObservedTableName, column.ColumnName);
                         }
                     }
 
@@ -266,7 +183,7 @@ namespace Models.PostSimulationTools
                     // write units to table.
                     foreach (string fieldName in commonCols)
                     {
-                        string units = dataStore.Reader.Units(PredictedTableName, fieldName);
+                        string units = reader.Units(PredictedTableName, fieldName);
                         if (units != null && units != "()")
                         {
                             string unitsMinusBrackets = units.Replace("(", "").Replace(")", "");
@@ -282,8 +199,8 @@ namespace Models.PostSimulationTools
                 else
                 {
                     // Determine what went wrong.
-                    DataTable predictedData = dataStore.Reader.GetDataUsingSql("SELECT * FROM [" + PredictedTableName + "]");
-                    DataTable observedData = dataStore.Reader.GetDataUsingSql("SELECT * FROM [" + ObservedTableName + "]");
+                    DataTable predictedData = reader.GetDataUsingSql("SELECT * FROM [" + PredictedTableName + "]");
+                    DataTable observedData = reader.GetDataUsingSql("SELECT * FROM [" + ObservedTableName + "]");
                     if (predictedData == null || predictedData.Rows.Count == 0)
                         throw new Exception(Name + ": Cannot find any predicted data.");
                     else if (observedData == null || observedData.Rows.Count == 0)

--- a/Models/Sensitivity/FactorialAnova.cs
+++ b/Models/Sensitivity/FactorialAnova.cs
@@ -119,7 +119,7 @@
         /// <param name="dataStore">The data store.</param>
         public void Run(IDataStore dataStore)
         {
-            string sql = "SELECT * FROM Report";
+            string sql = "SELECT * FROM [Report]";
             DataTable predictedData = dataStore.Reader.GetDataUsingSql(sql);
             if (predictedData != null)
             {

--- a/Models/Storage/AddCheckpointCommand.cs
+++ b/Models/Storage/AddCheckpointCommand.cs
@@ -32,7 +32,7 @@
         /// <param name="cancelToken">Is cancellation pending?</param>
         public void Run(CancellationTokenSource cancelToken)
         {
-            var checkpointData = new DataView(writer.Connection.ExecuteQuery("SELECT * FROM _Checkpoints"));
+            var checkpointData = new DataView(writer.Connection.ExecuteQuery("SELECT * FROM [_Checkpoints]"));
             checkpointData.RowFilter = "Name='Current'";
             if (checkpointData.Count == 1)
             {
@@ -44,7 +44,7 @@
 
                 // If checkpoint already exists then delete old one.
                 int newCheckId;
-                checkpointData.RowFilter = string.Format("Name='{0}'", newCheckpointName);
+                checkpointData.RowFilter = string.Format("[Name]='{0}'", newCheckpointName);
                 if (checkpointData.Count == 1)
                 {
                     // Yes checkpoint already exists - delete old data.
@@ -54,7 +54,7 @@
                         List<string> columnNames = writer.Connection.GetColumnNames(tableName);
                         if (columnNames.Contains("CheckpointID"))
                         {
-                            var deleteSql = string.Format("DELETE FROM {0} WHERE CheckpointID={1}",
+                            var deleteSql = string.Format("DELETE FROM [{0}] WHERE [CheckpointID]={1}",
                                                     tableName, newCheckId);
                             writer.Connection.ExecuteNonQuery(deleteSql);
                         }
@@ -62,9 +62,9 @@
 
                     // Update row in checkpoints table.
                     var sql = string.Format("UPDATE [_Checkpoints] " +
-                                            "SET Version='{0}' " +
-                                            "SET Date='{1}') " +
-                                            "WHERE ID={2}",
+                                            "SET [Version]='{0}' " +
+                                            "SET [Date]='{1}') " +
+                                            "WHERE [ID]={2}",
                                             version, now, newCheckId);
                 }
                 else
@@ -91,10 +91,10 @@
                             csvFieldNames += "[" + columnName + "]";
                         }
 
-                        var sql = string.Format("INSERT INTO [{0}] (CheckpointID,{1})" +
+                        var sql = string.Format("INSERT INTO [{0}] ([CheckpointID],{1})" +
                                                 " SELECT {2},{1}" +
-                                                " FROM {0}" +
-                                                " WHERE CheckpointID = {3}",
+                                                " FROM [{0}]" +
+                                                " WHERE [CheckpointID] = {3}",
                                                 tableName, csvFieldNames, newCheckId, currentCheckId);
                         writer.Connection.ExecuteNonQuery(sql);
                     }

--- a/Models/Storage/DataStore.cs
+++ b/Models/Storage/DataStore.cs
@@ -222,5 +222,19 @@
                 connection = null;
             }
         }
+
+        /// <summary>
+        /// Get the list of column names within a table
+        /// </summary>
+        /// <param name="tableName">Name of the table</param>
+        /// <returns></returns>
+        public IEnumerable<string> ColumnNames(string tableName)
+        {
+            if (connection != null)
+                return connection.GetColumnNames(tableName);
+            else
+                return null;
+        }
+
     }
 }

--- a/Models/Storage/DataStore.cs
+++ b/Models/Storage/DataStore.cs
@@ -222,19 +222,5 @@
                 connection = null;
             }
         }
-
-        /// <summary>
-        /// Get the list of column names within a table
-        /// </summary>
-        /// <param name="tableName">Name of the table</param>
-        /// <returns></returns>
-        public IEnumerable<string> ColumnNames(string tableName)
-        {
-            if (connection != null)
-                return connection.GetColumnNames(tableName);
-            else
-                return null;
-        }
-
     }
 }

--- a/Models/Storage/DataStore.cs
+++ b/Models/Storage/DataStore.cs
@@ -192,8 +192,25 @@
 
             connection.OpenDatabase(FileName, readOnly: false);
 
-            dbReader.SetConnection(connection);
-            dbWriter.SetConnection(connection);
+            Exception caughtException = null;
+            try
+            {
+                dbReader.SetConnection(connection);
+            }
+            catch (Exception e)
+            {
+                caughtException = e;
+            }
+            try
+            {
+                dbWriter.SetConnection(connection);
+            }
+            catch (Exception e)
+            {
+                caughtException = e;
+            }
+            if (caughtException != null)
+                throw caughtException;
         }
 
         /// <summary>Close the database.</summary>

--- a/Models/Storage/DataStoreReader.cs
+++ b/Models/Storage/DataStoreReader.cs
@@ -177,7 +177,7 @@
                 fieldList = fieldNames.ToList();
 
             bool hasSimulationName = fieldList.Contains("SimulationID") || fieldList.Contains("SimulationName") || simulationName != null;
-            bool hasCheckpointName = fieldList.Contains("CheckpointID") || fieldList.Contains("CheckpointName") || checkpointName != null;
+            bool hasCheckpointName = fieldNamesInTable.Contains("CheckpointID") || fieldNamesInTable.Contains("CheckpointName") || checkpointName != null;
 
             sql.Append("SELECT ");
 

--- a/Models/Storage/DataStoreReader.cs
+++ b/Models/Storage/DataStoreReader.cs
@@ -104,6 +104,33 @@
             return Connection.GetStringColumnNames(tableName);
         }
 
+        /// <summary>
+        /// Gets a "brief" column name for a column
+        /// </summary>
+        /// <param name="tablename"></param>
+        /// <param name="fullColumnName">The "full" name of the column</param>
+        /// <returns>The "brief" name of the column</returns>
+        public string BriefColumnName(string tablename, string fullColumnName)
+        {
+            if (Connection is Firebird)
+                return (Connection as Firebird).GetShortColumnName(tablename, fullColumnName);
+            else
+                return fullColumnName;
+        }
+
+        /// <summary>
+        /// Gets the "full" column name for a column
+        /// </summary>
+        /// <param name="tablename"></param>
+        /// <param name="queryColumnName"></param>
+        /// <returns>The "full" name of the column</returns>
+        public string FullColumnName(string tablename, string queryColumnName)
+        {
+            if (Connection is Firebird)
+                return (Connection as Firebird).GetLongColumnName(tablename, queryColumnName);
+            else
+                return queryColumnName;
+        }
 
         /// <summary>Returns a list of table names</summary>
         public List<string> TableNames { get { return Connection.GetTableNames().FindAll(t => !t.StartsWith("_")); } }

--- a/Models/Storage/DataStoreWriter.cs
+++ b/Models/Storage/DataStoreWriter.cs
@@ -216,7 +216,15 @@
         /// <summary>Delete all data in datastore, except for checkpointed data.</summary>
         public void Empty()
         {
-            Start();
+            try
+            {
+                Start();
+            }
+            catch
+            {
+                // The call to Start may fail if the database is corrupt, which may well be why we want to empty it.
+                // For that reason, catch any exceptions and proceed.
+            }
             commands.Add(new EmptyCommand(Connection));
             Stop();
         }
@@ -340,10 +348,13 @@
         /// <param name="dbConnection">The database connection to read from.</param>
         private void ReadExistingDatabase(IDatabaseConnection dbConnection)
         {
+            if (dbConnection == null)
+                return;
+
             simulationIDs.Clear();
             if (dbConnection.TableExists("_Simulations"))
             {
-                var data = dbConnection.ExecuteQuery("SELECT * FROM _Simulations");
+                var data = dbConnection.ExecuteQuery("SELECT * FROM [_Simulations]");
                 foreach (DataRow row in data.Rows)
                     simulationIDs.Add(row["Name"].ToString(), Convert.ToInt32(row["ID"]));
             }
@@ -351,7 +362,7 @@
             checkpointIDs.Clear();
             if (dbConnection.TableExists("_Checkpoints"))
             {
-                var data = dbConnection.ExecuteQuery("SELECT * FROM _Checkpoints");
+                var data = dbConnection.ExecuteQuery("SELECT * FROM [_Checkpoints]");
                 foreach (DataRow row in data.Rows)
                     checkpointIDs.Add(row["Name"].ToString(), Convert.ToInt32(row["ID"]));
             }

--- a/Models/Storage/DatabaseTableDetails.cs
+++ b/Models/Storage/DatabaseTableDetails.cs
@@ -54,7 +54,8 @@
             foreach (DataColumn column in table.Columns)
             { 
                 columnNamesInDb.Add(column.ColumnName);
-                colTypes.Add(connection.GetDBDataTypeName(column.DataType));
+                bool allowLongStrings = table.TableName.StartsWith("_");
+                colTypes.Add(connection.GetDBDataTypeName(column.DataType, allowLongStrings));
             }
 
             connection.CreateTable(Name, columnNamesInDb.ToList(), colTypes);
@@ -79,7 +80,8 @@
                     }
 
                     // Column is missing from database file - write it.
-                    connection.AddColumn(Name, column.ColumnName, connection.GetDBDataTypeName(column.DataType));
+                    bool allowLongStrings = table.TableName.StartsWith("_");
+                    connection.AddColumn(Name, column.ColumnName, connection.GetDBDataTypeName(column.DataType, allowLongStrings));
                     columnNamesInDb.Add(column.ColumnName);
                 }
             }

--- a/Models/Storage/DeleteRowsCommand.cs
+++ b/Models/Storage/DeleteRowsCommand.cs
@@ -33,43 +33,47 @@
         {
             if (database.TableExists(table))
             {
-                string sql;
+                string sql = string.Empty;
+                bool dropEntireTable = false;
 
-                bool tableWasDropped = false;
                 if (simIds == null)
                 {
                     if (checkId == 0)
-                    {
-                        sql = string.Format("DROP TABLE {0}", table);
-                        tableWasDropped = true;
-                    }
+                        dropEntireTable = true;
                     else
-                        sql = string.Format("DELETE FROM {0} WHERE CheckpointID={1}", table, checkId);
+                        sql = string.Format("DELETE FROM [{0}] WHERE [CheckpointID]={1}", table, checkId);
                 }
                 else
                 {
                     List<string> columns = database.GetTableColumns(table);
                     string ids = StringUtilities.BuildString(simIds, ",");
                     if (columns.Contains("SimulationID"))
-                        sql = string.Format("DELETE FROM {0} WHERE CheckpointID={1} AND SimulationID IN ({2})", table, checkId, ids);
+                        sql = string.Format("DELETE FROM [{0}] WHERE [CheckpointID]={1} AND [SimulationID] IN ({2})", table, checkId, ids);
                     else if (columns.Contains("SimulationName"))
                     {
-                        sql = string.Format("DELETE T FROM {0} T INNER JOIN _Simulations S ON SimulationName=SimulationName WHERE SimulationID IN ({1})", table, ids);
+                        sql = string.Format("DELETE T FROM [{0}] T INNER JOIN [_Simulations] S ON T.[SimulationName]=S.[SimulationName] WHERE [SimulationID] IN ({1})", table, ids);
                         if (checkId != 0)
-                            sql += string.Format(" AND CheckpointID={0}", checkId);
+                            sql += string.Format(" AND [CheckpointID]={0}", checkId);
                     }
                     else
-                        sql = string.Format("DROP TABLE {0}", table);
+                        dropEntireTable = true;
                 }
-                database.ExecuteNonQuery(sql);
 
-                // If there are no rows left in table then drop the table.
-                if (!tableWasDropped)
+                if (dropEntireTable)
+                    database.DropTable(table);
+                else
                 {
-                    var data = database.ExecuteQuery(string.Format("SELECT * FROM {0} LIMIT 1", table));
+                    database.ExecuteNonQuery(sql);
+
+                    // If there are no rows left in table then drop the table.
+                    System.Data.DataTable data;
+                    if (database is Firebird)
+                        data = database.ExecuteQuery(string.Format("SELECT FIRST 1 * FROM [{0}]", table));
+                    else
+                        data = database.ExecuteQuery(string.Format("SELECT * FROM [{0}] LIMIT 1", table));
                     if (data.Rows.Count == 0)
                     {
-                        database.ExecuteNonQuery(string.Format("DROP TABLE {0}", table));
+                        database.DropTable(table);
                     }
                 }
             }

--- a/Models/Storage/DeleteRowsCommand.cs
+++ b/Models/Storage/DeleteRowsCommand.cs
@@ -64,17 +64,9 @@
                 else
                 {
                     database.ExecuteNonQuery(sql);
-
                     // If there are no rows left in table then drop the table.
-                    System.Data.DataTable data;
-                    if (database is Firebird)
-                        data = database.ExecuteQuery(string.Format("SELECT FIRST 1 * FROM [{0}]", table));
-                    else
-                        data = database.ExecuteQuery(string.Format("SELECT * FROM [{0}] LIMIT 1", table));
-                    if (data.Rows.Count == 0)
-                    {
+                    if (database.TableIsEmpty(table))
                         database.DropTable(table);
-                    }
                 }
             }
         }

--- a/Models/Storage/EmptyCommand.cs
+++ b/Models/Storage/EmptyCommand.cs
@@ -59,12 +59,7 @@
             {
                 if (!tableName.StartsWith("_"))
                 {
-                    DataTable data = null;
-                    if (database is Firebird)
-                        data = database.ExecuteQuery(string.Format("SELECT FIRST 1 * FROM [{0}]", tableName));
-                    else
-                        data = database.ExecuteQuery(string.Format("SELECT * FROM [{0}] LIMIT 1", tableName));
-                    if (data.Rows.Count == 0)
+                    if (database.TableIsEmpty(tableName))
                         tableNamesToDelete.Add(tableName);
                     else
                         allTablesEmpty = false;

--- a/Models/Storage/EmptyCommand.cs
+++ b/Models/Storage/EmptyCommand.cs
@@ -22,9 +22,12 @@
         /// <param name="cancelToken">Is cancellation pending?</param>
         public void Run(CancellationTokenSource cancelToken)
         {
+            if (database == null)
+                return;
+
             if (database.TableExists("_Checkpoints"))
             {
-                var checkpointData = new DataView(database.ExecuteQuery("SELECT * FROM _Checkpoints"));
+                var checkpointData = new DataView(database.ExecuteQuery("SELECT * FROM [_Checkpoints]"));
                 checkpointData.RowFilter = "Name='Current'";
                 if (checkpointData.Count == 1)
                 {
@@ -34,7 +37,7 @@
                     foreach (string tableName in database.GetTableNames())
                     {
                         if (!tableName.StartsWith("_"))
-                            database.ExecuteNonQuery(string.Format("DELETE FROM {0} WHERE CheckpointID={1}", tableName, checkId));
+                            database.ExecuteNonQuery(string.Format("DELETE FROM [{0}] WHERE [CheckpointID]={1}", tableName, checkId));
                     }
                 }
             }
@@ -45,7 +48,7 @@
                 foreach (string tableName in database.GetTableNames())
                 {
                     if (!tableName.StartsWith("_"))
-                        database.ExecuteNonQuery(string.Format("DELETE FROM {0}", tableName));
+                        database.ExecuteNonQuery(string.Format("DELETE FROM [{0}]", tableName));
                 }
             }
 
@@ -56,7 +59,11 @@
             {
                 if (!tableName.StartsWith("_"))
                 {
-                    var data = database.ExecuteQuery(string.Format("SELECT * FROM {0} LIMIT 1", tableName));
+                    DataTable data = null;
+                    if (database is Firebird)
+                        data = database.ExecuteQuery(string.Format("SELECT FIRST 1 * FROM [{0}]", tableName));
+                    else
+                        data = database.ExecuteQuery(string.Format("SELECT * FROM [{0}] LIMIT 1", tableName));
                     if (data.Rows.Count == 0)
                         tableNamesToDelete.Add(tableName);
                     else
@@ -69,8 +76,7 @@
                 tableNamesToDelete = database.GetTableNames();
 
             foreach (string tableName in tableNamesToDelete)
-                database.ExecuteNonQuery(string.Format("DROP TABLE {0}", tableName));
-            database.ExecuteNonQuery("VACUUM");
+                database.DropTable(tableName);
         }
     }
 }

--- a/Models/Storage/IDataStore.cs
+++ b/Models/Storage/IDataStore.cs
@@ -2,7 +2,6 @@
 {
     using Models.Core;
     using System;
-    using System.Collections.Generic;
 
     /// <summary>An interface  for reading and writing to/from a database.</summary>
     public interface IDataStore : IDisposable
@@ -15,13 +14,6 @@
 
         /// <summary>Get a writer to perform write operations on the datastore.</summary>
         IStorageWriter Writer { get; }
-
-        /// <summary>
-        /// Get the list of column names within a table
-        /// </summary>
-        /// <param name="tableName">Name of the table</param>
-        /// <returns></returns>
-        IEnumerable<string> ColumnNames(string tableName);
 
         /// <summary>Opens the databse connection.</summary>
         void Open();

--- a/Models/Storage/IDataStore.cs
+++ b/Models/Storage/IDataStore.cs
@@ -2,6 +2,7 @@
 {
     using Models.Core;
     using System;
+    using System.Collections.Generic;
 
     /// <summary>An interface  for reading and writing to/from a database.</summary>
     public interface IDataStore : IDisposable
@@ -14,6 +15,13 @@
 
         /// <summary>Get a writer to perform write operations on the datastore.</summary>
         IStorageWriter Writer { get; }
+
+        /// <summary>
+        /// Get the list of column names within a table
+        /// </summary>
+        /// <param name="tableName">Name of the table</param>
+        /// <returns></returns>
+        IEnumerable<string> ColumnNames(string tableName);
 
         /// <summary>Opens the databse connection.</summary>
         void Open();

--- a/Models/Storage/IStorageReader.cs
+++ b/Models/Storage/IStorageReader.cs
@@ -52,10 +52,26 @@ namespace Models.Storage
         /// <returns>Can return an empty list but never null.</returns>
         List<string> ColumnNames(string tableName);
 
-        /// <summary>Return a list of column names of type string for a table. Never returns null.</summary>
+        /// <summary>Return a list of full column names of type string for a table. Never returns null.</summary>
         /// <param name="tableName">The table name to return column names for.</param>
         /// <returns>Can return an empty list but never null.</returns>
         List<string> StringColumnNames(string tableName);
+
+        /// <summary>
+        /// Gets a "brief" column name for a column
+        /// </summary>
+        /// <param name="tablename"></param>
+        /// <param name="fullColumnName">The "full" name of the column</param>
+        /// <returns>The "brief" name of the column</returns>
+        string BriefColumnName(string tablename, string fullColumnName);
+
+        /// <summary>
+        /// Gets the "full" column name for a column
+        /// </summary>
+        /// <param name="tablename"></param>
+        /// <param name="queryColumnName"></param>
+        /// <returns>The "full" name of the column</returns>
+        string FullColumnName(string tablename, string queryColumnName);
 
         /// <summary>
         /// Return a checkpoint ID for the specified checkpoint name.

--- a/Models/Storage/RevertCheckpointCommand.cs
+++ b/Models/Storage/RevertCheckpointCommand.cs
@@ -28,12 +28,12 @@
         /// <param name="cancelToken">Is cancellation pending?</param>
         public void Run(CancellationTokenSource cancelToken)
         {
-            int currentID = writer.Connection.ExecuteQueryReturnInt("SELECT ID FROM _Checkpoints WHERE Name='Current'");
+            int currentID = writer.Connection.ExecuteQueryReturnInt("SELECT ID FROM [_Checkpoints] WHERE [Name]='Current'");
             if (currentID != -1)
             {
                 if (writer.Connection.TableExists("_CheckpointFiles"))
                 {
-                    var filesData = writer.Connection.ExecuteQuery("SELECT * FROM _CheckpointFiles WHERE CheckpointID=" + checkpointIDToRevertTo);
+                    var filesData = writer.Connection.ExecuteQuery("SELECT * FROM [_CheckpointFiles] WHERE [CheckpointID]=" + checkpointIDToRevertTo);
                     // Revert all files.
                     foreach (DataRow row in filesData.Rows)
                         File.WriteAllBytes(row["FileName"] as string, row["Contents"] as byte[]);
@@ -60,10 +60,10 @@
                                                             "] WHERE CheckpointID = " + currentID);
 
                         // Copy checkpoint values to current values.
-                        writer.Connection.ExecuteNonQuery("INSERT INTO [" + tableName + "] (" + "CheckpointID," + csvFieldNames + ")" +
+                        writer.Connection.ExecuteNonQuery("INSERT INTO [" + tableName + "] (" + "[CheckpointID]," + csvFieldNames + ")" +
                                                             " SELECT " + currentID + "," + csvFieldNames +
                                                             " FROM [" + tableName +
-                                                            "] WHERE CheckpointID = " + checkpointIDToRevertTo);
+                                                            "] WHERE [CheckpointID] = " + checkpointIDToRevertTo);
                     }
                 }
             }

--- a/Models/Storage/WriteTableCommand.cs
+++ b/Models/Storage/WriteTableCommand.cs
@@ -40,7 +40,7 @@
                     tables.Add(dataToWrite.TableName, table);
                 }
 
-                var query = new InsertQuery(dataToWrite.TableName);
+                var query = new InsertQuery(dataToWrite);
 
                 // Make sure the table has the correct columns.
                 table.EnsureTableExistsAndHasRequiredColumns(dataToWrite);

--- a/Tests/UnitTests/Storage/DataStoreReaderTests.cs
+++ b/Tests/UnitTests/Storage/DataStoreReaderTests.cs
@@ -120,7 +120,7 @@
             CreateTable(database);
 
             DataStoreReader reader = new DataStoreReader(database);
-            var data = reader.GetDataUsingSql("SELECT Col1 FROM Report");
+            var data = reader.GetDataUsingSql("SELECT [Col1] FROM [Report]");
 
             Assert.AreEqual(Utilities.TableToString(data),
                                            "      Col1\r\n" +

--- a/Tests/UnitTests/Storage/DataStoreWriterTests.cs
+++ b/Tests/UnitTests/Storage/DataStoreWriterTests.cs
@@ -144,7 +144,7 @@
             writer.WriteTable(data2);
             writer.Stop();
 
-            Assert.AreEqual(Utilities.TableToStringUsingSQL(database, "SELECT * FROM Report ORDER BY Col"),
+            Assert.AreEqual(Utilities.TableToStringUsingSQL(database, "SELECT * FROM [Report] ORDER BY [Col]"),
                            "CheckpointID,SimulationID,Col\r\n" +
                            "           1,           1,  3\r\n");
         }

--- a/Tests/UnitTests/Storage/MockStorage.cs
+++ b/Tests/UnitTests/Storage/MockStorage.cs
@@ -71,11 +71,6 @@ namespace UnitTests.Storage
             return null;
         }
 
-        public IEnumerable<string> ColumnNames(string tableName)
-        {
-            return null;
-        }
-
         public void DeleteAllTables(bool cleanSlate = false)
         {
         }

--- a/Tests/UnitTests/TextStorageReader.cs
+++ b/Tests/UnitTests/TextStorageReader.cs
@@ -102,6 +102,29 @@ namespace UnitTests
             throw new System.NotImplementedException();
         }
 
+        /// <summary>
+        /// Gets a "brief" column name for a column
+        /// </summary>
+        /// <param name="tablename"></param>
+        /// <param name="fullColumnName">The "full" name of the column</param>
+        /// <returns>The "brief" name of the column</returns>
+        public string BriefColumnName(string tablename, string fullColumnName)
+        {
+            return fullColumnName;
+        }
+
+        /// <summary>
+        /// Gets the "full" column name for a column
+        /// </summary>
+        /// <param name="tablename"></param>
+        /// <param name="queryColumnName"></param>
+        /// <returns>The "full" name of the column</returns>
+        public string FullColumnName(string tablename, string queryColumnName)
+        {
+            return queryColumnName;
+        }
+
+
         public void Refresh()
         {
             throw new System.NotImplementedException();

--- a/Tests/UnitTests/Utilities.cs
+++ b/Tests/UnitTests/Utilities.cs
@@ -72,7 +72,7 @@ namespace UnitTests
                     sql += fieldName;
                 }
             }
-            sql += " FROM " + tableName;
+            sql += " FROM [" + tableName + "]";
             var orderByFieldNames = new List<string>();
             if (database.GetColumnNames(tableName).Contains("CheckpointID"))
                 orderByFieldNames.Add("[CheckpointID]");


### PR DESCRIPTION
Working on #2821.

This patch allows the use of Firebird databases for the datatore, although to do so requires the user to manually modify the .apsimx file. Firebird support should still be regarded as "test" only. There is no good reason to switch to it, as performance is a bit poorer than that of the existing SQLite implementation. However, I think it's still worth having it present, as it could easily be adjusted to allow the database to reside on a remote server rather than the local machine, and this might be useful for bulk Condor or Docker runs.