### PR TITLE
Added a hack to allow for zone names containing "from" and "to"

### DIFF
--- a/Models/Report/ReportColumn.cs
+++ b/Models/Report/ReportColumn.cs
@@ -284,6 +284,7 @@
         public static ReportColumn Create(string descriptor, IClock clock, IStorageWriter storage, ILocator locator, IEvent events)
         {
             string columnName = StringUtilities.RemoveWordAfter(ref descriptor, "as");
+            string originalDescriptor = descriptor;
             object to = StringUtilities.RemoveWordAfter(ref descriptor, "to");
             object from = StringUtilities.RemoveWordAfter(ref descriptor, "from");
             if (clock is IModel)
@@ -301,6 +302,10 @@
                         to = toValue;
                 }
             }
+
+            if (to == null || from == null)
+                descriptor = originalDescriptor;
+
             string aggregationFunction = StringUtilities.RemoveWordBefore(ref descriptor, "of");
 
             string variableName = descriptor;  // variable name is what is left over.


### PR DESCRIPTION
Working on #4593

This change will cause report to ignore the "from" or "to" keywords if only one is provided. Note this doesn't help at all if the model name contains "as" or "of".