### PR TITLE
Small tidy up of gotophase

### DIFF
--- a/Models/PMF/Phenology/Phases/GotoPhase.cs
+++ b/Models/PMF/Phenology/Phases/GotoPhase.cs
@@ -30,9 +30,14 @@ namespace Models.PMF.Phen
         [Description("Start")]
         public string Start { get; set; }
 
-        /// <summary>The end</summary>
-        [Description("End")]
-        public string End { get; set; }
+        /// <summary>The end stage name.</summary>
+        public string End
+        {
+            get
+            {
+                return phenology.FindChild<IPhase>(PhaseNameToGoto)?.Start;
+            }
+        }
 
         /// <summary>The phase name to goto</summary>
         [Description("PhaseNameToGoto")]

--- a/Models/PMF/Phenology/Phases/IPhase.cs
+++ b/Models/PMF/Phenology/Phases/IPhase.cs
@@ -10,10 +10,10 @@ namespace Models.PMF.Phen
         string Name { get; }
         
         /// <summary>The start</summary>
-        string Start { get; set; }
+        string Start { get; }
 
         /// <summary>The end</summary>
-        string End { get; set; }
+        string End { get; }
 
         /// <summary>This function returns a non-zero value if the phase target is met today </summary>
         bool DoTimeStep(ref double PropOfDayToUse);

--- a/Models/PMF/Phenology/Phenology.cs
+++ b/Models/PMF/Phenology/Phenology.cs
@@ -514,8 +514,6 @@ namespace Models.PMF.Phen
                     row[1] = child.Name;
                     row[2] = (child as IPhase).Start;
                     row[3] = (child as IPhase).End;
-                    if (child is GotoPhase)
-                        row[3] = (child as GotoPhase).PhaseNameToGoto;
                     tableData.Rows.Add(row);
                     N++;
                 }

--- a/Prototypes/TropicalPasture/TropicalPasture.apsimx
+++ b/Prototypes/TropicalPasture/TropicalPasture.apsimx
@@ -30,7 +30,7 @@
             {
               "$type": "Models.Functions.AccumulateFunction, Models",
               "StartStageName": "Germination",
-              "EndStageName": "Old",
+              "EndStageName": "EndReproductive",
               "ResetStageName": null,
               "FractionRemovedOnCut": 0.0,
               "FractionRemovedOnHarvest": 0.0,


### PR DESCRIPTION
Resolves #6630 

See the change to Phenology.cs for the rationale behind this change.

I'm not sure if the GotoPhase's end stage name should be its PhaseNameToGoto (which is what it's set to in all existing instances of this class), or the start stage name of the target phase, which would make more sense to me based on what this class actually does.