### PR TITLE
Rework how simulation progress is displayed in the UI

### DIFF
--- a/APSIM.Shared/APSIM.Shared.csproj
+++ b/APSIM.Shared/APSIM.Shared.csproj
@@ -31,6 +31,7 @@
       <Private>false</Private>
       <SpecificVersion>false</SpecificVersion>
     </Reference>
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/APSIM.Shared/JobRunning/JobRunner.cs
+++ b/APSIM.Shared/JobRunning/JobRunner.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -31,7 +32,8 @@
         /// A list of jobs current running. 
         /// We keep track of this to allow us to query how much of each job has been completed
         /// </summary>
-        public List<IRunnable> SimsRunning { get; private set; } = new List<IRunnable>();
+        /// <remarks>Using ImmutableList here for thread safety.</remarks>
+        public ImmutableList<IRunnable> SimsRunning { get; private set; } = ImmutableList<IRunnable>.Empty;
 
         /// <summary>
         /// Lock object controlling access to SimsRunning list
@@ -174,7 +176,7 @@
                 if (!(job is JobRunnerSleepJob))
                     lock (runningLock)
                     {
-                        SimsRunning.Add(job);
+                        SimsRunning = SimsRunning.Add(job);
                     }
 
                 var startTime = DateTime.Now;
@@ -198,7 +200,7 @@
                     lock (runningLock)
                     {
                         NumJobsCompleted++;
-                        SimsRunning.Remove(job);
+                        SimsRunning = SimsRunning.Remove(job);
                     }
             }
             finally

--- a/ApsimNG/Commands/RunCommand.cs
+++ b/ApsimNG/Commands/RunCommand.cs
@@ -48,6 +48,7 @@
         /// <summary>Perform the command</summary>
         public void Do()
         {
+            explorerPresenter.MainPresenter.ClearStatusPanel();
             IsRunning = true;
             jobRunner.Run();
 
@@ -59,6 +60,8 @@
                 timer.Elapsed += OnTimerTick;
                 timer.Start();
             }
+            // Manually fire of an OnTimerTick event.
+            OnTimerTick(this, null);
         }
 
         /// <summary>All jobs have completed</summary>
@@ -79,9 +82,8 @@
                 // We could display the error message, but we're about to display output to the user anyway.
             }
             if (errors.Count == 0)
