### PR TITLE
Timeout for unit tests in NativeSocketConnectionTests

### DIFF
--- a/Tests/UnitTests/Server/NativeSocketConnectionTests.cs
+++ b/Tests/UnitTests/Server/NativeSocketConnectionTests.cs
@@ -10,6 +10,7 @@ using System.IO.Pipes;
 namespace UnitTests.Server
 {
     [TestFixture]
+    [Timeout(5 * 1000)]
     public class NativeSocketConnectionTests
     {
         private const string pipePath = "/tmp/CoreFxPipe_";


### PR DESCRIPTION
If a change breaks the protocol, these tests would previously deadlock.

Working on #6529.