### PR TITLE
Improved ability to recognise various excel file formats

### DIFF
--- a/APSIM.Shared/Utilities/ApsimTextFile.cs
+++ b/APSIM.Shared/Utilities/ApsimTextFile.cs
@@ -146,8 +146,8 @@ namespace APSIM.Shared.Utilities
             _FileName = fileName;
             _SheetName = sheetName;
 
-            IsCSVFile = System.IO.Path.GetExtension(fileName).ToLower() == ".csv";
-            IsExcelFile = System.IO.Path.GetExtension(fileName).ToLower() == ExcelUtilities.ExcelExtension;
+            IsCSVFile = Path.GetExtension(fileName).ToLower() == ".csv";
+            IsExcelFile = ExcelUtilities.IsExcelFile(fileName);
 
             if (IsExcelFile)
             {

--- a/APSIM.Shared/Utilities/ExcelUtilities.cs
+++ b/APSIM.Shared/Utilities/ExcelUtilities.cs
@@ -45,7 +45,7 @@ namespace APSIM.Shared.Utilities
         public static bool IsExcelFile(string fileName)
         {
             string extension = Path.GetExtension(fileName).ToLower();
-            return openXmlExtensions.Contains(fileName) || oldExcelFormats.Contains(fileName);
+            return openXmlExtensions.Contains(extension) || oldExcelFormats.Contains(extension);
         }
 
         /// <summary>

--- a/APSIM.Shared/Utilities/ExcelUtilities.cs
+++ b/APSIM.Shared/Utilities/ExcelUtilities.cs
@@ -12,22 +12,41 @@ namespace APSIM.Shared.Utilities
     using DocumentFormat.OpenXml.Spreadsheet;
     using System.IO;
     using ExcelDataReader;
-    
-    
+    using System.Linq;
+
+
     /// <summary>
     /// Utilities for working with Excel (".xlxs") Files
     /// </summary>
     public class ExcelUtilities
     {
-        #region Variables and Constants 
+        /// <summary>
+        /// List of common binary (office '03) excel file extensions.
+        /// </summary>
+        private static readonly string[] oldExcelFormats = new string[]
+        {
+            ".xls"
+        };
 
         /// <summary>
-        /// a constant to represent a valid excel file extension.
+        /// List of common OpenXML (office '07) excel file extensions. 
         /// </summary>
-        public const string ExcelExtension = ".xlsx";
+        private static readonly string[] openXmlExtensions = new string[]
+        {
+            ".xlsx",
+            ".xlsm"
+        };
 
-        #endregion
-
+        /// <summary>
+        /// Checks whether a file is an Excel file.
+        /// The check is purely based on file extension, so it's a bit primitive.
+        /// </summary>
+        /// <param name="fileName">Path/name of the file to check.</param>
+        public static bool IsExcelFile(string fileName)
+        {
+            string extension = Path.GetExtension(fileName).ToLower();
+            return openXmlExtensions.Contains(fileName) || oldExcelFormats.Contains(fileName);
+        }
 
         /// <summary>
         /// This will read the names of all of the worksheets within this file
@@ -57,20 +76,19 @@ namespace APSIM.Shared.Utilities
         /// <returns>a DataTable</returns>
         public static DataTable ReadExcelFileData(string fileName, string sheetName, bool headerRow = false)
         {
-            DataTable data = new DataTable();
-
-            if (Path.GetExtension(fileName) != ExcelUtilities.ExcelExtension)
-            {
-                throw new Exception("The Excel File must be an '.xlsx' file.");
-            }
-
             using (FileStream stream = File.Open(fileName, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
-                //Reading from a binary Excel file ('97-2003 format; *.xls)
-                //IExcelDataReader excelReader = ExcelReaderFactory.CreateBinaryReader(stream);
-
-                //Reading from a OpenXml Excel file (2007 format; *.xlsx)
-                IExcelDataReader excelReader = ExcelReaderFactory.CreateOpenXmlReader(stream);
+                string fileExtension = Path.GetExtension(fileName);
+                IExcelDataReader excelReader;
+                if (oldExcelFormats.Contains(fileExtension))
+                    // Reading from a binary Excel file ('97-2003 format; *.xls)
+                    excelReader = ExcelReaderFactory.CreateBinaryReader(stream);
+                else
+                    // Assume that any unknown extension is an OpenXML file.
+                    // The call to CreateOpenXmlReader should throw if this is untrue.
+                    //
+                    // Reading from a OpenXml Excel file (2007 format; *.xlsx)
+                    excelReader = ExcelReaderFactory.CreateOpenXmlReader(stream);
 
                 DataSet result;
                 if (headerRow)
@@ -85,9 +103,8 @@ namespace APSIM.Shared.Utilities
                     });
                 else
                     result = excelReader.AsDataSet();
-                data = result.Tables[sheetName];
 
-                return data;
+                return result.Tables[sheetName];
             }
         }
     }

--- a/ApsimNG/Presenters/MetDataPresenter.cs
+++ b/ApsimNG/Presenters/MetDataPresenter.cs
@@ -5,7 +5,6 @@
     using System.Data;
     using System.Drawing;
     using System.Globalization;
-    using System.IO;
     using System.Text;
     using APSIM.Shared.Utilities;
     using Models;
@@ -88,7 +87,7 @@
         {
             if (this.weatherData.FullFileName != PathUtilities.GetAbsolutePath(fileName, this.explorerPresenter.ApsimXFile.FileName))
             {
-                if (Path.GetExtension(fileName) == ExcelUtilities.ExcelExtension)
+                if (ExcelUtilities.IsExcelFile(fileName))
                 {
                     //// Extend height of Browse Panel to show Drop Down for Sheet names
                     this.weatherDataView.ShowExcelSheets(true);
@@ -183,7 +182,7 @@
                 this.weatherDataView.Filename = PathUtilities.GetAbsolutePath(filename, this.explorerPresenter.ApsimXFile.FileName);
                 try
                 {
-                    if (Path.GetExtension(filename) == ExcelUtilities.ExcelExtension)
+                    if (ExcelUtilities.IsExcelFile(filename))
                     {
                         // Extend height of Browse Panel to show Drop Down for Sheet names
                         this.weatherDataView.ShowExcelSheets(true);


### PR DESCRIPTION
This also allows for excel files in the old binary format (.xls).

I think this should resolve #5109. @lie112 see my change to ExcelUtilities.cs, where we've got an array of accepted file formats. Feel free to add any you think are missing. When reading a file, if the file format does not match any of these formats, we will attempt to read the file using the openXML file reader.