### PR TITLE
When rebuilding nutrient graph, reuse old arc/node locations.

### DIFF
--- a/Models/Soils/Nutrients/Nutrient.cs
+++ b/Models/Soils/Nutrients/Nutrient.cs
@@ -487,6 +487,7 @@
         /// <summary>Calculate / create a directed graph from model</summary>
         public void CalculateDirectedGraph()
         {
+            DirectedGraph oldGraph = directedGraphInfo;
             if (directedGraphInfo == null)
                 directedGraphInfo = new DirectedGraph();
 
@@ -496,7 +497,11 @@
 
             foreach (NutrientPool pool in this.FindAllChildren<NutrientPool>())
             {
-                directedGraphInfo.AddNode(pool.Name, ColourUtilities.ChooseColour(3), Color.Black);
+                Point location = default(Point);
+                Node oldNode;
+                if (oldGraph != null && pool.Name != null && (oldNode = oldGraph.Nodes.Find(f => f.Name == pool.Name)) != null)
+                    location = oldNode.Location;
+                directedGraphInfo.AddNode(pool.Name, ColourUtilities.ChooseColour(3), Color.Black, location);
 
                 foreach (CarbonFlow cFlow in pool.FindAllChildren<CarbonFlow>())
                 {
@@ -508,7 +513,13 @@
                             destName = "Atmosphere";
                             needAtmosphereNode = true;
                         }
-                        directedGraphInfo.AddArc(null, pool.Name, destName, Color.Black);
+
+                        location = default(Point);
+                        Arc oldArc;
+                        if (oldGraph != null && pool.Name != null && (oldArc = oldGraph.Arcs.Find(f => f.SourceName == pool.Name && f.DestinationName == destName)) != null)
+                            location = oldArc.Location;
+
+                        directedGraphInfo.AddArc(null, pool.Name, destName, Color.Black, location);
 
                     }
                 }


### PR DESCRIPTION
Resolves #5763. Not sure why this suddenly became a problem.