### PR TITLE
Add ability to check if a simulation resets its state correctly

### DIFF
--- a/APSIM.Server/Sensibility/Logger.cs
+++ b/APSIM.Server/Sensibility/Logger.cs
@@ -1,0 +1,56 @@
+using System;
+using APSIM.Shared.Utilities;
+using Models;
+using Models.Core;
+
+namespace APSIM.Server.Sensibility
+{
+    /// <summary>
+    /// This model will serialize the entire simulation to JSON after the first
+    /// day of the simulation.
+    /// </summary>
+    internal class Logger : Model
+    {
+        /// <summary>
+        /// Link to clock, used to find first day of simulation.
+        /// </summary>
+        [Link]
+        private Clock clock = null;
+
+        /// <summary>
+        /// Link to the simulation. This is what will be serialized.
+        /// </summary>
+        [Link(Type = LinkType.Ancestor)]
+        private Simulation sim = null;
+
+        /// <summary>
+        /// This is the simulation serialized to json after the first day.
+        /// </summary>
+        public string Json { get; set; }
+
+        /// <summary>
+        /// Called at end of day. If today is simulation start date, will
+        /// serialize the simulation to json.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="args"></param>
+        [EventSubscribe("EndOfDay")]
+        private void Log(object sender, EventArgs args)
+        {
+            if (clock.Today == clock.StartDate)
+            {
+                // Set json to null before logging, to prevent it from being serialized.
+                string oldJson = Json;
+                Json = null;
+                Json = ReflectionUtilities.JsonSerialise(sim, true);
+                if (!string.IsNullOrEmpty(oldJson))
+                {
+                    // Second run.
+                    if (!string.Equals(oldJson, Json, StringComparison.Ordinal))
+                        throw new SimulationResetException(sim.Name, oldJson, Json);
+                    clock.EndDate = clock.Today;
+                }
+            }
+        }
+    }
+}

--- a/APSIM.Server/Sensibility/Logger.cs
+++ b/APSIM.Server/Sensibility/Logger.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using APSIM.Shared.Utilities;
 using Models;
 using Models.Core;
@@ -24,9 +26,11 @@ namespace APSIM.Server.Sensibility
         private Simulation sim = null;
 
         /// <summary>
-        /// This is the simulation serialized to json after the first day.
+        /// This is a dictionary mapping models to their serialized json.
         /// </summary>
-        public string Json { get; set; }
+        /// <typeparam name="IModel">A model.</typeparam>
+        /// <typeparam name="string">Serialized form of the model.</typeparam>
+        private IDictionary<IModel, string> state;
 
         /// <summary>
         /// Called at end of day. If today is simulation start date, will
@@ -40,17 +44,81 @@ namespace APSIM.Server.Sensibility
             if (clock.Today == clock.StartDate)
             {
                 // Set json to null before logging, to prevent it from being serialized.
-                string oldJson = Json;
-                Json = null;
-                Json = ReflectionUtilities.JsonSerialise(sim, true);
-                if (!string.IsNullOrEmpty(oldJson))
+                IDictionary<IModel, string> previousState = state;
+                state = null;
+                state = GetSimulationState();
+                if (previousState != null)
                 {
                     // Second run.
-                    if (!string.Equals(oldJson, Json, StringComparison.Ordinal))
-                        throw new SimulationResetException(sim.Name, oldJson, Json);
+                    VerifyState(previousState, state);
+
+                    // Terminate simulation early.
                     clock.EndDate = clock.Today;
                 }
             }
