### PR TITLE
Autodocs should include remarks tags where they exist.

### DIFF
--- a/ApsimNG/Commands/CreateParamsInputsOutputsDocCommand.cs
+++ b/ApsimNG/Commands/CreateParamsInputsOutputsDocCommand.cs
@@ -89,6 +89,7 @@
 
             tags.Add(new AutoDocumentation.Heading((objectToDocument as IModel).Name, 1));
             AutoDocumentation.ParseTextForTags(AutoDocumentation.GetSummary(objectToDocument.GetType()), modelToDocument, tags, 1, 0,false);
+            AutoDocumentation.ParseTextForTags(AutoDocumentation.GetRemarks(objectToDocument.GetType()), modelToDocument, tags, 1, 0,false);
 
             // If there are parameters then write them to the tags.
             if (parameterNames != null)
@@ -124,6 +125,7 @@
 
             tags.Add(new AutoDocumentation.Heading(typeToDocument.Name, 1));
             AutoDocumentation.ParseTextForTags(AutoDocumentation.GetSummary(typeToDocument), modelToDocument, tags, 1, 0, false);
+            AutoDocumentation.ParseTextForTags(AutoDocumentation.GetRemarks(typeToDocument), modelToDocument, tags, 1, 0, false);
 
             var outputs = GetProperties(typeToDocument, PropertyType.NonParameters);
             if (outputs != null && outputs.Count > 0)
@@ -189,6 +191,9 @@
                     var descriptionAttribute = property.GetCustomAttribute<DescriptionAttribute>();
                     description = descriptionAttribute?.ToString();
                 }
+                string remarks = AutoDocumentation.GetRemarks(property);
+                if (!string.IsNullOrEmpty(remarks))
+                    description += Environment.NewLine + Environment.NewLine + remarks;
 
                 row["Name"] = property.Name;
                 row["Type"] = typeName;
@@ -380,6 +385,10 @@
                         parameters += GetTypeName(argument.ParameterType) + " " + argument.Name;
                     }
                     string description = AutoDocumentation.GetSummary(method);
+                    string remarks = AutoDocumentation.GetRemarks(method);
+                    if (!string.IsNullOrEmpty(remarks))
+                        description += Environment.NewLine + Environment.NewLine + remarks;
+
                     if (description != null)
                         description = "<i>" + description + "</i>"; // italics
                     var st = string.Format("<p>{0} {1}({2})</p>{3}",

--- a/Models/Core/AutoDocumentation.cs
+++ b/Models/Core/AutoDocumentation.cs
@@ -110,7 +110,6 @@ namespace Models.Core
                 ParseTextForTags(summaryNode.InnerXml, model, tags, headingLevel, indent, documentAllChildren);
         }
 
-
         /// <summary>
         /// Get the summary of a member (field, property)
         /// </summary>
@@ -127,12 +126,36 @@ namespace Models.Core
         }
 
         /// <summary>
-        /// Get the summary of a member (field, property)
+        /// Get the summary of a type.
         /// </summary>
         /// <param name="t">The type to get the summary for.</param>
         public static string GetSummary(Type t)
         {
             return GetSummary(t.FullName, 'T');
+        }
+
+        /// <summary>
+        /// Get the remarks tag of a type (if it exists).
+        /// </summary>
+        /// <param name="t">The type.</param>
+        public static string GetRemarks(Type t)
+        {
+            return GetRemarks(t.FullName, 'T');
+        }
+
+        /// <summary>
+        /// Get the remarks of a member (field, property) if it exists.
+        /// </summary>
+        /// <param name="member">The member.</param>
+        public static string GetRemarks(MemberInfo member)
+        {
+            var fullName = member.ReflectedType + "." + member.Name;
+            if (member is PropertyInfo)
+                return GetRemarks(fullName, 'P');
+            else if (member is FieldInfo)
+                return GetRemarks(fullName, 'F');
+            else
+                return GetRemarks(fullName, 'M');
         }
 
         /// <summary>
@@ -152,6 +175,30 @@ namespace Models.Core
             path = path.Replace("+", ".");
 
             string nameToFindInSummary = string.Format("members/{0}:{1}/summary", typeLetter, path);
+            XmlNode summaryNode = XmlUtilities.Find(doc.DocumentElement, nameToFindInSummary);
+            if (summaryNode != null)
+                return summaryNode.InnerXml;
+            return null;
+        }
+
+        /// <summary>
+        /// Get the remarks of a member (class, field, property).
+        /// </summary>
+        /// <param name="path">The path to the member.</param>
+        /// <param name="typeLetter">Type letter: 'T' for type, 'F' for field, 'P' for property.</param>
+        /// <returns></returns>
+        private static string GetRemarks(string path, char typeLetter)
+        {
+            if (doc == null)
+            {
+                string fileName = Path.ChangeExtension(Assembly.GetExecutingAssembly().Location, ".xml");
+                doc = new XmlDocument();
+                doc.Load(fileName);
+            }
+
+            path = path.Replace("+", ".");
+
+            string nameToFindInSummary = string.Format("members/{0}:{1}/remarks", typeLetter, path);
             XmlNode summaryNode = XmlUtilities.Find(doc.DocumentElement, nameToFindInSummary);
             if (summaryNode != null)
                 return summaryNode.InnerXml;


### PR DESCRIPTION
This is in addition to the contents of the summary tag, which is already included in the autodocs.

Resolves #1726