### PR TITLE
Bugfix for reading from streams in pipeutils

### DIFF
--- a/APSIM.Shared/Utilities/PipeUtilities.cs
+++ b/APSIM.Shared/Utilities/PipeUtilities.cs
@@ -97,7 +97,14 @@
             {
                 // Read bytes for object.
                 var buffer = new byte[numBytes];
-                pipeReader.Read(buffer, 0, numBytes);
+                int totalRead = 0;
+                int read = 0;
+                do
+                {
+                    read = pipeReader.Read(buffer, totalRead, numBytes - totalRead);
+                    totalRead += read;
+                }
+                while (totalRead < numBytes && read > 0);
 
                 Console.WriteLine($"RECV {string.Join("-", buffer.Select(b => $"{b:X2}"))}");
 

--- a/APSIM.Shared/Utilities/PipeUtilities.cs
+++ b/APSIM.Shared/Utilities/PipeUtilities.cs
@@ -13,30 +13,10 @@
     /// </summary>
     public class PipeUtilities
     {
-        // /// <summary>
-        // /// Get an object from the specified anonymous in pipe.
-        // /// </summary>
-        // /// <param name="pipeReader">The pipe to read from.</param>
-        // /// <returns>The object or null if no object read.</returns>
-        // public static object GetObjectFromPipe(AnonymousPipeClientStream pipeReader)
-        // {
-        //     // Read number of bytes.
-        //     var intBuffer = new byte[4];
-        //     pipeReader.Read(intBuffer, 0, 4);
-        //     var numBytes = BitConverter.ToInt32(intBuffer, 0);
-
-        //     if (numBytes > 0)
-        //     {
-        //         // Read bytes for object.
-        //         var buffer = new byte[numBytes];
-        //         pipeReader.Read(buffer, 0, numBytes);
-
-        //         // Convert bytes to object.
-        //         return ReflectionUtilities.BinaryDeserialise(new MemoryStream(buffer));
-        //     }
-        //     return null;
-        // }
-
+        /// <summary>
+        /// Serialize an object and encode the result as a base64 string.
+        /// </summary>
+        /// <param name="obj">Object to be serialized.</param>
         private static MemoryStream SerialiseTo(object obj)
         {
             // Serialise the object, then encode the result in base64.
@@ -53,6 +33,11 @@
             return result;
         }
 
+        /// <summary>
+        /// Read from the stream, decode from base64, then deserialize
+        /// the result.
+        /// </summary>
+        /// <param name="stream">Stream to read from.</param>
         private static object DeserialiseFrom(Stream stream)
         {
             // Decode from base64, then deserialise the result.
@@ -76,7 +61,8 @@
 
                 // Write the objStream.
                 byte[] buf = stream.ToArray();
-                Console.WriteLine($"SEND {string.Join("-", buf.Select(b => $"{b:X2}"))}");
+
+                // todo: should probably chunk this.
                 pipeWriter.Write(buf, 0, numBytes);
             }
         }
@@ -96,70 +82,38 @@
             if (numBytes > 0)
             {
                 // Read bytes for object.
-                var buffer = new byte[numBytes];
-                int totalRead = 0;
-                int read = 0;
-                do
-                {
-                    read = pipeReader.Read(buffer, totalRead, numBytes - totalRead);
-                    totalRead += read;
-                }
-                while (totalRead < numBytes && read > 0);
-
-                Console.WriteLine($"RECV {string.Join("-", buffer.Select(b => $"{b:X2}"))}");
+                byte[] buffer = Read(pipeReader, numBytes);
 
                 // Convert bytes to object.
                 using (MemoryStream stream = new MemoryStream(buffer))
-                {
-                    object result = DeserialiseFrom(stream);
-                    // Console.WriteLine($"RECV {result}");
-                    return result;
-                }
+                    return DeserialiseFrom(stream);
             }
             return null;
         }
 
-        // /// <summary>
-        // /// Send an object to the specified anonymous out pipe.
-        // /// </summary>
-        // /// <param name="pipeWriter">The pipe to write to.</param>
-        // /// <param name="obj">The object to send.</param>
-        // public static void SendObjectToPipe(AnonymousPipeServerStream pipeWriter, object obj)
-        // {
-        //     var objStream = ReflectionUtilities.BinarySerialise(obj) as MemoryStream;
+        /// <summary>
+        /// Read N bytes from the stream.
+        /// </summary>
+        /// <remarks>
+        /// This method accounts for the possibility of message being split across
+        /// multiple datagrams (e.g. as in a network socket connection).
+        /// </remarks>
+        /// <param name="stream">Stream to read from.</param>
+        /// <param name="numBytes">Number of bytes to read.</param>
+        private static byte[] Read(Stream stream, int numBytes)
+        {
+            var buffer = new byte[numBytes];
+            int totalRead = 0;
+            int read = 0;
+            do
+            {
+                read = stream.Read(buffer, totalRead, numBytes - totalRead);
+                totalRead += read;
+            }
+            while (totalRead < numBytes && read > 0);
 
-        //     // Write the number of bytes
-        //     var numBytes = Convert.ToInt32(objStream.Length);
-        //     var intBuffer = BitConverter.GetBytes(numBytes);
-        //     pipeWriter.Write(intBuffer, 0, 4);
-
-        //     // Write the objStream.
-        //     pipeWriter.Write(objStream.ToArray(), 0, numBytes);
-        // }
-
-        // /// <summary>
-        // /// Get an object from the specified anonymous in pipe.
-        // /// </summary>
-        // /// <param name="pipeReader">The pipe to read from.</param>
-        // /// <returns>The object or null if no object read.</returns>
-        // public static object GetObjectFromPipe(Stream pipeReader)
-        // {
-        //     // Read number of bytes.
-        //     var intBuffer = new byte[4];
-        //     pipeReader.Read(intBuffer, 0, 4);
-        //     var numBytes = BitConverter.ToInt32(intBuffer, 0);
-
-        //     if (numBytes > 0)
-        //     {
-        //         // Read bytes for object.
-        //         var buffer = new byte[numBytes];
-        //         pipeReader.Read(buffer, 0, numBytes);
-
-        //         // Convert bytes to object.
-        //         return ReflectionUtilities.BinaryDeserialise(new MemoryStream(buffer));
-        //     }
-        //     return null;
-        // }
+            return buffer;
+        }
 
         /// <summary>
         /// Get an object from the specified anonymous in pipe.
@@ -174,12 +128,7 @@
             var numBytes = BitConverter.ToInt32(intBuffer, 0);
 
             if (numBytes > 0)
-            {
-                // Read bytes for object.
-                var buffer = new byte[numBytes];
-                pipeReader.Read(buffer, 0, numBytes);
-                return buffer;
-            }
+                return Read(pipeReader, numBytes);
             return null;
         }
 
@@ -196,6 +145,7 @@
             pipeWriter.Write(intBuffer, 0, 4);
 
             // Write the objStream.
+            // todo: really ought to chunk this.
             pipeWriter.Write(buffer, 0, numBytes);
         }
     }


### PR DESCRIPTION
Need to account for the possibility of a message being split across multiple datagrams.

Working on #6529.