### PR TITLE
PredictedObserved should check for duplicate observed datapoints.

### DIFF
--- a/Models/PostSimulationTools/PredictedObserved.cs
+++ b/Models/PostSimulationTools/PredictedObserved.cs
@@ -278,6 +278,7 @@ HAVING N > 1";
             if (duplicates.Rows.Count > 0)
             {
                 StringBuilder msg = new StringBuilder();
+                msg.AppendLine($"Error in file {System.IO.Path.ChangeExtension(dataStore.FileName, ".apsimx")}:");
                 msg.AppendLine($"Error in PredictedObserved {Name}: duplicate records detected for {duplicates.Rows.Count} simulations in observed table {ObservedTableName}:");
                 msg.AppendLine($"You are seeing this error because there are multiple (N) rows in this table which have the same simulation name, {string.Join(", ", fieldsToMatchOn)}.");
                 DataTableUtilities.DataTableToText(duplicates, 0, ", ", true, new System.IO.StringWriter(msg));


### PR DESCRIPTION
And by check, I mean throw a fatal error if any are found.

Resolves #4710 and resolves #4708

@hol353 - this is for damage assessment purposes and will not run green. If it does run green, please don't merge it.