### PR TITLE
Remove redundant methods

### DIFF
--- a/Models/PMF/Organs/Leaf.cs
+++ b/Models/PMF/Organs/Leaf.cs
@@ -1927,30 +1927,6 @@ namespace Models.PMF.Organs
                 throw new Exception(Name + "Some Leaf N was not allocated.");
         }
 
-        /// <summary>Remove maintenance respiration from live component of organs.</summary>
-        /// <param name="respiration">The respiration to remove</param>
-        public virtual void RemoveMaintenanceRespiration(double respiration)
-        {
-            double totalResLeaf = MaintenanceRespiration;
-
-            foreach (LeafCohort L in Leaves)
-            {
-                double totalBMLeafCohort = L.Live.MetabolicWt + L.Live.StorageWt;
-                double resLeafCohort = respiration * L.MaintenanceRespiration / totalResLeaf;
-
-                if (resLeafCohort > Double.Epsilon && resLeafCohort - totalBMLeafCohort > 0.00001)
-                    throw new Exception("Respiration is more than total biomass of metabolic and storage in live component.");
-
-                if (resLeafCohort > 0 && (L.Live.MetabolicWt + L.Live.StorageWt) > 0)
-                {
-                    L.Live.MetabolicWt -= (resLeafCohort * L.Live.MetabolicWt / totalBMLeafCohort);
-                    L.Live.StorageWt -= (resLeafCohort * L.Live.StorageWt / totalBMLeafCohort);
-                    needToRecalculateLiveDead = true;
-                }
-            }
-        }
-
-
         /// <summary>Gets or sets the minimum nconc.</summary>
         public double MinNconc
         {

--- a/Models/PMF/Organs/Nodule.cs
+++ b/Models/PMF/Organs/Nodule.cs
@@ -424,19 +424,6 @@ namespace Models.PMF.Organs
             potentialDMAllocation.Storage = dryMatter.Storage;
         }
 
-        /// <summary>Remove maintenance respiration from live component of organs.</summary>
-        /// <param name="respiration">The respiration to remove</param>
-        public virtual void RemoveMaintenanceRespiration(double respiration)
-        {
-            double total = Live.MetabolicWt + Live.StorageWt;
-            if (respiration > total)
-            {
-                throw new Exception("Respiration is more than total biomass of metabolic and storage in live component.");
-            }
-            Live.MetabolicWt = Live.MetabolicWt - MathUtilities.Divide(respiration * Live.MetabolicWt, total, 0);
-            Live.StorageWt = Live.StorageWt - MathUtilities.Divide(respiration * Live.StorageWt, total, 0);
-        }
-
         /// <summary>Clears this instance.</summary>
         protected virtual void Clear()
         {
@@ -551,10 +538,11 @@ namespace Models.PMF.Organs
 
                 // Do maintenance respiration
                 MaintenanceRespiration = 0;
-                if (maintenanceRespirationFunction != null && (Live.MetabolicWt + Live.StorageWt) > 0)
+                if (maintenanceRespirationFunction.Value() > 0)
                 {
-                    MaintenanceRespiration += Live.MetabolicWt * maintenanceRespirationFunction.Value();
-                    MaintenanceRespiration += Live.StorageWt * maintenanceRespirationFunction.Value();
+                    MaintenanceRespiration = (Live.MetabolicWt + Live.StorageWt) * maintenanceRespirationFunction.Value();
+                    Live.MetabolicWt *= (1 - maintenanceRespirationFunction.Value());
+                    Live.StorageWt *= (1 - maintenanceRespirationFunction.Value());
                 }
             }
         }

--- a/Models/PMF/Organs/PerennialLeaf.cs
+++ b/Models/PMF/Organs/PerennialLeaf.cs
@@ -681,20 +681,6 @@ namespace Models.PMF.Organs
                 throw new Exception("Insufficient Storage N to account for Retranslocation and Reallocation in Perrenial Leaf");
         }
 
-        /// <summary>Remove maintenance respiration from live component of organs.</summary>
-        /// <param name="respiration">The respiration to remove</param>
-        public virtual void RemoveMaintenanceRespiration(double respiration)
-        {
-            double total = Live.MetabolicWt + Live.StorageWt;
-            if (respiration > total)
-            {
-                throw new Exception("Respiration is more than total biomass of metabolic and storage in live component.");
-            }
-            Live.MetabolicWt = Live.MetabolicWt - (respiration * Live.MetabolicWt / total);
-            Live.StorageWt = Live.StorageWt - (respiration * Live.StorageWt / total);
-        }
-
-
         /// <summary>Gets or sets the maximum nconc.</summary>
         public double MaxNconc { get { return MaximumNConc.Value(); } }
 

--- a/Models/PMF/Organs/ReproductiveOrgan.cs
+++ b/Models/PMF/Organs/ReproductiveOrgan.cs
@@ -320,14 +320,6 @@ namespace Models.PMF.Organs
         {
             if (Phenology.OnStartDayOf(RipeStage))
                 _ReadyForHarvest = true;
-
-            //Do Maintenance respiration
-            MaintenanceRespiration = 0;
-            if (MaintenanceRespirationFunction != null && (Live.MetabolicWt + Live.StorageWt) > 0)
-            {
-                MaintenanceRespiration += Live.MetabolicWt * MaintenanceRespirationFunction.Value();
-                MaintenanceRespiration += Live.StorageWt * MaintenanceRespirationFunction.Value();
-            }
         }
         /// <summary>Sets the dry matter potential allocation.</summary>
         public void SetDryMatterPotentialAllocation(BiomassPoolType dryMatter)
@@ -400,19 +392,6 @@ namespace Models.PMF.Organs
                 else
                     return 0.0;
             }