+        }
+
+        /// <summary>
+        /// Verify that the given simulation state matches the state from a
+        /// previous run, for all models.
+        /// </summary>
+        /// <param name="previousState">State from a previous run.</param>
+        /// <param name="state">State from the recent run.</param>
+        private void VerifyState(IDictionary<IModel, string> previousState, IDictionary<IModel, string> state)
+        {
+            List<Exception> errors = new List<Exception>();
+            foreach ((IModel model, string json) in previousState)
+            {
+                try
+                {
+                    VerifyModel(model, json, state);
+                }
+                catch (Exception error)
+                {
+                    errors.Add(error);
+                }
+            }
+            if (errors.Any())
+            {
+                bool plural = errors.Count > 1;
+                throw new AggregateException($"{errors.Count} model{(plural ? "s" : "")} failed to reset {(plural ? "their" : "its")} state", errors);
+            }
+        }
+
+        /// <summary>
+        /// Ensure that a model's state matches the state recorded for the model
+        /// in the provided state dictionary.
+        /// </summary>
+        /// <param name="model">A model.</param>
+        /// <param name="json">Json representation of the model.</param>
+        /// <param name="state">Cache of state from a previous simulation run.</param>
+        private void VerifyModel(IModel model, string json, IDictionary<IModel, string> state)
+        {
+            if (!state.TryGetValue(model, out string newJson))
+                throw new Exception($"Model {model.FullPath} was removed from simulation {sim.Name}");
+            if (!string.Equals(json, newJson, StringComparison.Ordinal))
+                throw new SimulationResetException(sim.Name, model, json, newJson);
+        }
+
+        /// <summary>
+        /// Serialize all models in the simulation, individually.
+        /// </summary>
+        private IDictionary<IModel, string> GetSimulationState()
+        {
+            Dictionary<IModel, string> result = new Dictionary<IModel, string>();
+            foreach (IModel model in sim.FindAllDescendants())
+                result[model] = GetModelState(model);
+            return result;
+        }
+
+        /// <summary>
+        /// Serialize a model to json. All private members will be serialized,
+        /// but child models will not.
+        /// </summary>
+        /// <param name="model">The model to be serialized.</param>
+        private string GetModelState(IModel model)
+        {
+            return ReflectionUtilities.JsonSerialise(model, true, includeChildren: false);
         }
     }
 }

--- a/APSIM.Server/Sensibility/SimulationChecker.cs
+++ b/APSIM.Server/Sensibility/SimulationChecker.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Models.Core;
+using Models.Core.Run;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace APSIM.Server.Sensibility
+{
+    /// <summary>
+    /// This class will verify that an .apsimx file correctly zeroes/resets its
+    /// state between runs.
+    /// </summary>
+    public class SimulationChecker : IRunner
+    {
+        /// <summary>
+        /// Blocking wait until running complete?
+        /// </summary>
+        private readonly bool wait;
+
+        /// <summary>
+        /// The runner instance.
+        /// </summary>
+        private readonly Runner runner;
+
+        /// <summary>
+        /// Have we finished the first run?
+        /// </summary>
+        private bool finishedFirstRun = false;
+
+        private CancellationTokenSource cts = new CancellationTokenSource();
+
+        /// <summary>
+        /// Create a new <see cref="SimulationChecker"/> instance.
+        /// </summary>
+        /// <param name="wait">Blocking wait until running completes?</param>
+        public SimulationChecker(IModel model, bool wait)
+        {
+            this.wait = wait;
+            runner = new Runner(model, runPostSimulationTools: false, runTests: false, wait: true);
+            runner.Use(new SimulationCheckerJobRunner());
+        }
+
+        /// <inheritdoc />
+        public Action<Exception> ErrorHandler { get => runner.ErrorHandler; set => runner.ErrorHandler = value; }
+
+        /// <inheritdoc />
+        public double Progress => finishedFirstRun ? 1 : runner.Progress;
+
+        /// <summary>
+        /// Custom status message. If null, the job runner's internal 
+        /// status will be retrieved.
+        /// </summary>
+        private string status;
+
+        /// <inheritdoc />
+        public string Status => status ?? runner.Status;
+
+        /// <inheritdoc />
+        public event EventHandler<Runner.AllJobsCompletedArgs> AllSimulationsCompleted;
+
+        /// <summary>
+        /// Verify that an .apsimx file correctly zeroes/resets its state
+        /// between runs.
+        /// </summary>
+        /// <param name="model">
+        /// The model(s) to be checked. This can be any kind of model; this
+        /// model and all descendant simulations will be checked.
+        /// </param>
+        public List<Exception> Run()
+        {
+            Task<List<Exception>> task = Task.Run(() => Check(cts.Token));
+            if (wait)
+            {
+                task.Wait();
+                return task.Result;
+            }
+            else
+                return new List<Exception>();
+        }
+
+        /// <summary>
+        /// Verify that an .apsimx file correctly zeroes/resets its state
+        /// between runs.
+        /// 
+        /// This method will block.
+        /// </summary>
+        /// <param name="model">
+        /// The model(s) to be checked. This can be any kind of model; this
+        /// model and all descendant simulations will be checked.
+        /// </param>
+        public List<Exception> Check(CancellationToken cancelToken)
+        {
+            status = null;
+            finishedFirstRun = false;
+            DateTime startTime = DateTime.Now;
+
+            List<Exception> errors = runner.Run();
+
+            finishedFirstRun = true;
+
+            if (errors.Any())
+                return errors;
+
+            if (cancelToken.IsCancellationRequested)
+                return new List<Exception>();
+
+            status = "Verifying that simulation state has been reset";
+            errors = runner.Run();
+            DateTime finishTime = DateTime.Now;
+
+            Runner.AllJobsCompletedArgs args = new Runner.AllJobsCompletedArgs();
+            args.AllExceptionsThrown = errors;
+            args.ElapsedTime = finishTime - startTime;
+            AllSimulationsCompleted?.Invoke(this, args);
+
+            return errors;
+        }
+
+        /// <inheritdoc />
+        public void Stop()
+        {
+            cts.Cancel();
+            runner.Stop();
+        }
+    }
+}

