### PR TITLE
Fix executable file permissions in Debian installation.

### DIFF
--- a/Setup/netcoreapp3.1/debian/buildDebianInstaller
+++ b/Setup/netcoreapp3.1/debian/buildDebianInstaller
@@ -47,7 +47,7 @@ bin=data/usr/local/bin
 mkdir $bin
 echo exec dotnet $inst/bin/Models.dll '"$@"' >$bin/Models
 echo exec dotnet $inst/bin/ApsimNG.dll '"$@"' >$bin/apsim
-chmod u+x $bin/*
+chmod 755 $bin/*
 
 # Get estimated disk usage of installed package
 size=$(du -sk data | cut -f 1)


### PR DESCRIPTION
Resolves #2604. (The other problems mentioned in that issue are either fixed or not relevant to the .net core builds.)