### PR TITLE
'Fix' legends on graph

### DIFF
--- a/APSIM.Interop/Graphing/Extensions/PlotModelExtensions.cs
+++ b/APSIM.Interop/Graphing/Extensions/PlotModelExtensions.cs
@@ -14,89 +14,67 @@ namespace APSIM.Interop.Graphing.Extensions
     {
         public static void SetLegendBorder(this PlotModel plot, OxyColor colour)
         {
-
-                foreach (LegendBase legend in plot.Legends)
-                    legend.LegendBorder = colour;
-
+            foreach (LegendBase legend in plot.Legends)
+                legend.LegendBorder = colour;
         }
 
         public static void SetLegendTextColour(this PlotModel plot, OxyColor colour)
         {
-
-                foreach (LegendBase legend in plot.Legends)
-                    legend.LegendTextColor = colour;
-
+            foreach (LegendBase legend in plot.Legends)
+                legend.LegendTextColor = colour;
         }
 
         public static void SetLegendTitleColour(this PlotModel plot, OxyColor colour)
         {
-
-                foreach (LegendBase legend in plot.Legends)
-                    legend.LegendTitleColor = colour;
-
+            foreach (LegendBase legend in plot.Legends)
+                legend.LegendTitleColor = colour;
         }
 
         public static void SetLegendBackground(this PlotModel plot, OxyColor colour)
         {
-
-            foreach (LegendBase legend in plot.Legends)
-                legend.LegendBackground = colour;
-
+        foreach (LegendBase legend in plot.Legends)
+            legend.LegendBackground = colour;
         }
 
         public static void SetLegendFontSize(this PlotModel plot, double size)
         {
-
-                foreach (LegendBase legend in plot.Legends)
-                    legend.LegendFontSize = size;
-
+            foreach (LegendBase legend in plot.Legends)
+                legend.LegendFontSize = size;
         }
 
         public static void SetLegendFont(this PlotModel plot, string font)
         {
-
-                foreach (LegendBase legend in plot.Legends)
-                    legend.LegendFont = font;
-
+            foreach (LegendBase legend in plot.Legends)
+                legend.LegendFont = font;
         }
 
         public static void SetLegendPosition(this PlotModel plot, LegendPosition position)
         {
-
-                foreach (LegendBase legend in plot.Legends)
-                    legend.LegendPosition = position;
-
+            foreach (LegendBase legend in plot.Legends)
+                legend.LegendPosition = position;
         }
 
         public static void SetLegendOrientation(this PlotModel plot, LegendOrientation orientation)
         {
-
-                foreach (LegendBase legend in plot.Legends)
-                    legend.LegendOrientation = orientation;
-
+            foreach (LegendBase legend in plot.Legends)
+                legend.LegendOrientation = orientation;
         }
 
         public static void SetLegendSymbolLength(this PlotModel plot, double length)
         {
-
-                foreach (LegendBase legend in plot.Legends)
-                    legend.LegendSymbolLength = length;
-
+            foreach (LegendBase legend in plot.Legends)
+                legend.LegendSymbolLength = length;
         }
 
         public static void SetLegendPlacement(this PlotModel plot, LegendPlacement placement)
         {
-
-                foreach (LegendBase legend in plot.Legends)
-                    legend.LegendPlacement = placement;
-
+            foreach (LegendBase legend in plot.Legends)
+                legend.LegendPlacement = placement;
         }
 
         public static LegendPlacement GetLegendPlacement(this PlotModel plot)
         {
-
-                return plot.Legends.FirstOrDefault()?.LegendPlacement ?? LegendPlacement.Inside;
-
+            return plot.Legends.FirstOrDefault()?.LegendPlacement ?? LegendPlacement.Inside;
         }
     }
 }

--- a/ApsimNG/Views/GraphView.cs
+++ b/ApsimNG/Views/GraphView.cs
@@ -1108,6 +1108,8 @@
         /// <param name="orientation">Orientation of items in the legend.</param>
         public void FormatLegend(APSIM.Shared.Graphing.LegendPosition legendPositionType, APSIM.Shared.Graphing.LegendOrientation orientation)
         {
+            if (!plot1.Model.Legends.Any())
+                plot1.Model.Legends.Add(new OxyPlot.Legends.Legend());
             OxyLegendPosition oxyLegendPosition;
             if (Enum.TryParse(legendPositionType.ToString(), out oxyLegendPosition))
             {


### PR DESCRIPTION
This is a quick fix to get graph legends working again. It's more of a hack, but the bigger issue is that the graphing UI needs to be changed to take advantage of the graph -> oxyplot pipeline used for autodocs. I will create a separate issue for this, as it will be a bit of work to get it done, and in the meantime people probably just want their graph legends back.

Resolves #6880.