--- a/APSIM.Server/Sensibility/SimulationCheckerJobRunner.cs
+++ b/APSIM.Server/Sensibility/SimulationCheckerJobRunner.cs
@@ -1,0 +1,42 @@
+using APSIM.Shared.JobRunning;
+using Models.Core;
+using Models.Core.Run;
+
+namespace APSIM.Server.Sensibility
+{
+    /// <summary>
+    /// A job runner used by the simulation state checker. This job runner
+    /// will insert a Logger model into each simulation before it is run, iff
+    /// the simulation doesn't already contain a logger object.
+    /// </summary>
+    internal class SimulationCheckerJobRunner : ServerJobRunner
+    {
+        /// <inheritdoc />
+        protected override void Run(IRunnable job)
+        {
+            if (job is SimulationDescription desc)
+                AddLoggerToSim(desc.SimulationToRun);
+            base.Run(job);
+        }
+
+        /// <summary>
+        /// Add a logger instance to the given simulation if the simulation
+        /// doesn't already contain a logger. This function will also connect
+        /// links and events to the logger object.
+        /// </summary>
+        /// <param name="sim">The simulation.</param>
+        private void AddLoggerToSim(Simulation sim)
+        {
+            if (sim.FindChild<Logger>() == null)
+            {
+                Logger logger = new Logger();
+                sim.Children.Add(logger);
+                logger.Parent = sim;
+                var links = new Links(sim.Services);
+                links.Resolve(logger, true, throwOnFail: true);
+                var events = new Events(logger);
+                events.ConnectEvents();
+            }
+        }
+    }
+}

--- a/APSIM.Server/Sensibility/SimulationResetException.cs
+++ b/APSIM.Server/Sensibility/SimulationResetException.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Text;
+
+namespace APSIM.Server.Sensibility
+{
+    public class SimulationResetException : Exception
+    {
+        /// <summary>
+        /// Simulation serialized to json before bering run.
+        /// </summary>
+        private readonly string oldJson;
+
+        /// <summary>
+        /// Simulation serialized to json after being run once.
+        /// </summary>
+        private readonly string newJson;
+
+        public SimulationResetException(string simulationName, string oldJson, string newJson) : base($"Simulation {simulationName} failed to reset its state")
+        {
+            this.oldJson = oldJson;
+            this.newJson = newJson;
+        }
+
+        public override string ToString()
+        {
+            StringBuilder message = new StringBuilder();
+            message.AppendLine(Message);
+            message.AppendLine("Simulation before being run:");
+            message.AppendLine(oldJson);
+            message.AppendLine("Simulation after being run once:");
+            message.AppendLine(newJson);
+            message.AppendLine(StackTrace);
+
+            return message.ToString();
+        }
+    }
+}

