### PR TITLE
Allow users to mute the sound played after simulations finish in the UI

### DIFF
--- a/ApsimNG/Commands/RunCommand.cs
+++ b/ApsimNG/Commands/RunCommand.cs
@@ -80,24 +80,27 @@
             else
                 explorerPresenter.MainPresenter.ShowError(errors);
 
-            // Play a completion sound.
-            SoundPlayer player = new SoundPlayer();
-            if (errors.Count > 0)
+            if (!Configuration.Settings.Muted)
             {
-                if (File.Exists(Configuration.Settings.SimulationCompleteWithErrorWavFileName))
-                    player.SoundLocation = Configuration.Settings.SimulationCompleteWithErrorWavFileName;
+                // Play a completion sound.
+                SoundPlayer player = new SoundPlayer();
+                if (errors.Count > 0)
+                {
+                    if (File.Exists(Configuration.Settings.SimulationCompleteWithErrorWavFileName))
+                        player.SoundLocation = Configuration.Settings.SimulationCompleteWithErrorWavFileName;
+                    else
+                        player.Stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("ApsimNG.Resources.Sounds.Fail.wav");
+                }
                 else
-                    player.Stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("ApsimNG.Resources.Sounds.Fail.wav");
+                {
+                    if (File.Exists(Configuration.Settings.SimulationCompleteWavFileName))
+                        player.SoundLocation = Configuration.Settings.SimulationCompleteWithErrorWavFileName;
+                    else
+                        player.Stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("ApsimNG.Resources.Sounds.Success.wav");
+                }
+
+                player.Play();
             }
-            else
-            {
-                if (File.Exists(Configuration.Settings.SimulationCompleteWavFileName))
-                    player.SoundLocation = Configuration.Settings.SimulationCompleteWithErrorWavFileName;
-                else
-                    player.Stream = System.Reflection.Assembly.GetExecutingAssembly().GetManifestResourceStream("ApsimNG.Resources.Sounds.Success.wav");
-            }
-            
-            player.Play();
         }
 
         /// <summary>

--- a/ApsimNG/Utility/Configuration.cs
+++ b/ApsimNG/Utility/Configuration.cs
@@ -44,6 +44,9 @@ namespace Utility
         /// <summary>Keeps track of whether the dark theme is enabled.</summary>
         public bool DarkTheme { get; set; }
 
+        /// <summary>Iff true, the GUI will not play a sound when simulations finish running.</summary>
+        public bool Muted { get; set; }
+
         /// <summary>Return the name of the summary file JPG.</summary>
         public string SummaryPngFileName
         {


### PR DESCRIPTION
Working on #4674

This option is stored in the config file and so will be persistent across restarts of apsim. There is no mechanism to change this from the UI.