### PR TITLE
Add the ability for DataStoreWriter to run a clean command internally

### DIFF
--- a/Models/Core/Run/SimulationGroup.cs
+++ b/Models/Core/Run/SimulationGroup.cs
@@ -237,8 +237,7 @@
                                         names.Add(name);
                                 }
                             }
-                            if (names.Count > 0)
-                                jobs.Insert(0, storage.Writer.Clean(names));
+                            storage.Writer.StartClean(names);
                         }
                         foreach (IRunnable job in jobs)
                             Add(job);

--- a/Models/Storage/CleanCommand.cs
+++ b/Models/Storage/CleanCommand.cs
@@ -9,10 +9,10 @@ namespace Models.Storage
     internal class CleanCommand : IRunnable
     {
         private DataStoreWriter writer;
-        private List<string> names;
-        private List<int> ids;
+        private IEnumerable<string> names;
+        private IEnumerable<int> ids;
 
-        public CleanCommand(DataStoreWriter dataStoreWriter, List<string> names, List<int> ids)
+        public CleanCommand(DataStoreWriter dataStoreWriter, IEnumerable<string> names, IEnumerable<int> ids)
         {
             writer = dataStoreWriter;
             this.names = names;

--- a/Models/Storage/DataStoreWriter.cs
+++ b/Models/Storage/DataStoreWriter.cs
@@ -446,13 +446,24 @@
         /// Create a db clean command.
         /// </summary>
         /// <param name="names">A list of simulation names that are about to run.</param>
-        public IRunnable Clean(List<string> names)
+        public IRunnable Clean(IEnumerable<string> names)
         {
             var ids = new List<int>();
             foreach (var name in names)
                 if (simulationIDs.TryGetValue(name, out SimulationDetails details))
                     ids.Add(details.ID);
             return new CleanCommand(this, names, ids);
+        }
+
+        /// <summary>
+        /// Initiate a clean of the database.
+        /// </summary>
+        /// <param name="names">Simulation names to be cleaned.</param>
+        public void StartClean(IEnumerable<string> names)
+        {
+            Start();
+            lock (lockObject)
+                commands.Add(Clean(names));
         }
 
         /// <summary>Create a command runner one hasn't already been created.</summary>

--- a/Models/Storage/IStorageWriter.cs
+++ b/Models/Storage/IStorageWriter.cs
@@ -92,6 +92,12 @@
         /// Create a db clean command.
         /// </summary>
         /// <param name="names">A list of simulation names that are about to run.</param>
-        IRunnable Clean(List<string> names);
+        IRunnable Clean(IEnumerable<string> names);
+
+        /// <summary>
+        /// Start a db clean command.
+        /// </summary>
+        /// <param name="names">A list of simulation names that are about to run.</param>
+        void StartClean(IEnumerable<string> names);
     }
 }

--- a/Tests/UnitTests/Storage/MockStorage.cs
+++ b/Tests/UnitTests/Storage/MockStorage.cs
@@ -299,5 +299,15 @@ namespace UnitTests.Storage
         {
             throw new NotImplementedException();
         }
+
+        public IRunnable Clean(IEnumerable<string> names)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void StartClean(IEnumerable<string> names)
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
Working on #6577.

@hol353 is there any reason in particular why you added the CleanCommand to the job manager's list of jobs, rather than the datastorewriter's internal list of jobs?