### PR TITLE
Fixed some bugs in the importer

### DIFF
--- a/Models/Core/Apsim710File/Importer.cs
+++ b/Models/Core/Apsim710File/Importer.cs
@@ -268,6 +268,7 @@
                 {
                     XmlNode newSim = this.AddCompNode(destParent, "Simulation", XmlUtilities.NameAttr(compNode));
                     this.AddChildComponents(compNode, newSim);
+                    AddCompNode(newSim, "SoilArbitrator", "SoilArbitrator");
                 }
                 else if (compNode.Name == "folder")
                 {
@@ -428,6 +429,10 @@
                 {
                     this.ImportPlant(compNode, destParent, newNode);
                 }
+                else if (string.Equals("irrigation", compNode.Name, StringComparison.InvariantCultureIgnoreCase))
+                    AddCompNode(destParent, "Irrigation", "Irrigation");
+                else if (string.Equals("fertiliser", compNode.Name, StringComparison.InvariantCultureIgnoreCase))
+                    AddCompNode(destParent, "Fertiliser", "Fertiliser");
                 else
                 {
                     // Do nothing.


### PR DESCRIPTION
Resolves #5696

Not sure why we never previously added a SoilArbitrator automatically - I thought it had to be present in every simulation? I've changed the converter so it gets automatically added, so let me know if that's not right.