### PR TITLE
Bug Fixed: CalculateRootActivityValues must not include ProportionThroughLayer

### DIFF
--- a/Models/Plant/Organs/RootZoneState.cs
+++ b/Models/Plant/Organs/RootZoneState.cs
@@ -286,9 +286,8 @@ namespace Models.PMF.Organs
                 if (layer <= soil.LayerIndexOfDepth(Depth))
                     if (LayerLive[layer].Wt > 0)
                     {
-                        RAw[layer] = - WaterUptake[layer] / LayerLive[layer].Wt
-                                   * soil.Thickness[layer]
-                                   * soil.ProportionThroughLayer(layer, Depth);
+                        RAw[layer] = -WaterUptake[layer] / LayerLive[layer].Wt
+                                   * soil.Thickness[layer];
                         RAw[layer] = Math.Max(RAw[layer], 1e-20);  // Make sure small numbers to avoid lack of info for partitioning
                     }
                     else if (layer > 0)


### PR DESCRIPTION
Resolves #5076 
Proportion of each soil layer through which root has penetrated is already accounted for when calculating water uptake.

Working on #5079 