### PR TITLE
Changed IPlant to inherit from IModel

### DIFF
--- a/Models/Core/IPlant.cs
+++ b/Models/Core/IPlant.cs
@@ -5,7 +5,7 @@
     /// crops must have. In effect this interface describes the interactions
     /// between a crop and the other models in APSIM.
     /// </summary>
-    public interface IPlant
+    public interface IPlant : IModel
     {
         /// <summary>The plant type.</summary>
         /// <remarks>A substitute for the old Leguminosity.</remarks>


### PR DESCRIPTION
Working on #6139

Perhaps it would make sense to do the same to some of our other interfaces such as IClock, ISummary, ICanopy, etc. That is, if we don't care about losing the ability to have, say, a clock that's not also a model.