### PR TITLE
Allow data store writer to keep track of which tables have been modified

### DIFF
--- a/APSIMRunner/StorageViaSockets.cs
+++ b/APSIMRunner/StorageViaSockets.cs
@@ -43,6 +43,7 @@
 
         public IStorageWriter Writer { get { return this; } }
 
+        public List<string> TablesModified { get; set; }
 
         public void Empty()
         {

--- a/Models/Core/Run/SimulationGroup.cs
+++ b/Models/Core/Run/SimulationGroup.cs
@@ -132,6 +132,9 @@
         {
             if (!initialised)
                 SpinWait.SpinUntil(() => initialised);
+
+            if (storage?.Writer != null)
+                storage.Writer.TablesModified.Clear();
         }
 
         /// <summary>Called once when all jobs have completed running. Should throw on error.</summary>

--- a/Models/PostSimulationTools/PredictedObserved.cs
+++ b/Models/PostSimulationTools/PredictedObserved.cs
@@ -60,183 +60,187 @@ namespace Models.PostSimulationTools
         /// <summary>Main run method for performing our calculations and storing data.</summary>
         public void Run()
         {
-            if (PredictedTableName != null && ObservedTableName != null)
+            if (PredictedTableName == null || ObservedTableName == null)
+                return;
+
+            // If the predicted table has not been modified during the current simulations run, don't do anything.
+            if (dataStore?.Writer != null && !dataStore.Writer.TablesModified.Contains(PredictedTableName))
+                return;
+
+            IEnumerable<string> predictedDataNames = dataStore.Reader.ColumnNames(PredictedTableName);
+            IEnumerable<string> observedDataNames = dataStore.Reader.ColumnNames(ObservedTableName);
+
+            if (predictedDataNames == null)
+                throw new ApsimXException(this, "Could not find model data table: " + PredictedTableName);
+
+            if (observedDataNames == null)
+                throw new ApsimXException(this, "Could not find observed data table: " + ObservedTableName);
+
+            // get the common columns between these lists of columns
+            List<string> commonCols = predictedDataNames.Intersect(observedDataNames).ToList();
+
+            IStorageReader reader = dataStore.Reader;
+            string match1ObsShort = reader.BriefColumnName(ObservedTableName, FieldNameUsedForMatch);
+            string match2ObsShort = reader.BriefColumnName(ObservedTableName, FieldName2UsedForMatch);
+            string match3ObsShort = reader.BriefColumnName(ObservedTableName, FieldName3UsedForMatch);
+
+            string match1PredShort = reader.BriefColumnName(PredictedTableName, FieldNameUsedForMatch);
+            string match2PredShort = reader.BriefColumnName(PredictedTableName, FieldName2UsedForMatch);
+            string match3PredShort = reader.BriefColumnName(PredictedTableName, FieldName3UsedForMatch);
+
+            StringBuilder query = new StringBuilder("SELECT ");
+            for (int i = 0; i < commonCols.Count; i++)
             {
-                IEnumerable<string> predictedDataNames = dataStore.Reader.ColumnNames(PredictedTableName);
-                IEnumerable<string> observedDataNames = dataStore.Reader.ColumnNames(ObservedTableName);
+                string s = commonCols[i];
+                string obsColShort = reader.BriefColumnName(ObservedTableName, s);
+                string predColShort = reader.BriefColumnName(PredictedTableName, s);
+                if (i != 0)
+                    query.Append(", ");
 
-                if (predictedDataNames == null)
-                    throw new ApsimXException(this, "Could not find model data table: " + PredictedTableName);
-
-                if (observedDataNames == null)
-                    throw new ApsimXException(this, "Could not find observed data table: " + ObservedTableName);
-
-                // get the common columns between these lists of columns
-                List<string> commonCols = predictedDataNames.Intersect(observedDataNames).ToList();
-
-                IStorageReader reader = dataStore.Reader;
-                string match1ObsShort = reader.BriefColumnName(ObservedTableName, FieldNameUsedForMatch);
-                string match2ObsShort = reader.BriefColumnName(ObservedTableName, FieldName2UsedForMatch);
-                string match3ObsShort = reader.BriefColumnName(ObservedTableName, FieldName3UsedForMatch);
-
-                string match1PredShort = reader.BriefColumnName(PredictedTableName, FieldNameUsedForMatch);
-                string match2PredShort = reader.BriefColumnName(PredictedTableName, FieldName2UsedForMatch);
-                string match3PredShort = reader.BriefColumnName(PredictedTableName, FieldName3UsedForMatch);
-
-                StringBuilder query = new StringBuilder("SELECT ");
-                for (int i = 0; i < commonCols.Count; i++)
-                {
-                    string s = commonCols[i];
-                    string obsColShort = reader.BriefColumnName(ObservedTableName, s);
-                    string predColShort = reader.BriefColumnName(PredictedTableName, s);
-                    if (i != 0)
-                        query.Append(", ");
-
-                    if (s == FieldNameUsedForMatch || s == FieldName2UsedForMatch || s == FieldName3UsedForMatch)
-                        query.Append($"O.[{obsColShort}]");
-                    else
-                        query.Append($"O.[{obsColShort}] AS [Observed.{obsColShort}], P.[{predColShort}] AS [Predicted.{predColShort}]");
-                }
-
-                query.AppendLine();
-                query.AppendLine("FROM [" + ObservedTableName + "] O");
-                query.AppendLine($"INNER JOIN [{PredictedTableName}] P");
-                query.Append($"USING ([SimulationID], [CheckpointID], [{FieldNameUsedForMatch}]");
-                if (!string.IsNullOrEmpty(FieldName2UsedForMatch))
-                    query.Append($", [{FieldName2UsedForMatch}]");
-                if (!string.IsNullOrEmpty(FieldName3UsedForMatch))
-                    query.Append($", [{FieldName3UsedForMatch}]");
-                query.AppendLine(")");
-
-                int checkpointID = dataStore.Writer.GetCheckpointID("Current");
-                query.AppendLine("WHERE [CheckpointID] = " + checkpointID);
-                query.Replace("O.[SimulationID] AS [Observed.SimulationID], P.[SimulationID] AS [Predicted.SimulationID]", "O.[SimulationID] AS [SimulationID]");
-                query.Replace("O.[CheckpointID] AS [Observed.CheckpointID], P.[CheckpointID] AS [Predicted.CheckpointID]", "O.[CheckpointID] AS [CheckpointID]");
-
-                if (Parent is Folder)
-                {
-                    // Limit it to particular simulations in scope.
-                    List<string> simulationNames = new List<string>();
-                    foreach (Experiment experiment in Apsim.FindAll(this, typeof(Experiment)))
-                    {
-                        var names = experiment.GenerateSimulationDescriptions().Select(s => s.Name);
-                        simulationNames.AddRange(names);
-                    }
-
-                    foreach (Simulation simulation in Apsim.FindAll(this, typeof(Simulation)))
-                        if (!(simulation.Parent is Experiment))
-                            simulationNames.Add(simulation.Name);
-
-                    query.Append(" AND O.[SimulationID] in (");
-                    foreach (string simulationName in simulationNames)
-                    {
-                        if (simulationName != simulationNames[0])
-                            query.Append(',');
-                        query.Append(dataStore.Writer.GetSimulationID(simulationName, null));
-                    }
-                    query.Append(")");
-                }
-
-                DataTable predictedObservedData = reader.GetDataUsingSql(query.ToString());
-
-                if (predictedObservedData != null)
-                {
-                    foreach (DataColumn column in predictedObservedData.Columns)
-                    {
-                        if (column.ColumnName.StartsWith("Predicted."))
-                        {
-                            string shortName = column.ColumnName.Substring("Predicted.".Length);
-                            column.ColumnName = "Predicted." + reader.FullColumnName(PredictedTableName, shortName);
-                        }
-                        else if (column.ColumnName.StartsWith("Observed."))
-                        {
-                            string shortName = column.ColumnName.Substring("Observed.".Length);
-                            column.ColumnName = "Observed." + reader.FullColumnName(ObservedTableName, shortName);
-                        }
-                        else if (column.ColumnName.Equals(match1ObsShort) || column.ColumnName.Equals(match2ObsShort) || column.ColumnName.Equals(match3ObsShort))
-                        {
-                            column.ColumnName = reader.FullColumnName(ObservedTableName, column.ColumnName);
-                        }
-                    }
-
-                    // Add in error columns for each data column.
-                    foreach (string columnName in commonCols)
-                    {
-                        if (predictedObservedData.Columns.Contains("Predicted." + columnName) &&
-                            predictedObservedData.Columns["Predicted." + columnName].DataType == typeof(double))
-                        {
-                            var predicted = DataTableUtilities.GetColumnAsDoubles(predictedObservedData, "Predicted." + columnName);
-                            var observed = DataTableUtilities.GetColumnAsDoubles(predictedObservedData, "Observed." + columnName);
-                            if (predicted.Length > 0 && predicted.Length == observed.Length)
-                            {
-                                var errorData = MathUtilities.Subtract(predicted, observed);
-                                var errorColumnName = "Pred-Obs." + columnName;
-                                var errorColumn = predictedObservedData.Columns.Add(errorColumnName, typeof(double));
-                                DataTableUtilities.AddColumn(predictedObservedData, errorColumnName, errorData);
-                                predictedObservedData.Columns[errorColumnName].SetOrdinal(predictedObservedData.Columns["Predicted." + columnName].Ordinal + 1);
-                            }
-                        }
-
-                    }
-
-                    // Write table to datastore.
-                    predictedObservedData.TableName = this.Name;
-                    dataStore.Writer.WriteTable(predictedObservedData);
-
-                    List<string> unitFieldNames = new List<string>();
-                    List<string> unitNames = new List<string>();
-
-                    // write units to table.
-                    reader.Refresh();
-
-                    foreach (string fieldName in commonCols)
-                    {
-                        string units = reader.Units(PredictedTableName, fieldName);
-                        if (units != null && units != "()")
-                        {
-                            string unitsMinusBrackets = units.Replace("(", "").Replace(")", "");
-                            unitFieldNames.Add("Predicted." + fieldName);
-                            unitNames.Add(unitsMinusBrackets);
-                            unitFieldNames.Add("Observed." + fieldName);
-                            unitNames.Add(unitsMinusBrackets);
-                        }
-                    }
-
-                    if (unitNames.Count > 0)
-                    {
-                        // The Writer replaces tables, rather than appends to them,
-                        // so we actually need to re-write the existing units table values
-                        // Is there a better way to do this?
-                        DataView allUnits = new DataView(reader.GetData("_Units"));
-                        allUnits.Sort = "TableName";
-                        DataTable tableNames = allUnits.ToTable(true, "TableName");
-                        foreach (DataRow row in tableNames.Rows)
-                        {
-                            string tableName = row["TableName"] as string;
-                            List<string> colNames = new List<string>();
-                            List<string> unitz = new List<string>();
-                            foreach (DataRowView rowView in allUnits.FindRows(tableName))
-                            {
-                                colNames.Add(rowView["ColumnHeading"].ToString());
-                                unitz.Add(rowView["Units"].ToString());
-                            }
-                            dataStore.Writer.AddUnits(tableName, colNames, unitz);
-                        }
-                        dataStore.Writer.AddUnits(Name, unitFieldNames, unitNames);
-                    }
-                }
+                if (s == FieldNameUsedForMatch || s == FieldName2UsedForMatch || s == FieldName3UsedForMatch)
+                    query.Append($"O.[{obsColShort}]");
                 else
+                    query.Append($"O.[{obsColShort}] AS [Observed.{obsColShort}], P.[{predColShort}] AS [Predicted.{predColShort}]");
+            }
+
+            query.AppendLine();
+            query.AppendLine("FROM [" + ObservedTableName + "] O");
+            query.AppendLine($"INNER JOIN [{PredictedTableName}] P");
+            query.Append($"USING ([SimulationID], [CheckpointID], [{FieldNameUsedForMatch}]");
+            if (!string.IsNullOrEmpty(FieldName2UsedForMatch))
+                query.Append($", [{FieldName2UsedForMatch}]");
+            if (!string.IsNullOrEmpty(FieldName3UsedForMatch))
+                query.Append($", [{FieldName3UsedForMatch}]");
+            query.AppendLine(")");
+
+            int checkpointID = dataStore.Writer.GetCheckpointID("Current");
+            query.AppendLine("WHERE [CheckpointID] = " + checkpointID);
+            query.Replace("O.[SimulationID] AS [Observed.SimulationID], P.[SimulationID] AS [Predicted.SimulationID]", "O.[SimulationID] AS [SimulationID]");
+            query.Replace("O.[CheckpointID] AS [Observed.CheckpointID], P.[CheckpointID] AS [Predicted.CheckpointID]", "O.[CheckpointID] AS [CheckpointID]");
+
+            if (Parent is Folder)
+            {
+                // Limit it to particular simulations in scope.
+                List<string> simulationNames = new List<string>();
+                foreach (Experiment experiment in Apsim.FindAll(this, typeof(Experiment)))
                 {
-                    // Determine what went wrong.
-                    DataTable predictedData = reader.GetDataUsingSql("SELECT * FROM [" + PredictedTableName + "]");
-                    DataTable observedData = reader.GetDataUsingSql("SELECT * FROM [" + ObservedTableName + "]");
-                    if (predictedData == null || predictedData.Rows.Count == 0)
-                        throw new Exception(Name + ": Cannot find any predicted data.");
-                    else if (observedData == null || observedData.Rows.Count == 0)
-                        throw new Exception(Name + ": Cannot find any observed data in node: " + ObservedTableName + ". Check for missing observed file or move " + ObservedTableName + " to top of child list under DataStore (order is important!)");
-                    else
-                        throw new Exception(Name + ": Observed data was found but didn't match the predicted values. Make sure the values in the SimulationName column match the simulation names in the user interface. Also ensure column names in the observed file match the APSIM report column names.");
+                    var names = experiment.GenerateSimulationDescriptions().Select(s => s.Name);
+                    simulationNames.AddRange(names);
                 }
+
+                foreach (Simulation simulation in Apsim.FindAll(this, typeof(Simulation)))
+                    if (!(simulation.Parent is Experiment))
+                        simulationNames.Add(simulation.Name);
+
+                query.Append(" AND O.[SimulationID] in (");
+                foreach (string simulationName in simulationNames)
+                {
+                    if (simulationName != simulationNames[0])
+                        query.Append(',');
+                    query.Append(dataStore.Writer.GetSimulationID(simulationName, null));
+                }
+                query.Append(")");
+            }
+
+            DataTable predictedObservedData = reader.GetDataUsingSql(query.ToString());
+
+            if (predictedObservedData != null)
+            {
+                foreach (DataColumn column in predictedObservedData.Columns)
+                {
+                    if (column.ColumnName.StartsWith("Predicted."))
+                    {
+                        string shortName = column.ColumnName.Substring("Predicted.".Length);
+                        column.ColumnName = "Predicted." + reader.FullColumnName(PredictedTableName, shortName);
+                    }
+                    else if (column.ColumnName.StartsWith("Observed."))
+                    {
+                        string shortName = column.ColumnName.Substring("Observed.".Length);
+                        column.ColumnName = "Observed." + reader.FullColumnName(ObservedTableName, shortName);
+                    }
+                    else if (column.ColumnName.Equals(match1ObsShort) || column.ColumnName.Equals(match2ObsShort) || column.ColumnName.Equals(match3ObsShort))
+                    {
+                        column.ColumnName = reader.FullColumnName(ObservedTableName, column.ColumnName);
+                    }
+                }
+
+                // Add in error columns for each data column.
+                foreach (string columnName in commonCols)
+                {
+                    if (predictedObservedData.Columns.Contains("Predicted." + columnName) &&
+                        predictedObservedData.Columns["Predicted." + columnName].DataType == typeof(double))
+                    {
+                        var predicted = DataTableUtilities.GetColumnAsDoubles(predictedObservedData, "Predicted." + columnName);
+                        var observed = DataTableUtilities.GetColumnAsDoubles(predictedObservedData, "Observed." + columnName);
+                        if (predicted.Length > 0 && predicted.Length == observed.Length)
+                        {
+                            var errorData = MathUtilities.Subtract(predicted, observed);
+                            var errorColumnName = "Pred-Obs." + columnName;
+                            var errorColumn = predictedObservedData.Columns.Add(errorColumnName, typeof(double));
+                            DataTableUtilities.AddColumn(predictedObservedData, errorColumnName, errorData);
+                            predictedObservedData.Columns[errorColumnName].SetOrdinal(predictedObservedData.Columns["Predicted." + columnName].Ordinal + 1);
+                        }
+                    }
+
+                }
+
+                // Write table to datastore.
+                predictedObservedData.TableName = this.Name;
+                dataStore.Writer.WriteTable(predictedObservedData);
+
+                List<string> unitFieldNames = new List<string>();
+                List<string> unitNames = new List<string>();
+
+                // write units to table.
+                reader.Refresh();
+
+                foreach (string fieldName in commonCols)
+                {
+                    string units = reader.Units(PredictedTableName, fieldName);
+                    if (units != null && units != "()")
+                    {
+                        string unitsMinusBrackets = units.Replace("(", "").Replace(")", "");
+                        unitFieldNames.Add("Predicted." + fieldName);
+                        unitNames.Add(unitsMinusBrackets);
+                        unitFieldNames.Add("Observed." + fieldName);
+                        unitNames.Add(unitsMinusBrackets);
+                    }
+                }
+
+                if (unitNames.Count > 0)
+                {
+                    // The Writer replaces tables, rather than appends to them,
+                    // so we actually need to re-write the existing units table values
+                    // Is there a better way to do this?
+                    DataView allUnits = new DataView(reader.GetData("_Units"));
+                    allUnits.Sort = "TableName";
+                    DataTable tableNames = allUnits.ToTable(true, "TableName");
+                    foreach (DataRow row in tableNames.Rows)
+                    {
+                        string tableName = row["TableName"] as string;
+                        List<string> colNames = new List<string>();
+                        List<string> unitz = new List<string>();
+                        foreach (DataRowView rowView in allUnits.FindRows(tableName))
+                        {
+                            colNames.Add(rowView["ColumnHeading"].ToString());
+                            unitz.Add(rowView["Units"].ToString());
+                        }
+                        dataStore.Writer.AddUnits(tableName, colNames, unitz);
+                    }
+                    dataStore.Writer.AddUnits(Name, unitFieldNames, unitNames);
+                }
+            }
+            else
+            {
+                // Determine what went wrong.
+                DataTable predictedData = reader.GetDataUsingSql("SELECT * FROM [" + PredictedTableName + "]");
+                DataTable observedData = reader.GetDataUsingSql("SELECT * FROM [" + ObservedTableName + "]");
+                if (predictedData == null || predictedData.Rows.Count == 0)
+                    throw new Exception(Name + ": Cannot find any predicted data.");
+                else if (observedData == null || observedData.Rows.Count == 0)
+                    throw new Exception(Name + ": Cannot find any observed data in node: " + ObservedTableName + ". Check for missing observed file or move " + ObservedTableName + " to top of child list under DataStore (order is important!)");
+                else
+                    throw new Exception(Name + ": Observed data was found but didn't match the predicted values. Make sure the values in the SimulationName column match the simulation names in the user interface. Also ensure column names in the observed file match the APSIM report column names.");
             }
         }
     }

