### PR TITLE
Fixing if check

### DIFF
--- a/ApsimNG/Utility/WeatherDownloadDialog.cs
+++ b/ApsimNG/Utility/WeatherDownloadDialog.cs
@@ -153,7 +153,7 @@ namespace Utility
         {
             try
             {
-                if (!CheckValue(entryLatitude) || !CheckValue(entryLatitude))
+                if (!CheckValue(entryLatitude) || !CheckValue(entryLongitude))
                     return;
                 if (String.IsNullOrWhiteSpace(entryFilePath.Text))
                 {


### PR DESCRIPTION
Fixes if check when pressing "OK" button in download weather window.

You could have clicked "OK" without entering longitude (since it wasn't checking if anything was entered), which would result in an error.

Resolves #6901.