### PR TITLE
Changed folder view so it doesn't hide legends by default

### DIFF
--- a/ApsimNG/Presenters/DataStorePresenter.cs
+++ b/ApsimNG/Presenters/DataStorePresenter.cs
@@ -45,9 +45,6 @@ namespace UserInterface.Presenters
         private EditView rowFilterEditBox;
 
         /// <summary>Row filter edit box.</summary>
-        private GridView grid;
-
-        /// <summary>Row filter edit box.</summary>
         private EditView maxNumRecordsEditBox;
 
         /// <summary>Gets or sets the experiment filter. When specified, will only show experiment data.</summary>

--- a/ApsimNG/Views/FolderView.cs
+++ b/ApsimNG/Views/FolderView.cs
@@ -75,7 +75,6 @@
                         gview.ShowControls(false);
                         gview.Refresh();
                         gview.SingleClick += OnGraphClick;
-                        gview.IsLegendVisible = false;
                         gview.MainWidget.SetSizeRequest(400, 400);
                         gview.ShowControls(false);
                         table.Attach(gview.MainWidget, col, col + 1, row, row + 1);


### PR DESCRIPTION
Resolves #5153 

To keep the legends hidden, disable them in the series settings.