### PR TITLE
Ensure the grid resets when combobox editing has been cancelled.

### DIFF
--- a/ApsimNG/Views/GridView.cs
+++ b/ApsimNG/Views/GridView.cs
@@ -1940,6 +1940,7 @@
         {
             try
             {
+                (sender as CellRenderer).EditingCanceled += (src, _) => { EndEdit(); };
                 (e.Editable as ComboBox).Changed += (o, _) =>
                 {
                     IGridCell currentCell = GetCurrentCell;


### PR DESCRIPTION
Resolves #3959