### PR TITLE
Fixed soil depth units

### DIFF
--- a/Models/Soils/Chemical.cs
+++ b/Models/Soils/Chemical.cs
@@ -13,7 +13,7 @@
     {
         /// <summary>Depth strings. Wrapper around Thickness.</summary>
         [Description("Depth")]
-        [Units("mm")]
+        [Units("cm")]
         public string[] Depth
         {
             get

--- a/Models/Soils/Organic.cs
+++ b/Models/Soils/Organic.cs
@@ -13,7 +13,7 @@
     {
         /// <summary>Depth strings. Wrapper around Thickness.</summary>
         [Description("Depth")]
-        [Units("mm")]
+        [Units("cm")]
         public string[] Depth
         {
             get

--- a/Models/Soils/Sample.cs
+++ b/Models/Soils/Sample.cs
@@ -80,7 +80,7 @@
 
         /// <summary>Depth strings. Wrapper around Thickness.</summary>
         [Description("Depth")]
-        [Units("mm")]
+        [Units("cm")]
         public string[] Depth
         {
             get

--- a/Models/Soils/SoilWaterBackend/SoilWater.cs
+++ b/Models/Soils/SoilWaterBackend/SoilWater.cs
@@ -277,7 +277,7 @@ namespace Models.Soils
 
         /// <summary>Depth strings. Wrapper around Thickness.</summary>
         [Description("Depth")]
-        [Units("mm")]
+        [Units("cm")]
         public string[] Depth
         {
             get


### PR DESCRIPTION
These were incorrectly labelled as mm. Thicknesses are stored in mm, but there is a conversion to cm applied when converting thicknesses to depths in SoilUtilities.ToDepthStrings().

Resolves #4587