### PR TITLE
Manager completion: don't attempt to load System.Drawing.dll

### DIFF
--- a/ApsimNG/Intellisense/CodeCompletionService.cs
+++ b/ApsimNG/Intellisense/CodeCompletionService.cs
@@ -212,7 +212,6 @@ namespace UserInterface.Intellisense
                 typeof(Uri).Assembly, // System.dll
                 typeof(Enumerable).Assembly, // System.Core.dll
                 typeof(System.Xml.XmlDocument).Assembly, // System.Xml.dll
-                typeof(System.Drawing.Bitmap).Assembly, // System.Drawing.dll
                 typeof(Models.Core.IModel).Assembly, // Models.exe
                 typeof(APSIM.Shared.Utilities.StringUtilities).Assembly, // APSIM.Shared.dll
                 typeof(MathNet.Numerics.Combinatorics).Assembly, // MathNet.Numerics


### PR DESCRIPTION
Working on #6681. I don't think this is likely to be a problem, although in the longer term a better fix might be desirable.