### PR TITLE
Rename RadIntTot to RadiationIntercepted.

### DIFF
--- a/Models/Core/ApsimFile/Converter.cs
+++ b/Models/Core/ApsimFile/Converter.cs
@@ -23,7 +23,7 @@
     public class Converter
     {
         /// <summary>Gets the latest .apsimx file format version.</summary>
-        public static int LatestVersion { get { return 123; } }
+        public static int LatestVersion { get { return 124; } }
 
         /// <summary>Converts a .apsimx string to the latest version.</summary>
         /// <param name="st">XML or JSON string to convert.</param>
@@ -3235,6 +3235,28 @@
                             variables.RemoveAt(i);
                     report["VariableNames"] = variables;
                 }
+            }
+        }
+
+        /// <summary>
+        /// Rename RadIntTot to RadiationIntercepted.
+        /// </summary>
+        /// <param name="root">The root json token.</param>
+        /// <param name="fileName">The name of the apsimx file.</param>
+        private static void UpgradeToVersion124(JObject root, string fileName)
+        {
+            Tuple<string, string>[] changes = new Tuple<string, string>[1]
+            {
+                new Tuple<string, string>("RadIntTot", "RadiationIntercepted")
+            };
+            JsonUtilities.RenameVariables(root, changes);
+            foreach (ManagerConverter manager in JsonUtilities.ChildManagers(root))
+            {
+                bool changed = false;
+                foreach (Tuple<string, string> change in changes)
+                    changed |= manager.Replace(change.Item1, change.Item2, true);
+                if (changed)
+                    manager.Save();
             }
         }
 

--- a/Models/PMF/Organs/EnergyBalance.cs
+++ b/Models/PMF/Organs/EnergyBalance.cs
@@ -199,10 +199,10 @@
         /// <summary>Gets the cover dead.</summary>
         public double CoverDead { get { return 1.0 - Math.Exp(-KDead * LAIDead); } }
 
-        /// <summary>Gets the RAD int tot.</summary>
+        /// <summary>Gets the total radiation intercepted.</summary>
         [Units("MJ/m^2/day")]
         [Description("This is the intercepted radiation value that is passed to the RUE class to calculate DM supply")]
-        public double RadIntTot
+        public double RadiationIntercepted
         {
             get
             {

--- a/Models/PMF/Organs/Leaf.cs
+++ b/Models/PMF/Organs/Leaf.cs
@@ -770,7 +770,7 @@ namespace Models.PMF.Organs
         /// <summary>Gets the RAD int tot.</summary>
         [Units("MJ/m^2/day")]
         [Description("This is the intercepted radiation value that is passed to the RUE class to calculate DM supply")]
-        public double RadIntTot
+        public double RadiationIntercepted
         {
             get
             {

--- a/Models/PMF/Organs/PerennialLeaf.cs
+++ b/Models/PMF/Organs/PerennialLeaf.cs
@@ -344,10 +344,10 @@ namespace Models.PMF.Organs
         /// <summary>Gets the cover dead.</summary>
         public double CoverDead { get { return 1.0 - Math.Exp(-ExtinctionCoefficientDead.Value() * LAIDead); } }
 
-        /// <summary>Gets the RAD int tot.</summary>
+        /// <summary>Gets the total radiation intercepted.</summary>
         [Units("MJ/m^2/day")]
         [Description("This is the intercepted radiation value that is passed to the RUE class to calculate DM supply")]
-        public double RadIntTot
+        public double RadiationIntercepted
         {
             get
             {

--- a/Models/PMF/Organs/SimpleLeaf.cs
+++ b/Models/PMF/Organs/SimpleLeaf.cs
@@ -663,7 +663,7 @@
         /// Intercepted radiation value that is passed to the RUE class to calculate DM supply.
         /// </summary>
         [Units("MJ/m^2/day")]
-        public double RadIntTot
+        public double RadiationIntercepted
         {
             get
             {

--- a/Models/PMF/Organs/SorghumLeaf.cs
+++ b/Models/PMF/Organs/SorghumLeaf.cs
@@ -378,10 +378,10 @@ namespace Models.PMF.Organs
         public double LAIDead { get; set; }
 
 
-        /// <summary>Gets the RAD int tot.</summary>
+        /// <summary>Gets the total radiation intercepted.</summary>
         [Units("MJ/m^2/day")]
         [Description("This is the intercepted radiation value that is passed to the RUE class to calculate DM supply")]
-        public double RadIntTot
+        public double RadiationIntercepted
         {
             get
             {
@@ -797,9 +797,9 @@ namespace Models.PMF.Organs
             double dlt_dm_transp = PotentialBiomassTEFunction.Value();
 
             //double radnCanopy = divide(plant->getRadnInt(), coverGreen, plant->today.radn);
-            double effectiveRue = MathUtilities.Divide(Photosynthesis.Value(), RadIntTot, 0);
+            double effectiveRue = MathUtilities.Divide(Photosynthesis.Value(), RadiationIntercepted, 0);
 
-            double radnCanopy = MathUtilities.Divide(RadIntTot, CoverGreen, MetData.Radn);
+            double radnCanopy = MathUtilities.Divide(RadiationIntercepted, CoverGreen, MetData.Radn);
             if (MathUtilities.FloatsAreEqual(CoverGreen, 0))
                 radnCanopy = 0;
 


### PR DESCRIPTION
Resolves #3836

Looks like the other part of that issue (checking for null LightProfiles) has already been fixed.