### PR TITLE
Don't give Linux users the ability to switch themes.

### DIFF
--- a/ApsimNG/Presenters/MainPresenter.cs
+++ b/ApsimNG/Presenters/MainPresenter.cs
@@ -532,11 +532,13 @@
                                 "View Cloud Jobs",
                                         new Gtk.Image(null, "ApsimNG.Resources.Cloud.png"),
                                         this.OnViewCloudJobs);
-            startPage.AddButton(
+            if (!ProcessUtilities.CurrentOS.IsLinux)
+            {
+                startPage.AddButton(
                                 "Toggle Theme",
-                                        new Gtk.Image(null, Configuration.Settings.DarkTheme ? "ApsimNG.Resources.MenuImages.Sun.png" : "ApsimNG.Resources.MenuImages.Moon.png"),
-                                        OnToggleTheme);
-
+                                new Gtk.Image(null, Configuration.Settings.DarkTheme ? "ApsimNG.Resources.MenuImages.Sun.png" : "ApsimNG.Resources.MenuImages.Moon.png"),
+                                OnToggleTheme);
+            }
             startPage.AddButton(
                                 "Help",
                                         new Gtk.Image(null, "ApsimNG.Resources.MenuImages.Help.png"),

--- a/ApsimNG/Views/MainView.cs
+++ b/ApsimNG/Views/MainView.cs
@@ -196,7 +196,9 @@
                 InitMac();
                 //Utility.Configuration.Settings.DarkTheme = Utility.MacUtilities.DarkThemeEnabled();
             }
-            RefreshTheme();
+
+            if (!ProcessUtilities.CurrentOS.IsLinux)
+                RefreshTheme();
         }
 
         /// <summary>


### PR DESCRIPTION
Working on #3748 

Apsim on Linux should now give no option to change themes, but will respect the system-wide gtk theme. I've tested this with a few of the different stock themes shipped with gnome and it seems to work ok.