### PR TITLE
Prototype box and whisker plot feature

### DIFF
--- a/ApsimNG/Interfaces/IGraphView.cs
+++ b/ApsimNG/Interfaces/IGraphView.cs
@@ -198,6 +198,29 @@ namespace UserInterface.Interfaces
             bool showOnLegend);
 
         /// <summary>
+        /// Draw a box-and-whisker plot.
+        /// colour.
+        /// </summary>
+        /// <param name="title">The series title</param>
+        /// <param name="x">The x values for the series</param>
+        /// <param name="y">The y values for the series</param>
+        /// <param name="xAxisType">The axis type the x values are related to</param>
+        /// <param name="yAxisType">The axis type the y values are related to</param>
+        /// <param name="colour">The series color</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1305:FieldNamesMustNotUseHungarianNotation", Justification = "Reviewed.")]
+        void DrawBoxPLot(
+            string title,
+            object[] x,
+            double[] y,
+            Axis.AxisType xAxisType,
+            Axis.AxisType yAxisType,
+            Color colour,
+            bool showOnLegend,
+            LineType lineType,
+            MarkerType markerType,
+            LineThicknessType lineThickness);
+
+        /// <summary>
         /// Draw text on the graph at the specified coordinates.
         /// </summary>
         /// <param name="text">The text to put on the graph</param>

--- a/ApsimNG/Presenters/GraphPresenter.cs
+++ b/ApsimNG/Presenters/GraphPresenter.cs
@@ -298,6 +298,19 @@ namespace UserInterface.Presenters
                             colour,
                             definition.ShowInLegend);
                     }
+                    else if (definition.Type == SeriesType.Box)
+                    {
+                        graphView.DrawBoxPLot(definition.Title,
+                            definition.X.Cast<object>().ToArray(),
+                            definition.Y.Cast<double>().ToArray(),
+                            definition.XAxis,
+                            definition.YAxis,
+                            definition.Colour,
+                            definition.ShowInLegend,
+                            definition.Line,
+                            definition.Marker,
+                            definition.LineThickness);
+                    }
                 }
                 catch (Exception err)
                 {

--- a/ApsimNG/Presenters/SeriesPresenter.cs
+++ b/ApsimNG/Presenters/SeriesPresenter.cs
@@ -576,6 +576,8 @@ namespace UserInterface.Presenters
             this.seriesView.X.IsEditable = !isBoxPlot;
             seriesView.MarkerSize.IsEditable = !isBoxPlot;
             seriesView.MarkerType.IsEditable = !isBoxPlot;
+            seriesView.XCumulative.IsSensitive = !isBoxPlot;
+            seriesView.XOnTop.IsSensitive = !isBoxPlot;
         }
 
         /// <summary>Populate the line drop down.</summary>

--- a/ApsimNG/Presenters/SeriesPresenter.cs
+++ b/ApsimNG/Presenters/SeriesPresenter.cs
@@ -208,10 +208,15 @@ namespace UserInterface.Presenters
         {
             SeriesType seriesType = (SeriesType)Enum.Parse(typeof(SeriesType), this.seriesView.SeriesType.SelectedValue);
             this.SetModelProperty("Type", seriesType);
-            
+
             // This doesn't quite work yet. If the previous series was a scatter plot, there is no x2, y2 to work with
             // and things go a bit awry.
             // this.seriesView.ShowX2Y2(series.Type == SeriesType.Area);
+
+            // If the series is a box plot, then we want to disable certain unused controls
+            // such as x variable, marker type, etc. These also need to be
+            // re-enabled if we change series type.
+            DisableUnusedControls();
         }
 
         /// <summary>Series line type has been changed by the user.</summary>
@@ -556,9 +561,21 @@ namespace UserInterface.Presenters
 
             this.seriesView.ShowX2Y2(series.Type == SeriesType.Region);
 
+            DisableUnusedControls();
+
             explorerPresenter.MainPresenter.ClearStatusPanel();
             if (warnings != null && warnings.Count > 0)
                 explorerPresenter.MainPresenter.ShowMessage(warnings, Simulation.MessageType.Warning);
+        }
+
+        private void DisableUnusedControls()
+        {
+            // Box plots ignore x variable, markertype, marker size,
+            // so don't make these controls editable if the series is a box plot.
+            bool isBoxPlot = series.Type == SeriesType.Box;
+            this.seriesView.X.IsEditable = !isBoxPlot;
+            seriesView.MarkerSize.IsEditable = !isBoxPlot;
+            seriesView.MarkerType.IsEditable = !isBoxPlot;
         }
 
         /// <summary>Populate the line drop down.</summary>

