### PR TITLE
Crop converter tool should show in center of screen. 

### DIFF
--- a/ApsimNG/Views/FileConverterView.cs
+++ b/ApsimNG/Views/FileConverterView.cs
@@ -218,7 +218,7 @@
                 //string fileName = MasterView.AskUserForOpenFileName("*.xml|*.xml", Utility.Configuration.Settings.PreviousFolder, false);
                 IFileDialog dialog = new FileDialog();
                 dialog.Action = FileDialog.FileActionType.Open;
-                dialog.FileType = "XML Files (*.xml) | *.xml";
+                dialog.FileType = "XML Files (*.xml) | *.xml|JSON Files (*.json) | *.json";
                 dialog.Prompt = "Choose XML files.";
                 string[] files = dialog.GetFiles();
                 if (files != null && files.Any(f => !string.IsNullOrEmpty(f)))

--- a/ApsimNG/Views/FileConverterView.cs
+++ b/ApsimNG/Views/FileConverterView.cs
@@ -93,6 +93,7 @@
 
             mainWindow = new Window("File Converter");
             mainWindow.TransientFor = owner.MainWidget.Toplevel as Window;
+            mainWindow.WindowPosition = WindowPosition.Center;
             mainWindow.Add(controlsContainer);
             mainWindow.DeleteEvent += OnDelete;
             mainWindow.Destroyed += OnClose;


### PR DESCRIPTION
Resolves #3765 

I think this should fix the problem where the dialog doesn't show in the middle of the screen - it fixes it for me on Windows anyway. I've found in the past that the window position property can be a bit sketchy though, so let me know if the dialog still pops up in weird places.