-                explorerPresenter.MainPresenter.ShowMessage(string.Format("{0} complete [{1} sec]", jobName, e.ElapsedTime.TotalSeconds.ToString("#.00")), Simulation.MessageType.Information);
-            else
-                explorerPresenter.MainPresenter.ShowError(errors);
+                explorerPresenter.MainPresenter.ShowMessage(string.Format("{0} complete [{1} sec]", jobName, e.ElapsedTime.TotalSeconds.ToString("#.00")), Simulation.MessageType.Information, false);
+            // We don't need to display error messages now - they are displayed as they occur.
 
             if (!Configuration.Settings.Muted)
             {
@@ -114,13 +116,9 @@
         private void OnStopSimulation(object sender, EventArgs e)
         {
             Stop();
-            string msg = jobName + " aborted";
-            if (errors.Count == 0)
-                explorerPresenter.MainPresenter.ShowMessage(msg, Simulation.MessageType.Information);
-            else
-            {
-                explorerPresenter.MainPresenter.ShowError(errors);
-            }
+            // Any error messages will already be onscreen, as they are
+            // rendered as they occur.
+            explorerPresenter.MainPresenter.ShowMessage($"{jobName} aborted", Simulation.MessageType.Information, false);
         }
 
         /// <summary>
@@ -128,6 +126,7 @@
         /// </summary>
         private void Stop()
         {
+            explorerPresenter.MainPresenter.HideProgressBar();
             this.explorerPresenter.MainPresenter.RemoveStopHandler(OnStopSimulation);
             if (timer != null)
             {
@@ -154,8 +153,8 @@
             else //if (jobRunner?.TotalNumberOfSimulations > 0)
             {
                 double progress = jobRunner?.Progress ?? 0;
-                explorerPresenter.MainPresenter.ShowMessage($"{jobName} running ({jobRunner.Status})", Simulation.MessageType.Information);
-                explorerPresenter.MainPresenter.ShowProgress(Convert.ToInt32(progress * 100, CultureInfo.InvariantCulture));
+                explorerPresenter.MainPresenter.ShowProgressMessage($"{jobName} running ({jobRunner.Status})");
+                explorerPresenter.MainPresenter.ShowProgress(progress);
             }
             //else if (jobRunner != null)
             //    explorerPresenter.MainPresenter.ShowProgress(Convert.ToInt32(jobRunner.Progress * 100, CultureInfo.InvariantCulture));

--- a/ApsimNG/Interfaces/IMainView.cs
+++ b/ApsimNG/Interfaces/IMainView.cs
@@ -109,6 +109,11 @@ namespace UserInterface.Interfaces
         void ShowMessage(string message, Models.Core.Simulation.ErrorLevel errorLevel, bool overwrite = true, bool addSeparator = false, bool withButton = true);
 
         /// <summary>
+        /// Clear the status panel.
+        /// </summary>
+        void ClearStatusPanel();
+
+        /// <summary>
         /// Displays an error message with a 'more info' button.
         /// </summary>
         /// <param name="err">Error for which we want to display information.</param>
@@ -133,9 +138,20 @@ namespace UserInterface.Interfaces
         /// <summary>
         /// Show progress bar with the specified percent.
         /// </summary>
-        /// <param name="percent">Progress (in %)</param>
+        /// <param name="progress">Progress (0 - 1)</param>
         /// <param name="showStopButton">Should a stop button be displayed as well?</param>
-        void ShowProgress(int percent, bool showStopButton = true);
+        void ShowProgress(double progress, bool showStopButton = true);
+
+        /// <summary>
+        /// Show a message next to the progress bar.
+        /// </summary>
+        /// <param name="message">Message to be displayed.</param>
+        void ShowProgressMessage(string message);
+
+        /// <summary>
+        /// Hide the progress bar.
+        /// </summary>
+        void HideProgressBar();
 
         /// <summary>
         /// Set the wait cursor (or not).

--- a/ApsimNG/Menus/ContextMenu.cs
+++ b/ApsimNG/Menus/ContextMenu.cs
@@ -164,6 +164,7 @@
                 {
                     Model model = this.explorerPresenter.ApsimXFile.FindByPath(this.explorerPresenter.CurrentNodePath)?.Value as Model;
                     var runner = new Runner(model, runType: Runner.RunTypeEnum.MultiThreaded, wait: false);
+                    runner.ErrorHandler = e => explorerPresenter.MainPresenter.ShowError(e, false);
                     this.command = new RunCommand(model.Name, runner, this.explorerPresenter);
                     this.command.Do();
                 }

--- a/ApsimNG/Presenters/MainPresenter.cs
+++ b/ApsimNG/Presenters/MainPresenter.cs
@@ -209,7 +209,7 @@
         /// </summary>
         public void ClearStatusPanel()
         {
-            view.ShowMessage(string.Empty, Simulation.ErrorLevel.Information);
+            view.ClearStatusPanel();
         }
 
         /// <summary>
@@ -218,7 +218,8 @@
         /// </summary>
         /// <param name="message">The message test</param>
         /// <param name="messageType">The error level value</param>
-        public void ShowMessage(string message, Simulation.MessageType messageType)
+        /// <param name="overwrite">Overwrite existing messages?</param>
+        public void ShowMessage(string message, Simulation.MessageType messageType, bool overwrite = true)
         {
             Simulation.ErrorLevel errorType = Simulation.ErrorLevel.Information;
 
@@ -227,7 +228,12 @@
             else if (messageType == Simulation.MessageType.Warning)
                 errorType = Simulation.ErrorLevel.Warning;
 
-            this.view.ShowMessage(message, errorType);
+            this.view.ShowMessage(message, errorType, overwrite);
+        }
+
+        public void HideProgressBar()
+        {
+            view.HideProgressBar();
         }
         
         /// <summary>
@@ -279,7 +285,7 @@
                 else
                 {
                     LastError = new List<string> { error.ToString() };
-                    view.ShowMessage(GetInnerException(error).Message, Simulation.ErrorLevel.Error, overwrite: overwrite);
+                    view.ShowMessage(GetInnerException(error).Message, Simulation.ErrorLevel.Error, overwrite: overwrite, addSeparator: !overwrite);
                 }
             }
             else
@@ -346,11 +352,22 @@
         /// <summary>
         /// Show progress bar with the specified percent.
         /// </summary>
-        /// <param name="percent">The progress</param>
+        /// <param name="progress">The progress (0 - 1)</param>
         /// <param name="showStopButton">Should a stop button be displayed as well?</param>
-        public void ShowProgress(int percent, bool showStopButton = true)
+        public void ShowProgress(double progress, bool showStopButton = true)
         {
-            this.view.ShowProgress(percent, showStopButton);
+            this.view.ShowProgress(progress, showStopButton);
+        }
+
+        /// <summary>
+        /// Add a status message. A message of null will clear the status message.
+        /// For error messages, use <see cref="ShowError(Exception, bool)"/>.
+        /// </summary>
+        /// <param name="message">The message test</param>
+        /// <param name="messageType">The error level value</param>
+        public void ShowProgressMessage(string message)
+        {
+            view.ShowProgressMessage(message);
         }
 
         /// <summary>

--- a/ApsimNG/Resources/Glade/MainView.glade
+++ b/ApsimNG/Resources/Glade/MainView.glade
@@ -101,33 +101,57 @@
           </packing>
         </child>
         <child>
-          <object class="GtkHBox" id="hbox1">
+          <object class="GtkVBox" id="vbox3">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
-              <object class="GtkProgressBar" id="progressBar">
+              <object class="GtkHBox" id="hbox2">
+                <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="no_show_all">True</property>
+                <child>
+                  <object class="GtkProgressBar" id="progressBar">
+                    <property name="can_focus">False</property>
+                    <property name="no_show_all">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="stopButton">
+                    <property name="label" translatable="yes">Stop</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="no_show_all">True</property>
+                    <property name="has_tooltip">True</property>
+                    <property name="image_position">top</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="lblStatus">
+                    <property name="can_focus">False</property>
+                    <property name="no_show_all">True</property>
+                    <property name="xalign">0</property>
+                    <property name="xpad">5</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
                 <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="stopButton">
-                <property name="label" translatable="yes">Stop</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="no_show_all">True</property>
-                <property name="has_tooltip">True</property>
-                <property name="image_position">top</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
               </packing>
             </child>
             <child>
@@ -148,7 +172,7 @@
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
-                <property name="position">2</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>

--- a/ApsimNG/Resources/Style/global.css
+++ b/ApsimNG/Resources/Style/global.css
@@ -10,3 +10,7 @@ scrollbar, scrollbar button, scrollbar slider {
 	min-width: 8px;
 	min-height: 8px;
 }
+
+progressbar.fat-progress-bar progress, progressbar.fat-progress-bar trough {
+	min-height: 34px;
+}

--- a/ApsimNG/Views/MainView.cs
+++ b/ApsimNG/Views/MainView.cs
@@ -66,6 +66,15 @@
         private ProgressBar progressBar = null;
 
         /// <summary>
+        /// Label adjacent to progress bar. Used to display
+        /// progress status updates. The progress bar does
+        /// support displaying text by itself, but vertical
+        /// space here is limited so we display it in this
+        /// label instead.
+        /// </summary>
+        private Label lblStatus = null;
+
+        /// <summary>
         /// Status window used to display error messages and other information.
         /// </summary>
         private TextView statusWindow = null;
@@ -103,7 +112,7 @@
         /// <summary>
         /// Gtk widget which holds the status panel.
         /// </summary>
-        private HBox hbox1 = null;
+        private Widget hbox1 = null;
 
         /// <summary>
         /// Dark theme icon.
@@ -134,6 +143,7 @@
             Builder builder = BuilderFromResource("ApsimNG.Resources.Glade.MainView.glade");
             window1 = (Window)builder.GetObject("window1");
             progressBar = (ProgressBar)builder.GetObject("progressBar");
+            lblStatus = (Label)builder.GetObject("lblStatus");
             statusWindow = (TextView)builder.GetObject("StatusWindow");
             stopButton = (Button)builder.GetObject("stopButton");
             notebook1 = (Notebook)builder.GetObject("notebook1");
@@ -141,7 +151,7 @@
             vbox1 = (VBox)builder.GetObject("vbox1");
             vbox2 = (VBox)builder.GetObject("vbox2");
             hpaned1 = (HPaned)builder.GetObject("hpaned1");
-            hbox1 = (HBox)builder.GetObject("hbox1");
+            hbox1 = (Widget)builder.GetObject("vbox3");
             mainWidget = window1;
             window1.Icon = new Gdk.Pixbuf(null, "ApsimNG.Resources.apsim logo32.png");
             listButtonView1 = new ListButtonView(this);
@@ -220,6 +230,14 @@
 
 #if NETCOREAPP
             LoadStylesheets();
+
+            CssProvider provider = new CssProvider();
+            StringBuilder css = new StringBuilder();
+            css.AppendLine("progress, trough {");
+            css.AppendLine($"min-height: 34px;");
+            css.Append("}");
+            provider.LoadFromData(css.ToString());
+            progressBar.StyleContext.AddProvider(provider, StyleProviderPriority.Application);
 #endif
         }
 
@@ -765,6 +783,18 @@
             }
         }
 
