### PR TITLE
Don't attempt to force treeview icons to 24x24px

### DIFF
--- a/ApsimNG/Views/TreeView.cs
+++ b/ApsimNG/Views/TreeView.cs
@@ -82,7 +82,6 @@ namespace UserInterface.Views
             treeview1.Model = treemodel;
             TreeViewColumn column = new TreeViewColumn();
             CellRendererPixbuf iconRender = new Gtk.CellRendererPixbuf();
-            iconRender.StockSize = (uint)IconSize.LargeToolbar;
             column.PackStart(iconRender, false);
             textRender = new Gtk.CellRendererText();
             textRender.Editable = false;
@@ -439,7 +438,7 @@ namespace UserInterface.Views
         {
             Gdk.Pixbuf pixbuf = null;
             if (MasterView != null && MasterView.HasResource(description.ResourceNameForImage))
-                pixbuf = new Gdk.Pixbuf(null, description.ResourceNameForImage, 24, 24);
+                pixbuf = new Gdk.Pixbuf(null, description.ResourceNameForImage);
             string tick = description.Checked ? "✓" : "";
             treemodel.SetValues(node, description.Name, pixbuf, description.ToolTip, tick, description.Colour, description.Strikethrough);
 


### PR DESCRIPTION
@hol353 - I'm reverting the changes in #6351, as forcing the icon size to 24x24 doesn't work well on most displays. I'm actually not sure why the icons are so big in the gtk2 GUI, but I think the best way to imitate this in gtk3 builds will be to actually invest in some better icons.

Working on #6139