### PR TITLE
Add error handling to divide

### DIFF
--- a/Models/AgPasture/AgPasture.PastureSpecies.Organs.cs
+++ b/Models/AgPasture/AgPasture.PastureSpecies.Organs.cs
@@ -1638,7 +1638,7 @@ namespace Models.AgPasture
                 for (int layer = 0; layer < nLayers; layer++)
                 {
                     DMLayer[layer] += DMLayersTransferedIn[layer];
-                    NamountLayer[layer] += NLayersTransferedIn[layer] - (NRemobilised * (NLayersTransferedIn[layer] / NTransferedIn));
+                    NamountLayer[layer] += NLayersTransferedIn[layer] - (NRemobilised * MathUtilities.Divide(NLayersTransferedIn[layer], NTransferedIn, 0));
                 }
             }
         }


### PR DESCRIPTION
resolves #4117 
@sno036 @rcichota I encountered a fatal error in Agpasture while trying to get canopy rainfall interception code working properly.  I traced it back to this unprotected divide