+        /// <summary>
+        /// Clear the status panel.
+        /// </summary>
+        public void ClearStatusPanel()
+        {
+            Application.Invoke(delegate
+            {
+                numberOfButtons = 0;
+                statusWindow.Buffer.Clear();
+            });
+        }
+
         /// <summary>Add a status message to the explorer window</summary>
         /// <param name="message">The message.</param>
         /// <param name="errorLevel">The error level.</param>
@@ -818,8 +848,6 @@
                 }
 
                 //this.toolTip1.SetToolTip(this.StatusWindow, message);
-                progressBar.Visible = false;
-                stopButton.Visible = false;
             });
         }
 
@@ -971,11 +999,24 @@
         }
 
         /// <summary>
+        /// Show a message next to the progress bar.
+        /// </summary>
+        /// <param name="message">Message to be displayed.</param>
+        public void ShowProgressMessage(string message)
+        {
+            Application.Invoke(delegate
+            {
+                lblStatus.Visible = !string.IsNullOrEmpty(message);
+                lblStatus.Text = message ?? "";
+            });
+        }
+
+        /// <summary>
         /// Show progress bar with the specified percent.
         /// </summary>
-        /// <param name="percent">Percentage complete.</param>
+        /// <param name="progress">Progress (0 - 1).</param>
         /// <param name="showStopButton">Should a stop button be shown?</param>
