### PR TITLE
Improvements to soil water profile view

### DIFF
--- a/ApsimNG/Classes/Grid/GridColumn.cs
+++ b/ApsimNG/Classes/Grid/GridColumn.cs
@@ -153,7 +153,12 @@ namespace UserInterface.Classes
 
             set
             {
-                this.gridView.SetColBackgroundColor(this.ColumnIndex, new Gdk.Color(value.R, value.G, value.B));
+                Gdk.Color colour;
+                if (value == Color.Empty)
+                    colour = gridView.MainWidget.Style.Base(StateType.Normal);
+                else
+                    colour = new Gdk.Color(value.R, value.G, value.B);
+                this.gridView.SetColBackgroundColor(ColumnIndex, colour);
             }
         }
 
@@ -170,7 +175,12 @@ namespace UserInterface.Classes
 
             set
             {
-                this.gridView.SetColForegroundColor(this.ColumnIndex, new Gdk.Color(value.R, value.G, value.B));
+                Gdk.Color colour;
+                if (value == Color.Empty)
+                    colour = gridView.MainWidget.Style.Foreground(StateType.Normal);
+                else
+                    colour = new Gdk.Color(value.R, value.G, value.B);
+                this.gridView.SetColForegroundColor(ColumnIndex, colour);
             }
         }
 

--- a/ApsimNG/Presenters/ProfilePresenter.cs
+++ b/ApsimNG/Presenters/ProfilePresenter.cs
@@ -137,6 +137,9 @@
                     {
                         string columnName = propertiesInGrid[col].ColumnName;
 
+                        if (columnName.Contains("\r\n"))
+                            StringUtilities.SplitOffAfterDelimiter(ref columnName, "\r\n");
+
                         // crop colours
                         if (columnName.Contains("LL"))
                         {
@@ -150,6 +153,7 @@
                             cropLLSeries.XAxis = Axis.AxisType.Top;
                             cropLLSeries.YAxis = Axis.AxisType.Left;
                             cropLLSeries.YFieldName = (parentForGraph is Soil ? Apsim.FullPath(parentForGraph) : "[Soil]") + ".DepthMidPoints";
+                            cropLLSeries.XFieldName = Apsim.FullPath((propertiesInGrid[col].ObjectWithProperty as Model)) + "." + propertiesInGrid[col].PropertyName;
                             //cropLLSeries.XFieldName = Apsim.FullPath(property.Object as Model) + "." + property.Name;
                             cropLLSeries.Parent = this.graph;
 

--- a/ApsimNG/Views/FormattedGridView.cs
+++ b/ApsimNG/Views/FormattedGridView.cs
@@ -189,15 +189,25 @@
             {
                 if (!Convert.IsDBNull(changedCell.Value))
                 {
-                    var column = columnMetadata[changedCell.ColumnIndex];
-                    var array = column.Values as Array;
+                    GridColumnMetaData column = columnMetadata[changedCell.ColumnIndex];
+                    Array array = column.Values as Array;
+                    int numValues = e.ChangedCells.Max(cell => cell.RowIndex);
                     if (array == null)
                     {
-                        var numValues = e.ChangedCells.Max(cell => cell.RowIndex);
                         array = Array.CreateInstance(column.ColumnDataType, numValues + 1);
-                        column.Values = array;
+                    }
+
+                    // If we've added a new row, the column metadata will not contain an entry
+                    // for this row (the array will be too short).
+                    if (array.Length <= changedCell.RowIndex)
+                    {
+                        Array newArray = Array.CreateInstance(column.ColumnDataType, numValues + 1);
+                        array.CopyTo(newArray, 0);
+                        array = newArray;
                     }
                     array.SetValue(Convert.ChangeType(changedCell.Value, column.ColumnDataType), changedCell.RowIndex);
+
+                    column.Values = array;
                     column.ValuesHaveChanged = true;
                     if (column.AddTotalToColumnName)
                         refreshGrid = true;

--- a/ApsimNG/Views/FormattedGridView.cs
+++ b/ApsimNG/Views/FormattedGridView.cs
@@ -19,8 +19,8 @@
         public string Format { get; set; }
         public IEnumerable Values { get; set; }
         public bool ValuesHaveChanged { get; set; }
-        public Color BackgroundColour { get; set; } = Color.Black;
-        public Color ForegroundColour { get; set; } = Color.White;
+        public Color BackgroundColour { get; set; } = Color.Empty;
+        public Color ForegroundColour { get; set; } = Color.Empty;
         public bool IsReadOnly { get; set; }
         public string[] CellToolTips { get; set; }
         public string[] HeaderContextMenuItems { get; set; }

--- a/ApsimNG/Views/GridView.cs
+++ b/ApsimNG/Views/GridView.cs
@@ -399,9 +399,19 @@
             int colNo = -1;
             string text = string.Empty;
             CellRendererText textRenderer = cell as CellRendererText;
+
             if (colLookup.TryGetValue(cell, out colNo) && rowNo < DataSource.Rows.Count && colNo < DataSource.Columns.Count)
             {
                 StateType cellState = CellIsSelected(rowNo, colNo) ? StateType.Selected : StateType.Normal;
+
+                if (!colAttributes.TryGetValue(colNo, out ColRenderAttributes attributes))
+                {
+                    attributes = new ColRenderAttributes();
+                    attributes.BackgroundColor = MainWidget.Style.Base(cellState);
+                    attributes.ForegroundColor = Grid.Style.Foreground(cellState);
+                    colAttributes.Add(colNo, attributes);
+                }
+
                 if (IsSeparator(rowNo))
                 {
                     textRenderer.ForegroundGdk = view.Style.Foreground(StateType.Normal);
@@ -411,8 +421,8 @@
                 }
                 else
                 {
-                    cell.CellBackgroundGdk = MainWidget.Style.Base(cellState);
-                    textRenderer.ForegroundGdk = Grid.Style.Foreground(cellState);
+                    cell.CellBackgroundGdk = attributes.BackgroundColor; ;
+                    textRenderer.ForegroundGdk = attributes.ForegroundColor;
                     textRenderer.Editable = true;
                 }
 
@@ -1473,10 +1483,13 @@
             for (int i = 0; i < numCols; i++)
             {
                 ColRenderAttributes attrib = new ColRenderAttributes();
-                attrib.ForegroundColor = Grid.Style.Foreground(StateType.Normal);
-                attrib.BackgroundColor = Grid.Style.Base(StateType.Normal);
-                colAttributes.Add(i, attrib);
-
+                if (!colAttributes.TryGetValue(i, out _))
+                {
+                    // Only fallback to defaults if no custom colour specified.
+                    attrib.ForegroundColor = Grid.Style.Foreground(StateType.Normal);
+                    attrib.BackgroundColor = Grid.Style.Base(StateType.Normal);
+                    colAttributes.Add(i, attrib);
+                }
                 // Design plan: include renderers for text, toggles and combos, but hide all but one of them
                 CellRendererText textRender = new CellRendererText();
                 CellRendererToggle toggleRender = new CellRendererToggle();


### PR DESCRIPTION
Resolves #4098 

There's one problem I didn't fix - if you change a cell in the profile grid, then immediately hit undo, the change will not be undone. This is because we don't actually change the model until we call the presenter's `Detach()` method when the user clicks on another node. I've touched this stuff on another branch so am hesitant to fix it here.