### PR TITLE
Guard clause for sorghum code.

### DIFF
--- a/Models/Plant/Organs/Root.cs
+++ b/Models/Plant/Organs/Root.cs
@@ -1110,7 +1110,7 @@ namespace Models.PMF.Organs
             double[] supply = new double[PlantZone.soil.Thickness.Length];
 
             var currentLayer = Soil.LayerIndexOfDepth(Depth, PlantZone.soil.Thickness);
-            var layertop = MathUtilities.Sum(PlantZone.soil.Thickness, 0, currentLayer-1);
+            var layertop = MathUtilities.Sum(PlantZone.soil.Thickness, 0, Math.Max(0, currentLayer - 1));
             var layerBottom = MathUtilities.Sum(PlantZone.soil.Thickness, 0, currentLayer);
             var layerProportion = Math.Min(MathUtilities.Divide(Depth - layertop, layerBottom - layertop, 0.0), 1.0);
 


### PR DESCRIPTION
Working on #572

@jbrider can you have a look at this? This fixes a bug I ran into - to reproduce, just set sowing depth to 15 in any of the sorghum leaf simulations. This fixes the problem, but I have no idea if this is the best way to fix it or not.

Also seems odd that this code is only used by sorghum since it's in Root.cs.