### PR TITLE
Context menu should be disposed of when closing a tab.

### DIFF
--- a/ApsimNG/Presenters/ExplorerPresenter.cs
+++ b/ApsimNG/Presenters/ExplorerPresenter.cs
@@ -151,6 +151,7 @@
             this.view.Tree.AllowDrop -= this.OnAllowDrop;
             this.view.Tree.Droped -= this.OnDrop;
             this.view.Tree.Renamed -= this.OnRename;
+            this.view.Tree.ContextMenu.Destroy();
             this.HideRightHandPanel();
             if (this.view is Views.ExplorerView)
             {

--- a/ApsimNG/Presenters/MainPresenter.cs
+++ b/ApsimNG/Presenters/MainPresenter.cs
@@ -891,7 +891,10 @@
             {
                 IPresenter presenter = Presenters1[e.Index - 1];
                 e.AllowClose = true;
-                if (presenter.GetType() == typeof(ExplorerPresenter)) e.AllowClose = ((ExplorerPresenter)presenter).SaveIfChanged();
+
+                if (presenter is ExplorerPresenter)
+                    e.AllowClose = ((ExplorerPresenter)presenter).SaveIfChanged();
+
                 if (e.AllowClose)
                 {
                     presenter.Detach();

--- a/ApsimNG/Views/ExplorerView.cs
+++ b/ApsimNG/Views/ExplorerView.cs
@@ -25,7 +25,6 @@ namespace UserInterface.Views
     public class ExplorerView : ViewBase, IExplorerView
     {
         private Viewport rightHandView;
-        private MenuView popup;
         private Gtk.TreeView treeviewWidget;
 
         /// <summary>Default constructor for ExplorerView</summary>
@@ -38,7 +37,6 @@ namespace UserInterface.Views
             treeviewWidget = (Gtk.TreeView)builder.GetObject("treeview1");
             treeviewWidget.Realized += OnLoaded;
             Tree = new TreeView(owner, treeviewWidget);
-            popup = new MenuView();
             rightHandView = (Viewport)builder.GetObject("RightHandView");
             rightHandView.ShadowType = ShadowType.EtchedOut;
             mainWidget.Destroyed += OnDestroyed;
@@ -119,7 +117,6 @@ namespace UserInterface.Views
                 }
             }
             ToolStrip.Destroy();
-            popup.Destroy();
             mainWidget.Destroyed -= OnDestroyed;
             owner = null;
         }


### PR DESCRIPTION
Previously, some event handlers for the context menu were not being detached, which was keeping alive a reference to the context menu, which contains a link to the data store. This caused the data store to not be garbage collected when closing a tab.

Working on #3989