### PR TITLE
SWIM should throw an explicit error if KS not provided.

### DIFF
--- a/Models/Soils/SWIM/Swim.cs
+++ b/Models/Soils/SWIM/Swim.cs
@@ -1107,9 +1107,18 @@ namespace Models.Soils
         [EventSubscribe("StartOfSimulation")]
         private void OnInitialised(object sender, EventArgs e)
         {
+            ErrorChecking();
             OnReset();
             initDone = true;
             Sum_Report();
+        }
+
+        private void ErrorChecking()
+        {
+            if (soilPhysical.KS == null
+                || !MathUtilities.ValuesInArray(soilPhysical.KS)
+                || soilPhysical.KS.All(ks => ks == 0))
+                throw new ApsimXException(this, "KS not provided. Check Soil.Physical configuration");
         }
 
         /// <summary>


### PR DESCRIPTION
Resolves #5804 

@hut104 Maybe it's worth adding some other error/bounds checks here too. If you let me know what you want I can add it in.