### PR TITLE
Improvements for manager completion metadata

### DIFF
--- a/ApsimNG/Classes/ScriptCompletionProvider.cs
+++ b/ApsimNG/Classes/ScriptCompletionProvider.cs
@@ -171,9 +171,10 @@ namespace UserInterface.Intellisense
                 // gets hidden/removed when the sourceview loses focus.
                 methodSignaturePopup.AttachedTo = view;
 
+                methodSignaturePopup.ShowAll();
+
                 // Move the info window to the location of the cursor.
                 methodSignaturePopup.MoveToIter(view, iter);
-                methodSignaturePopup.ShowAll();
             }
 
             // Return false, to allow the sourceview to automatically handle

--- a/ApsimNG/Classes/ScriptCompletionProvider.cs
+++ b/ApsimNG/Classes/ScriptCompletionProvider.cs
@@ -211,12 +211,22 @@ namespace UserInterface.Intellisense
         /// gtk_source_completion_proposal_get_info() is used as the content of
         /// the GtkLabel.
         /// </summary>
-        /// <param name="proposal"></param>
-        /// <returns></returns>
+        /// <remarks>
+        /// This implementation is essentially the same as the default behvaiour
+        /// when this method is not implemented (ie when it returns null),
+        /// except that I've set UseMarkup to false, to ensure that generic
+        /// members/parameters are displayed correctly without being parsed as
+        /// markup.
+        /// </remarks>
+        /// <param name="proposal">The completion proposal.</param>
         public Widget GetInfoWidget(ICompletionProposal proposal)
         {
-            // tbi
-            return null;
+            return new Label()
+            {
+                UseMarkup = false,
+                Text = proposal.Info,
+                Visible = true
+            };
         }
 
         /// <summary>

--- a/ApsimNG/Intellisense/CodeCompletionService.cs
+++ b/ApsimNG/Intellisense/CodeCompletionService.cs
@@ -21,6 +21,66 @@ namespace UserInterface.Intellisense
     /// </summary>
     internal class CodeCompletionService
     {
+        /// <summary>
+        /// Formatting options for parameter symbols' metadata.
+        /// </summary>
+        private static readonly SymbolDisplayParameterOptions parameterOptions = SymbolDisplayParameterOptions.IncludeDefaultValue
+                                                                               | SymbolDisplayParameterOptions.IncludeName
+                                                                               | SymbolDisplayParameterOptions.IncludeOptionalBrackets
+                                                                               | SymbolDisplayParameterOptions.IncludeParamsRefOut
+                                                                               | SymbolDisplayParameterOptions.IncludeType;
+
+        /// <summary>
+        /// Formatting options for generic type parameter symbols' metadata.
+        /// </summary>
+        private static readonly SymbolDisplayGenericsOptions genericOptions = SymbolDisplayGenericsOptions.IncludeTypeConstraints
+                                                                            | SymbolDisplayGenericsOptions.IncludeTypeParameters
+                                                                            | SymbolDisplayGenericsOptions.IncludeVariance;
+
+        /// <summary>
+        /// Formatting options for member symbols' metadata.
+        /// </summary>
+        private static readonly SymbolDisplayMemberOptions memberOptions = SymbolDisplayMemberOptions.IncludeContainingType
+                                                                         | SymbolDisplayMemberOptions.IncludeConstantValue
+                                                                         | SymbolDisplayMemberOptions.IncludeModifiers
+                                                                         | SymbolDisplayMemberOptions.IncludeParameters
+                                                                         | SymbolDisplayMemberOptions.IncludeRef
+                                                                         | SymbolDisplayMemberOptions.IncludeType;
+
+        /// <summary>
+        /// Formatting options for local symbols' metadata.
+        /// </summary>
+        private static readonly SymbolDisplayLocalOptions localOptions = SymbolDisplayLocalOptions.IncludeConstantValue
+                                                                       | SymbolDisplayLocalOptions.IncludeRef
+                                                                       | SymbolDisplayLocalOptions.IncludeType;
+
+        /// <summary>
+        /// Formatting metadata for symbol "kind" metadata.
+        /// </summary>
+        private static readonly SymbolDisplayKindOptions kindOptions = SymbolDisplayKindOptions.IncludeNamespaceKeyword
+                                                                     | SymbolDisplayKindOptions.IncludeTypeKeyword;
+
+        /// <summary>
+        /// Miscellaneous formatting options for symbol metadata.
+        /// </summary>
+        private static readonly SymbolDisplayMiscellaneousOptions miscellaneousOptions = SymbolDisplayMiscellaneousOptions.UseSpecialTypes
+                                                                                       | SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers
+                                                                                       | SymbolDisplayMiscellaneousOptions.UseAsterisksInMultiDimensionalArrays
+                                                                                       | SymbolDisplayMiscellaneousOptions.AllowDefaultLiteral;
+
+        /// <summary>
+        /// Formatting options for metadata displayed in the "details" area of the GUI.
+        /// </summary>
+        private static readonly SymbolDisplayFormat format = new SymbolDisplayFormat(typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypes,
+                                                                                     genericsOptions: genericOptions,
+                                                                                     memberOptions: memberOptions,
+                                                                                     delegateStyle: SymbolDisplayDelegateStyle.NameAndSignature,
+                                                                                     parameterOptions: parameterOptions,
+                                                                                     propertyStyle: SymbolDisplayPropertyStyle.ShowReadWriteDescriptor,
+                                                                                     localOptions: localOptions,
+                                                                                     kindOptions: kindOptions,
+                                                                                     miscellaneousOptions: miscellaneousOptions);
+
         private MefHostServices host;
         private AdhocWorkspace workspace;
         private ProjectInfo projectInfo;
@@ -118,7 +178,7 @@ namespace UserInterface.Intellisense
                                             completions.Add(new NeedContextItemsArgs.ContextItem()
                                             {
                                                 Name = symbol.Name,
-                                                Descr = symbol.ToDisplayString(),
+                                                Descr = symbol.ToDisplayString(format),
                                                 IsMethod = symbol.Kind == SymbolKind.Method,
                                                 IsProperty = symbol.Kind == SymbolKind.Property,
                                                 IsEvent = symbol.Kind == SymbolKind.Event

--- a/ApsimNG/Intellisense/CodeCompletionService.cs
+++ b/ApsimNG/Intellisense/CodeCompletionService.cs
@@ -26,7 +26,6 @@ namespace UserInterface.Intellisense
         /// </summary>
         private static readonly SymbolDisplayParameterOptions parameterOptions = SymbolDisplayParameterOptions.IncludeDefaultValue
                                                                                | SymbolDisplayParameterOptions.IncludeName
-                                                                               | SymbolDisplayParameterOptions.IncludeOptionalBrackets
                                                                                | SymbolDisplayParameterOptions.IncludeParamsRefOut
                                                                                | SymbolDisplayParameterOptions.IncludeType;
 


### PR DESCRIPTION
- Displaying much more info now
- Metadata displayed near the cursor, rather than in top-left corner of screen

Resolves #7197.