### PR TITLE
Fixed a floating point error in nutrient constrained allocation method

### DIFF
--- a/Models/PMF/Arbitrator/Methods/NutrientConstrainedAllocationMethod.cs
+++ b/Models/PMF/Arbitrator/Methods/NutrientConstrainedAllocationMethod.cs
@@ -31,7 +31,7 @@ namespace Models.PMF.Arbitrator
             for (int i = 0; i < Organs.Length; i++)
             {
                 double TotalNDemand = N.StructuralDemand[i] + N.MetabolicDemand[i] + N.StorageDemand[i];
-                if (N.TotalAllocation[i] >= TotalNDemand)
+                if (N.TotalAllocation[i] > TotalNDemand || MathUtilities.FloatsAreEqual(N.TotalAllocation[i], TotalNDemand))
                     N.ConstrainedGrowth[i] = 100000000; //given high value so where there is no N deficit in organ and N limitation to growth  
                 else
                     if (N.TotalAllocation[i] == 0 | Organs[i].MinNconc == 0)


### PR DESCRIPTION
This was causing some simulations to be quite sensitive to their initial conditions, and we were also getting different results depending on the runtime and OS on which they were run.

Working on #6107 