-        }
-
-        /// <summary>Remove maintenance respiration from live component of organs.</summary>
-        /// <param name="respiration">The respiration to remove</param>
-        public virtual void RemoveMaintenanceRespiration(double respiration)
-        {
-            double total = Live.MetabolicWt + Live.StorageWt;
-            if (respiration > total)
-            {
-                throw new Exception("Respiration is more than total biomass of metabolic and storage in live component.");
-            }
-            Live.MetabolicWt = Live.MetabolicWt - (respiration * Live.MetabolicWt / total);
-            Live.StorageWt = Live.StorageWt - (respiration * Live.StorageWt / total);
         }
 
         /// <summary>Removes biomass from organs when harvest, graze or cut events are called.</summary>

--- a/Models/PMF/Organs/Root.cs
+++ b/Models/PMF/Organs/Root.cs
@@ -814,19 +814,6 @@
                 throw new Exception("Error in N Allocation: " + Name);
         }
 
-        /// <summary>Remove maintenance respiration from live component of organs.</summary>
-        /// <param name="respiration">The respiration to remove</param>
-        public virtual void RemoveMaintenanceRespiration(double respiration)
-        {
-            double total = Live.MetabolicWt + Live.StorageWt;
-            if (respiration > total)
-            {
-                throw new Exception("Respiration is more than total biomass of metabolic and storage in live component.");
-            }
-            Live.MetabolicWt = Live.MetabolicWt - (respiration * Live.MetabolicWt / total);
-            Live.StorageWt = Live.StorageWt - (respiration * Live.StorageWt / total);
-        }
-
         /// <summary>Gets or sets the water supply.</summary>
         /// <param name="zone">The zone.</param>
         public double[] CalculateWaterSupply(ZoneWaterAndN zone)
@@ -1164,11 +1151,11 @@
                 RemoveBiomass(null, new OrganBiomassRemovalType() { FractionLiveToResidue = senescenceRate.Value() });
 
                 // Do maintenance respiration
-                MaintenanceRespiration = 0;
-                if (maintenanceRespirationFunction != null && (Live.MetabolicWt + Live.StorageWt) > 0)
+                if (maintenanceRespirationFunction.Value() > 0)
                 {
-                    MaintenanceRespiration += Live.MetabolicWt * maintenanceRespirationFunction.Value();
-                    MaintenanceRespiration += Live.StorageWt * maintenanceRespirationFunction.Value();
+                    MaintenanceRespiration = (Live.MetabolicWt + Live.StorageWt) * maintenanceRespirationFunction.Value();
+                    Live.MetabolicWt *= (1 - maintenanceRespirationFunction.Value());
+                    Live.StorageWt *= (1 - maintenanceRespirationFunction.Value());
                 }
                 needToRecalculateLiveDead = true;
             }

--- a/Models/PMF/Organs/SimpleLeaf.cs
+++ b/Models/PMF/Organs/SimpleLeaf.cs
@@ -921,11 +921,11 @@
                 }
 
                 // Do maintenance respiration
-                MaintenanceRespiration = 0;
-                if (maintenanceRespiration != null && (Live.MetabolicWt + Live.StorageWt) > 0)
+                if (maintenanceRespiration.Value() > 0)
                 {
-                    MaintenanceRespiration += Live.MetabolicWt * maintenanceRespiration.Value();
-                    MaintenanceRespiration += Live.StorageWt * maintenanceRespiration.Value();
+                    MaintenanceRespiration = (Live.MetabolicWt + Live.StorageWt) * maintenanceRespiration.Value();
+                    Live.MetabolicWt *= (1 - maintenanceRespiration.Value());
+                    Live.StorageWt *= (1 - maintenanceRespiration.Value());
                 }
             }
         }
@@ -1077,19 +1077,6 @@
             Live.StorageN -= storageNReallocation;
             Live.MetabolicN -= (nitrogen.Reallocation - storageNReallocation);
             Allocated.StorageN -= nitrogen.Reallocation;
-        }
-
-        /// <summary>
-        /// Remove maintenance respiration from live component of organs.
-        /// </summary>
-        /// <param name="respiration">The respiration to remove</param>
-        public virtual void RemoveMaintenanceRespiration(double respiration)
-        {
-            double total = Live.MetabolicWt + Live.StorageWt;
-            if (respiration > total)
-                throw new Exception("Respiration is more than total biomass of metabolic and storage in live component.");
-            Live.MetabolicWt = Live.MetabolicWt - MathUtilities.Divide(respiration * Live.MetabolicWt , total, 0);
-            Live.StorageWt = Live.StorageWt - MathUtilities.Divide(respiration * Live.StorageWt , total, 0);
         }
 
         /// <summary>

--- a/Models/PMF/Organs/SorghumLeaf.cs
+++ b/Models/PMF/Organs/SorghumLeaf.cs
@@ -428,13 +428,6 @@ namespace Models.PMF.Organs
             DMSupply.Fixation = DMSupplyFixation.Value();
         }
 
-        /// <summary>The amount of mass lost each day from maintenance respiration</summary>
-        public double MaintenanceRespiration { get; }
-
-        /// <summary>Remove maintenance respiration from live component of organs.</summary>
-        public void RemoveMaintenanceRespiration(double respiration)
-        { }
-
         #endregion
 
         #region Events


### PR DESCRIPTION
working on #5651 
Delete redundant RemoveMaintenanceRespiration methods and put Maintenance respiration calculation in OnDoActualPlantGrowth for organs that have a MaintenanceRespirationFunction.  There are some organs that do not have a MaintenanceRespirationFunction.  This will need to be added if and when required.