### PR TITLE
Changed upgrade UI to use markdownview

### DIFF
--- a/ApsimNG/ApsimNG.csproj
+++ b/ApsimNG/ApsimNG.csproj
@@ -66,6 +66,7 @@
     <ApplicationIcon>ApsimLogo.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
+    <EmbeddedResource Include="../LICENSE.md" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <SubType>Designer</SubType>

--- a/ApsimNG/Resources/Glade/UpgradeView.glade
+++ b/ApsimNG/Resources/Glade/UpgradeView.glade
@@ -303,15 +303,19 @@
           </packing>
         </child>
         <child>
-          <object class="GtkAlignment" id="HTMLalign">
-            <property name="height_request">200</property>
+          <object class="GtkScrolledWindow" id="licenseScroller">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="bottom_padding">10</property>
-            <property name="left_padding">10</property>
-            <property name="right_padding">10</property>
+            <property name="can_focus">True</property>
+            <property name="hscrollbar_policy">automatic</property>
+            <property name="vscrollbar_policy">automatic</property>
             <child>
-              <placeholder/>
+              <object class="GtkViewport" id="licenseContainer">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <placeholder/>
+                </child>
+              </object>
             </child>
           </object>
           <packing>

--- a/ApsimNG/Views/UpgradeView.cs
+++ b/ApsimNG/Views/UpgradeView.cs
@@ -53,13 +53,13 @@
         private Entry emailBox = null;
         private ComboBox countryBox = null;
         private Label label1 = null;
-        private Alignment htmlAlign = null;
+        private Container licenseContainer = null;
         private CheckButton checkbutton1 = null;
         private Gtk.TreeView listview1 = null;
         private Alignment alignment7 = null;
         private CheckButton oldVersions = null;
         private ListStore listmodel = new ListStore(typeof(string), typeof(string), typeof(string));
-        private HTMLView htmlView;
+        private MarkdownView licenseView;
 
         /// <summary>
         /// Constructor
@@ -78,7 +78,7 @@
             emailBox = (Entry)builder.GetObject("emailBox");
             countryBox = (ComboBox)builder.GetObject("countryBox");
             label1 = (Label)builder.GetObject("label1");
-            htmlAlign = (Alignment)builder.GetObject("HTMLalign");
+            licenseContainer = (Container)builder.GetObject("licenseContainer");
             checkbutton1 = (CheckButton)builder.GetObject("checkbutton1");
             listview1 = (Gtk.TreeView)builder.GetObject("listview1");
             alignment7 = (Alignment)builder.GetObject("alignment7");
@@ -121,8 +121,8 @@
             table1.FocusChain = new Widget[] { alignment7, button1, button2 };
             table2.FocusChain = new Widget[] { firstNameBox, lastNameBox, emailBox, organisationBox, countryBox };
 
-            htmlView = new HTMLView(new ViewBase(null));
-            htmlAlign.Add(htmlView.MainWidget);
+            licenseView = new MarkdownView(owner);
+            licenseContainer.Add(licenseView.MainWidget);
             tabbedExplorerView = owner as IMainView;
 
             window1.TransientFor = owner.MainWidget.Toplevel as Window;
@@ -205,23 +205,10 @@
                 button1.Sensitive = false;
                 table2.Hide();
                 checkbutton1.Hide();
-                htmlView.SetContents("<center><span style=\"color:red\"><b>WARNING!</b></span><br/>You are currently using a custom build<br/><b>Upgrade is not available!</b></center>", false, false);
+                licenseView.Text = "You are currently using a custom build - **Upgrade is not available!**";
             }
             else
-            {
-                try
-                {
-                    // web.DownloadFile(@"https://apsimdev.apsim.info/APSIM.Registration.Portal/APSIM_NonCommercial_RD_licence.htm", tempLicenseFileName);
-                    // HTMLview.SetContents(File.ReadAllText(tempLicenseFileName), false, true);
-                    htmlView.SetContents(@"https://apsimdev.apsim.info/APSIM.Registration.Portal/APSIM_NonCommercial_RD_licence.htm", false, true);
-                }
-                catch (Exception)
-                {
-                    ViewBase.MasterView.ShowMsgDialog("Cannot download the license.", "Error", MessageType.Error, ButtonsType.Ok, window1);
-                    loadFailure = true;
-                }
-            }
-
+                licenseView.Text = ReflectionUtilities.GetResourceAsString("ApsimNG.LICENSE.md");
         }
 
         /// <summary>


### PR DESCRIPTION
Working on #5344

@sarahcleary - fyi I've changed the user interface for the upgrade process. The license agreement which is displayed is now taken directly from the [license agreement in this repo](https://github.com/APSIMInitiative/ApsimX/blob/master/LICENSE.md), as the license agreements on the website are stored in .docx format and we also don't know whether the user is covered under a commercial vs non-commercial agreement (previously we always displayed the commercial license agreement).