### PR TITLE
Allow the "@" character to be used in Report aliases (along with the …

### DIFF
--- a/Models/Report/ReportColumn.cs
+++ b/Models/Report/ReportColumn.cs
@@ -257,7 +257,7 @@
                           $@"(?<var>((?!\s+from\s+|\s+as\s+|\s+on\s+).)+)" +                    // APSIM variable or expression
                           $@"(\s+on\s+(?<on>((?!\s+from\s+|\s+as\s+).)+))?" +                   // on keyword
                           $@"(\s+from\s+(?<from>\S+)\s+to\s+(?<to>((?!\s+as)\S)+))?" +          // from and to keywords
-                          @"(\s+as\s+(?<alias>[\w.]+))?";                                       // alias
+                          @"(\s+as\s+(?<alias>[\w.@]+))?";                                      // alias
 
             var regEx = new Regex(pattern);
             var match = regEx.Match(descriptor);


### PR DESCRIPTION
…current alphanumeric, "_" and "." characters). Working on #4080