### PR TITLE
Allow apsim to spin up docker containers to run CroptimizR simulations

### DIFF
--- a/APSIM.Shared/APSIM.Shared.csproj
+++ b/APSIM.Shared/APSIM.Shared.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="7.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
+    <PackageReference Include="Docker.DotNet" Version="3.125.5" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">

--- a/APSIM.Shared/Containers/Docker.cs
+++ b/APSIM.Shared/Containers/Docker.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using APSIM.Shared.Documentation.Extensions;
+using APSIM.Shared.Extensions.Collections;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+
+namespace APSIM.Shared.Containers
+{
+    /// <summary>
+    /// Encapsulates a docker client.
+    /// </summary>
+    public class Docker
+    {
+        /// <summary>
+        /// Docker client, used to interact with the docker daemon.
+        /// </summary>
+        private DockerClient client;
+
+        /// <summary>
+        /// Callback to be invoked when stdout is received from a container.
+        /// </summary>
+        private readonly Action<string> outputHandler;
+
+        /// <summary>
+        /// Handler for warnings from docker.
+        /// </summary>
+        private Action<string> warningHandler;
+
+        /// <summary>
+        /// Callback to be invoked when stderr is received from a container.
+        /// </summary>
+        private Action<string> errorHandler;
+
+        /// <summary>
+        /// Create a new docker client instance.
+        /// </summary>
+        /// <param name="outputHandler">Handler for receiving stdout from the container.</param>
+        /// <param name="warningHandler">Handler for warnings from docker.</param>
+        /// <param name="errorHandler">Callback for stderr from the container.</param>
+        public Docker(Action<string> outputHandler = null, Action<string> warningHandler = null, Action<string> errorHandler = null)
+        {
+            Uri uri = new Uri("unix:///var/run/docker.sock");
+            client = new DockerClientConfiguration(uri).CreateClient();
+            this.outputHandler = outputHandler;
+            this.warningHandler = warningHandler;
+            this.errorHandler = errorHandler;
+        }
+
+        /// <summary>
+        /// Run a container.
+        /// </summary>
+        /// <param name="image"></param>
+        /// <param name="entrypoint"></param>
+        /// <param name="args"></param>
+        /// <param name="volumes"></param>
+        /// <param name="environment"></param>
+        /// <param name="cancelToken"></param>
+        /// <returns></returns>
+        public async Task RunContainerAsync(string image, string entrypoint, IEnumerable<string> args, IReadOnlyList<Volume> volumes, Dictionary<string, string> environment, CancellationToken cancelToken)
+        {
+            CreateContainerParameters parameters = new CreateContainerParameters()
+            {
+                Image = image,
+                Entrypoint = entrypoint.ToEnumerable().AppendMany(args).ToList(),
+                Env = environment?.Select((x, y) => $"{x}={y}")?.ToList(),
+                Tty = false,
+                HostConfig = new HostConfig()
+                {
+                    Binds = volumes.Select(v => $"{v.SourcePath}:{v.DestinationPath}").ToList()
+                }
+            };
+
+            // Create the container.
+            CreateContainerResponse container = await client.Containers.CreateContainerAsync(parameters, cancelToken);
+
+            try
+            {
+                // Report any warnings from the docker daemon.
+                foreach (string warning in container.Warnings)
+                    warningHandler(warning);
+
+                // Start the container, and wait for it to exit.
+                await client.Containers.StartContainerAsync(container.ID, new ContainerStartParameters(), cancelToken);
+
+                // Watch stdout and/or stderr as necessary.
+                Task stdoutListener = WatchStdoutStreamAsync(container.ID, cancelToken);
+                Task stderrListener = WatchStderrStreamAsync(container.ID, cancelToken);
+
+                // Wait for the container to exit.
+                ContainerWaitResponse waitResponse = await client.Containers.WaitContainerAsync(container.ID, cancelToken);
+
+                // Wait for output listeners if cancellation has not been requested.
+                if (!cancelToken.IsCancellationRequested)
+                {
+                    await stdoutListener.ConfigureAwait(false);
+                    await stderrListener.ConfigureAwait(false);
+                }
+
+                // If cancellation isn't requested, ensure the container exited gracefully.
+                if (!cancelToken.IsCancellationRequested && waitResponse.StatusCode != 0)
+                {
+                    (string stdout, string stderr) = await GetContainerLogsAsync(container.ID, parameters.Tty, cancelToken);
+                    StringBuilder output = new StringBuilder();
+                    output.AppendLine(stdout);
+                    output.AppendLine(stderr);
+                    throw new Exception($"Container exited with non-zero exit code. Container log:\n{output}");
+                }
+            }
+            finally
+            {
+                ContainerRemoveParameters removeParameters = new ContainerRemoveParameters()
+                {
+                    RemoveVolumes = true,
+                    Force = true
+                };
+                ContainerKillParameters killParameters = new ContainerKillParameters()
+                {
+                };
+                // Only attempt to kill the container if it's still running.
+                if (await IsRunning(container.ID))
+                    await client.Containers.KillContainerAsync(container.ID, killParameters);
+                await client.Containers.RemoveContainerAsync(container.ID, removeParameters);
+            }
+        }
+
+        /// <summary>
+        /// Check if a container is running.
+        /// </summary>
+        /// <param name="id">ID of the container to be checked.</param>
+        private async Task<bool> IsRunning(string id)
+        {
+            IDictionary<string, bool> idFilter = new Dictionary<string, bool>() { { id, true } };
+            Dictionary<string, IDictionary<string, bool>> filters = new Dictionary<string, IDictionary<string, bool>>()
+            {
+                { "id", idFilter }
+            };
+            ContainersListParameters parameters = new ContainersListParameters()
+            {
+                All = true,
+                Filters = filters
+            };
+            IList<ContainerListResponse> containers = await client.Containers.ListContainersAsync(parameters);
+
+            // If it doesn't exist it's not running.
+            if (containers.Count < 1)
+                return false;
+
+            // todo: could we ever have >1 container matching these filters?
+
+            ContainerListResponse response = containers[0];
+            return response.State == "running";
+        }
+
+        /// <summary>
+        /// Create a cancellable task to watch the stdout stream from a running
+        /// container. The <see cref="outputHandler"/> callback will be invoked
+        /// whenever we receive a message from the container.
+        /// </summary>
+        /// <param name="id">ID of the container.</param>
+        /// <param name="cancelToken">Cancellation token.</param>
+        private async Task WatchStdoutStreamAsync(string id, CancellationToken cancelToken)
+        {
+            if (outputHandler == null)
+                return;
+            await WatchOutputStreamsAsync(id, true, false, outputHandler, cancelToken);
+        }
+
+        /// <summary>
+        /// Create a cancellable task to watch the stderr stream from a running
+        /// container. The <see cref="errorHandler"/> callback will be invoked
+        /// whenever we receive a message from the container.
+        /// </summary>
+        /// <param name="id">ID of the container.</param>
+        /// <param name="cancelToken">Cancellation token.</param>
+        private async Task WatchStderrStreamAsync(string id, CancellationToken cancelToken)
+        {
+            if (errorHandler == null)
+                return;
+            await WatchOutputStreamsAsync(id, false, true, errorHandler, cancelToken);
+        }
+
+        /// <summary>
+        /// Create a task to monitor the stdout and/or stderr streams from a
+        /// running container, and invoke the given callback whenever data is
+        /// written to the stream(s).
+        /// </summary>
+        /// <param name="id">ID of the container.</param>
+        /// <param name="stdout">Monitor the container's stdout stream?</param>
+        /// <param name="stderr">Monitor the container's stderr stream?</param>
+        /// <param name="handler">Message callback.</param>
+        /// <param name="cancelToken">Cancellation tokne.</param>
+        private async Task WatchOutputStreamsAsync(string id, bool stdout, bool stderr, Action<string> handler, CancellationToken cancelToken)
+        {
+            if (handler == null)
+                throw new ArgumentNullException(nameof(handler));
+
+            ContainerLogsParameters logParameters = new ContainerLogsParameters()
+            {
+                ShowStdout = stdout,
+                ShowStderr = stderr,
+                Follow = true
+            };
+            Progress<string> callback = new Progress<string>(msg =>
+            {
+                try
+                {
+                    handler(msg);
+                }
+                catch (Exception error)
+                {
+                    Console.WriteLine($"Error in output callback:\n{error}");
+                }
+            });
+            await client.Containers.GetContainerLogsAsync(id, logParameters, cancelToken, callback);
+        }
+
+        /// <summary>
+        /// Read and return container logs as a tuple of (stdout, stderr).
+        /// </summary>
+        /// <param name="id">Container ID.</param>
+        /// <param name="tty">Was the container started with TTY enabled?</param>
+        /// <param name="cancelToken">Cancellation token.</param>
+        private async Task<(string, string)> GetContainerLogsAsync(string id, bool tty, CancellationToken cancelToken)
+        {
+            ContainerLogsParameters logParameters = new ContainerLogsParameters()
+            {
+                ShowStdout = true,
+                ShowStderr = true,
+                Follow = false
+            };
+            using (MultiplexedStream logStream = await client.Containers.GetContainerLogsAsync(id, tty, logParameters, cancelToken))
+                return await logStream.ReadOutputToEndAsync(cancelToken);
+        }
+    }
+}

