### PR TITLE
Replacements should be a scoped model.

### DIFF
--- a/Models/Core/Replacements.cs
+++ b/Models/Core/Replacements.cs
@@ -12,6 +12,7 @@ namespace Models.Core
     /// </summary>
     [ValidParent(ParentType=typeof(Simulations))]
     [Serializable]
+    [ScopedModel]
     public class Replacements : Model
     {
 


### PR DESCRIPTION
Resolves #3802 

This will prevent calls to `Apsim.FindAll(...)` from finding models under the replacements node.