### PR TITLE
Added area series

### DIFF
--- a/ApsimNG/Interfaces/IGraphView.cs
+++ b/ApsimNG/Interfaces/IGraphView.cs
@@ -135,7 +135,7 @@ namespace UserInterface.Interfaces
         /// <param name="yAxisType">The axis type the y values are related to</param>
         /// <param name="colour">The series color</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1305:FieldNamesMustNotUseHungarianNotation", Justification = "Reviewed.")]
-        void DrawArea(
+        void DrawRegion(
             string title,
             IEnumerable x1,
             IEnumerable y1,
@@ -145,6 +145,26 @@ namespace UserInterface.Interfaces
             Models.Graph.Axis.AxisType yAxisType,
             Color colour,
             bool showInLegend);
+
+        /// <summary>
+        /// Draw an  area series with the specified arguments. Similar to a
+        /// line series, but the area under the curve will be filled with colour.
+        /// </summary>
+        /// <param name="title">The series title</param>
+        /// <param name="x">The x values for the series</param>
+        /// <param name="y">The y values for the series</param>
+        /// <param name="xAxisType">The axis type the x values are related to</param>
+        /// <param name="yAxisType">The axis type the y values are related to</param>
+        /// <param name="colour">The series color</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1305:FieldNamesMustNotUseHungarianNotation", Justification = "Reviewed.")]
+        void DrawArea(
+            string title,
+            double[] x,
+            double[] y,
+            Axis.AxisType xAxisType,
+            Axis.AxisType yAxisType,
+            Color colour,
+            bool showOnLegend);
 
         /// <summary>
         /// Draw text on the graph at the specified coordinates.

--- a/ApsimNG/Presenters/GraphPresenter.cs
+++ b/ApsimNG/Presenters/GraphPresenter.cs
@@ -219,9 +219,9 @@ namespace UserInterface.Presenters
                                                     definition.MarkerSize,
                                                     definition.ShowInLegend);
                     }
-                    else if (definition.Type == SeriesType.Area)
+                    else if (definition.Type == SeriesType.Region)
                     {
-                        graphView.DrawArea(
+                        graphView.DrawRegion(
                                             definition.Title,
                                             definition.X,
                                             definition.Y,
@@ -231,6 +231,17 @@ namespace UserInterface.Presenters
                                             definition.YAxis,
                                             colour,
                                             definition.ShowInLegend);
+                    }
+                    else if (definition.Type == SeriesType.Area)
+                    {
+                        graphView.DrawArea(
+                            definition.Title,
+                            definition.X.Cast<double>().ToArray(),
+                            definition.Y.Cast<double>().ToArray(),
+                            definition.XAxis,
+                            definition.YAxis,
+                            colour,
+                            definition.ShowInLegend);
                     }
                 }
                 catch (Exception err)

--- a/ApsimNG/Presenters/SeriesPresenter.cs
+++ b/ApsimNG/Presenters/SeriesPresenter.cs
@@ -549,7 +549,7 @@ namespace UserInterface.Presenters
             // Populate filter textbox.
             this.seriesView.Filter.Value = series.Filter;
 
-            this.seriesView.ShowX2Y2(series.Type == SeriesType.Area);
+            this.seriesView.ShowX2Y2(series.Type == SeriesType.Region);
 
             explorerPresenter.MainPresenter.ClearStatusPanel();
             if (warnings != null && warnings.Count > 0)

--- a/ApsimNG/Views/GraphView.cs
+++ b/ApsimNG/Views/GraphView.cs
@@ -458,7 +458,8 @@ namespace UserInterface.Views
             series.Fill = OxyColor.FromArgb(colour.A, colour.R, colour.G, colour.B);
             List<DataPoint> points = this.PopulateDataPointSeries(x1, y1, xAxisType, yAxisType);
             List<DataPoint> points2 = this.PopulateDataPointSeries(x2, y2, xAxisType, yAxisType);
-
+            if (showOnLegend)
+                series.Title = title;
             if (points != null && points2 != null)
             {
                 foreach (DataPoint point in points)

--- a/ApsimNG/Views/GraphView.cs
+++ b/ApsimNG/Views/GraphView.cs
@@ -21,6 +21,7 @@ namespace UserInterface.Views
     using OxyPlot.GtkSharp;
     using EventArguments;
     using APSIM.Shared.Utilities;
+    using System.Linq;
 
     /// <summary>
     /// A view that contains a graph and click zones for the user to allow
@@ -441,7 +442,7 @@ namespace UserInterface.Views
         /// <param name="yAxisType">The axis type the y values are related to</param>
         /// <param name="colour">The series color</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1305:FieldNamesMustNotUseHungarianNotation", Justification = "Reviewed.")]
-        public void DrawArea(
+        public void DrawRegion(
             string title,
             IEnumerable x1,
             IEnumerable y1,
@@ -473,6 +474,33 @@ namespace UserInterface.Views
             series.CanTrackerInterpolatePoints = false;
 
             this.plot1.Model.Series.Add(series);
+        }
+
+        /// <summary>
+        /// Draw an  area series with the specified arguments. Similar to a
+        /// line series, but the area under the curve will be filled with colour.
+        /// </summary>
+        /// <param name="title">The series title</param>
+        /// <param name="x">The x values for the series</param>
+        /// <param name="y">The y values for the series</param>
+        /// <param name="xAxisType">The axis type the x values are related to</param>
+        /// <param name="yAxisType">The axis type the y values are related to</param>
+        /// <param name="colour">The series color</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1305:FieldNamesMustNotUseHungarianNotation", Justification = "Reviewed.")]
+        public void DrawArea(
+            string title,
+            double[] x,
+            double[] y,
+            Models.Graph.Axis.AxisType xAxisType,
+            Models.Graph.Axis.AxisType yAxisType,
+            Color colour,
+            bool showOnLegend)
+        {
+            // Just use a region series (colours area between two curves), and use y = 0 for the second curve.
+            List<double> y2 = new List<double>();
+            y2.AddRange(Enumerable.Repeat(0d, y.Length));
+
+            DrawRegion(title, x, y, x, y2, xAxisType, yAxisType, colour, showOnLegend);
         }
 
         /// <summary>

--- a/Models/Graph/IGraphable.cs
+++ b/Models/Graph/IGraphable.cs
@@ -36,8 +36,15 @@
         /// <summary>A scatter series</summary>
         Scatter,
 
-        /// <summary>An area series</summary>
-        Area 
+        /// <summary>
+        /// A region series - two series with the area between them filled with colour.
+        /// </summary>
+        Region,
+
+        /// <summary>
+        /// An area series - a line series with the area between the line and the x-axis filled with colour.
+        /// </summary>
+        Area
     }
 
     /// <summary>An enumeration for the different types of markers</summary>


### PR DESCRIPTION
Working on #3843 

This implements an area series (colouring area under a curve) however it may be of limited usefulness because the colours we use in the colour palette are not transparent, so if you have a graph with multiple series, each series draws over the top of the previous series. 

e.g. in this screenshot, the 'eighth' series does not show because it is above all of the other series and so it gets drawn first and all other series draw over the top of it. If I move the 'eighth' below all of the other series in the tree, it shows up.

![image](https://user-images.githubusercontent.com/36427516/58392477-7db82c00-807d-11e9-9ecf-6a5911d2d078.png)
