### PR TITLE
GUI should remain responsive while running post-simulation tools

### DIFF
--- a/ApsimNG/Menus/ContextMenu.cs
+++ b/ApsimNG/Menus/ContextMenu.cs
@@ -89,18 +89,9 @@
         {
             try
             {
-                // Run all child model post processors.
-                var runner = new Runner(explorerPresenter.ApsimXFile, runSimulations: false);
-                runner.Run();
-
-                if (runner.ExceptionsThrown != null && runner.ExceptionsThrown.Count > 0)
-                {
-                    explorerPresenter.MainPresenter.ShowError(runner.ExceptionsThrown);
-                    return;
-                }
-
-                (explorerPresenter.CurrentPresenter as DataStorePresenter).PopulateGrid();
-                this.explorerPresenter.MainPresenter.ShowMessage("Post processing models have successfully completed", Simulation.MessageType.Information);
+                Runner runner = new Runner(explorerPresenter.ApsimXFile, runSimulations: false, wait: false);
+                ICommand command = new RunCommand("Post-simulation tools", runner, explorerPresenter);
+                command.Do(null);
             }
             catch (Exception err)
             {

--- a/Models/Core/Run/EmptyJob.cs
+++ b/Models/Core/Run/EmptyJob.cs
@@ -21,6 +21,6 @@ namespace Models.Core.Run
         /// <summary>
         /// Returns the job's progress as a real number in range [0, 1].
         /// </summary>
-        public double Progress { get { return 0; } }
+        public double Progress { get { return 1; } }
     }
 }


### PR DESCRIPTION
Working on #5257 

It's not a perfect fix - the progress bar is always at 100%, although the status message will correctly show which IPostSimulationTool is currently running so you do have some idea of progress. Fixing the progress bar will require a fairly major rework of the job running code, specifically in regards to SimulationGroup and how the IPostSimulationTools are run.