--- a/APSIM.Shared/Containers/RDocker.cs
+++ b/APSIM.Shared/Containers/RDocker.cs
@@ -1,0 +1,89 @@
+using APSIM.Shared.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using APSIM.Shared.Documentation.Extensions;
+
+namespace APSIM.Shared.Containers
+{
+    /// <summary>
+    /// Runs R code inside a docker container.
+    /// </summary>
+    public class RDocker : IR
+    {
+        /// <summary>
+        /// Name of an environment variable, which, if set to 1, will cause
+        /// apsim to /not/ run R code through docker.
+        /// </summary>
+        private const string skipDockerVariable = "APSIM_NO_DOCKER";
+
+        /// <summary>
+        /// Name of the docker image which will be run.
+        /// </summary>
+        private const string apsimCompleteImageName = "apsiminitiative/apsimng-complete:latest";
+
+        /// <summary>
+        /// Callback to be invoked when stdout is received from a container.
+        /// </summary>
+        private readonly Action<string> outputHandler;
+
+        /// <summary>
+        /// Handler for warnings from docker.
+        /// </summary>
+        private Action<string> warningHandler;
+
+        /// <summary>
+        /// Callback to be invoked when stderr is received from a container.
+        /// </summary>
+        private Action<string> errorHandler;
+
+        /// <summary>
+        /// Create a new <see cref="RDocker"/> instance.
+        /// </summary>
+        /// <param name="outputHandler">Handler for receiving stdout from the container.</param>
+        /// <param name="warningHandler">Handler for warnings from docker.</param>
+        /// <param name="errorHandler">Callback for stderr from the container.</param>
+        public RDocker(Action<string> outputHandler = null, Action<string> warningHandler = null, Action<string> errorHandler = null)
+        {
+            this.outputHandler = outputHandler;
+            this.warningHandler = warningHandler;
+            this.errorHandler = errorHandler;
+        }
+
+        /// <summary>
+        /// Run an R script asynchronously. Throws if an error occurs.
+        /// </summary>
+        /// <param name="scriptPath">Path to the R script. Note that all other files required by the R script must live in the same directory tree as the script.</param>
+        /// <param name="arguments">Arguments to be passed to the R script.</param>
+        /// <param name="cancelToken">Cancellation token, used to cancel script execution.</param>
+        public async Task RunScriptAsync(string scriptPath, IEnumerable<string> arguments, CancellationToken cancelToken)
+        {
+            string hostScriptDirectory = Path.GetDirectoryName(scriptPath);
+            Volume volume = new Volume(hostScriptDirectory, hostScriptDirectory);
+
+            // Set the APSIM_NO_DOCKER environment variable in the container,
+            // to ensure that the container doesn't attempt to recursively use
+            // docker to run the file.
+            Dictionary<string, string> env = new Dictionary<string, string>()
+            {
+                { skipDockerVariable, "1" }
+            };
+
+            Docker docker = new Docker(outputHandler, warningHandler, errorHandler);
+            await docker.RunContainerAsync(apsimCompleteImageName, "Rscript", arguments.Prepend(scriptPath), volume.ToReadOnlyList(), env, cancelToken);
+        }
+
+        /// <summary>
+        /// Should docker be used to run R code?
+        /// </summary>
+        public static bool UseDocker()
+        {
+            if (Environment.GetEnvironmentVariable(skipDockerVariable) == "1")
+                return false;
+            return true;
+        }
+    }
+}

