### PR TITLE
Exposing SoilNitrogen parameters

### DIFF
--- a/Models/Soils/SoilNitrogen/SoilNitrogen.Variables.cs
+++ b/Models/Soils/SoilNitrogen/SoilNitrogen.Variables.cs
@@ -131,7 +131,7 @@ namespace Models.Soils
         [Units("g/g")]
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [JsonIgnore]
-        public double DefaultCarbonInSoilOM = 0.588;
+        public double DefaultCarbonInSoilOM { get; set; } = 0.588;
 
         /// <summary>
         /// Default carbon weight fraction in FOM (g/g).
@@ -142,14 +142,14 @@ namespace Models.Soils
         [Units("g/g")]
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [JsonIgnore]
-        public double DefaultCarbonInFOM = 0.4;
+        public double DefaultCarbonInFOM { get; set; } = 0.4;
 
         /// <summary>
         /// Default initial pH, used case no pH is initialised in model.
         /// </summary>
         [Units("")]
         [JsonIgnore]
-        public double DefaultInitialpH = 6.0;
+        public double DefaultInitialpH { get; set; } = 6.0;
 
         /// <summary>
         /// Threshold for raising a warning due to small negative values.
@@ -182,7 +182,7 @@ namespace Models.Soils
         [Bounds(Lower = 5, Upper = 30)]
         [Units("g/g")]
         [JsonIgnore]
-        public double[] HumusCNr = { 10.0, 11.0 };
+        public double[] HumusCNr { get; set; } = { 10.0, 11.0 };
 
         /// <summary>
         /// The C:N ratio of soil microbial biomass.
@@ -193,7 +193,7 @@ namespace Models.Soils
         [Bounds(Lower = 5, Upper = 15)]
         [Units("")]
         [JsonIgnore]
-        public double MBiomassCNr = 8.0;
+        public double MBiomassCNr { get; set; } = 8.0;
 
         /// <summary>
         /// Proportion of biomass-C in the initial mineralisable humic-C (g/g).
@@ -201,7 +201,7 @@ namespace Models.Soils
         [Bounds(Lower = 0, Upper = 1)]
         [Units("g/g")]
         [JsonIgnore]
-        public double[] FBiom = { 0.05, 0.01 };
+        public double[] FBiom { get; set; } = { 0.05, 0.01 };
 
         /// <summary>
         /// Proportion of the initial total soil C that is inert, cannot be mineralised (g/g).
@@ -209,7 +209,7 @@ namespace Models.Soils
         [Bounds(Lower = 0, Upper = 1)]
         [Units("g/g")]
         [JsonIgnore]
-        public double[] FInert = { 0.5, 0.95 };
+        public double[] FInert { get; set; } = { 0.5, 0.95 };
 
         #endregion params for OM setup
 
@@ -221,7 +221,7 @@ namespace Models.Soils
         [Bounds(Lower = 0, Upper = 100000)]
         [Units("kg/ha")]
         [JsonIgnore]
-        public double InitialFOMWt = 2000;
+        public double InitialFOMWt { get; set; } = 2000;
 
         /// <summary>
         /// Initial depth over which FOM is distributed within the soil profile (mm).
@@ -232,7 +232,7 @@ namespace Models.Soils
         /// </remarks>
         [Units("mm")]
         [JsonIgnore]
-        public double InitialFOMDepth = -99.0;
+        public double InitialFOMDepth { get; set; } = -99.0;
 
         /// <summary>
         /// Exponent of function used to compute initial distribution of FOM in the soil.
@@ -240,12 +240,12 @@ namespace Models.Soils
         [Bounds(Lower = 0.01, Upper = 10.0)]
         [Units("")]
         [JsonIgnore]
-        public double InitialFOMDistCoefficient = 3.0;
+        public double InitialFOMDistCoefficient { get; set; } = 3.0;
 
         /// <summary>Initial C:N ratio of soil FOM (g/g).</summary>
         [Units("g/g")]
         [JsonIgnore]
-        public double InitialFOMCNr = 40.0;
+        public double InitialFOMCNr { get; set; } = 40.0;
 
         /// <summary>
         /// FOM type used on initialisation and reset.
@@ -320,7 +320,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("g/g")]
         [JsonIgnore]
-        public double ResiduesRespirationFactor = 0.6;
+        public double ResiduesRespirationFactor { get; set; } = 0.6;
 
         /// <summary>
         /// Fraction of retained residue C transferred to microbial biomass (g/g).
@@ -331,7 +331,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("g/g")]
         [JsonIgnore]
-        public double ResiduesFractionIntoBiomass = 0.9;
+        public double ResiduesFractionIntoBiomass { get; set; } = 0.9;
 
         /// <summary>
         /// Depth from which mineral N can be immobilised when decomposing surface residues (mm).
@@ -339,7 +339,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 1000.0)]
         [Units("mm")]
         [JsonIgnore]
