### PR TITLE
Store font as a string rather than Pango.FontDescription

### DIFF
--- a/ApsimNG/Utility/Configuration.cs
+++ b/ApsimNG/Utility/Configuration.cs
@@ -125,7 +125,7 @@ namespace Utility
         /// Stores the user's preferred font.
         /// </summary>
         /// <value></value>
-        public Pango.FontDescription Font { get; set; }
+        public string Font { get; set; }
 
         public ApsimFileMetadata GetMruFile(string fileName)
         {

--- a/ApsimNG/Utility/Configuration.cs
+++ b/ApsimNG/Utility/Configuration.cs
@@ -125,7 +125,7 @@ namespace Utility
         /// Stores the user's preferred font.
         /// </summary>
         /// <value></value>
-        public string Font { get; set; }
+        public string FontName { get; set; } = "Segoe UI 11";
 
         public ApsimFileMetadata GetMruFile(string fileName)
         {

--- a/ApsimNG/Utility/ConfigurationConverter.cs
+++ b/ApsimNG/Utility/ConfigurationConverter.cs
@@ -96,7 +96,7 @@ namespace Utility
                 string fontString = $"{family} {style} {variant} {weight} {stretch} {gravity} {size}";
 
                 rootNode.RemoveChild(fontNode);
-                XmlNode newFontNode = rootNode.OwnerDocument.CreateElement("Font");
+                XmlNode newFontNode = rootNode.OwnerDocument.CreateElement("FontName");
                 newFontNode.InnerText = fontString;
                 rootNode.AppendChild(newFontNode);
             }

--- a/ApsimNG/Utility/ConfigurationConverter.cs
+++ b/ApsimNG/Utility/ConfigurationConverter.cs
@@ -14,7 +14,7 @@ namespace Utility
 {
     public class ConfigurationConverter
     {
-        public const int LatestVersion = 1;
+        public const int LatestVersion = 2;
 
         public static Configuration DoConvert(string fileName)
         {
@@ -77,6 +77,28 @@ namespace Utility
                 XmlNode newChild = doc[typeof(ApsimFileMetadata).Name];
                 newChild = mruList.OwnerDocument.ImportNode(newChild, true);
                 mruList.ReplaceChild(newChild, child);
+            }
+        }
+
+        private static void UpgradeToVersion2(XmlNode rootNode)
+        {
+            XmlNode fontNode = rootNode["Font"];
+            if (fontNode != null)
+            {
+                string family = fontNode["Family"].InnerText;
+                int size = int.Parse(fontNode["Size"].InnerText) / 1024;
+                string gravity = fontNode["Gravity"].InnerText;
+                string stretch = fontNode["Stretch"].InnerText;
+                string style = fontNode["Style"].InnerText;
+                string variant = fontNode["Variant"].InnerText;
+                string weight = fontNode["Weight"].InnerText;
+
+                string fontString = $"{family} {style} {variant} {weight} {stretch} {gravity} {size}";
+
+                rootNode.RemoveChild(fontNode);
+                XmlNode newFontNode = rootNode.OwnerDocument.CreateElement("Font");
+                newFontNode.InnerText = fontString;
+                rootNode.AppendChild(newFontNode);
             }
         }
     }

--- a/ApsimNG/Views/ListButtonView.cs
+++ b/ApsimNG/Views/ListButtonView.cs
@@ -170,7 +170,7 @@
 
             // Unsure why, but sometimes the label's font is incorrect
             // (inconsistent with default font).
-            Pango.FontDescription font = Pango.FontDescription.FromString(Utility.Configuration.Settings.Font);
+            Pango.FontDescription font = Pango.FontDescription.FromString(Utility.Configuration.Settings.FontName);
             if (font != null && font != btnLabel.Style.FontDescription)
                 btnLabel.ModifyFont(font);
 

--- a/ApsimNG/Views/ListButtonView.cs
+++ b/ApsimNG/Views/ListButtonView.cs
@@ -170,9 +170,10 @@
 
             // Unsure why, but sometimes the label's font is incorrect
             // (inconsistent with default font).
-            Pango.FontDescription font = Utility.Configuration.Settings.Font;
+            Pango.FontDescription font = Pango.FontDescription.FromString(Utility.Configuration.Settings.Font);
             if (font != null && font != btnLabel.Style.FontDescription)
-                btnLabel.ModifyFont(Utility.Configuration.Settings.Font);
+                btnLabel.ModifyFont(font);
+
             btnLabel.LineWrap = true;
             btnLabel.LineWrapMode = Pango.WrapMode.Word;
             btnLabel.Justify = Justification.Center;

--- a/ApsimNG/Views/MainView.cs
+++ b/ApsimNG/Views/MainView.cs
@@ -155,7 +155,7 @@
 
             notebook1.GetTabLabel(notebook1.Children[0]).Name = "selected-tab";
 
-            hbox1.HeightRequest = 20;            
+            hbox1.HeightRequest = 20;
 
             TextTag tag = new TextTag("error");
             // Make errors orange-ish in dark mode.
@@ -182,17 +182,21 @@
 
             // If font is null, or font family is null, or font size is 0, fallback
             // to the default font (on windows only).
-            if (ProcessUtilities.CurrentOS.IsWindows && (Utility.Configuration.Settings.Font == null ||
-                                                         Utility.Configuration.Settings.Font.Family == null ||
-                                                         Utility.Configuration.Settings.Font.Size == 0))
+            Pango.FontDescription f = Pango.FontDescription.FromString(Utility.Configuration.Settings.Font);
+            if (ProcessUtilities.CurrentOS.IsWindows && (string.IsNullOrEmpty(Utility.Configuration.Settings.Font) ||
+                                                         f.Family == null ||
+                                                         f.Size == 0))
             {
                 // Default font on Windows is Segoe UI. Will fallback to sans if unavailable.
-                Utility.Configuration.Settings.Font = Pango.FontDescription.FromString("Segoe UI 11");
+                Utility.Configuration.Settings.Font = Pango.FontDescription.FromString("Segoe UI 11").ToString();
             }
 
             // Can't set font until widgets are initialised.
-            if (Utility.Configuration.Settings.Font != null)
-                ChangeFont(Utility.Configuration.Settings.Font);
+            if (!string.IsNullOrEmpty(Utility.Configuration.Settings.Font))
+            {
+                Pango.FontDescription font = Pango.FontDescription.FromString(Utility.Configuration.Settings.Font);
+                ChangeFont(font);
+            }
 
             //window1.ShowAll();
             if (ProcessUtilities.CurrentOS.IsMac)
@@ -902,7 +906,7 @@
             try
             {
                 Pango.FontDescription newFont = Pango.FontDescription.FromString(fontDialog.FontName);
-                Utility.Configuration.Settings.Font = newFont;
+                Utility.Configuration.Settings.Font = newFont.ToString();
                 ChangeFont(newFont);
             }
             catch (Exception err)

--- a/ApsimNG/Views/MainView.cs
+++ b/ApsimNG/Views/MainView.cs
@@ -182,19 +182,19 @@
 
             // If font is null, or font family is null, or font size is 0, fallback
             // to the default font (on windows only).
-            Pango.FontDescription f = Pango.FontDescription.FromString(Utility.Configuration.Settings.Font);
-            if (ProcessUtilities.CurrentOS.IsWindows && (string.IsNullOrEmpty(Utility.Configuration.Settings.Font) ||
+            Pango.FontDescription f = Pango.FontDescription.FromString(Utility.Configuration.Settings.FontName);
+            if (ProcessUtilities.CurrentOS.IsWindows && (string.IsNullOrEmpty(Utility.Configuration.Settings.FontName) ||
                                                          f.Family == null ||
                                                          f.Size == 0))
             {
                 // Default font on Windows is Segoe UI. Will fallback to sans if unavailable.
-                Utility.Configuration.Settings.Font = Pango.FontDescription.FromString("Segoe UI 11").ToString();
+                Utility.Configuration.Settings.FontName = Pango.FontDescription.FromString("Segoe UI 11").ToString();
             }
 
             // Can't set font until widgets are initialised.
-            if (!string.IsNullOrEmpty(Utility.Configuration.Settings.Font))
+            if (!string.IsNullOrEmpty(Utility.Configuration.Settings.FontName))
             {
-                Pango.FontDescription font = Pango.FontDescription.FromString(Utility.Configuration.Settings.Font);
+                Pango.FontDescription font = Pango.FontDescription.FromString(Utility.Configuration.Settings.FontName);
                 ChangeFont(font);
             }
 
@@ -881,8 +881,8 @@
             fontDialog.WindowPosition = WindowPosition.CenterOnParent;
 
             // Select the current font.
-            if (Utility.Configuration.Settings.Font != null)
-                fontDialog.SetFontName(Utility.Configuration.Settings.Font.ToString());
+            if (Utility.Configuration.Settings.FontName != null)
+                fontDialog.SetFontName(Utility.Configuration.Settings.FontName.ToString());
 
             // Event handlers.
             fontDialog.OkButton.Clicked += OnChangeFont;
@@ -906,7 +906,7 @@
             try
             {
                 Pango.FontDescription newFont = Pango.FontDescription.FromString(fontDialog.FontName);
-                Utility.Configuration.Settings.Font = newFont.ToString();
+                Utility.Configuration.Settings.FontName = newFont.ToString();
                 ChangeFont(newFont);
             }
             catch (Exception err)

--- a/ApsimNG/Views/MainView.cs
+++ b/ApsimNG/Views/MainView.cs
@@ -180,7 +180,11 @@
             stopButton.Clicked += OnStopClicked;
             window1.DeleteEvent += OnClosing;
 
-            if (ProcessUtilities.CurrentOS.IsWindows && Utility.Configuration.Settings.Font == null)
+            // If font is null, or font family is null, or font size is 0, fallback
+            // to the default font (on windows only).
+            if (ProcessUtilities.CurrentOS.IsWindows && (Utility.Configuration.Settings.Font == null ||
+                                                         Utility.Configuration.Settings.Font.Family == null ||
+                                                         Utility.Configuration.Settings.Font.Size == 0))
             {
                 // Default font on Windows is Segoe UI. Will fallback to sans if unavailable.
                 Utility.Configuration.Settings.Font = Pango.FontDescription.FromString("Segoe UI 11");


### PR DESCRIPTION
This also improves the robustness of the font resolution algorithm, which should be helpful if switching between the master and netcore3 branches.

Working on #5344 