--- a/APSIM.Shared/Containers/Volume.cs
+++ b/APSIM.Shared/Containers/Volume.cs
@@ -1,0 +1,39 @@
+using System.IO;
+
+namespace APSIM.Shared.Containers
+{
+    /// <summary>
+    /// Represents a volume which may be mounted into a docker container.
+    /// </summary>
+    public class Volume
+    {
+        /// <summary>
+        /// Source path of the volume. Should be a directory on local disk.
+        /// </summary>
+        public string SourcePath { get; private set; }
+
+        /// <summary>
+        /// Path at which the volume should be mounted in a container.
+        /// </summary>
+        public string DestinationPath { get; private set; }
+
+        /// <summary>
+        /// Create a new <see cref="Volume"/> instance.
+        /// </summary>
+        /// <param name="source">Source path of the volume. Should be a directory.</param>
+        /// <param name="dest">Path at which the volume should be mounted.</param>
+        public Volume(string source, string dest)
+        {
+            if (!Directory.Exists(source))
+                throw new DirectoryNotFoundException($"Directory '{source}' does not exist.");
+            SourcePath = source;
+            DestinationPath = dest;
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"{SourcePath}:{DestinationPath}";
+        }
+    }
+}

--- a/APSIM.Shared/Documentation/Extensions/ExtensionMethods.cs
+++ b/APSIM.Shared/Documentation/Extensions/ExtensionMethods.cs
@@ -19,6 +19,16 @@ namespace APSIM.Shared.Documentation.Extensions
         }
 
         /// <summary>
