### PR TITLE
CropReader traps invalid land id being used

### DIFF
--- a/Models/CLEM/FileCrop.cs
+++ b/Models/CLEM/FileCrop.cs
@@ -318,7 +318,26 @@ namespace Models.CLEM
 
             //http://www.csharp-examples.net/dataview-rowfilter/
 
-            string filter = $"({SoilTypeColumnName} = '" + landId + $"') AND ({CropNameColumnName} = " + "'" + cropName + "'" + ")"
+            string soiltypeparenth = (forageFileAsTable.Columns[SoilTypeColumnName].DataType == typeof(System.String)) ? "'" : "";
+            string cropnameparenth = (forageFileAsTable.Columns[CropNameColumnName].DataType == typeof(System.String)) ? "'" : "";
+
+            // check that entry is in correct type
+            if(forageFileAsTable.Columns[SoilTypeColumnName].DataType == typeof(System.Single))
+            {
+                if(!System.Single.TryParse(landId, out Single val))
+                {
+                    throw new ApsimXException(this, $"[o={this.Parent.Name}.{this.Name}] encountered a problem reading data\nCause: The value [{landId}] specified for column [{SoilTypeColumnName}] is not a [Single] type as expected by the data provided.\nFix: Ensure the Land Id [{landId}] assigned to the Land type used is present in column [{SoilTypeColumnName}] of the production data provided.");
+                }
+            }
+            if (forageFileAsTable.Columns[CropNameColumnName].DataType == typeof(System.Single))
+            {
+                if (!System.Single.TryParse(cropName, out Single val))
+                {
+                    throw new ApsimXException(this, $"[o={this.Parent.Name}.{this.Name}] encountered a problem reading data\nCause: The value [{cropName}] specified for column [{CropNameColumnName}] is not a [Single] type as expected by the data provided.\nFix: Ensure the Crop name [{cropName}] required is present in column [{CropNameColumnName}] of the production data provided.");
+                }
+            }
+
+            string filter = $"({SoilTypeColumnName} = {soiltypeparenth}{landId}{soiltypeparenth}) AND ({CropNameColumnName} = {cropnameparenth}{cropName}{cropnameparenth})"
                 + " AND ("
                 + $"( {YearColumnName} = " + startYear + $" AND {MonthColumnName} >= " + startMonth + ")"
                 + $" OR  ( {YearColumnName} > " + startYear + $" AND {YearColumnName} < " + endYear + ")"

--- a/Models/CLEM/Resources/RuminantTypeCohort.cs
+++ b/Models/CLEM/Resources/RuminantTypeCohort.cs
@@ -114,11 +114,18 @@ namespace Models.CLEM.Resources
 
                 for (int i = 1; i <= number; i++)
                 {
-                    double u1 = RandomNumberGenerator.Generator.NextDouble();
-                    double u2 = RandomNumberGenerator.Generator.NextDouble();
-                    double randStdNormal = Math.Sqrt(-2.0 * Math.Log(u1)) *
-                                 Math.Sin(2.0 * Math.PI * u2);
-                    double weight = Weight + WeightSD * randStdNormal;
+                    double weight = 0;
+                    if(Weight > 0)
+                    {
+                        // avoid accidental small weight if SD provided but weight is 0
+                        // if weight is 0 then the normalised weight will be applied in Ruminant constructor.
+                        double u1 = RandomNumberGenerator.Generator.NextDouble();
+                        double u2 = RandomNumberGenerator.Generator.NextDouble();
+                        double randStdNormal = Math.Sqrt(-2.0 * Math.Log(u1)) *
+                                     Math.Sin(2.0 * Math.PI * u2);
+                        weight = Weight + WeightSD * randStdNormal;
+                    }
+
                     object ruminantBase;
                     if (this.Gender == Sex.Male)
                     {


### PR DESCRIPTION
resolves #5315 

This problem was resolved by throwing a suitable error as rather than address the SQL query type mismatch from ascii table creation, the problem relates to the land id provided not being present in the production data.