### PR TITLE
Enabling/disabling a model should be undoable

### DIFF
--- a/ApsimNG/Commands/ChangeProperty.cs
+++ b/ApsimNG/Commands/ChangeProperty.cs
@@ -132,8 +132,8 @@
             /// <param name="value">The new value of the property</param>
             public Property(object obj, string name, object value)
             {
-                if (obj is IModel && (obj as IModel).ReadOnly && name != "ReadOnly")
-                    throw new ApsimXException(obj as IModel, string.Format("Unable to modify {0} - it is read-only.", (obj as IModel).Name));
+                if (obj is IModel model && model.ReadOnly && name != nameof(model.ReadOnly) && name != nameof(model.Enabled))
+                    throw new ApsimXException(obj as IModel, string.Format("Unable to modify {0} - it is read-only.", Apsim.FullPath(model)));
                 this.Obj = obj;
                 this.Name = name;
                 this.NewValue = value;

--- a/ApsimNG/Menus/ContextMenu.cs
+++ b/ApsimNG/Menus/ContextMenu.cs
@@ -757,9 +757,15 @@
                 IModel model = Apsim.Get(explorerPresenter.ApsimXFile, explorerPresenter.CurrentNodePath) as IModel;
                 if (model != null)
                 {
-                    model.Enabled = !model.Enabled;
+                    List<ChangeProperty.Property> changes = new List<ChangeProperty.Property>();
+                    changes.Add(new ChangeProperty.Property(model, nameof(model.Enabled), !model.Enabled));
+
                     foreach (IModel child in Apsim.ChildrenRecursively(model))
-                        child.Enabled = model.Enabled;
+                        changes.Add(new ChangeProperty.Property(child, nameof(model.Enabled), !model.Enabled));
+
+                    ChangeProperty command = new ChangeProperty(changes);
+                    explorerPresenter.CommandHistory.Add(command);
+
                     explorerPresenter.PopulateContextMenu(explorerPresenter.CurrentNodePath);
                     explorerPresenter.Refresh();
                 }
@@ -790,9 +796,9 @@
                 List<ChangeProperty.Property> changes = new List<ChangeProperty.Property>();
                 
                 // Toggle read-only on the model and all descendants.
-                changes.Add(new ChangeProperty.Property(model, "ReadOnly", readOnly));
+                changes.Add(new ChangeProperty.Property(model, nameof(model.ReadOnly), readOnly));
                 foreach (IModel child in Apsim.ChildrenRecursively(model))
-                    changes.Add(new ChangeProperty.Property(child, "ReadOnly", readOnly));
+                    changes.Add(new ChangeProperty.Property(child, nameof(child.ReadOnly), readOnly));
 
                 // Apply changes.
                 ChangeProperty command = new ChangeProperty(changes);

--- a/ApsimNG/Menus/MainMenu.cs
+++ b/ApsimNG/Menus/MainMenu.cs
@@ -70,6 +70,7 @@
             try
             {
                 this.explorerPresenter.CommandHistory.Undo();
+                explorerPresenter.Refresh();
             }
             catch (Exception err)
             {
@@ -88,6 +89,7 @@
             try
             {
                 explorerPresenter.CommandHistory.Redo();
+                explorerPresenter.Refresh();
             }
             catch (Exception err)
             {


### PR DESCRIPTION
Resolves #5142 

@hol353 - as part of this I discovered that users can't disable models which have readonly children (ie resource models - wheat, waterbalance, ...). I've changed this behaviour so that users can now disable read-only models. It's not really ideal but we have 3 conflicting directives:

1. User should be able to disable wheat
2. Disabling a model should disable all of its descendants
3. User should not be able to disable read-only models