### PR TITLE
Post-simulation tools should not call DataStoreReader.Refresh()

### DIFF
--- a/Models/PostSimulationTools/PredictedObserved.cs
+++ b/Models/PostSimulationTools/PredictedObserved.cs
@@ -233,9 +233,6 @@ namespace Models.PostSimulationTools
                     List<string> unitFieldNames = new List<string>();
                     List<string> unitNames = new List<string>();
 
-                    // write units to table.
-                    reader.Refresh();
-
                     foreach (string fieldName in commonCols)
                     {
                         string units = reader.Units(PredictedTableName, fieldName);


### PR DESCRIPTION
Resolves #7143. This fixes the immediate problem, but it really highlights the need for a refactor of the datastore code.