### PR TITLE
Rename create documentation context menu option.

### DIFF
--- a/ApsimNG/Menus/ContextMenu.cs
+++ b/ApsimNG/Menus/ContextMenu.cs
@@ -797,7 +797,9 @@ namespace UserInterface.Presenters
         /// </summary>
         /// <param name="sender">Sender of the event</param>
         /// <param name="e">Event arguments</param>
-        [ContextMenu(MenuName = "Create documentation", FollowsSeparator = true)]
+        [ContextMenu(MenuName = "Create simulation documentation",
+                     FollowsSeparator = true,
+                     AppliesTo = new[] { typeof(Simulations) })]
         public void CreateDocumentation(object sender, EventArgs e)
         {
             try


### PR DESCRIPTION
Resolves #4349 

I also changed this so that the option only shows up after right clicking on the Simulations node. Don't know that it really makes sense otherwise since it's not context-sensitive.