### PR TITLE
Fixed a bug where morris/sobol parameter array never gets emptied.

### DIFF
--- a/Models/Sensitivity/Morris.cs
+++ b/Models/Sensitivity/Morris.cs
@@ -156,6 +156,7 @@
             set
             {
                 ParametersHaveChanged = true;
+                Parameters.Clear();
                 foreach (DataRow row in value[0].Rows)
                 {
                     Parameter param = new Parameter();

--- a/Models/Sensitivity/Sobol.cs
+++ b/Models/Sensitivity/Sobol.cs
@@ -124,6 +124,7 @@
             set
             {
                 ParametersHaveChanged = true;
+                Parameters.Clear();
                 foreach (DataRow row in value[0].Rows)
                 {
                     Parameter param = new Parameter();


### PR DESCRIPTION
Working on #4565 