### PR TITLE
Improved SimulationStats UI

### DIFF
--- a/APSIM.Shared/Utilities/ReflectionUtilities.cs
+++ b/APSIM.Shared/Utilities/ReflectionUtilities.cs
@@ -460,7 +460,7 @@
                 for (int j = 0; j < arr.Length; j++)
                 {
                     if (j > 0)
-                        stringValue += ",";
+                        stringValue += ", ";
                     stringValue += ObjectToString(arr.GetValue(j));
                 }
                 return stringValue;

--- a/APSIM.Shared/Utilities/ReflectionUtilities.cs
+++ b/APSIM.Shared/Utilities/ReflectionUtilities.cs
@@ -414,7 +414,9 @@
                 // Arrays do not implement IConvertible, so we cannot just split the string on
                 // the commas and parse the string array into Convert.ChangeType. Instead, we
                 // must convert each element of the array individually.
-                object[] arr = newValue.Split(',').Select(s => StringToObject(dataType.GetElementType(), s, format)).ToArray();
+                //
+                // Note: we trim the start of each element, so "a, b, c , d" becomes ["a","b","c ","d"].
+                object[] arr = newValue.Split(',').Select(s => StringToObject(dataType.GetElementType(), s.TrimStart(), format)).ToArray();
 
                 // An object array is not good enough. We need an array with correct element type.
                 Array result = Array.CreateInstance(dataType.GetElementType(), arr.Length);

--- a/Models/Core/VariableProperty.cs
+++ b/Models/Core/VariableProperty.cs
@@ -549,7 +549,7 @@
                     {
                         if (j > 0)
                         {
-                            stringValue += ",";
+                            stringValue += ", ";
                         }
 
                         Array arr2d = arr.GetValue(j) as Array;

--- a/Models/PostSimulationTools/SimulationStats.cs
+++ b/Models/PostSimulationTools/SimulationStats.cs
@@ -28,8 +28,8 @@
         public string TableName { get; set; }
 
         /// <summary>The fields to split on.</summary>
-        [Description("Fields to split om (csv)")]
-        [Display]
+        [Description("Fields to split on (csv)")]
+        [Tooltip("Values must be separated by commas")]
         public string[] FieldNamesToSplitOn { get; set; } = new string[] { "SimulationName" };
 
         /// <summary>.</summary>

--- a/Tests/UnitTests/APSIMShared/ReflectionUtilitiesTests.cs
+++ b/Tests/UnitTests/APSIMShared/ReflectionUtilitiesTests.cs
@@ -9,12 +9,11 @@ namespace UnitTests.APSIMShared
     public class ReflectionUtilitiesTests
     {
         /// <summary>
-        /// Tests the StringToObject conversion utility.
+        /// Test array conversion. Should allow for comma-separated values.
         /// </summary>
         [Test]
-        public void TestStringToObject()
+        public void TestStringToObjectArray()
         {
-            // Test array conversion. Should allow for comma-separated values.
             string input = "a,b,c";
             object output = ReflectionUtilities.StringToObject(typeof(string[]), input);
             string[] expectedOutput = new string[3] { "a", "b", "c" };
@@ -23,16 +22,28 @@ namespace UnitTests.APSIMShared
         }
 
         /// <summary>
-        /// Tests the StringToObject conversion utility.
+        /// Test array conversion. Should allow for spaces between comma-separated values.
         /// </summary>
         [Test]
-        public void TestStringToObjectWithSpaces()
+        public void TestStringToObjectArrayWithSpaces()
         {
-            // Test array conversion. Should allow for spaces between comma-separated values.
             string input = "a, b , c";
             object output = ReflectionUtilities.StringToObject(typeof(string[]), input);
             string[] expectedOutput = new string[3] { "a", "b ", "c" };
             
+            Assert.AreEqual(expectedOutput, output);
+        }
+
+        /// <summary>
+        /// Test array conversion to string. Should generate comma-separated values
+        /// with a space after each comma.
+        /// </summary>
+        [Test]
+        public void TestArrayObjectToString()
+        {
+            string[] input = new[] { "a", "b", " c", "d " };
+            string output = ReflectionUtilities.ObjectToString(input);
+            string expectedOutput = "a, b,  c, d ";
             Assert.AreEqual(expectedOutput, output);
         }
     }

--- a/Tests/UnitTests/APSIMShared/ReflectionUtilitiesTests.cs
+++ b/Tests/UnitTests/APSIMShared/ReflectionUtilitiesTests.cs
@@ -1,0 +1,39 @@
+namespace UnitTests.APSIMShared
+{
+    using APSIM.Shared.Utilities;
+    using NUnit.Framework;
+    using System;
+    using System.Collections.Generic;
+
+    [TestFixture]
+    public class ReflectionUtilitiesTests
+    {
+        /// <summary>
+        /// Tests the StringToObject conversion utility.
+        /// </summary>
+        [Test]
+        public void TestStringToObject()
+        {
+            // Test array conversion. Should allow for comma-separated values.
+            string input = "a,b,c";
+            object output = ReflectionUtilities.StringToObject(typeof(string[]), input);
+            string[] expectedOutput = new string[3] { "a", "b", "c" };
+            
+            Assert.AreEqual(expectedOutput, output);
+        }
+
+        /// <summary>
+        /// Tests the StringToObject conversion utility.
+        /// </summary>
+        [Test]
+        public void TestStringToObjectWithSpaces()
+        {
+            // Test array conversion. Should allow for spaces between comma-separated values.
+            string input = "a, b , c";
+            object output = ReflectionUtilities.StringToObject(typeof(string[]), input);
+            string[] expectedOutput = new string[3] { "a", "b ", "c" };
+            
+            Assert.AreEqual(expectedOutput, output);
+        }
+    }
+}

--- a/Tests/UnitTests/UnitTests.csproj
+++ b/Tests/UnitTests/UnitTests.csproj
@@ -144,6 +144,7 @@
     <Compile Include="APSIMShared\JobRunning\JobManagerTests.cs" />
     <Compile Include="APSIMShared\JobRunning\JobRunnerTests.cs" />
     <Compile Include="APSIMShared\MockJob.cs" />
+    <Compile Include="APSIMShared\ReflectionUtilitiesTests.cs" />
     <Compile Include="CommandLineArgsTests.cs" />
     <Compile Include="Core\ApsimFile\EditFileTests.cs" />
     <Compile Include="Core\ModelTests.cs" />


### PR DESCRIPTION
And possibly others as well, since the changes to array handling are fairly generic. Note that the SimulationStats will still not work correctly if any of the field names contain spaces, however the UI will automatically trim any spaces immediately after a comma when you type in new values. So something like this should be fine:

![image](https://user-images.githubusercontent.com/36427516/93947774-f5848c80-fd7f-11ea-9c56-1cc0de13c962.png)


Resolves #5680