+        /// Create an <see cref="IReadOnlyList{T}"/> instance containing a single item.
+        /// </summary>
+        /// <param name="item">The item which the list should contain.</param>
+        /// <typeparam name="T">The item's type.</typeparam>
+        public static IReadOnlyList<T> ToReadOnlyList<T>(this T item)
+        {
+            return new List<T>(1) { item };
+        }
+
+        /// <summary>
         /// Count the number of items in a non-generic IEnumerable collection.
         /// </summary>
         /// <param name="collection">The collection.</param>

--- a/APSIM.Shared/Interfaces/IR.cs
+++ b/APSIM.Shared/Interfaces/IR.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace APSIM.Shared.Interfaces
+{
+    /// <summary>
+    /// An interface to an R client.
+    /// </summary>
+    public interface IR
+    {
+        /// <summary>
+        /// Run an R script asynchronously. Throws if an error occurs.
+        /// </summary>
+        /// <param name="scriptPath">Path to the R script.</param>
+        /// <param name="arguments">Arguments to be passed to the R script.</param>
+        /// <param name="cancelToken">Cancellation token, used to cancel script execution.</param>
+        Task RunScriptAsync(string scriptPath, IEnumerable<string> arguments, CancellationToken cancelToken);
+    }
+}

--- a/Examples/Optimisation/CroptimizRExample.apsimx
+++ b/Examples/Optimisation/CroptimizRExample.apsimx
@@ -2156,7 +2156,7 @@
         {
           "$type": "Models.PostSimulationTools.ExcelInput, Models",
           "FileNames": [
-            "%root%\\Examples\\Optimisation\\ObservedExample.xlsx"
+            "ObservedExample.xlsx"
           ],
           "SheetNames": [
             "Observed"
@@ -2384,7 +2384,7 @@
                 {
                   "$type": "Models.Climate.Weather, Models",
                   "ConstantsFile": null,
-                  "FileName": "%root%\\Examples\\Optimisation\\APS6.met",
+                  "FileName": "APS6.met",
                   "ExcelWorkSheetName": null,
                   "Name": "Weather",
                   "Children": [],

--- a/Models/Optimisation/CroptimizR.cs
+++ b/Models/Optimisation/CroptimizR.cs
@@ -1,4 +1,5 @@
-﻿using APSIM.Shared.JobRunning;
+﻿using APSIM.Shared.Interfaces;
+using APSIM.Shared.JobRunning;
 using APSIM.Shared.Utilities;
 using Models.Core;
 using Models.Core.Run;
@@ -17,8 +18,10 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Threading.Tasks;
 using Models.Sensitivity;
 using Models.Core.ApsimFile;
+using APSIM.Shared.Containers;
 
 namespace Models.Optimisation
 {
@@ -54,6 +57,12 @@ namespace Models.Optimisation
     [ValidParent(ParentType = typeof(Simulations))]
     public class CroptimizR : Model, IModelAsTable, IRunnable, IReportsStatus
     {
+        /// <summary>
+        /// File name of the generated csv file containing croptimizR
+        /// outputs.
+        /// </summary>
+        private const string outputCsvFileName = "optim_results.csv";
+
         /// <summary>
         /// This ID is used to identify temp files used by this tool.
         /// </summary>
@@ -210,10 +219,15 @@ namespace Models.Optimisation
         /// <param name="e">Event arguments.</param>
         private void OnOutputReceivedFromR(object sender, DataReceivedEventArgs e)
         {
-            if (e.Data.Contains("Working:"))
+            OnOutputReceived(e.Data);
+        }
+
+        private void OnOutputReceived(string output)
+        {
+            if (output.Contains("Working:"))
             {
                 // Update progress.
-                Match match = Regex.Match(e.Data, @"Working: ([^%]+)%");
+                Match match = Regex.Match(output, @"Working: ([^%]+)%");
                 string progressString = match.Groups[1].Value;
                 if (double.TryParse(progressString, NumberStyles.Float, CultureInfo.CurrentCulture, out double progress))
                     Progress = progress / 100; // The R script reports progress as percent
@@ -235,27 +249,41 @@ namespace Models.Optimisation
 
             // If we're reading from the PredictedObserved table, need to fix
             // Predicted./Observed. suffix for the observed variables.
+            string escapedOutputPath = outputPath.Replace(@"\", "/");
             string[] sanitisedObservedVariables = GetObservedVariableName().Select(x => $"'{x.Trim()}'").ToArray();
             string dateVariable = VariableNames.Any(v => v.StartsWith("Predicted.")) ? "Predicted.Clock.Today" : "Clock.Today";
             contents.AppendLine($"observed_variable_names <- c({string.Join(", ", sanitisedObservedVariables)}, '{dateVariable}')");
-            contents.AppendLine($"apsimx_path <- '{typeof(IModel).Assembly.Location.Replace(@"\", @"\\")}'");
-            contents.AppendLine($"apsimx_file <- '{apsimxFileName.Replace(@"\", @"\\")}'");
+            contents.AppendLine($"apsimx_path <- '{PathToModels().Replace(@"\", "/")}'");
+            contents.AppendLine($"apsimx_file <- '{apsimxFileName.Replace(@"\", "/")}'");
             contents.AppendLine($"simulation_names <- {GetSimulationNames()}");
             contents.AppendLine($"predicted_table_name <- '{PredictedTableName}'");
             contents.AppendLine($"observed_table_name <- '{ObservedTableName}'");
             contents.AppendLine($"param_info <- {GetParamInfo()}");
             contents.AppendLine();
             contents.AppendLine(OptimizationMethod.GenerateOptimizationOptions("optim_options"));
-            contents.AppendLine($"optim_options$path_results <- '{outputPath.Replace(@"\", @"\\")}'");
+            contents.AppendLine($"optim_options$path_results <- '{escapedOutputPath}'");
             if (RandomSeed != null)
                 contents.AppendLine($"optim_options$ranseed <- {RandomSeed}");
             contents.AppendLine();
             contents.AppendLine($"crit_function <- {OptimizationMethod.CritFunction}");
             contents.AppendLine($"optim_method <- '{OptimizationMethod.ROptimizerName}'");
             contents.AppendLine();
-            contents.Append(ReflectionUtilities.GetResourceAsString("Models.Resources.RScripts.OptimizR.r"));
+            contents.AppendLine(ReflectionUtilities.GetResourceAsString("Models.Resources.RScripts.OptimizR.r"));
+
+            // Don't use Path.Combine() - as this may be running in a (linux) docker container.
+            // R will work with forward slashes for path separators on win and linux,
+            // but backslashes will not work on linux.
+            string rDataExpectedPath = $"{escapedOutputPath}/optim_results.Rdata";
+            contents.AppendLine(CreateReadRDataScript(rDataExpectedPath));
 
             File.WriteAllText(fileName, contents.ToString());
+        }
+
+        private string PathToModels()
+        {
+            if (RDocker.UseDocker())
+                return "/opt/apsim/Models";
+            return typeof(IModel).Assembly.Location;
         }
 
         private string[] GetObservedVariableName()
@@ -273,7 +301,7 @@ namespace Models.Optimisation
         private string GenerateApsimXFile()
         {
             Simulations rootNode = FindAncestor<Simulations>();
-            string apsimxFileName = GetTempFileName($"apsimx_file_{id}", ".apsimx");
+            string apsimxFileName = GetTempFileName("input_file.apsimx");
 
             Simulations sims = new Simulations();
             sims.Children.AddRange(Children.Select(c => Apsim.Clone(c)));
@@ -299,7 +327,7 @@ namespace Models.Optimisation
                 originalFile = storage?.FileName;
 
             // Copy files across.
-            foreach (IReferenceExternalFiles fileReference in (rootNode ?? sims).FindAllDescendants<IReferenceExternalFiles>().Cast<IReferenceExternalFiles>())
+            foreach (IReferenceExternalFiles fileReference in (rootNode ?? sims).FindAllDescendants<IReferenceExternalFiles>())
             {
                 foreach (string file in fileReference.GetReferencedFileNames())
                 {
@@ -378,12 +406,19 @@ namespace Models.Optimisation
         /// <summary>
         /// Returns a unique temporary filename.
         /// </summary>
-        /// <param name="name">Base name of the file. The returned filename will contain this name.</param>
-        /// <param name="extension">File extension to be used.</param>
+        /// <param name="name">Base name of the file, with file extension included.</param>
         /// <returns>Unique temporary filename.</returns>
-        private string GetTempFileName(string name, string extension)
+        private string GetTempFileName(string name)
         {
-            return Path.ChangeExtension(Path.Combine(Path.GetTempPath(), name + id), extension);
+            return Path.Combine(GetWorkingDirectory(), name);
+        }
+
+        /// <summary>
+        /// Get the working directory, into which all files used by croptimizr should be saved.
+        /// </summary>
+        private string GetWorkingDirectory()
+        {
+            return Path.Combine(Path.GetTempPath(), $"{Name}-{id}");
         }
 
         /// <summary>
@@ -402,29 +437,50 @@ namespace Models.Optimisation
         {
             Progress = 0;
 
-            Status = "Installing R Packages";
-
-            R r = new R(cancelToken.Token);
-            r.InstallPackages("remotes", "dplyr", "nloptr", "DiceDesign", "DBI", "cli");
-            r.InstallFromGithub("hol430/ApsimOnR", "SticsRPacks/CroptimizR");
-
             Status = "Generating R Script";
-            string fileName = GetTempFileName($"parameter_estimation_{id}", ".r");
+            string fileName = GetTempFileName("parameter_estimation.r");
 
-            string outputPath = Path.Combine(Path.GetTempPath(), $"croptimizr-output-{id}");
+            string outputPath = GetWorkingDirectory();
             if (!Directory.Exists(outputPath))
                 Directory.CreateDirectory(outputPath);
 
             string apsimxFileName = GenerateApsimXFile();
             GenerateRScript(fileName, outputPath, apsimxFileName);
 
-            // todo - capture stderr as well?
-            r.OutputReceived += OnOutputReceivedFromR;
+            if (RDocker.UseDocker())
+            {
+                IR client = new RDocker(
+                    outputHandler: OnOutputReceived
+                    // warningHandler: w => FindInScope<ISummary>()?.WriteMessage(this, w, MessageType.Warning),
+                    // errorHandler: e => FindInScope<ISummary>()?.WriteMessage(this, e, MessageType.Error)
+                );
 
-            Status = "Running Parameter Optimization";
-            string stdout = r.Run(fileName);
-            r.OutputReceived -= OnOutputReceivedFromR;
-            WriteMessage(stdout);
+                Status = "Running Parameter Optimization";
+                try
+                {
+                    client.RunScriptAsync(fileName, new List<string>(), cancelToken.Token).Wait();
+                }
+                catch (AggregateException errors)
+                {
+                    if (errors.InnerExceptions.Count == 1 && errors.InnerExceptions[0] is TaskCanceledException)
+                        return;
+                    throw;
+                }
+            }
+            else
+            {
+                Status = "Installing R Packages";
+                R r = new R(cancelToken.Token);
+                r.InstallPackages("remotes", "dplyr", "nloptr", "DiceDesign", "DBI", "cli");
+                r.InstallFromGithub("hol430/ApsimOnR", "SticsRPacks/CroptimizR");
+
+
+                // todo - capture stderr as well?
+                r.OutputReceived += OnOutputReceivedFromR;
+                string stdout = r.Run(fileName);
+                r.OutputReceived -= OnOutputReceivedFromR;
+                WriteMessage(stdout);
+            }
 
             // Copy output files into appropriate output directory, if one is specified. Otherwise, delete them.
             Status = "Reading Output";
@@ -439,7 +495,7 @@ namespace Models.Optimisation
             bool firstFile = true;
             foreach (string file in Directory.EnumerateFiles(outputPath))
             {
-                if (Path.GetExtension(file) == ".Rdata")
+                if (Path.GetFileName(file) == outputCsvFileName)
                 {
                     if (storage != null && storage.Writer != null)
                     {
@@ -452,12 +508,11 @@ namespace Models.Optimisation
                 if (!string.IsNullOrEmpty(apsimxFileDir))
                     File.Copy(file, Path.Combine(apsimxFileDir, Path.Combine($"{Name}-{Path.GetFileName(file)}")), true);
             }
-            Directory.Delete(outputPath, true);
 
             // Now, we run the simulations with the optimal values, and store
             // the results in a checkpoint called 'After'. Checkpointing has
             // not been implemented on the sockets storage implementation.
-            if (FindInScope<IDataStore>().Writer is DataStoreWriter)
+            if (output != null && FindInScope<IDataStore>().Writer is DataStoreWriter)
             {
                 Status = "Running simulations with optimised parameters";
                 IEnumerable<CompositeFactor> optimalValues = GetOptimalValues(output);
@@ -470,6 +525,9 @@ namespace Models.Optimisation
                 if (errors != null && errors.Count > 0)
                     throw errors[0];
             }
+
+            // Delete temp outputs.
+            Directory.Delete(outputPath, true);
         }
 
         /// <summary>
@@ -523,15 +581,7 @@ namespace Models.Optimisation
         /// <param name="path">Path to the .Rdata file on disk.</param>
         public DataTable ReadRData(string path)
         {
-            StringBuilder script = new StringBuilder();
-            script.AppendLine($"load('{path.Replace(@"\", @"\\")}')");
-            IEnumerable<string> paramNames = Parameters.Select(p => $"'{p.Name}'");
-            script.AppendLine($"param_names <- c({string.Join(", ", paramNames)})");
-            script.AppendLine(ReflectionUtilities.GetResourceAsString("Models.Resources.RScripts.read_croptimizr_output.r"));
-            R r = new R();
-            string scriptPath = GetTempFileName("read_croptimizr_output", ".r");
-            File.WriteAllText(scriptPath, script.ToString());
-            DataTable table = r.RunToTable(scriptPath);
+            DataTable table = ApsimTextFile.ToTable(path);
 
             // The repetition column will be of type float. Need to change this to int.
             string repCol = "Repetition";
@@ -543,6 +593,19 @@ namespace Models.Optimisation
 
             table.TableName = "CroptimizR";
             return table;
+        }
+
+        private string CreateReadRDataScript(string rDataPath)
+        {
+            StringBuilder script = new StringBuilder();
+            string directory = Path.GetDirectoryName(rDataPath).Replace(@"\", "/");
+            string csvFile = $"{directory}/{outputCsvFileName}";
+            script.AppendLine($"output_file <- '{csvFile}'");
+            script.AppendLine($"load('{rDataPath.Replace(@"\", "/")}')");
+            IEnumerable<string> paramNames = Parameters.Select(p => $"'{p.Name}'");
+            script.AppendLine($"param_names <- c({string.Join(", ", paramNames)})");
+            script.AppendLine(ReflectionUtilities.GetResourceAsString("Models.Resources.RScripts.read_croptimizr_output.r"));
+            return script.ToString();
         }
     }
 }

--- a/Models/Optimisation/CroptimizR.cs
+++ b/Models/Optimisation/CroptimizR.cs
@@ -282,6 +282,8 @@ namespace Models.Optimisation
         private string PathToModels()
         {
             if (RDocker.UseDocker())
+            // This is the expected path to the models executable in the docker
+            // image. Nasty stuff.
                 return "/opt/apsim/Models";
             return typeof(IModel).Assembly.Location;
         }
@@ -449,6 +451,9 @@ namespace Models.Optimisation
 
             if (RDocker.UseDocker())
             {
+                // todo: we should really be reporting warnings/errors here.
+                // However any summary file will not have its links connected,
+                // due to the way that CroptimizR is run. This needs further thought.
                 IR client = new RDocker(
                     outputHandler: OnOutputReceived
                     // warningHandler: w => FindInScope<ISummary>()?.WriteMessage(this, w, MessageType.Warning),
@@ -462,6 +467,7 @@ namespace Models.Optimisation
                 }
                 catch (AggregateException errors)
                 {
+                    // Don't propagate task canceled exceptions.
                     if (errors.InnerExceptions.Count == 1 && errors.InnerExceptions[0] is TaskCanceledException)
                         return;
                     throw;

--- a/Models/Resources/RScripts/read_croptimizr_output.r
+++ b/Models/Resources/RScripts/read_croptimizr_output.r
@@ -29,4 +29,4 @@ for (param in param_names) {
 }
 cols <- c(cols, 'Message')
 colnames(df) <- cols
-write.table(df, row.names = F, col.names = T, sep = ',')
+write.table(df, file = output_file, row.names = F, col.names = T, sep = ',')


### PR DESCRIPTION
Working on #6984.

I've made docker the default R engine for CroptimizR simulations only, but the user can revert to old behaviour by setting environment variable `APSIM_NO_DOCKER=1`. Should this be the other way around?

I've created an `IR` interface to abstract away the comms with R. This is implemented by the new `RDocker` class, but not by the old `R` class (which runs R code "natively"). It probably wouldn't be too hard to refactor the original R class so that it can implement the interface, but things still wouldn't quite be transparent to the caller; you need to be really careful with regards to file management when using docker.

When running a croptimizr simulation via docker, all dependent files (such as .met, .xlsx, etc) need to be in the same directory as the .apsimx file, and cannot be referenced via the %root% macro.