--- a/Models/PostSimulationTools/PredictedObserved.cs
+++ b/Models/PostSimulationTools/PredictedObserved.cs
@@ -63,8 +63,10 @@ namespace Models.PostSimulationTools
             if (PredictedTableName == null || ObservedTableName == null)
                 return;
 
-            // If the predicted table has not been modified during the current simulations run, don't do anything.
-            if (dataStore?.Writer != null && !dataStore.Writer.TablesModified.Contains(PredictedTableName))
+            // If neither the predicted nor obseved tables have been modified during
+            // the most recent simulations run, don't do anything.
+            if (dataStore?.Writer != null &&
+              !(dataStore.Writer.TablesModified.Contains(PredictedTableName) || dataStore.Writer.TablesModified.Contains(ObservedTableName)))
                 return;
 
             IEnumerable<string> predictedDataNames = dataStore.Reader.ColumnNames(PredictedTableName);

--- a/Models/PostSimulationTools/Probability.cs
+++ b/Models/PostSimulationTools/Probability.cs
@@ -47,6 +47,10 @@
         /// <summary>Main run method for performing our calculations and storing data.</summary>
         public void Run()
         {
+            // If the target table has not been modified during the simulation run, don't do anything.
+            if (dataStore?.Writer != null && dataStore.Writer.TablesModified.Contains(TableName))
+                return;
+
             if (string.IsNullOrWhiteSpace(TableName))
                 throw new Exception(string.Format("Error in probability model {0}: TableName is null", Name));
             else if (!dataStore.Reader.TableNames.Contains(TableName))

--- a/Models/Sensitivity/FactorialAnova.cs
+++ b/Models/Sensitivity/FactorialAnova.cs
@@ -121,6 +121,11 @@
         /// <summary>Main run method for performing our post simulation calculations</summary>
         public void Run()
         {
+            // Note - we seem to be assuming that the predicted data table is called Report.
+            // If the predicted table has not been modified during the most recent simulations run, don't do anything.
+            if (dataStore?.Writer != null && !dataStore.Writer.TablesModified.Contains("Report"))
+                return;
+
             string sql = "SELECT * FROM [Report]";
             DataTable predictedData = dataStore.Reader.GetDataUsingSql(sql);
             if (predictedData != null)

--- a/Models/Sensitivity/Morris.cs
+++ b/Models/Sensitivity/Morris.cs
@@ -307,6 +307,11 @@
         /// <summary>Main run method for performing our post simulation calculations</summary>
         public void Run()
         {
+            // If the predicted table has not been modified, don't do anything.
+            // This can happen if other simulations were run but the Morris model was not.
+            if (dataStore?.Writer != null && !dataStore.Writer.TablesModified.Contains(TableName))
+                return;
+
             DataTable predictedData = dataStore.Reader.GetData(TableName, filter: "SimulationName LIKE '" + Name + "%'", orderBy: "SimulationID");
             if (predictedData != null)
             {

--- a/Models/Sensitivity/Sobol.cs
+++ b/Models/Sensitivity/Sobol.cs
@@ -287,6 +287,9 @@
         /// <summary>Main run method for performing our calculations and storing data.</summary>
         public void Run()
         {
+            if (dataStore?.Writer != null && !dataStore.Writer.TablesModified.Contains("Report"))
+                return;
+
             DataTable predictedData = dataStore.Reader.GetData("Report", filter: "SimulationName LIKE '" + Name + "%'", orderBy: "SimulationID");
             if (predictedData != null)
             {

--- a/Models/Storage/DataStoreWriter.cs
+++ b/Models/Storage/DataStoreWriter.cs
@@ -94,6 +94,11 @@
         }
 
         /// <summary>
+        /// A list of table names which have been modified in the most recent simulations run.
+        /// </summary>
+        public List<string> TablesModified { get; private set; } = new List<string>();
+
+        /// <summary>
         /// 
         /// </summary>
         public int NumJobs { get { return 0; } }
@@ -121,6 +126,8 @@
             lock (lockObject)
             {
                 commands.Add(new WriteTableCommand(Connection, table));
+                if (!TablesModified.Contains(table.TableName))
+                    TablesModified.Add(table.TableName);
             }
         }
 
@@ -153,6 +160,8 @@
             lock (lockObject)
             {
                 commands.Add(new WriteTableCommand(Connection, table));
+                if (!TablesModified.Contains(table.TableName))
+                    TablesModified.Add(table.TableName);
             }
         }
 
@@ -163,6 +172,9 @@
         public void DeleteTable(string tableName)
         {
             Connection.ExecuteNonQuery($"DROP TABLE {tableName}");
+            lock (lockObject)
+                if (!TablesModified.Contains(tableName))
+                    TablesModified.Add(tableName);
         }
 
         /// <summary>Wait for all records to be written.</summary>

--- a/Models/Storage/IStorageWriter.cs
+++ b/Models/Storage/IStorageWriter.cs
@@ -9,6 +9,14 @@
     public interface IStorageWriter
     {
         /// <summary>
+        /// A list of table names which have been modified in the most recent simulations run.
+        /// </summary>
+        /// <remarks>
+        /// This is currently used to determine which post-simulation tools to run.
+        /// </remarks>
+        List<string> TablesModified { get; }
+
+        /// <summary>
         /// Add rows to a table in the db file. Note that the data isn't written immediately.
         /// </summary>
         /// <param name="data">Name of simulation the values correspond to.</param>

--- a/Tests/UnitTests/Storage/MockStorage.cs
+++ b/Tests/UnitTests/Storage/MockStorage.cs
@@ -54,6 +54,8 @@ namespace UnitTests.Storage
 
         public List<string> TableAndViewNames => throw new NotImplementedException();
 
+        public List<string> TablesModified { get; set; }
+
         [Serializable]
         internal class Row
         {


### PR DESCRIPTION
Resolves #3808

This allows data store writer to keep track of which tables have been modified during a simulations run. This is used by post-simulation tools such as Probability and PredictedObserved, so that they only get run if their predicted/observed data table has been modified.

Unsure if this is the best solution to the problem, but the only other solution I can think of is to close the issue as "not a bug".