-        public double ResiduesDecompDepth = 100;
+        public double ResiduesDecompDepth { get; set; } = 100;
 
         #endregion
 
@@ -351,7 +351,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("/day")]
         [JsonIgnore]
-        public double[] Pool1FOMTurnOverRate = { 0.2, 0.1 };
+        public double[] Pool1FOMTurnOverRate { get; set; } = { 0.2, 0.1 };
 
         /// <summary>
         /// Optimum rate for decomposition of FOM pool 2 [cellulose], aerobic and anaerobic conditions (/day).
@@ -359,7 +359,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("/day")]
         [JsonIgnore]
-        public double[] Pool2FOMTurnOverRate = { 0.05, 0.25 };
+        public double[] Pool2FOMTurnOverRate { get; set; } = { 0.05, 0.25 };
 
         /// <summary>
         /// Optimum rate for decomposition of FOM pool 3 [lignin], aerobic and anaerobic conditions (/day).
@@ -367,7 +367,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("/day")]
         [JsonIgnore]
-        public double[] Pool3FOMTurnOverRate = { 0.0095, 0.003 };
+        public double[] Pool3FOMTurnOverRate { get; set; } = { 0.0095, 0.003 };
 
         /// <summary>
         /// Fraction of the FOM C decomposed lost to atmopshere due to respiration (g/g).
@@ -375,7 +375,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("g/g")]
         [JsonIgnore]
-        public double FOMRespirationFactor = 0.6;
+        public double FOMRespirationFactor { get; set; } = 0.6;
 
         /// <summary>
         /// Fraction of the retained FOM C transferred to biomass (g/g).
@@ -386,7 +386,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("g/g")]
         [JsonIgnore]
-        public double FOMFractionIntoBiomass = 0.9;
+        public double FOMFractionIntoBiomass { get; set; } = 0.9;
 
         #region Limiting factors
 
@@ -396,7 +396,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 10.0)]
         [Units("")]
         [JsonIgnore]
-        public double FOMDecomp_CNCoefficient = 0.693;
+        public double FOMDecomp_CNCoefficient { get; set; } = 0.693;
 
         /// <summary>
         /// Value of C:N ratio above which decomposition rate of FOM declines.
@@ -404,7 +404,7 @@ namespace Models.Soils
         [Bounds(Lower = 5.0, Upper = 100.0)]
         [Units("g/g")]
         [JsonIgnore]
-        public double FOMDecomp_CNThreshold = 25.0;
+        public double FOMDecomp_CNThreshold { get; set; } = 25.0;
 
         /// <summary>
         /// Data for calculating the temperature effect on FOM decomposition.
@@ -485,7 +485,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("/day")]
         [JsonIgnore]
-        public double[] MBiomassTurnOverRate = { 0.0081, 0.004 };
+        public double[] MBiomassTurnOverRate { get; set; } = { 0.0081, 0.004 };
 
         /// <summary>
         /// Fraction of microbial biomass C mineralised that is lost to the atmosphere due to respiration (g/g).
@@ -493,7 +493,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("g/g")]
         [JsonIgnore]
-        public double MBiomassRespirationFactor = 0.6;
+        public double MBiomassRespirationFactor { get; set; } = 0.6;
 
         /// <summary>
         /// Fraction of retained microbial biomass C that goes back to microbial biomass (g/g).
@@ -504,7 +504,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("g/g")]
         [JsonIgnore]
-        public double MBiomassFractionIntoBiomass = 0.6;
+        public double MBiomassFractionIntoBiomass { get; set; } = 0.6;
 
         /// <summary>
         /// Potential rate of active humus mineralisation, aerobic and anaerobic conditions (/day).
@@ -512,7 +512,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("/day")]
         [JsonIgnore]
-        public double[] AHumusTurnOverRate = { 0.00015, 0.00007 };
+        public double[] AHumusTurnOverRate { get; set; } = { 0.00015, 0.00007 };
 
         /// <summary>
         /// Fraction of active humic C mineralised that is lost to the atmosphere due to respiration (g/g).
@@ -520,7 +520,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("/g/")]
         [JsonIgnore]
-        public double AHumusRespirationFactor = 0.6;
+        public double AHumusRespirationFactor { get; set; } = 0.6;
 
         #region Limiting factors
 
@@ -607,7 +607,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("/day")]
         [JsonIgnore]
-        public double UreaHydrol_MinRate = 0.25;
+        public double UreaHydrol_MinRate { get; set; } = 0.25;
 
         /// <summary>
         /// Parameter A for the potential urea hydrolysis function.
@@ -725,7 +725,7 @@ namespace Models.Soils
         /// </remarks>
         [Units("ppm/day")]
         [JsonIgnore]
-        public double NitrificationMaxPotential = 40.0;
+        public double NitrificationMaxPotential { get; set; } = 40.0;
 
         /// <summary>
         /// NH4 concentration at half potential nitrification, Michaelis-Menten dynamics (ppm).
