### PR TITLE
Minor leaf appearance bugs

### DIFF
--- a/Models/Plant/Structure/Structure.cs
+++ b/Models/Plant/Structure/Structure.cs
@@ -269,6 +269,8 @@ namespace Models.PMF.Struct
                     if ((AllCohortsInitialised) && (LastLeafAppearing))
                     {
                         NextLeafProportion = 1 - (leaf.InitialisedCohortNo - finalLeafNumber.Value());
+                        if (NextLeafProportion <= 0)
+                            NextLeafProportion = 0.000001; //Get problems with leaf appearance if this is zero
                     }
                     else
                     {
@@ -287,7 +289,7 @@ namespace Models.PMF.Struct
                     }
 
                     PotLeafTipsAppeared += DeltaTipNumber;
-                    LeafTipsAppeared = Math.Min(PotLeafTipsAppeared, finalLeafNumber.Value());
+                    LeafTipsAppeared = Math.Min(PotLeafTipsAppeared, Math.Max(finalLeafNumber.Value(),leaf.InitialisedCohortNo));
 
                     TimeForAnotherLeaf = PotLeafTipsAppeared >= (leaf.AppearedCohortNo + 1);
                     int LeavesToAppear = (int)(LeafTipsAppeared - (leaf.AppearedCohortNo - (1 - NextLeafProportion)));


### PR DESCRIPTION
resolves #4700 
Fix logic to not allow zero final leaf proportions and not allow Appeared leaf tip appearance to exceed the number of cohorts initialized.

