### PR TITLE
Fixed reporting on events from models with names containing spaces

### DIFF
--- a/Models/Properties/AssemblyInfo.cs
+++ b/Models/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -19,3 +20,5 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("7925afff-b8a2-4209-a14f-5a20a94297f7")]
+
+[assembly: InternalsVisibleTo("UnitTests")]

--- a/Models/Report/EventReportFrequency.cs
+++ b/Models/Report/EventReportFrequency.cs
@@ -1,4 +1,5 @@
-﻿using Models.Core;
+﻿using APSIM.Shared.Utilities;
+using Models.Core;
 using System;
 
 namespace Models
@@ -18,7 +19,7 @@ namespace Models
         /// <returns>true if line was able to be parsed.</returns>
         public static bool TryParse(string line, Report report, IEvent events)
         {
-            string[] tokens = line.Split(" ", StringSplitOptions.RemoveEmptyEntries);
+            string[] tokens = StringUtilities.SplitStringHonouringBrackets(line, " ", '[', ']');
             if (tokens.Length == 1)
             {
                 new EventReportFrequency(report, events, tokens[0]);

--- a/Tests/UnitTests/Report/EventReportFrequencyTests.cs
+++ b/Tests/UnitTests/Report/EventReportFrequencyTests.cs
@@ -1,0 +1,41 @@
+using APSIM.Shared.Utilities;
+using Models;
+using Models.Core;
+using Moq;
+using NUnit.Framework;
+using System;
+
+namespace UnitTests.Reporting
+{
+    /// <summary>
+    /// Unit tests for <see cref="EventReportFrequency"/> class.
+    /// </summary>
+    [TestFixture]
+    public class EventReportFrequencyTests
+    {
+        /// <summary>
+        /// Mocked events service.
+        /// </summary>
+        private Mock<IEvent> mockEvents;
+
+        /// <summary>
+        /// Setup the test environment.
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            mockEvents = new Mock<IEvent>();
+        }
+
+        /// <summary>
+        /// Ensure that the given reporting frequency is a valid event reporting frequency.
+        /// </summary>
+        /// <param name="frequency">Input line - should be any valid reporting frequency using a model event.</param>
+        [TestCase("[Clock].DoReport")]
+        [TestCase("[Clock with space].DoReport")]
+        public void TestReportingFrequency(string frequency)
+        {
+            Assert.True(EventReportFrequency.TryParse(frequency, new Models.Report(), mockEvents.Object));
+        }
+    }
+}


### PR DESCRIPTION
Resolves #7180.