-        public void ShowProgress(int percent, bool showStopButton = true)
+        public void ShowProgress(double progress, bool showStopButton = true)
         {
             // We need to use "Invoke" if the timer is running in a
             // different thread. That means we can use either
@@ -984,10 +1025,20 @@
             Application.Invoke(delegate
             {
                 progressBar.Visible = true;
-                progressBar.Fraction = percent / 100.0;
+                progressBar.Fraction = progress;
                 if (showStopButton)
                     stopButton.Visible = true;
             });
+        }
+
+        /// <summary>
+        /// Hide the progress bar.
+        /// </summary>
+        public void HideProgressBar()
+        {
+            progressBar.Visible = false;
+            stopButton.Visible = false;
+            lblStatus.Hide();
         }
 
         /// <summary>User is trying to close the application - allow that to happen?</summary>

--- a/ApsimNG/Views/MainView.cs
+++ b/ApsimNG/Views/MainView.cs
@@ -174,6 +174,12 @@
             notebook1.GetTabLabel(notebook1.Children[0]).Name = "selected-tab";
 
             hbox1.HeightRequest = 20;
+#if NETCOREAPP
+            // Normally, one would specify the style class in the UI (.glade) file.
+            // However, doing so breaks gtk2-compatibility, so for now, we will just
+            // set the style class in code.
+            progressBar.StyleContext.AddClass("fat-progress-bar");
+#endif
 
             TextTag tag = new TextTag("error");
             // Make errors orange-ish in dark mode.
@@ -230,14 +236,6 @@
 
 #if NETCOREAPP
             LoadStylesheets();
-
-            CssProvider provider = new CssProvider();
-            StringBuilder css = new StringBuilder();
-            css.AppendLine("progress, trough {");
-            css.AppendLine($"min-height: 34px;");
-            css.Append("}");
-            provider.LoadFromData(css.ToString());
-            progressBar.StyleContext.AddProvider(provider, StyleProviderPriority.Application);
 #endif
         }
 

--- a/ApsimNG/Views/MainView.cs
+++ b/ApsimNG/Views/MainView.cs
@@ -247,7 +247,7 @@
             if (!provider.LoadFromData(css))
                 throw new Exception("Unable to parse global.css");
 
