### PR TITLE
Remove inappropriate argument from call to GetMap, to get mapping wor…

### DIFF
--- a/APSIM.Interop/Mapping/MapRenderer.cs
+++ b/APSIM.Interop/Mapping/MapRenderer.cs
@@ -102,7 +102,7 @@ namespace APSIM.Interop.Mapping
         {
             Map exported = map.ToSharpMap();
             exported.Size = new Size(width, width);
-            return exported.GetMap(width);
+            return exported.GetMap();
         }
 
         /// <summary>

--- a/ApsimNG/Views/MapView.cs
+++ b/ApsimNG/Views/MapView.cs
@@ -224,7 +224,7 @@
         private void RefreshMap()
         {
             if (map != null)
-                image.Pixbuf = ImageToPixbuf(map.GetMap(defaultWidth));
+                image.Pixbuf = ImageToPixbuf(map.GetMap());
         }
 
         /// <summary>

--- a/Models/Map.cs
+++ b/Models/Map.cs
@@ -97,7 +97,7 @@ namespace Models
         /// <summary>
         /// Zoom level
         /// </summary>
-        private Double _Zoom = 360;
+        private Double _Zoom = 1.0;
 
         /// <summary>
         /// Document the model.


### PR DESCRIPTION
…king again on Windows. Resolves #6891.
I'm not sure why the overloaded version of GetMap with a "resolution" argument was ever called,
but it wasn't the right thing to do. When used, that argument is passed to System.Drawing.Bitmap.SetResolution, and attempts to set the DPI of the bitmap, which is clearly not what was intended.