### PR TITLE
Make Factor and CompositFactor valid parents for Manager and Opperations

### DIFF
--- a/Models/Manager.cs
+++ b/Models/Manager.cs
@@ -25,6 +25,8 @@
     [ValidParent(ParentType = typeof(Zones.RectangularZone))]
     [ValidParent(ParentType = typeof(Zones.CircularZone))]
     [ValidParent(ParentType = typeof(Agroforestry.AgroforestrySystem))]
+    [ValidParent(ParentType = typeof(Factorial.CompositeFactor))]
+    [ValidParent(ParentType = typeof(Factorial.Factor))]
     public class Manager : Model, IOptionallySerialiseChildren
     {
         private static bool haveTrappedAssemblyResolveEvent = false;

--- a/Models/Operations.cs
+++ b/Models/Operations.cs
@@ -56,6 +56,8 @@ namespace Models
     [PresenterName("UserInterface.Presenters.OperationsPresenter")]
     [ValidParent(ParentType = typeof(Zone))]
     [ValidParent(ParentType = typeof(Simulation))]
+    [ValidParent(ParentType = typeof(Factorial.CompositeFactor))]
+    [ValidParent(ParentType = typeof(Factorial.Factor))]
     public class Operations : Model
     {
         /// <summary>The clock</summary>


### PR DESCRIPTION
Resolves #3947 

Not sure this is the best way to resolve this problem.  It resolves the specific issue and > 90% of experiment set ups are overwriting a manager or operations model so this should facilitate setting up of experiments from the GUI in most cases.  However there are cases where a soil, or clock or water or weather or something else is overwritten in experiment structures.  Should we put valid parent tags in all the models that are occasionally dropped on factors as well?  or can we change factor and composite factor so they will accept all drops? 