### PR TITLE
Improved array support in expression parser

### DIFF
--- a/APSIM.Shared/Utilities/ExpressionEvaluator.cs
+++ b/APSIM.Shared/Utilities/ExpressionEvaluator.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Text;
 
 namespace APSIM.Shared.Utilities
@@ -685,7 +686,10 @@ namespace APSIM.Shared.Utilities
                     if (args.Length == 1)
                     {
                         result.m_name = name + "(" + ((Symbol)args[0]).m_value.ToString() + ")";
-                        result.m_value = System.Math.Cos(((Symbol)args[0]).m_value);
+                        if (args[0].m_values == null)
+                            result.m_value = System.Math.Cos(((Symbol)args[0]).m_value);
+                        else
+                            result.m_values = args[0].m_values.Select(Math.Cos).ToArray();
                     }
                     else
                     {
@@ -697,7 +701,14 @@ namespace APSIM.Shared.Utilities
                     if (args.Length == 1)
                     {
                         result.m_name = name + "(" + ((Symbol)args[0]).m_value.ToString() + ")";
-                        result.m_value = System.Math.Sin(((Symbol)args[0]).m_value);
+                        if (args[0].m_values == null)
+                        {
+                            result.m_value = System.Math.Sin(((Symbol)args[0]).m_value);
+                        }
+                        else
+                        {
+                            result.m_values = args[0].m_values.Select(Math.Sin).ToArray();
+                        }
                     }
                     else
                     {
@@ -709,7 +720,10 @@ namespace APSIM.Shared.Utilities
                     if (args.Length == 1)
                     {
                         result.m_name = name + "(" + ((Symbol)args[0]).m_value.ToString() + ")";
-                        result.m_value = System.Math.Tan(((Symbol)args[0]).m_value);
+                        if (args[0].m_values == null)
+                            result.m_value = System.Math.Tan(((Symbol)args[0]).m_value);
+                        else
+                            result.m_values = args[0].m_values.Select(Math.Tan).ToArray();
                     }
                     else
                     {
@@ -721,7 +735,10 @@ namespace APSIM.Shared.Utilities
                     if (args.Length == 1)
                     {
                         result.m_name = name + "(" + ((Symbol)args[0]).m_value.ToString() + ")";
-                        result.m_value = System.Math.Cosh(((Symbol)args[0]).m_value);
+                        if (args[0].m_values == null)
+                            result.m_value = System.Math.Cosh(((Symbol)args[0]).m_value);
+                        else
+                            result.m_values = args[0].m_values.Select(Math.Cosh).ToArray();
                     }
                     else
                     {
@@ -733,7 +750,10 @@ namespace APSIM.Shared.Utilities
                     if (args.Length == 1)
                     {
                         result.m_name = name + "(" + ((Symbol)args[0]).m_value.ToString() + ")";
-                        result.m_value = System.Math.Sinh(((Symbol)args[0]).m_value);
+                        if (args[0].m_values == null)
+                            result.m_value = System.Math.Sinh(((Symbol)args[0]).m_value);
+                        else
+                            result.m_values = args[0].m_values.Select(Math.Sinh).ToArray();
                     }
                     else
                     {
@@ -745,7 +765,10 @@ namespace APSIM.Shared.Utilities
                     if (args.Length == 1)
                     {
                         result.m_name = name + "(" + ((Symbol)args[0]).m_value.ToString() + ")";
-                        result.m_value = System.Math.Tanh(((Symbol)args[0]).m_value);
+                        if (args[0].m_values == null)
+                            result.m_value = System.Math.Tanh(((Symbol)args[0]).m_value);
+                        else
+                            result.m_values = args[0].m_values.Select(Math.Tanh).ToArray();
                     }
                     else
                     {
@@ -757,7 +780,10 @@ namespace APSIM.Shared.Utilities
                     if (args.Length == 1)
                     {
                         result.m_name = name + "(" + ((Symbol)args[0]).m_value.ToString() + ")";
-                        result.m_value = System.Math.Log10(((Symbol)args[0]).m_value);
+                        if (args[0].m_values == null)
+                            result.m_value = System.Math.Log10(((Symbol)args[0]).m_value);
+                        else
+                            result.m_values = args[0].m_values.Select(Math.Log10).ToArray();
                     }
                     else
                     {
@@ -769,7 +795,10 @@ namespace APSIM.Shared.Utilities
                     if (args.Length == 1)
                     {
                         result.m_name = name + "(" + ((Symbol)args[0]).m_value.ToString() + ")";
-                        result.m_value = System.Math.Log(((Symbol)args[0]).m_value);
+                        if (args[0].m_values == null)
+                            result.m_value = System.Math.Log(((Symbol)args[0]).m_value);
+                        else
+                            result.m_values = args[0].m_values.Select(v => Math.Log(v)).ToArray();
                     }
                     else
                     {
@@ -780,8 +809,19 @@ namespace APSIM.Shared.Utilities
                 case "logn":
                     if (args.Length == 2)
                     {
-                        result.m_name = name + "(" + ((Symbol)args[0]).m_value.ToString() + "'" + ((Symbol)args[1]).m_value.ToString() + ")";
-                        result.m_value = System.Math.Log(((Symbol)args[0]).m_value, ((Symbol)args[1]).m_value);
+                        if (args[1].m_values == null)
+                        {
+                            result.m_name = name + "(" + ((Symbol)args[0]).m_value.ToString() + "'" + ((Symbol)args[1]).m_value.ToString() + ")";
+                            if (args[0].m_values == null)
+                                result.m_value = System.Math.Log(((Symbol)args[0]).m_value, ((Symbol)args[1]).m_value);
+                            else
+                                result.m_values = args[0].m_values.Select(v => Math.Log(v, args[1].m_value)).ToArray();
+                        }
+                        else
+                        {
+                            result.m_name = "logn function does not support vector of bases";
+                            result.m_type = ExpressionType.Error;
+                        }
                     }
                     else
                     {
@@ -793,7 +833,10 @@ namespace APSIM.Shared.Utilities
                     if (args.Length == 1)
                     {
                         result.m_name = name + "(" + ((Symbol)args[0]).m_value.ToString() + ")";
-                        result.m_value = System.Math.Sqrt(((Symbol)args[0]).m_value);
+                        if (args[0].m_values == null)
+                            result.m_value = System.Math.Sqrt(((Symbol)args[0]).m_value);
+                        else
+                            result.m_values = args[0].m_values.Select(Math.Sqrt).ToArray();
                     }
                     else
                     {
@@ -805,7 +848,10 @@ namespace APSIM.Shared.Utilities
                     if (args.Length == 1)
                     {
                         result.m_name = name + "(" + ((Symbol)args[0]).m_value.ToString() + ")";
-                        result.m_value = System.Math.Abs(((Symbol)args[0]).m_value);
+                        if (args[0].m_values == null)
+                            result.m_value = System.Math.Abs(((Symbol)args[0]).m_value);
+                        else
+                            result.m_values = args[0].m_values.Select(Math.Abs).ToArray();
                     }
                     else
                     {
@@ -817,7 +863,10 @@ namespace APSIM.Shared.Utilities
                     if (args.Length == 1)
                     {
                         result.m_name = name + "(" + ((Symbol)args[0]).m_value.ToString() + ")";
-                        result.m_value = System.Math.Acos(((Symbol)args[0]).m_value);
+                        if (args[0].m_values == null)
+                            result.m_value = System.Math.Acos(((Symbol)args[0]).m_value);
+                        else
+                            result.m_values = args[0].m_values.Select(Math.Acos).ToArray();
                     }
                     else
                     {
@@ -829,7 +878,10 @@ namespace APSIM.Shared.Utilities
                     if (args.Length == 1)
                     {
                         result.m_name = name + "(" + ((Symbol)args[0]).m_value.ToString() + ")";
-                        result.m_value = System.Math.Asin(((Symbol)args[0]).m_value);
+                        if (args[0].m_values == null)
+                            result.m_value = System.Math.Asin(((Symbol)args[0]).m_value);
+                        else
+                            result.m_values = args[0].m_values.Select(Math.Asin).ToArray();
                     }
                     else
                     {
@@ -841,7 +893,10 @@ namespace APSIM.Shared.Utilities
                     if (args.Length == 1)
                     {
                         result.m_name = name + "(" + ((Symbol)args[0]).m_value.ToString() + ")";
-                        result.m_value = System.Math.Atan(((Symbol)args[0]).m_value);
+                        if (args[0].m_values == null)
+                            result.m_value = System.Math.Atan(((Symbol)args[0]).m_value);
+                        else
+                            result.m_values = args[0].m_values.Select(Math.Atan).ToArray();
                     }
                     else
                     {
@@ -999,7 +1054,10 @@ namespace APSIM.Shared.Utilities
                     if (args.Length == 1)
                     {
                         result.m_name = name + "(" + ((Symbol)args[0]).m_value.ToString() + ")";
-                        result.m_value = Math.Floor(((Symbol)args[0]).m_value);
+                        if (args[0].m_values == null)
+                            result.m_value = Math.Floor(((Symbol)args[0]).m_value);
+                        else
+                            result.m_values = args[0].m_values.Select(Math.Floor).ToArray();
                     }
                     else
                     {
@@ -1012,7 +1070,10 @@ namespace APSIM.Shared.Utilities
                     if (args.Length == 1)
                     {
                         result.m_name = name + "(" + ((Symbol)args[0]).m_value.ToString() + ")";
-                        result.m_value = Math.Ceiling(((Symbol)args[0]).m_value);
+                        if (args[0].m_values == null)
+                            result.m_value = Math.Ceiling(((Symbol)args[0]).m_value);
+                        else
+                            result.m_values = args[0].m_values.Select(Math.Ceiling).ToArray();
                     }
                     else
                     {

--- a/APSIM.Shared/Utilities/ExpressionEvaluator.cs
+++ b/APSIM.Shared/Utilities/ExpressionEvaluator.cs
@@ -776,7 +776,7 @@ namespace APSIM.Shared.Utilities
                         result.m_type = ExpressionType.Error;
                     }
                     break;
-                case "log":
+                case "log10":
                     if (args.Length == 1)
                     {
                         result.m_name = name + "(" + ((Symbol)args[0]).m_value.ToString() + ")";

--- a/Models/Core/ApsimFile/Converter.cs
+++ b/Models/Core/ApsimFile/Converter.cs
@@ -24,7 +24,7 @@ namespace Models.Core.ApsimFile
     public class Converter
     {
         /// <summary>Gets the latest .apsimx file format version.</summary>
-        public static int LatestVersion { get { return 146; } }
+        public static int LatestVersion { get { return 147; } }
 
         /// <summary>Converts a .apsimx string to the latest version.</summary>
         /// <param name="st">XML or JSON string to convert.</param>
@@ -3871,6 +3871,23 @@ namespace Models.Core.ApsimFile
                 replace |= manager.ReplaceRegex(errorPattern, errorReplace);
                 if (replace)
                     manager.Save();
+            }
+        }
+
+        /// <summary>
+        /// Rename report function log to log10.
+        /// </summary>
+        /// <param name="root">Root node.</param>
+        /// <param name="fileName">File name.</param>
+        private static void UpgradeToVersion147(JObject root, string fileName)
+        {
+            foreach (JObject report in JsonUtilities.ChildrenRecursively(root, "Report"))
+            {
+                JArray variables = report["VariableNames"] as JArray;
+                if (variables != null)
+                    foreach (JValue variable in variables)
+                        if (variable.Value is string)
+                            variable.Value = ((string)variable.Value).Replace("log(", "log10(");
             }
         }
 

--- a/Models/Resources/AGPBrowntop.json
+++ b/Models/Resources/AGPBrowntop.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/AGPCocksfoot.json
+++ b/Models/Resources/AGPCocksfoot.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/AGPKikuyu.json
+++ b/Models/Resources/AGPKikuyu.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/AGPLucerne.json
+++ b/Models/Resources/AGPLucerne.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/AGPPaspalum.json
+++ b/Models/Resources/AGPPaspalum.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/AGPPhalaris.json
+++ b/Models/Resources/AGPPhalaris.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/AGPRedClover.json
+++ b/Models/Resources/AGPRedClover.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/AGPRhodes.json
+++ b/Models/Resources/AGPRhodes.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/AGPRyegrass.json
+++ b/Models/Resources/AGPRyegrass.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/AGPTallFescue.json
+++ b/Models/Resources/AGPTallFescue.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/AGPWhiteClover.json
+++ b/Models/Resources/AGPWhiteClover.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Barley.json
+++ b/Models/Resources/Barley.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Chickpea.json
+++ b/Models/Resources/Chickpea.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Chicory.json
+++ b/Models/Resources/Chicory.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Eucalyptus.json
+++ b/Models/Resources/Eucalyptus.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Fertiliser.json
+++ b/Models/Resources/Fertiliser.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/FodderBeet.json
+++ b/Models/Resources/FodderBeet.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Gliricidia.json
+++ b/Models/Resources/Gliricidia.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Grapevine.json
+++ b/Models/Resources/Grapevine.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Angus.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Angus.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Beef Shorthorn.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Beef Shorthorn.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Brahman.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Brahman.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/British x Brahman.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/British x Brahman.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/British x Charolais.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/British x Charolais.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/British x Friesian.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/British x Friesian.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/British x Holstein.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/British x Holstein.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Charolais x Friesian.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Charolais x Friesian.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Charolais x Holstein.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Charolais x Holstein.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Charolais.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Charolais.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Chianina.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Chianina.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Hereford.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Hereford.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Limousin.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Limousin.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Simmental.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Simmental.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/South Devon.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/South Devon.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Ujimqin Cattle.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Ujimqin Cattle.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Ujimqin x Angus (1st cross).json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Ujimqin x Angus (1st cross).json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Ujimqin x Angus (2nd cross).json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Ujimqin x Angus (2nd cross).json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Ujimqin x Charolais (1st cross).json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Ujimqin x Charolais (1st cross).json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Ujimqin x Charolais (2nd cross).json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Ujimqin x Charolais (2nd cross).json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Ayrshire.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Ayrshire.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Brown Swiss.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Brown Swiss.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Dairy Shorthorn.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Dairy Shorthorn.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Friesian.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Friesian.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Guernsey.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Guernsey.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Holstein.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Holstein.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Jersey.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Jersey.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Goats/Ujimqin Goats.json
+++ b/Models/Resources/GrazPlan/Genotypes/Goats/Ujimqin Goats.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Crossbreds/Border Leicester x Merino.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Crossbreds/Border Leicester x Merino.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Crossbreds/Dorset x Merino.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Crossbreds/Dorset x Merino.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Crossbreds/Mongolian x Merino.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Crossbreds/Mongolian x Merino.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Blackface x Whiteface.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Blackface x Whiteface.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Border Leicester.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Border Leicester.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Cheviot.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Cheviot.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Columbia.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Columbia.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Dorset.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Dorset.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Finnsheep.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Finnsheep.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Hampshire.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Hampshire.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Polypay.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Polypay.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Rambouillet.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Rambouillet.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Ryeland.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Ryeland.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Southdown (US).json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Southdown (US).json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Southdown.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Southdown.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Suffolk (US).json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Suffolk (US).json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Suffolk.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Suffolk.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Texel.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Texel.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Ujimqin Sheep.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Ujimqin Sheep.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Corriedale.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Corriedale.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Delaine-Merino.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Delaine-Merino.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Large Merino.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Large Merino.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Medium Merino.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Medium Merino.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Polwarth.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Polwarth.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Romney.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Romney.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Small Merino.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Small Merino.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Targhee.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Targhee.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/Maize.json
+++ b/Models/Resources/Maize.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Nutrient.json
+++ b/Models/Resources/Nutrient.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Oats.json
+++ b/Models/Resources/Oats.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/OilPalm.json
+++ b/Models/Resources/OilPalm.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Peanut.json
+++ b/Models/Resources/Peanut.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Pinus.json
+++ b/Models/Resources/Pinus.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Plantain.json
+++ b/Models/Resources/Plantain.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Potato.json
+++ b/Models/Resources/Potato.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/RedClover.json
+++ b/Models/Resources/RedClover.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/SCRUM.json
+++ b/Models/Resources/SCRUM.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Slurp.json
+++ b/Models/Resources/Slurp.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Soybean.json
+++ b/Models/Resources/Soybean.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Sugarcane.json
+++ b/Models/Resources/Sugarcane.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/SurfaceOrganicMatter.json
+++ b/Models/Resources/SurfaceOrganicMatter.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/WaterBalance.json
+++ b/Models/Resources/WaterBalance.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Wheat.json
+++ b/Models/Resources/Wheat.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/WhiteClover.json
+++ b/Models/Resources/WhiteClover.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 146,
+  "Version": 147,
   "Name": "Simulations",
   "Children": [
     {

--- a/Tests/UnitTests/APSIMShared/ExpressionEvaluatorTests.cs
+++ b/Tests/UnitTests/APSIMShared/ExpressionEvaluatorTests.cs
@@ -34,7 +34,7 @@ namespace UnitTests.APSIMShared
         [TestCase("sin(pi/2)", 1)]
         [TestCase("cos(pi)", -1)]
         [TestCase("tan(pi/4)", 1)]
-        [TestCase("log(10)", 1)]
+        [TestCase("log10(10)", 1)]
         [TestCase("ln(e)", 1)]
         [TestCase("logn(2, 2)", 1)]
         [TestCase("sqrt(9)", 3)]
@@ -114,7 +114,7 @@ namespace UnitTests.APSIMShared
             TestElementwiseFunction("sinh(x)", Math.Sinh, inputs);
             TestElementwiseFunction("cosh(x)", Math.Cosh, inputs);
             TestElementwiseFunction("tanh(x)", Math.Tanh, inputs);
-            TestElementwiseFunction("log(x)", Math.Log10, getLogNInputs(10));
+            TestElementwiseFunction("log10(x)", Math.Log10, getLogNInputs(10));
             TestElementwiseFunction("ln(x)", Math.Log, getLogNInputs(Math.E));
             TestElementwiseFunction("logn(x, 2)", Math.Log2, getLogNInputs(2));
             TestElementwiseFunction("sqrt(x)", Math.Sqrt, inputs);

--- a/Tests/UnitTests/APSIMShared/ExpressionEvaluatorTests.cs
+++ b/Tests/UnitTests/APSIMShared/ExpressionEvaluatorTests.cs
@@ -1,0 +1,167 @@
+using APSIM.Shared.Utilities;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UnitTests.APSIMShared
+{
+    /// <summary>
+    /// Unit tests for the expression parser.
+    /// <see cref="ExpressionEvaluator"/>.
+    /// </summary>
+    [TestFixture]
+    public class ExpressionEvaluatorTests
+    {
+        /// <summary>
+        /// Tolerance for floating point comparisons.
+        /// </summary>
+        private const double tolerance = 1e-12;
+
+        /// <summary>
+        /// Ensure that an expression can be parsed without error and
+        /// that the result matches an expected value.
+        /// </summary>
+        /// <param name="expression">Expression to be parsed.</param>
+        /// <param name="value">Expected value of the expression.</param>
+        [TestCase("1 + 2", 3)]
+        [TestCase("2 * 3", 6)]
+        [TestCase("1 - 4", -3)]
+        [TestCase("1 / 8", 0.125)]
+        [TestCase("2 ^ 6", 64)]
+        [TestCase("16 / 8 + 2 ^ 5 * 2", 66)]
+        [TestCase("(1 + 2) * 3", 9)]
+        [TestCase("sin(pi/2)", 1)]
+        [TestCase("cos(pi)", -1)]
+        [TestCase("tan(pi/4)", 1)]
+        [TestCase("log(10)", 1)]
+        [TestCase("ln(e)", 1)]
+        [TestCase("logn(2, 2)", 1)]
+        [TestCase("sqrt(9)", 3)]
+        [TestCase("abs(-1)", 1)]
+        [TestCase("abs(1)", 1)]
+        [TestCase("acos(-1)", Math.PI)]
+        [TestCase("asin(1)", Math.PI / 2)]
+        [TestCase("atan(1)", Math.PI / 4)]
+        [TestCase("exp(1)", Math.E)]
+        [TestCase("floor(2.99)", 2)]
+        [TestCase("ceil(3.1)", 4)]
+        [TestCase("ceiling(2.678)", 3)]
+        public void TestExpression(string expression, double value)
+        {
+            ExpressionEvaluator parser = new ExpressionEvaluator();
+            parser.Parse(expression);
+            parser.Infix2Postfix();
+            parser.EvaluatePostfix();
+            Assert.False(parser.Error);
+            Assert.AreEqual(value, parser.Result, tolerance);
+        }
+
+        /// <summary>
+        /// Test functions which take a vector and return a scalar.
+        /// </summary>
+        /// <param name="value">Expected result.</param>
+        /// <param name="expression">Expression to be parsed.</param>
+        /// <param name="inputs">Inputs to the function.</param>
+        [TestCase(0.5, "mean(x)", 0, 1)]
+        [TestCase(14, "sum(x)", 1, 2, 4, 7)]
+        [TestCase(8, "sum(x)", 8)]
+        [TestCase(3, "subtract(x)", 6, 1, 2)]
+        [TestCase(15, "subtract(x)", 15)]
+        [TestCase(120, "multiply(x)", 1, 2, 3, 4, 5)]
+        [TestCase(4, "multiply(x)", 4)]
+        [TestCase(0.125, "divide(x)", 1, 4, 2)]
+        [TestCase(2, "divide(x)", 2)]
+        [TestCase(2, "min(x)", 2, 2.01)]
+        [TestCase(34, "min(x)", 34)]
+        [TestCase(3, "max(x)", 2.99, 3)]
+        [TestCase(44, "max(x)", 44)]
+        [TestCase(0.5, "stddev(x)", 0, 1)]
+        [TestCase(3, "median(x)", 0, 1, 3, 4.21, 6)]
+        public void TestVectorToScalar(double value, string expression, params double[] inputs)
+        {
+            ExpressionEvaluator parser = new ExpressionEvaluator();
+            parser.Parse(expression);
+            parser.Infix2Postfix();
+
+            // blech
+            List<Symbol> variables = parser.Variables;
+            Assert.AreEqual(1, variables.Count, "Expression must have exactly 1 symbol");
+            Symbol symbol = variables[0];
+            symbol.m_values = inputs;
+            variables[0] = symbol;
+            parser.Variables = variables;
+
+            parser.EvaluatePostfix();
+            Assert.False(parser.Error);
+
+            Assert.AreEqual(value, parser.Result, tolerance);
+        }
+
+        [Test]
+        public void TestVectorToVectorFunctions()
+        {
+            // Inputs which return known values for sin/cos.
+            double[] inputs = new double[] { 0, 1, 2, 3, 4 };
+            double[] trigInputs = new[] { 0, Math.PI / 2, Math.PI, 1.5 * Math.PI, 2 * Math.PI };
+            double[] mixedInputs = new double[] { -2, -1, 0, 1, 2 };
+            double[] invTrigs = new[] { -1d, 0, 1 };
+            double[] floats = new[] { -0.75, -0.25, 0.25, 1.75 };
+            Func<double, double[]> getLogNInputs = x => new double[] { 0, Math.Pow(x, 1), Math.Pow(x, 2), Math.Pow(x, 3) };
+            TestElementwiseFunction("sin(x)", Math.Sin, trigInputs);
+            TestElementwiseFunction("cos(x)", Math.Cos, trigInputs);
+            TestElementwiseFunction("tan(x)", Math.Tan, trigInputs);
+            TestElementwiseFunction("sinh(x)", Math.Sinh, inputs);
+            TestElementwiseFunction("cosh(x)", Math.Cosh, inputs);
+            TestElementwiseFunction("tanh(x)", Math.Tanh, inputs);
+            TestElementwiseFunction("log(x)", Math.Log10, getLogNInputs(10));
+            TestElementwiseFunction("ln(x)", Math.Log, getLogNInputs(Math.E));
+            TestElementwiseFunction("logn(x, 2)", Math.Log2, getLogNInputs(2));
+            TestElementwiseFunction("sqrt(x)", Math.Sqrt, inputs);
+            TestElementwiseFunction("abs(x)", Math.Abs, mixedInputs);
+            TestElementwiseFunction("asin(x)", Math.Asin, invTrigs);
+            TestElementwiseFunction("acos(x)", Math.Acos, invTrigs);
+            TestElementwiseFunction("atan(x)", Math.Atan, invTrigs);
+            TestElementwiseFunction("exp(x)", Math.Exp, inputs);
+            TestElementwiseFunction("floor(x)", Math.Floor, floats);
+            TestElementwiseFunction("ceil(x)", Math.Ceiling, floats);
+            TestElementwiseFunction("ceiling(x)", Math.Ceiling, floats);
+        }
+
+        /// <summary>
+        /// Ensure that the given expression may be parsed without errors, and that
+        /// it returns an array with the given func applied to each input.
+        /// </summary>
+        /// <param name="expression">Expression to be parsed.</param>
+        /// <param name="inputs">Inputs to the function.</param>
+        /// <param name="func">Function which is expected to be performed element-wise on the inputs.</param>
+        public void TestElementwiseFunction(string expression, Func<double, double> func, params double[] inputs)
+        {
+            ExpressionEvaluator parser = new ExpressionEvaluator();
+            parser.Parse(expression);
+            parser.Infix2Postfix();
+
+            // blech
+            List<Symbol> variables = parser.Variables;
+            Symbol symbol;
+            if (variables.Count == 1)
+                symbol = variables[0];
+            else
+            {
+                symbol = variables.FirstOrDefault(v => v.m_name == "x");
+                Assert.NotNull(symbol);
+            }
+            symbol.m_values = inputs;
+            variables[0] = symbol;
+            parser.Variables = variables;
+
+            parser.EvaluatePostfix();
+            Assert.False(parser.Error);
+
+            Assert.NotNull(parser.Results, $"ExpressionEvaluator returned a scalar for {expression}");
+            Assert.AreEqual(inputs.Length, parser.Results.Length);
+            for (uint i = 0; i < inputs.Length; i++)
+                Assert.AreEqual(func(inputs[i]), parser.Results[i], tolerance, $"{expression.Replace("(x)", $"({inputs[i]})")}: incorrect return value");
+        }
+    }
+}


### PR DESCRIPTION
Resolves #6882 

- Added (element-wise) array support to scalar report functions (like ln, sin, etc)
- Rename log() to log10() (+ converter function)
- Unit tests for expression parser