### PR TITLE
Allow summary nodes to show summary for all simulations in scope

### DIFF
--- a/Models/Core/Scope.cs
+++ b/Models/Core/Scope.cs
@@ -70,7 +70,7 @@
         /// Returns null if non found.
         /// </summary>
         /// <param name="relativeTo">The model to use as a base.</param>
-        private static IModel FindScopedParentModel(IModel relativeTo)
+        public static IModel FindScopedParentModel(IModel relativeTo)
         {
             do
             {


### PR DESCRIPTION
If the summary is placed under a simulation or experiment it will still only show data for that node.

Resolves #1574