-            window1.StyleContext.AddProvider(provider, StyleProviderPriority.Application);
+            StyleContext.AddProviderForScreen(Gdk.Screen.Default, provider, StyleProviderPriority.Application);
         }
 #endif
 

--- a/Models/Core/Run/GenerateApsimXFiles.cs
+++ b/Models/Core/Run/GenerateApsimXFiles.cs
@@ -17,8 +17,8 @@
     public class GenerateApsimXFiles
     {
         /// <summary>A delegate that gets called to indicate progress during an operation.</summary>
-        /// <param name="percent">Percentage compete.</param>
-        public delegate void OnProgress(int percent);
+        /// <param name="progress">Progress (0 - 1).</param>
+        public delegate void OnProgress(double progress);
 
         /// <summary>
         /// Generates .apsimx files for each simulation in a runner.
@@ -90,7 +90,7 @@
                     errors.Add(err);
                 }
 
-                progressCallBack?.Invoke(Convert.ToInt32(100 * (i + 1) / simulations.Count));
+                progressCallBack?.Invoke(1.0 * (i + 1) / simulations.Count);
                 i++;
             }
             return errors;

--- a/Models/Core/Run/Runner.cs
+++ b/Models/Core/Run/Runner.cs
@@ -49,6 +49,12 @@
         }
 
         /// <summary>
+        /// If provided, this will be invoked whenever an error occurs.
+        /// </summary>
+        /// <value></value>
+        public Action<Exception> ErrorHandler { get; set; }
+
+        /// <summary>
         /// Gets the aggregate progress of all jobs as a real number in range [0, 1].
         /// </summary>
         public double Progress
@@ -352,6 +358,8 @@
                 if (ExceptionsThrown == null)
                     ExceptionsThrown = new List<Exception>();
                 ExceptionsThrown.Add(err);
+                if (ErrorHandler != null)
+                    ErrorHandler(err);
             }
         }
 

--- a/Models/Models.csproj
+++ b/Models/Models.csproj
@@ -86,6 +86,7 @@
     <!--<PackageReference Include="PDFsharp-MigraDoc-GDI" Version="1.50.5147" />    -->
 	<PackageReference Include="PDFsharp-MigraDoc" Version="1.51.5186-beta" />
   <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/UnitTests/Core/Run/GenerateApsimXFilesTests.cs
+++ b/Tests/UnitTests/Core/Run/GenerateApsimXFilesTests.cs
@@ -72,8 +72,8 @@
             GenerateApsimXFiles.Generate(runner, path, (s) => { progress.Add(s); });
 
             Assert.AreEqual(progress.Count, 2);
-            Assert.AreEqual(progress[0], 50);
-            Assert.AreEqual(progress[1], 100);
+            Assert.AreEqual(progress[0], 0.5);
+            Assert.AreEqual(progress[1], 1);
 
             var generatedFiles = Directory.GetFiles(path).OrderBy(x => x).ToArray();
             Assert.AreEqual(generatedFiles.Length, 2);

--- a/Tests/UnitTests/Core/Run/GenerateApsimXFilesTests.cs
+++ b/Tests/UnitTests/Core/Run/GenerateApsimXFilesTests.cs
@@ -65,7 +65,7 @@
             Directory.CreateDirectory(path);
 
             // Create a list of progress ints.
-            var progress = new List<int>();
+            var progress = new List<double>();
 
             // Create a runner for our folder.
             Runner runner = new Runner(folder);


### PR DESCRIPTION
Resolves #6556
Resolves #6600
Working on #6139

- Progress bar and stop button are no longer shown in text area. They're shown in the status panel just above the textview widget
- Simulation status (ie "X of Y completed") is shown in a label to the right of the progress bar, above the text area
- Errors in the simulation are displayed in the text area as they occur

Other changes not really relevant to users:

- Fixed the "collection has been modified" error which was being thrown when updating simulation progress. (This was being handled internally anyway, so was only visible when running with a debugger.)
- Fixed the progress bar appearance in gtk3 builds. I've set it to a fixed 34px height. It would be better to have it expand to the same size as the stop button.

![image](https://user-images.githubusercontent.com/36427516/124055770-d8e05800-da67-11eb-8589-ba50591abed0.png)
