### PR TITLE
Force garbage collection before trying to delete .db file

### DIFF
--- a/Tests/UserInterfaceTests/DeleteDBFile.cs
+++ b/Tests/UserInterfaceTests/DeleteDBFile.cs
@@ -39,6 +39,7 @@ public class Script
 			
 		// Try and delete the .db file.
 		string dbFile = Path.ChangeExtension(tempFile, ".db");
+		GC.Collect();
 		File.Delete(dbFile);
 		
         // Close the user interface.


### PR DESCRIPTION
If this runs green on jenkins, then it resolves #3989.

@zur003 @hol353 this *appears* to fix the problem with the failing DeleteDBFile test (although I'm not totally clear on why this is necessary). It doesn't fix the performance tests issue with stock giving slightly different numbers each time it's run.