### PR TITLE
Allow Windows users to open files with any extensions, not just .apsimx.

### DIFF
--- a/ApsimNG/Presenters/MainPresenter.cs
+++ b/ApsimNG/Presenters/MainPresenter.cs
@@ -960,7 +960,7 @@
         {
             try
             {
-                string fileName = this.AskUserForOpenFileName("*.apsimx|*.apsimx");
+                string fileName = this.AskUserForOpenFileName("ApsimX files|*.apsimx");
                 if (fileName != null)
                 {
                     bool onLeftTabControl = this.view.IsControlOnLeft(sender);
@@ -1196,7 +1196,7 @@
             try
             {
                 string initialPath = PathUtilities.GetAbsolutePath(Path.Combine("%root%", "Examples"), null);
-                string fileName = AskUserForOpenFileName("*.apsimx|*.apsimx", initialPath);
+                string fileName = AskUserForOpenFileName("ApsimX files|*.apsimx", initialPath);
 
                 if (fileName != null)
                 {

--- a/ApsimNG/Utility/FileDialog.cs
+++ b/ApsimNG/Utility/FileDialog.cs
@@ -209,12 +209,18 @@
 
             dialog.Title = Prompt;
 
-            if (string.IsNullOrEmpty(FileType))
-                dialog.Filter = "All files (*.*)|*.*";
-            else if (FileType.Contains("|"))
-                dialog.Filter = FileType;
-            else
-                dialog.Filter = FileType + "|" + FileType;
+            string filterString = String.Empty;
+            if (!string.IsNullOrEmpty(FileType))
+            {
+                if (FileType.Contains("|"))
+                    filterString = FileType;
+                else
+                    filterString = FileType + "|" + FileType;
+                if (!filterString.EndsWith("|"))
+                    filterString += "|";
+            }
+            dialog.Filter = filterString + "All files (*.*)|*.*";
+
 
             // This almost works, but Windows is buggy.
             // If the file name is long, it doesn't display in a sensible way. ¯\_(ツ)_/¯


### PR DESCRIPTION
Resolves #6462