### PR TITLE
Negative irrigation warning should not appear unless amount is negative.

### DIFF
--- a/Models/Irrigation/Irrigation.cs
+++ b/Models/Irrigation/Irrigation.cs
@@ -91,7 +91,7 @@
                 if (doOutput)
                     summary.WriteMessage(this, string.Format("{0:F1} mm of water added via irrigation at depth {1} mm", IrrigationApplied, Depth));
             }
-            else if (doOutput)
+            else if (doOutput && amount < 0)
                 summary.WriteMessage(this, "Irrigation did not occur because the amount given was negative");
         }
 


### PR DESCRIPTION
Resolves #4702 