### PR TITLE
Tidy up variable referencing

### DIFF
--- a/Models/Core/ApsimFile/Converter.cs
+++ b/Models/Core/ApsimFile/Converter.cs
@@ -16,7 +16,7 @@
     public class Converter
     {
         /// <summary>Gets the latest .apsimx file format version.</summary>
-        public static int LatestVersion { get { return 70; } }
+        public static int LatestVersion { get { return 71; } }
 
         /// <summary>Converts a .apsimx string to the latest version.</summary>
         /// <param name="st">XML or JSON string to convert.</param>
@@ -1382,6 +1382,21 @@
                     genotypes[i]["Conceptions"] = genotypes[i]["Conception"];
                     genotypes[i]["GenotypeName"] = genotypes[i]["Name"];
                 }
+            }
+        }
+
+        /// <summary>
+        /// Alters all existing linint functions to have a child variable reference IFunction called XValue instead of a
+        /// string property called XProperty that IFunction then had to locate
+        /// </summary>
+        /// <param name="root">The root JSON token.</param>
+        /// <param name="fileName">The name of the apsimx file.</param>
+        private static void UpgradeToVersion71(JObject root, string fileName)
+        {
+            foreach (JObject linint in JsonUtilities.ChildrenRecursively(root, "LinearInterpolationFunction"))
+            {
+                JsonUtilities.AddVariableReference(linint,"XValue", linint["XProperty"].ToString());
+                linint.Remove("XProperty");
             }
         }
 

--- a/Models/Core/ApsimFile/JsonUtilities.cs
+++ b/Models/Core/ApsimFile/JsonUtilities.cs
@@ -348,6 +348,31 @@ namespace Models.Core.ApsimFile
         }
 
         /// <summary>
+        /// Add a variable reference function to the specified JSON model token.
+        /// </summary>
+        /// <param name="modelToken">The APSIM model token.</param>
+        /// <param name="name">The name of the variable reference function</param>
+        /// <param name="Path">The variable reference path</param>
+        public static void AddVariableReference(JObject modelToken, string name, string Path)
+        {
+            if (ChildWithName(modelToken, name) == null)
+            {
+                JArray children = modelToken["Children"] as JArray;
+                if (children == null)
+                {
+                    children = new JArray();
+                    modelToken["Children"] = children;
+                }
+
+                JObject VariableRefModel = new JObject();
+                VariableRefModel["$type"] = "Models.Functions.VariableReference, Models";
+                VariableRefModel["Name"] = name;
+                VariableRefModel["VariableName"] = Path;
+                children.Add(VariableRefModel);
+            }
+        }
+
+        /// <summary>
         /// Adds the given model as a child of node.
         /// </summary>
         /// <param name="node">Node to which the model will be added.</param>

--- a/Models/Functions/LinearInterpolationFunction.cs
+++ b/Models/Functions/LinearInterpolationFunction.cs
@@ -15,7 +15,7 @@ namespace Models.Functions
     [Serializable]
     [ViewName("UserInterface.Views.GridView")]
     [PresenterName("UserInterface.Presenters.PropertyPresenter")]
-    [Description("A value is returned via linear interpolation of a given set of XY pairs")]
+    [Description("A Y value is returned for the current vaule of the XValue child via linear interpolation of the XY pairs specified")]
     public class LinearInterpolationFunction : Model, IFunction, ICustomDocumentation
     {
         /// <summary>The ys are all the same</summary>
@@ -25,14 +25,11 @@ namespace Models.Functions
         [Link(Type = LinkType.Child, ByName = true)]
         private XYPairs XYPairs = null;
 
-        [Link]
-        private ILocator locator = null;
-
         private Dictionary<double, double> cache = new Dictionary<double, double>();
 
-        /// <summary>The x property</summary>
-        [Description("XProperty")]
-        public string XProperty { get; set; }
+        /// <summary>The x value to use for interpolation</summary>
+        [Link(Type = LinkType.Scoped)]
+        IFunction XValue = null;
 
         /// <summary>Constructor</summary>
         public LinearInterpolationFunction() { }
@@ -44,12 +41,13 @@ namespace Models.Functions
         }
 
         /// <summary>Constructor</summary>
-        /// <param name="xproperty">x property</param>
+        /// <param name="xProperty">name of the x property</param>
         /// <param name="x">x values.</param>
         /// <param name="y">y values.</param>
