### PR TITLE
Temp fix daylength

### DIFF
--- a/Models/MicroClimate/MicroClimate.cs
+++ b/Models/MicroClimate/MicroClimate.cs
@@ -301,7 +301,7 @@ namespace Models
         {
             dayLengthLight = MathUtilities.DayLength(Clock.Today.DayOfYear, SunSetAngle, weather.Latitude);
             dayLengthEvap = MathUtilities.DayLength(Clock.Today.DayOfYear, SunAngleNetPositiveRadiation, weather.Latitude);
-            // VOS - a temporary kludge to get this running for high latitudes. MicroMet is due for a clean up so reconsider then.
+            // VOS - a temporary kludge to get this running for high latitudes. MicroMet is due for a clean up soon so reconsider then.
             dayLengthEvap = Math.Max(dayLengthEvap, (dayLengthLight * 2.0 / 3.0)); 
 
             if (zoneMicroClimates.Count == 2 && zoneMicroClimates[0].zone is Zones.RectangularZone && zoneMicroClimates[1].zone is Zones.RectangularZone)

--- a/Models/MicroClimate/MicroClimate.cs
+++ b/Models/MicroClimate/MicroClimate.cs
@@ -299,8 +299,10 @@ namespace Models
         [EventSubscribe("DoEnergyArbitration")]
         private void DoEnergyArbitration(object sender, EventArgs e)
         {
-            dayLengthEvap = MathUtilities.DayLength(Clock.Today.DayOfYear, SunAngleNetPositiveRadiation, weather.Latitude);
             dayLengthLight = MathUtilities.DayLength(Clock.Today.DayOfYear, SunSetAngle, weather.Latitude);
+            dayLengthEvap = MathUtilities.DayLength(Clock.Today.DayOfYear, SunAngleNetPositiveRadiation, weather.Latitude);
+            // VOS - a temporary kludge to get this running for high latitudes. MicroMet is due for a clean up so reconsider then.
+            dayLengthEvap = Math.Max(dayLengthEvap, (dayLengthLight * 2.0 / 3.0)); 
 
             if (zoneMicroClimates.Count == 2 && zoneMicroClimates[0].zone is Zones.RectangularZone && zoneMicroClimates[1].zone is Zones.RectangularZone)
             {


### PR DESCRIPTION
Resolves #3920 by making dayLengthEvap the maximum of the 15 degree value and 2.3 of dayLengthLight. Should fix the issue with the Danish simulations. Reconsider this work around when MicroClimate is next cleaned up (and it is probably overdue).