### PR TITLE
Add CLI option to import old .apsim files.

### DIFF
--- a/APSIM.Cli/Options/ImportOptions.cs
+++ b/APSIM.Cli/Options/ImportOptions.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using CommandLine;
+using CommandLine.Text;
+
+namespace APSIM.Cli.Options
+{
+    /// <summary>
+    /// APSIM command-line options for importing an old apsim file.
+    /// </summary>
+    [Verb("import", HelpText = "Import an old .apsim file")]
+    public class ImportOptions
+    {
+        /// <summary>Files to be imported.</summary>
+        [Value(0, HelpText = ".apsim file(s) to be imported.", MetaName = "ApsimXFileSpec", Required = true)]
+        public IEnumerable<string> Files { get; set; }
+
+        /// <summary>
+        /// Recursively search through subdirectories for files matching the file specification.
+        /// </summary>
+        [Option('r', "recursive", HelpText = "Recursively search through subdirectories for files matching the file specification.")]
+        public bool Recursive { get; set; }
+
+        /// <summary>
+        /// Concrete examples shown in help text.
+        /// </summary>
+        [Usage]
+        public static IEnumerable<Example> Examples
+        {
+            get
+            {
+                yield return new Example("Normal usage",
+                                         new ImportOptions()
+                                         {
+                                             Files = new[] { "file.apsim", "file2.apsim" }
+                                         });
+                yield return new Example("Recursively search subdirectories",
+                                         new ImportOptions()
+                                         {
+                                             Files = new[] { "*.apsim" },
+                                             Recursive = true
+                                         });
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves #7163.

Example usage, assuming the `apsim` executable (`apsim.exe` on windows) is on path:

```
apsim import --help
apsim import /path/to/my/file.apsim
apsim import --recursive *.apsim
```