### PR TITLE
VSCode default build task should build solution file.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
             "type": "process",
             "args": [
                 "build",
-                "${workspaceFolder}/ApsimNG/ApsimNG.csproj",
+                "${workspaceFolder}/ApsimX.sln",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],


### PR DESCRIPTION
Resolves #6253 