-        public LinearInterpolationFunction(string xproperty, double[] x, double[] y)
+        public LinearInterpolationFunction(string xProperty, double[] x, double[] y)
         {
-            XProperty = xproperty;
+            VariableReference XValue = new VariableReference();
+            XValue.VariableName = xProperty;
             XYPairs = new XYPairs();
             XYPairs.X = x;
             XYPairs.Y = y;
@@ -80,20 +78,8 @@ namespace Models.Functions
             // Shortcut exit when the Y values are all the same. Runs quicker.
             if (YsAreAllTheSame)
                 return XYPairs.Y[0];
-
-            
-            string PropertyName = XProperty;
-            object v = locator.Get(PropertyName);
-            if (v == null)
-                throw new Exception("Cannot find value for " + Name + " XProperty: " + XProperty);
-            double XValue;
-            if (v is Array)
-                XValue = (double)(v as Array).GetValue(arrayIndex);
-            else if (v is IFunction)
-                XValue = (v as IFunction).Value(arrayIndex);
             else
-                XValue = Convert.ToDouble(v, System.Globalization.CultureInfo.InvariantCulture);
-            return XYPairs.ValueIndexed(XValue);
+                return XYPairs.ValueIndexed(XValue.Value(arrayIndex));
         }
 
         /// <summary>Values for x.</summary>
@@ -122,12 +108,10 @@ namespace Models.Functions
                 // add graph and table.
                 if (XYPairs != null)
                 {
-                    IVariable xProperty = Apsim.GetVariableObject(this, XProperty);
-                    string xName = XProperty;
-                    if (xProperty != null && xProperty.UnitsLabel != string.Empty)
-                        xName += " " + xProperty.UnitsLabel;
-
-                    tags.Add(new AutoDocumentation.Paragraph("<i>" + Name + "</i> is calculated as a function of <i>" + StringUtilities.RemoveTrailingString(XProperty, ".Value()") + "</i>", indent));
+                    IModel xValue = (IModel)Apsim.Get(this, "XValue");
+                    string xName = xValue.Name;
+                    
+                    tags.Add(new AutoDocumentation.Paragraph("<i>" + Name + "</i> is calculated as a function of <i>" + xName + "</i>", indent));
 
                     tags.Add(new AutoDocumentation.GraphAndTable(XYPairs, string.Empty, xName, LookForYAxisTitle(this), indent));
                 }

--- a/Models/Functions/LinearInterpolationFunction.cs
+++ b/Models/Functions/LinearInterpolationFunction.cs
@@ -28,7 +28,7 @@ namespace Models.Functions
         private Dictionary<double, double> cache = new Dictionary<double, double>();
 
         /// <summary>The x value to use for interpolation</summary>
-        [Link(Type = LinkType.Scoped)]
+        [Link(Type = LinkType.Child, ByName = true)]
         IFunction XValue = null;
 
         /// <summary>Constructor</summary>

--- a/Tests/UnitTests/Core/ApsimFile/JsonUtilitiesTests.cs
+++ b/Tests/UnitTests/Core/ApsimFile/JsonUtilitiesTests.cs
@@ -246,7 +246,26 @@ namespace UnitTests.Core.ApsimFile
             Assert.AreEqual(constant["$type"].Value<string>(), "Models.Functions.Constant, Models");
             Assert.AreEqual(constant["FixedValue"].Value<string>(), "1");
         }
-        
+
+        /// <summary>
+        /// Ensures theAddVariableReference() method works correctly
+        /// </summary>
+        [Test]
+        public void AddVariableReferenceTests()
+        {
+            string json = ReflectionUtilities.GetResourceAsString("UnitTests.Core.ApsimFile.JsonUtilitiesTestsDescendantsByType.json");
+            JObject rootNode = JObject.Parse(json);
+
+            List<JObject> axes = JsonUtilities.ChildrenRecursively(rootNode, "Models.Graph.Axis");
+
+            JsonUtilities.AddVariableReference(axes[0], "XValue", "[Test].testies");
+
+            var VarRef = JsonUtilities.ChildWithName(axes[0], "XValue");
+            Assert.NotNull(VarRef);
+            Assert.AreEqual(VarRef["$type"].Value<string>(), "Models.Functions.VariableReference, Models");
+            Assert.AreEqual(VarRef["VariableName"].Value<string>(), "[Test].testies");
+        }
+
         /// <summary>
         /// Ensures the Values() method works correctly
         /// </summary>


### PR DESCRIPTION
Working on #4423.  Make the x property for Linint an I function and replace current XProperties with VariableReference funciton.  Aim is to reduce the amount of code where locator is used to make it easier to tidy up scoping