### PR TITLE
Soil depth should never be serialized to json.

### DIFF
--- a/Models/Core/ApsimFile/FileFormat.cs
+++ b/Models/Core/ApsimFile/FileFormat.cs
@@ -142,7 +142,7 @@
         {
             protected override List<MemberInfo> GetSerializableMembers(Type objectType)
             {
-                var result = base.GetSerializableMembers(objectType);
+                List<MemberInfo> result = base.GetSerializableMembers(objectType);
                 result.RemoveAll(m => m is PropertyInfo &&
                                       !(m as PropertyInfo).CanWrite);
                 result.RemoveAll(m => m.GetCustomAttribute(typeof(LinkAttribute)) != null);

--- a/Models/Soils/Chemical.cs
+++ b/Models/Soils/Chemical.cs
@@ -3,6 +3,7 @@
     using APSIM.Shared.APSoil;
     using APSIM.Shared.Utilities;
     using Models.Core;
+    using Newtonsoft.Json;
     using System;
 
     /// <summary>This class captures chemical soil data</summary>
@@ -15,6 +16,7 @@
         /// <summary>Depth strings. Wrapper around Thickness.</summary>
         [Description("Depth")]
         [Units("cm")]
+        [JsonIgnore]
         public string[] Depth
         {
             get

--- a/Models/Soils/Organic.cs
+++ b/Models/Soils/Organic.cs
@@ -4,6 +4,7 @@
     using APSIM.Shared.Utilities;
     using Models.Core;
     using System;
+    using Newtonsoft.Json;
 
     /// <summary>A model for capturing soil organic parameters</summary>
     [Serializable]
@@ -15,6 +16,7 @@
         /// <summary>Depth strings. Wrapper around Thickness.</summary>
         [Description("Depth")]
         [Units("cm")]
+        [JsonIgnore]
         public string[] Depth
         {
             get

--- a/Models/Soils/Physical.cs
+++ b/Models/Soils/Physical.cs
@@ -3,6 +3,7 @@
     using APSIM.Shared.APSoil;
     using APSIM.Shared.Utilities;
     using Models.Core;
+    using Newtonsoft.Json;
     using System;
     using System.Linq;
 
@@ -17,6 +18,7 @@
         [Description("Depth")]
         [Units("cm")]
         [Summary]
+        [JsonIgnore]
         public string[] Depth
         {
             get

--- a/Models/Soils/Sample.cs
+++ b/Models/Soils/Sample.cs
@@ -4,6 +4,7 @@
     using APSIM.Shared.Utilities;
     using Models.Core;
     using Models.Soils.Standardiser;
+    using Newtonsoft.Json;
     using System;
     using System.Diagnostics.CodeAnalysis;
 
@@ -87,6 +88,7 @@
         /// <summary>Depth strings. Wrapper around Thickness.</summary>
         [Description("Depth")]
         [Units("cm")]
+        [JsonIgnore]
         public string[] Depth
         {
             get


### PR DESCRIPTION
(Thickness is serialized instead.)

Working on #7030.