### PR TITLE
Classic import fix

### DIFF
--- a/ApsimNG/Presenters/MainPresenter.cs
+++ b/ApsimNG/Presenters/MainPresenter.cs
@@ -1141,12 +1141,13 @@
         {
             try
             {
-                string fileName = this.AskUserForOpenFileName("*.apsim|*.apsim");
+                string fileName = this.AskUserForOpenFileName("APSIM Classic Files|*.apsim");
                 this.view.ShowWaitCursor(true);
                 this.Import(fileName);
 
                 string newFileName = Path.ChangeExtension(fileName, ".apsimx");
                 this.OpenApsimXFileInTab(newFileName, this.view.IsControlOnLeft(sender));
+                Configuration.Settings.PreviousFolder = Path.GetDirectoryName(fileName);
             }
             catch (Exception err)
             {

--- a/Models/Core/ApsimFile/Converter.cs
+++ b/Models/Core/ApsimFile/Converter.cs
@@ -703,7 +703,7 @@ namespace Models.Core.ApsimFile
 
             // Get sample thickness and bulk density.
             var sampleThickness = sample["Thickness"].Values<double>().ToArray();
-            var sampleBD = Soils.Standardiser.Layers.MapConcentration(soilBD, soilThickness, sampleThickness, soilBD.Last());
+            var sampleBD = Soils.Standardiser.Layers.MapConcentration(soilBD, soilThickness, sampleThickness, soilBD.Last(), true);
 
             for (int i = 0; i < values.Count; i++)
                 values[i] = values[i].Value<double>() * 100 / (sampleBD[i] * sampleThickness[i]);
@@ -756,7 +756,7 @@ namespace Models.Core.ApsimFile
                         var analysisThickness = analysis["Thickness"].Values<double>().ToArray();
                         var sampleThickness = sample["Thickness"].Values<double>().ToArray();
                         var values = no3Values.Values<double>().ToArray();
-                        var mappedValues = Soils.Standardiser.Layers.MapConcentration(values, sampleThickness, analysisThickness, 1.0);
+                        var mappedValues = Soils.Standardiser.Layers.MapConcentration(values, sampleThickness, analysisThickness, 1.0, true);
                         no3Values = new JArray(mappedValues);
 
                         // Move from sample to analysis
@@ -783,7 +783,7 @@ namespace Models.Core.ApsimFile
                         var analysisThickness = analysis["Thickness"].Values<double>().ToArray();
                         var sampleThickness = sample["Thickness"].Values<double>().ToArray();
                         var values = nh4Values.Values<double>().ToArray();
-                        var mappedValues = Soils.Standardiser.Layers.MapConcentration(values, sampleThickness, analysisThickness, 0.2);
+                        var mappedValues = Soils.Standardiser.Layers.MapConcentration(values, sampleThickness, analysisThickness, 0.2, true);
                         nh4Values = new JArray(mappedValues);
 
                         // Move from sample to analysis
@@ -1153,7 +1153,7 @@ namespace Models.Core.ApsimFile
                         var values = chemical["ParticleSizeSand"].Values<double>().ToArray();
                         if (values.Length < physicalThickness.Length)
                             Array.Resize(ref values, chemicalThickness.Length);
-                        var mappedValues = Soils.Standardiser.Layers.MapConcentration(values, chemicalThickness, physicalThickness, values.Last());
+                        var mappedValues = Soils.Standardiser.Layers.MapConcentration(values, chemicalThickness, physicalThickness, values.Last(), true);
                         physical["ParticleSizeSand"] = new JArray(mappedValues);
                     }
 
@@ -1162,7 +1162,7 @@ namespace Models.Core.ApsimFile
                         var values = chemical["ParticleSizeSilt"].Values<double>().ToArray();
                         if (values.Length < physicalThickness.Length)
                             Array.Resize(ref values, chemicalThickness.Length);
-                        var mappedValues = Soils.Standardiser.Layers.MapConcentration(values, chemicalThickness, physicalThickness, values.Last());
+                        var mappedValues = Soils.Standardiser.Layers.MapConcentration(values, chemicalThickness, physicalThickness, values.Last(), true);
                         physical["ParticleSizeSilt"] = new JArray(mappedValues);
                     }
 
@@ -1171,7 +1171,7 @@ namespace Models.Core.ApsimFile
                         var values = chemical["ParticleSizeClay"].Values<double>().ToArray();
                         if (values.Length < physicalThickness.Length)
                             Array.Resize(ref values, chemicalThickness.Length);
-                        var mappedValues = Soils.Standardiser.Layers.MapConcentration(values, chemicalThickness, physicalThickness, values.Last());
+                        var mappedValues = Soils.Standardiser.Layers.MapConcentration(values, chemicalThickness, physicalThickness, values.Last(), true);
                         physical["ParticleSizeClay"] = new JArray(mappedValues);
                     }
 

--- a/Models/Soils/Standardiser/Layers.cs
+++ b/Models/Soils/Standardiser/Layers.cs
@@ -242,7 +242,7 @@
         {
             if (fromValues != null)
             {
-                if (fromValues.Length != fromThickness.Length)
+                if (fromValues.Length != fromThickness.Length && !allowMissingValues)
                     throw new Exception($"In MapConcentration, the number of values ({fromValues.Length}) doesn't match the number of thicknesses ({fromThickness.Length}).");
                 if (fromValues == null || fromThickness == null)
                     return null;


### PR DESCRIPTION
This allows importing of APSIM Classic files in which the number of e.g. NO3 values does not match the number of soil layers. I encountered this in a whole series of files from an APSIM Classic power user, in which they had 11 soil layers but had only populated the top six layers with NO3 and NH4. These files failed to import, with no error message to give the user a clue as to why. In their research they did not need these deeper soil nitrogen values to be anything other than 0. I saw that there was already code to tolerate missing values in MapConcentration(), so have enabled this during the import.

Resolves #7238

I have also made a minor UI change, to set the last opened location after an import. This makes it much easier to import multiple files from the same location. Without the change, the user has to repeatedly navigate back to the location of the files they want to import.

Resolves #7239 