### PR TITLE
Add default save file extension only on Windows

### DIFF
--- a/ApsimNG/Utility/FileDialog.cs
+++ b/ApsimNG/Utility/FileDialog.cs
@@ -202,7 +202,7 @@
 
                 
                 tryAgain = false;
-                if (Action == FileActionType.Save && fileChooser.Filter != allFilter && specParts != null)
+                if (ProcessUtilities.CurrentOS.IsWindows && Action == FileActionType.Save && fileChooser.Filter != allFilter && specParts != null)
                 {
                     string filterName = fileChooser.Filter.Name;
                     for (int i = 0; i < specParts.Length; i += 2)


### PR DESCRIPTION
Resolves #6660 

Things still don't work as well as I'd like, but I haven't been able to come up with anything better.