### PR TITLE
Fixed a bug causing server to not clean datastore on reruns.

### DIFF
--- a/APSIM.Server/ServerJobRunner.cs
+++ b/APSIM.Server/ServerJobRunner.cs
@@ -45,7 +45,10 @@ namespace APSIM.Server
         protected override void Run(IRunnable job)
         {
             if (job is SimulationDescription sim)
+            {
+                sim.Storage.Writer.Clean(new[] { sim.SimulationToRun.Name }, false);
                 sim.Run(cancelToken, Replacements);
+            }
             else
             {
                 base.Prepare(job);


### PR DESCRIPTION
Working on #6529

Probably not the perfect solution, but it does the job. Can't think of a better way without refactoring SimulationGroup.