@@ -736,7 +736,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 200.0)]
         [Units("ppm")]
         [JsonIgnore]
-        public double NitrificationNH4ForHalfRate = 90.0;
+        public double NitrificationNH4ForHalfRate { get; set; } = 90.0;
 
         /// <summary>
         /// Fraction of nitrification lost as denitrification
@@ -744,7 +744,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("")]
         [JsonIgnore]
-        public double Nitrification_DenitLossFactor = 0.0;
+        public double Nitrification_DenitLossFactor { get; set; } = 0.0;
 
         /// <summary>
         /// Parameters to calculate the temperature effect on nitrification.
@@ -1043,7 +1043,7 @@ namespace Models.Soils
 
         #endregion params for nitrification
 
-        #region Parameters for codenitrification and N2O emission processes
+        #region Parameters for co-denitrification and associated N2O emissions
 
         /// <summary>
         /// Denitrification rate coefficient (kg soil/mg C/day).
@@ -1064,7 +1064,7 @@ namespace Models.Soils
         [Bounds(Lower = 5.0, Upper = 100.0)]
         [Units("oC")]
         [JsonIgnore]
-        public double[] Codenitrification_TOptmimun
+        private double[] Codenitrification_TOptmimun
         {
             get { return Codenitrification_TemperatureFactorData.xValueForOptimum; }
             set { Codenitrification_TemperatureFactorData.xValueForOptimum = value; }
@@ -1076,7 +1076,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("")]
         [JsonIgnore]
-        public double[] Codenitrification_TFactorAtZero
+        private double[] Codenitrification_TFactorAtZero
         {
             get { return Codenitrification_TemperatureFactorData.yValueAtZero; }
             set { Codenitrification_TemperatureFactorData.yValueAtZero = value; }
@@ -1087,7 +1087,7 @@ namespace Models.Soils
         /// </summary>
         [Units("")]
         [JsonIgnore]
-        public double[] Codenitrification_TCurveCoeff
+        private double[] Codenitrification_TCurveCoeff
         {
             get { return Codenitrification_TemperatureFactorData.CurveExponent; }
             set { Codenitrification_TemperatureFactorData.CurveExponent = value; }
@@ -1107,7 +1107,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 3.0)]
         [Units("")]
         [JsonIgnore]
-        public double[] Codenitrification_NormWaterContents
+        private double[] Codenitrification_NormWaterContents
         {
             get { return Codenitrification_MoistureFactorData.xVals; }
             set { Codenitrification_MoistureFactorData.xVals = value; }
@@ -1119,7 +1119,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("")]
         [JsonIgnore]
-        public double[] Codenitrification_MoistureFactors
+        private double[] Codenitrification_MoistureFactors
         {
             get { return Codenitrification_MoistureFactorData.yVals; }
             set { Codenitrification_MoistureFactorData.yVals = value; }
@@ -1136,7 +1136,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 3.0)]
         [Units("")]
         [JsonIgnore]
-        public double[] Codenitrification_pHValues
+        private double[] Codenitrification_pHValues
         {
             get { return Codenitrification_pHFactorData.xVals; }
             set { Codenitrification_pHFactorData.xVals = value; }
@@ -1148,7 +1148,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("")]
         [JsonIgnore]
-        public double[] Codenitrification_pHFactors
+        private double[] Codenitrification_pHFactors
         {
             get { return Codenitrification_pHFactorData.yVals; }
             set { Codenitrification_pHFactorData.yVals = value; }
@@ -1165,7 +1165,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 100.0)]
         [Units("ppm")]
         [JsonIgnore]
-        public double[] Codenitrification_NHNOValues
+        private double[] Codenitrification_NHNOValues
         {
             get { return Codenitrification_NH3NO2FactorData.xVals; }
             set { Codenitrification_NH3NO2FactorData.xVals = value; }
@@ -1177,7 +1177,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("")]
         [JsonIgnore]
-        public double[] Codenitrification_NHNOFactors
+        private double[] Codenitrification_NHNOFactors
         {
             get { return Codenitrification_NH3NO2FactorData.yVals; }
             set { Codenitrification_NH3NO2FactorData.yVals = value; }
@@ -1193,7 +1193,7 @@ namespace Models.Soils
         [Bounds(Lower = 0.0, Upper = 1.0)]
         [Units("kg/mg")]
         [JsonIgnore]
-        public double DenitrificationRateCoefficient = 0.0006;
+        public double DenitrificationRateCoefficient { get; set; } = 0.0006;
 
         /// <summary>
         /// Parameter A of linear function to compute soluble carbon.


### PR DESCRIPTION
Resolves #7188 
I exposed a number of parameters that control N cycling in SoilNitrogen. Did this by converting fields into properties (simply by adding ```{ get; set; }``` after each name, so it should have minimal, if any, effect on the model performance.
I also made 'private' a few parameter that are not really used (codenitrification), so to reduce a bit the list of parameters from this model...