### PR TITLE
Removed extra newline from wheat cultivar alias

### DIFF
--- a/Models/Resources/Wheat.json
+++ b/Models/Resources/Wheat.json
@@ -7265,7 +7265,7 @@
                   "Children": [
                     {
                       "$type": "Models.Memo, Models",
-                      "Text": "This is a spring wheat with a high grain number and later tillering\n",
+                      "Text": "This is a spring wheat with a high grain number and later tillering",
                       "Name": "Memo",
                       "Children": [],
                       "IncludeInDocumentation": true,


### PR DESCRIPTION
Working on #6309 (it's a problem I noticed with the new property presenter. The cultivar name dropdown for wheat is two lines tall because of this alias).