--- a/ApsimNG/Views/CheckBoxView.cs
+++ b/ApsimNG/Views/CheckBoxView.cs
@@ -11,6 +11,9 @@ namespace UserInterface.Views
 
         /// <summary>Gets or sets whether the checkbox is checked.</summary>
         bool IsChecked { get; set; }
+
+        /// <summary>Gets or sets whether the checkbox can be changed by the user.</summary>
+        bool IsSensitive { get; set; }
     }
 
 
@@ -48,6 +51,19 @@ namespace UserInterface.Views
             set
             {
                 checkbutton1.Active = value;
+            }
+        }
+
+        /// <summary>Gets or sets whether the checkbox can be changed by the user.</summary>
+        public bool IsSensitive
+        {
+            get
+            {
+                return checkbutton1.Sensitive;
+            }
+            set
+            {
+                checkbutton1.Sensitive = value;
             }
         }
 

--- a/ApsimNG/Views/DropDownView.cs
+++ b/ApsimNG/Views/DropDownView.cs
@@ -204,6 +204,8 @@ namespace UserInterface.Views
             set
             {
                 comboRender.Editable = value;
+                comboRender.Sensitive = value;
+                combobox1.Sensitive = value;
             }
         }
 

--- a/ApsimNG/Views/GraphView.cs
+++ b/ApsimNG/Views/GraphView.cs
@@ -693,13 +693,32 @@ namespace UserInterface.Views
 
             // Line thickness
             if (lineThickness == LineThicknessType.Thin)
-                series.StrokeThickness = 0.5;
+            {
+                double thickness = 0.5;
+                series.StrokeThickness = thickness;
+                series.MeanThickness = thickness;
+                series.MedianThickness = thickness;
+            }
 
             OxyColor oxyColour = Utility.Colour.ToOxy(colour);
             series.Fill = oxyColour;
             series.Stroke = oxyColour;
 
+            EnsureAxisExists(xAxisType, typeof(double));
+            EnsureAxisExists(yAxisType, typeof(double));
+
+            series.XAxisKey = xAxisType.ToString();
+            series.YAxisKey = yAxisType.ToString();
+
+            double width = 0.5;
+            series.BoxWidth = width;
+            series.WhiskerWidth = width;
+
             plot1.Model.Series.Add(series);
+
+            OxyPlot.Axes.Axis xAxis = GetAxis(xAxisType);
+            xAxis.Minimum = 0 - width;
+            xAxis.Maximum = plot1.Model.Series.OfType<BoxPlotSeries>().Count() - 1 + width;
         }
 
         private List<BoxPlotItem> GetBoxPlotItems(double[] data)
@@ -711,8 +730,8 @@ namespace UserInterface.Views
             double upperQuartile = fiveNumberSummary[3];
             double max = fiveNumberSummary[4];
 
-
-            return new List<BoxPlotItem>() { new BoxPlotItem(0, min, lowerQuartile, median, upperQuartile, max) };
+            int index = plot1.Model.Series.OfType<BoxPlotSeries>().Count();
+            return new List<BoxPlotItem>() { new BoxPlotItem(index, min, lowerQuartile, median, upperQuartile, max) };
         }
 
         /// <summary>

--- a/Models/Graph/IGraphable.cs
+++ b/Models/Graph/IGraphable.cs
@@ -50,7 +50,12 @@
         /// <summary>
         /// A stacked area series - a line series with the area between the line and the x-axis filled with colour.
         /// </summary>
-        StackedArea
+        StackedArea,
+
+        /// <summary>
+        /// A box and whisker plot
+        /// </summary>
+        Box
     }
 
     /// <summary>An enumeration for the different types of markers</summary>


### PR DESCRIPTION
Working on #4285 

@sno036 Not sure exactly how you want it to work but here you go. It will ignore the x variable and only use the y variable to create the plot. Marker size/type also has no effect.

You can create multiple box plots on the same x axis by adding multiple series to the graph node, or by setting colour/line type to vary by simulation name. Each box plot will be graphed at x = 0, x = 1, etc. Width of each plot is hardcoded to 0.5 - do we want to expose this somehow to the user? Let me know what you want changed.

![image](https://user-images.githubusercontent.com/36427516/67653970-95cb0900-f997-11e9-9e1f-8bb03c5b8ab6.png)