### PR TITLE
Editing a file via command-line should also run the file

### DIFF
--- a/Docs/content/Usage/EditFile.md
+++ b/Docs/content/Usage/EditFile.md
@@ -11,7 +11,7 @@ The /Edit switch on Models.exe allows the user to edit an .apsimx file from the 
 
 The first argument, <PathToApsimXFile> should be the path to the .apsimx file which you want to edit. This file will be edited in-place - that is, if you don't want to modify the original .apsimx file, you should copy it somewhere else and edit the copy.
 
-The /Edit argument instructs APSIM to edit the .apsimx file rather than run it.
+The /Edit argument instructs APSIM to edit the .apsimx file before running it. The changed file is *not* saved to disk.
 
 The argument immediately following /Edit must be the path to a config file. The config file should contain zero or more lines of the form `path = value`.
 

--- a/Models/Core/ApsimFile/EditFile.cs
+++ b/Models/Core/ApsimFile/EditFile.cs
@@ -24,9 +24,9 @@ namespace Models.Core.ApsimFile
         /// </summary>
         /// <param name="apsimxFilePath">Absolute path to the .apsimx file.</param>
         /// <param name="configFilePath">Absolute path to the config file.</param>
-        public static void Do(string apsimxFilePath, string configFilePath)
+        public static Simulations Do(string apsimxFilePath, string configFilePath)
         {
-            ApplyChanges(apsimxFilePath, GetFactors(configFilePath));
+            return ApplyChanges(apsimxFilePath, GetFactors(configFilePath));
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace Models.Core.ApsimFile
         /// </summary>
         /// <param name="apsimxFileName">Path to an .apsimx file.</param>
         /// <param name="factors">Factors to apply to the file.</param>
-        private static void ApplyChanges(string apsimxFileName, List<CompositeFactor> factors)
+        private static Simulations ApplyChanges(string apsimxFileName, List<CompositeFactor> factors)
         {
             Simulations file = FileFormat.ReadFromFile<Simulations>(apsimxFileName, out List<Exception> errors);
             if (errors != null && errors.Count > 0)
@@ -113,7 +113,7 @@ namespace Models.Core.ApsimFile
                 else
                     ChangeVariableValue(variable, value);
             }
-            file.Write(apsimxFileName);
+            return file;
         }
 
         private static void ChangeVariableValue(IVariable variable, string value)

--- a/Models/Core/Run/Runner.cs
+++ b/Models/Core/Run/Runner.cs
@@ -103,6 +103,38 @@
         /// <param name="wait">Wait until all simulations are complete?</param>
         /// <param name="numberOfProcessors">Number of CPU processes to use. -1 indicates all processes.</param>
         /// <param name="simulationNamePatternMatch">A regular expression used to match simulation names to run.</param>
+        public Runner(IEnumerable<IModel> relativeTo,
+                      bool runSimulations = true,
+                      bool runPostSimulationTools = true,
+                      bool runTests = true,
+                      IEnumerable<string> simulationNamesToRun = null,
+                      RunTypeEnum runType = RunTypeEnum.MultiThreaded,
+                      bool wait = true,
+                      int numberOfProcessors = -1,
+                      string simulationNamePatternMatch = null)
+        {
+            this.runType = runType;
+            this.wait = wait;
+            this.numberOfProcessors = numberOfProcessors;
+
+            foreach (IModel model in relativeTo)
+            {
+                var simulationGroup = new SimulationGroup(model, runSimulations, runPostSimulationTools, runTests, simulationNamesToRun, simulationNamePatternMatch);
+                simulationGroup.Completed += OnSimulationGroupCompleted;
+                jobs.Add(simulationGroup);
+            }
+        }
+
+        /// <summary>Constructor</summary>
+        /// <param name="relativeTo">The model to use to search for simulations to run.</param>
+        /// <param name="runSimulations">Run simulations?</param>
+        /// <param name="runPostSimulationTools">Run post simulation tools?</param>
+        /// <param name="runTests">Run tests?</param>
+        /// <param name="simulationNamesToRun">Only run these simulations.</param>
+        /// <param name="runType">How should the simulations be run?</param>
+        /// <param name="wait">Wait until all simulations are complete?</param>
+        /// <param name="numberOfProcessors">Number of CPU processes to use. -1 indicates all processes.</param>
+        /// <param name="simulationNamePatternMatch">A regular expression used to match simulation names to run.</param>
         public Runner(IModel relativeTo,
                       bool runSimulations = true,
                       bool runPostSimulationTools = true,

--- a/Models/Main.cs
+++ b/Models/Main.cs
@@ -93,16 +93,21 @@
                     UpgradeFile(fileName, recurse);
                 else if (listSimulationNames)
                     ListSimulationNames();
-                else if (edit)
-                    ModifyFile(fileName, recurse);
                 else if (mergeDBFiles)
                     DBMerger.MergeFiles(fileName, recurse, Path.Combine(Path.GetDirectoryName(fileName), "merged.db"));
                 else
                 {
                     // Run simulations
-                    var runner = new Runner(fileName, ignorePaths, recurse, runTests, runType,
-                                            numberOfProcessors: numberOfProcessors,
-                                            simulationNamePatternMatch: simulationNameRegex);
+                    Runner runner;
+                    if (edit)
+                        runner = new Runner(ModifyFile(fileName, recurse), true, true,
+                                                runTests, runType: runType,
+                                                numberOfProcessors: numberOfProcessors,
+                                                simulationNamePatternMatch: simulationNameRegex);
+                    else
+                        runner = new Runner(fileName, ignorePaths, recurse, runTests, runType,
+                                                numberOfProcessors: numberOfProcessors,
+                                                simulationNamePatternMatch: simulationNameRegex);
                     runner.SimulationCompleted += OnJobCompleted;
                     runner.SimulationGroupCompleted += OnSimulationGroupCompleted;
                     runner.AllSimulationsCompleted += OnAllJobsCompleted;
@@ -197,7 +202,7 @@
         /// Performs pattern matching and edits all specified .apsimx
         /// files (e.g. *.apsimx /Recurse).
         /// </summary>
-        private static void ModifyFile(string fileName, bool recurse)
+        private static IEnumerable<Simulations> ModifyFile(string fileName, bool recurse)
         {
             int index = Array.IndexOf(arguments, "/Edit");
             if (index < 0)
@@ -212,7 +217,7 @@
 
             string[] files = Directory.EnumerateFiles(dir, Path.GetFileName(fileName), recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly).ToArray();
             foreach (string file in files)
-                EditFile.Do(file, configFileName);
+                yield return EditFile.Do(file, configFileName);
         }
 
         /// <summary>Job has completed</summary>


### PR DESCRIPTION
Working on #5195 

This will improve performance in optimisation scenarios, as it saves us having to open/close the file more than once per iteration.