### PR TITLE
Add API docs to website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,4 @@ Documentation/errors.txt
 *.db-wal
 Docs/docfx/api/*.yml
 Docs/docfx/api/.manifest
-Docs/api
+Docs/apsimx-docs/

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ Documentation/errors.txt
 *.db-journal
 *.db-shm
 *.db-wal
+Docs/docfx/api/*.yml
+Docs/docfx/api/.manifest
+Docs/api

--- a/Docs/docfx/api/index.md
+++ b/Docs/docfx/api/index.md
@@ -1,0 +1,2 @@
+# PLACEHOLDER
+TODO: Add .NET projects to the *src* folder and run `docfx` to generate **REAL** *API Documentation*!

--- a/Docs/docfx/api/index.md
+++ b/Docs/docfx/api/index.md
@@ -1,2 +1,1 @@
-# PLACEHOLDER
-TODO: Add .NET projects to the *src* folder and run `docfx` to generate **REAL** *API Documentation*!
+# APSIM Next Generation

--- a/Docs/docfx/articles/intro.md
+++ b/Docs/docfx/articles/intro.md
@@ -1,0 +1,1 @@
+# Add your introductions here!

--- a/Docs/docfx/articles/toc.yml
+++ b/Docs/docfx/articles/toc.yml
@@ -1,0 +1,2 @@
+- name: Introduction
+  href: intro.md

--- a/Docs/docfx/docfx.json
+++ b/Docs/docfx/docfx.json
@@ -50,7 +50,7 @@
         ]
       }
     ],
-    "dest": "../api",
+    "dest": "../apsimx-docs",
     "globalMetadataFiles": [],
     "fileMetadataFiles": [],
     "template": [

--- a/Docs/docfx/docfx.json
+++ b/Docs/docfx/docfx.json
@@ -12,7 +12,7 @@
         }
       ],
       "dest": "api",
-      "disableGitFeatures": true,
+      "disableGitFeatures": false,
       "disableDefaultFilter": false
     }
   ],
@@ -61,6 +61,6 @@
     "noLangKeyword": false,
     "keepFileLink": false,
     "cleanupCacheHistory": false,
-    "disableGitFeatures": true
+    "disableGitFeatures": false
   }
 }

--- a/Docs/docfx/docfx.json
+++ b/Docs/docfx/docfx.json
@@ -1,0 +1,66 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "files": [
+            "APSIM.Shared/APSIM.Shared.csproj",
+            "ApsimNG/ApsimNG.csproj",
+            "Models/Models.csproj"
+          ],
+          "src": "../../"
+        }
+      ],
+      "dest": "api",
+      "disableGitFeatures": true,
+      "disableDefaultFilter": false
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [
+          "api/**.yml",
+          "index.md",
+          "api/index.md"
+        ]
+      },
+      {
+        "files": [
+          "articles/**.md",
+          "articles/**/toc.yml",
+          "toc.yml",
+          "*.md"
+        ]
+      }
+    ],
+    "resource": [
+      {
+        "files": [
+          "static/images/**"
+        ],
+        "src": "../"
+      }
+    ],
+    "overwrite": [
+      {
+        "files": [
+        ],
+        "exclude": [
+        ]
+      }
+    ],
+    "dest": "../api",
+    "globalMetadataFiles": [],
+    "fileMetadataFiles": [],
+    "template": [
+      "default"
+    ],
+    "postProcessors": [],
+    "markdownEngineName": "markdig",
+    "noLangKeyword": false,
+    "keepFileLink": false,
+    "cleanupCacheHistory": false,
+    "disableGitFeatures": true
+  }
+}

