### PR TITLE
Fixed GLib-GObject-CRITICAL messages while editing manager script

### DIFF
--- a/ApsimNG/Classes/ScriptCompletionProvider.cs
+++ b/ApsimNG/Classes/ScriptCompletionProvider.cs
@@ -127,6 +127,7 @@ namespace UserInterface.Intellisense
             this.ShowError = ShowError;
             this.view = view;
             view.Completion.ShowHeaders = false;
+            view.KeyPressEvent += OnCompletionInfoKeyPress;
         }
 
         /// <summary>
@@ -169,7 +170,6 @@ namespace UserInterface.Intellisense
                 // We need to attach the popup window to the sourceview, so it
                 // gets hidden/removed when the sourceview loses focus.
                 methodSignaturePopup.AttachedTo = view;
-                view.KeyPressEvent += OnCompletionInfoKeyPress;
 
                 // Move the info window to the location of the cursor.
                 methodSignaturePopup.MoveToIter(view, iter);
@@ -186,10 +186,10 @@ namespace UserInterface.Intellisense
         {
             try
             {
-                if (args.Event.Key == Gdk.Key.Escape)
+                if (methodSignaturePopup != null && args.Event.Key == Gdk.Key.Escape)
                 {
-                    methodSignaturePopup.Hide();
                     methodSignaturePopup.Dispose();
+                    methodSignaturePopup = null;
                 }
             }
             catch (Exception err)

--- a/ApsimNG/Classes/ScriptCompletionProvider.cs
+++ b/ApsimNG/Classes/ScriptCompletionProvider.cs
@@ -277,10 +277,17 @@ namespace UserInterface.Intellisense
                     return;
 
                 IEnumerable<NeedContextItemsArgs.ContextItem> contextItems = task.Result.OrderBy(c => c.Name);
+                // Iff owned is true, the list will be freed by calls to Dispose().
+                bool owned = true;
+                // Iff elementsOwned is true, the list elements will be freed
+                // when the list is freed, which will result in double disposal
+                // of the list elements.
+                bool elementsOwned = false;
+
                 List proposals = new List(contextItems.Select(c => new CompletionProposalAdapter(new CustomScriptCompletionProposal(c))).ToArray(),
                                           typeof(CompletionProposalAdapter),
-                                          true,
-                                          true);
+                                          owned,
+                                          elementsOwned);
                 context.AddProposals(this, proposals, true);
             }
             catch (Exception err)

--- a/ApsimNG/Interfaces/IMethodCompletionView.cs
+++ b/ApsimNG/Interfaces/IMethodCompletionView.cs
@@ -3,11 +3,13 @@
     using System.Drawing;
     using Intellisense;
     using System.Collections.Generic;
+    using System;
+
     /// <summary>
     /// Interface for a small intellisense window which displays the 
     /// completion options for a method.
     /// </summary>
-    interface IMethodCompletionView
+    interface IMethodCompletionView : IDisposable
     {
         /// <summary>
         /// List of method completions for all overloads of this method.
@@ -23,7 +25,5 @@
         /// Gets or sets the location (top-left corner) of the popup window.
         /// </summary>
         Point Location { get; set; }
-
-        void Destroy();
     }
 }

--- a/ApsimNG/Presenters/IntellisensePresenter.cs
+++ b/ApsimNG/Presenters/IntellisensePresenter.cs
@@ -134,6 +134,8 @@
                 throw new ArgumentException("textEditor cannot be null.");
 
             view = new IntellisenseView(textEditor);
+            if (methodCompletionView != null)
+                methodCompletionView.Dispose();
             methodCompletionView = new MethodCompletionView(textEditor);
 
             // The way that the ItemSelected event handler works is a little complicated. If the user has half-typed 

--- a/ApsimNG/Views/MethodCompletionView.cs
+++ b/ApsimNG/Views/MethodCompletionView.cs
@@ -305,10 +305,5 @@
             lblArgumentSummaries.WidthChars = Math.Max(completion.Signature.Length, completion.Summary.Length);
             lblOverloadIndex.Text = string.Format("{0} of {1}", visibleCompletionIndex + 1, completions.Count);
         }
-
-        public void Destroy()
-        {
-            mainWindow.Dispose();
-        }
     }
 }

--- a/ApsimNG/Views/PropertyView.cs
+++ b/ApsimNG/Views/PropertyView.cs
@@ -100,6 +100,8 @@ namespace UserInterface.Views
 
             // Dispose of current properties table.
             box.Remove(propertyTable);
+            propertyTable.DetachAllHandlers();
+            propertyTable.Destroy();
             propertyTable.Dispose();
 
             // Construct a new properties table.


### PR DESCRIPTION
These were caused by double-disposal of ScriptCompletionProposal instances (once when the list containing the proposals is disposed (which doesn't set disposed on the proposal instances), then a second time when the GC kicks in).

Resolves #7191.

Edit: This PR contains a few fixes for some other problems which I noticed while debugging. See the individual commits for details.