### PR TITLE
Fixed gtk warning for invalid icon size

### DIFF
--- a/ApsimNG/Resources/Glade/ExplorerView.glade
+++ b/ApsimNG/Resources/Glade/ExplorerView.glade
@@ -11,7 +11,7 @@
         <property name="can_focus">False</property>
         <property name="double_buffered">False</property>
         <property name="toolbar_style">both</property>
-        <property name="icon_size">24</property>
+        <property name="icon_size">3</property>
       </object>
       <packing>
         <property name="expand">False</property>


### PR DESCRIPTION
Working on #5334 