--- a/APSIM.Server/Sensibility/SimulationResetException.cs
+++ b/APSIM.Server/Sensibility/SimulationResetException.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using Models.Core;
 
 namespace APSIM.Server.Sensibility
 {
@@ -15,7 +16,7 @@ namespace APSIM.Server.Sensibility
         /// </summary>
         private readonly string newJson;
 
-        public SimulationResetException(string simulationName, string oldJson, string newJson) : base($"Simulation {simulationName} failed to reset its state")
+        public SimulationResetException(string simulationName, IModel model, string oldJson, string newJson) : base($"Model {model.Name} in simulation {simulationName} failed to reset its state")
         {
             this.oldJson = oldJson;
             this.newJson = newJson;
@@ -25,9 +26,9 @@ namespace APSIM.Server.Sensibility
         {
             StringBuilder message = new StringBuilder();
             message.AppendLine(Message);
-            message.AppendLine("Simulation before being run:");
+            message.AppendLine("Before being run:");
             message.AppendLine(oldJson);
-            message.AppendLine("Simulation after being run once:");
+            message.AppendLine("After being run once:");
             message.AppendLine(newJson);
             message.AppendLine(StackTrace);
 

--- a/APSIM.Server/ServerJobRunner.cs
+++ b/APSIM.Server/ServerJobRunner.cs
@@ -13,7 +13,7 @@ namespace APSIM.Server
     /// </summary>
     public class ServerJobRunner : JobRunner
     {
-        public IEnumerable<IReplacement> Replacements { get; set; }
+        public IEnumerable<IReplacement> Replacements { get; set; } = Enumerable.Empty<IReplacement>();
         private List<(IRunnable, IJobManager)> jobs = new List<(IRunnable, IJobManager)>();
 
         /// <summary>

--- a/APSIM.Shared/Utilities/ReflectionUtilities.cs
+++ b/APSIM.Shared/Utilities/ReflectionUtilities.cs
@@ -342,13 +342,14 @@
         /// </summary>
         /// <param name="source">The source object.</param>
         /// <param name="includePrivates">Serialise private members as well as publics?</param>
+        /// <param name="includeChildren">Serialize child models as well?</param>
         /// <returns>The string representation of the object.</returns>
-        public static string JsonSerialise(object source, bool includePrivates)
+        public static string JsonSerialise(object source, bool includePrivates, bool includeChildren = true)
         {
             return JsonConvert.SerializeObject(source, Formatting.Indented,
                     new JsonSerializerSettings
                     {
-                        ContractResolver = new DynamicContractResolver(includePrivates),
+                        ContractResolver = new DynamicContractResolver(includePrivates, includeChildren),
                         ReferenceLoopHandling = ReferenceLoopHandling.Ignore
                     });
         }
@@ -357,19 +358,23 @@
         private class DynamicContractResolver : DefaultContractResolver
         {
             private BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy;
+            private readonly bool includeChildren;
 
-            public DynamicContractResolver(bool includePrivates)
+            public DynamicContractResolver(bool includePrivates, bool includeChildren)
             {
+                this.includeChildren = includeChildren;
                 if (includePrivates)
                     bindingFlags |= BindingFlags.NonPublic;
             }
 
             protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
             {
-                var props = GetAllFields(type, bindingFlags).Select(p => base.CreateProperty(p, memberSerialization))
-                            .Union(
-                            GetAllProperties(type, bindingFlags).Select(p => base.CreateProperty(p, memberSerialization))
-                            ).ToList();
+                IEnumerable<JsonProperty> fields = GetAllFields(type, bindingFlags).Select(p => base.CreateProperty(p, memberSerialization));
+                IEnumerable<JsonProperty> properties = GetAllProperties(type, bindingFlags).Select(p => base.CreateProperty(p, memberSerialization));
+                if (!includeChildren)
+                    properties = properties.Where(p => p.PropertyName != "Children");
+                List<JsonProperty> props = fields.Union(properties).ToList();
+
                 // If this type overrides a base class's property or field, then this list
                 // will contain multiple properties with the same name, which causes a
                 // serialization exception when we go to serialize these properties. The
@@ -380,7 +385,6 @@
                 return props.Where(p => p.PropertyName != "Parent" && p.Readable).ToList();
             }
         }
-
 
         /// <summary>
         /// Convert the specified 'stringValue' into an object of the specified 'type'

--- a/ApsimNG/ApsimNG.csproj
+++ b/ApsimNG/ApsimNG.csproj
@@ -36,6 +36,7 @@
     <ProjectReference Include="..\APSIM.Shared\APSIM.Shared.csproj" />
     <ProjectReference Include="..\APSIM.Interop\APSIM.Interop.csproj" />
     <ProjectReference Include="..\Models\Models.csproj" />
+    <ProjectReference Include="..\APSIM.Server\APSIM.Server.csproj" />
 	
     <!-- Shared package references -->
     <PackageReference Include="ClosedXML" Version="0.95.3" />

--- a/ApsimNG/Commands/RunCommand.cs
+++ b/ApsimNG/Commands/RunCommand.cs
@@ -17,7 +17,7 @@
         private string jobName;
 
         /// <summary>The collection of jobs to run</summary>
-        private Runner jobRunner;
+        private IRunner jobRunner;
 
         /// <summary>The explorer presenter.</summary>
         private ExplorerPresenter explorerPresenter;
@@ -32,7 +32,7 @@
         /// <param name="name">Name of the job to be displayed in the UI..</param>
         /// <param name="runner">Runner which will run the job.</param>
         /// <param name="presenter">The explorer presenter.</param>
-        public RunCommand(string name, Runner runner, ExplorerPresenter presenter)
+        public RunCommand(string name, IRunner runner, ExplorerPresenter presenter)
         {
             this.jobName = name;
             this.jobRunner = runner;

--- a/ApsimNG/Menus/ContextMenu.cs
+++ b/ApsimNG/Menus/ContextMenu.cs
@@ -26,6 +26,7 @@
     using APSIM.Interop.Documentation;
     using System.Threading.Tasks;
     using System.Threading;
+    using APSIM.Server.Sensibility;
 
     /// <summary>
     /// This class contains methods for all context menu items that the ExplorerView exposes to the user.
@@ -881,6 +882,27 @@
         {
             IModel model = explorerPresenter.CurrentNode as IModel;
             return model.ReadOnly;
+        }
+
+        /// <summary>
+        /// Ensure that the selected simulation will reset its state correctly
+        /// when used by an apsim server.
+        /// </summary>
+        /// <param name="sender">Sender object.</param>
+        /// <param name="args">Event arguments.</param>
+        [ContextMenu(MenuName = "Verify Server Compatibility", FollowsSeparator = true)]
+        public void CheckServerCompatibility(object sender, EventArgs args)
+        {
+            try
+            {
+                SimulationChecker checker = new SimulationChecker(explorerPresenter.CurrentNode, false);
+                RunCommand command = new RunCommand("State validation", checker, explorerPresenter);
+                command.Do();
+            }
+            catch (Exception error)
+            {
+                explorerPresenter.MainPresenter.ShowError(error);
+            }
         }
 
         /// <summary>

--- a/Models/Core/Run/IRunner.cs
+++ b/Models/Core/Run/IRunner.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using static Models.Core.Run.Runner;
+
+namespace Models.Core.Run
+{
+    /// <summary>
+    /// An interface for a class which runs things. This is used to abstract
+    /// runner implementations away from the GUI.
+    /// </summary>
+    public interface IRunner
+    {
+        /// <summary>
+        /// If provided, this will be invoked whenever an error occurs.
+        /// </summary>
+        Action<Exception> ErrorHandler { get; set; }
+
+        /// <summary>
+        /// Invoked when all jobs are completed.
+        /// </summary>
+        event EventHandler<AllJobsCompletedArgs> AllSimulationsCompleted;
+
+        /// <summary>
+        /// Gets the aggregate progress of all jobs as a real number in range [0, 1].
+        /// </summary>
+        double Progress { get; }
+
+        /// <summary>
+        /// Current status of the running jobs.
+        /// </summary>
+        string Status { get; }
+
+        /// <summary>
+        /// Run all simulations.
+        /// </summary>
+        /// <returns>A list of exception or null if no exceptions thrown.</returns>
+        List<Exception> Run();
+
+        /// <summary>
+        /// Stop any running jobs.
+        /// </summary>
+        void Stop();
+    }
+}

--- a/Models/Core/Run/Runner.cs
+++ b/Models/Core/Run/Runner.cs
@@ -13,7 +13,7 @@
     /// An class for encapsulating a list of simulations that are ready
     /// to be run. An instance of this class can be used with a job runner.
     /// </summary>
-    public class Runner
+    public class Runner : IRunner
     {
         /// <summary>The descriptions of simulations that we are going to run.</summary>
         private List<IJobManager> jobs = new List<IJobManager>();


### PR DESCRIPTION
Working on #6529.

New option in the GUI: right click -> verify server compatibility. This will run the simulation, serialize all the models, run the simulation again (without cloning), serialize again, and use the two serialized copies of the models to ensure that the models have all reset their state correctly. It's a bit crude, but should at least let you know if there are problems with the sims which will interfere with server runs.