### PR TITLE
Leaf 'GrowthDuration' should not be reduced if the final cohort has not fully appeared

### DIFF
--- a/Models/Plant/Organs/LeafCohort.cs
+++ b/Models/Plant/Organs/LeafCohort.cs
@@ -748,7 +748,7 @@ namespace Models.PMF.Organs
             IsAppeared = true;
 
             MaxArea = leafCohortParameters.MaxArea.Value() * CellDivisionStressFactor;
-            GrowthDuration = leafCohortParameters.GrowthDuration.Value() * cohortParams.FinalFraction;
+            GrowthDuration = leafCohortParameters.GrowthDuration.Value();
             LagDuration = leafCohortParameters.LagDuration.Value();
             SenescenceDuration = leafCohortParameters.SenescenceDuration.Value();
             DetachmentLagDuration = leafCohortParameters.DetachmentLagDuration.Value();


### PR DESCRIPTION
Resolves #5042 

I am not sure about this. But it is worth inspecting. 
**Admins**, please feel free to close the pull req if the proposed change is not needed.