--- a/Docs/docfx/index.md
+++ b/Docs/docfx/index.md
@@ -1,0 +1,4 @@
+# This is the **HOMEPAGE**.
+Refer to [Markdown](http://daringfireball.net/projects/markdown/) for how to write markdown files.
+## Quick Start Notes:
+1. Add images to the *images* folder if the file is referencing an image.

--- a/Docs/docfx/index.md
+++ b/Docs/docfx/index.md
@@ -1,4 +1,39 @@
-# This is the **HOMEPAGE**.
-Refer to [Markdown](http://daringfireball.net/projects/markdown/) for how to write markdown files.
-## Quick Start Notes:
-1. Add images to the *images* folder if the file is referencing an image.
+# ApsimX
+
+ApsimX is the next generation of [APSIM](http://www.apsim.info)
+
+* APSIM is an agricultural modelling framework used extensively worldwide.
+* It can simulate a wide range of agricultural systems.
+* It begins its third decade evolving into an agro-ecosystem framework.
+
+## Licencing Conditions
+
+Use of APSIM source code is provided under the terms and conditions provided by either the Non-Commercial or Commercial licence Agreements.  Use in any way is not permitted unless previously agreed to and currently bound by a licence agreement which can be reviewed on www.apsim.info. Any questions, please email apsim@csiro.au 
+
+## Getting Started
+
+**Hardware required**: 
+
+Any recent PC with a minimum of 2Gb of RAM.
+
+**Software required**:
+
+64-bit version of Microsoft Windows Vista, Windows 7, Windows 8, Windows 10, Linux or macOS.
+
+### Installation
+
+Installers for Windows, MacOS, and (Debian) Linux are available [here](http://apsimdev.apsim.info/APSIM.Registration.Portal/Main.aspx)
+
+Instructions for compiling from source are available [here](https://apsimnextgeneration.netlify.app/development/contribute/compile/)
+
+## Contributing
+
+Any individual or organisation (a 3rd party outside of the AI) who uses APSIM must be licensed do so by the AI. On download of APSIM, the terms and conditions of a standard Non-Commercial R&D Licence are agreed to and binds the user.
+
+Intellectual property rights in APSIM are retained by the AI. If a licensee makes any improvements to APSIM, the intellectual property rights to those improvements belong to the AI. This means that the AI can choose to make the improvements - including source code – and these improvements would then be made available to all licensed users. As part of the submission process, you are complying with this term as well as making it available to all licensed users. Any Improvements to APSIM are required to be unencumbered and the contributing party warrants that the IP being contributed does not and will not infringe any third party IPR rights.
+
+Please read our [guide](https://apsimnextgeneration.netlify.com/development/contribute/).
+
+## Publications 
+
+* [doi:10.1016/j.envsoft.2014.07.009](http://dx.doi.org/10.1016/j.envsoft.2014.07.009)

--- a/Docs/docfx/toc.yml
+++ b/Docs/docfx/toc.yml
@@ -1,0 +1,5 @@
+- name: Articles
+  href: articles/
+- name: Api Documentation
+  href: api/
+  homepage: api/index.md

--- a/Jenkins/deploy.bat
+++ b/Jenkins/deploy.bat
@@ -8,6 +8,7 @@ if "%2"=="" (
 	echo %usage%
 	exit /b 1
 )
+if "%apsimx%"=="" set "apsimx=%~dp0.."
 
 rem Add build to builds database
 @curl -f "https://apsimdev.apsim.info/APSIM.Builds.Service/Builds.svc/AddBuild?pullRequestNumber=%1&ChangeDBPassword=%2"
@@ -24,3 +25,16 @@ if errorlevel 1 (
 	echo Error triggering netlify build
 	exit /b 1
 )
+
+rem Generate API docs
+cd "%apsimx%\Docs\docfx"
+docfx
+
+if errorlevel 1 (
+	echo Error generating API documentation
+	exit /b 1
+)
+
+rem Upload API docs to website
+cd "%apsimx%\Docs"
+rsync -arz apsimx-docs/ admin@apsimdev.apsim.info:/cygdrive/d/Websites/APSIM/apsimx-docs/

--- a/Jenkins/deploy.bat
+++ b/Jenkins/deploy.bat
@@ -10,6 +10,27 @@ if "%2"=="" (
 )
 if "%apsimx%"=="" set "apsimx=%~dp0.."
 
+rem Generate API docs
+cd "%apsimx%\Docs\docfx"
+docfx
+
+if errorlevel 1 (
+	echo Error generating API documentation
+	exit /b 1
+)
+
+rem Upload API docs to website
+rem FTPing every file would be very slow. An rsync/ssh-based solution would be ideal,
+rem unfortunately port 22 is locked down and that's apparently not going to change. 😡
+rem This build machine is going to be retired "soon", so in the long term this problem
+rem should disappear. In the short term, we will FTP(!) up a zip archive, and then expect
+rem the server to magically unzip it.
+
+cd "%apsimx%\Docs"
+7z a apsimx-docs.zip apsimx-docs
+@curl -s -u !APSIM_SITE_CREDS! -T apsimx-docs.zip ftp://apsimdev.apsim.info/APSIM/
+rem rsync -arz apsimx-docs/ admin@apsimdev.apsim.info:/cygdrive/d/Websites/APSIM/apsimx-docs/
+
 rem Add build to builds database
 @curl -f "https://apsimdev.apsim.info/APSIM.Builds.Service/Builds.svc/AddBuild?pullRequestNumber=%1&ChangeDBPassword=%2"
 if errorlevel 1 exit /b 1
@@ -25,16 +46,3 @@ if errorlevel 1 (
 	echo Error triggering netlify build
 	exit /b 1
 )
-
-rem Generate API docs
-cd "%apsimx%\Docs\docfx"
-docfx
-
-if errorlevel 1 (
-	echo Error generating API documentation
-	exit /b 1
-)
-
-rem Upload API docs to website
-cd "%apsimx%\Docs"
-rsync -arz apsimx-docs/ admin@apsimdev.apsim.info:/cygdrive/d/Websites/APSIM/apsimx-docs/


### PR DESCRIPTION
Resolves #5537 

The docs are available at https://apsimdev.apsim.info/apsimx-docs/. There should be an initial version already there, which will be updated whenever a pull request is merged. To change the homepage, edit `ApsimX/Docs/docfx/index.md` and/or `ApsimX/Docs/docfx/api/index.md`. To add articles, add markdown (.md) files under `ApsiMX/Docs/articles/`.