### PR TITLE
Removed duplicate AboveGround member from plant.

### DIFF
--- a/Models/AgPasture/SimpleGrazing.cs
+++ b/Models/AgPasture/SimpleGrazing.cs
@@ -405,7 +405,7 @@
             foreach (var forage in forages)
             {
                 PreGrazeDM += forage.AboveGround.Wt;
-                PreGrazeHarvestableDM += forage.AboveGroundHarvestable.Wt;
+                PreGrazeHarvestableDM += forage.AboveGround.Wt;
             }
 
             // Convert to kg/ha

--- a/Models/PMF/Interfaces/IPlantDamage.cs
+++ b/Models/PMF/Interfaces/IPlantDamage.cs
@@ -19,9 +19,6 @@
         /// <summary>Total amount of above ground biomass.</summary>
         Biomass AboveGround { get;  }
 
-        /// <summary>Total amount of harvestable above ground biomass.</summary>
-        Biomass AboveGroundHarvestable { get; }
-
         /// <summary>Plant population.</summary>
         double Population { get; }
 

--- a/Models/PMF/Plant.cs
+++ b/Models/PMF/Plant.cs
@@ -60,9 +60,6 @@
         [Link(Type = LinkType.Child, ByName = true, IsOptional = true)]
         public Biomass AboveGround { get; set; }
 
-        /// <summary>Above ground weight</summary>
-        public Biomass AboveGroundHarvestable { get { return AboveGround; } }
-
         /// <summary>Used by several organs to determine the type of crop.</summary>
         public string CropType { get; set; }
 


### PR DESCRIPTION
Resolves #5448

@hut104 (and maybe @HamishBrownPFR fyi) the reason we had a separate AboveGround and AboveGroundHarvestable is because IPlantDamage contains these two as separate biomasses (biomi?). I have removed AboveGroundHarvestable from IPlantDamage (and Plant). Let me know if we do actually want both here.