### PR TITLE
Maintain initial Plant population when using 'seeds'

### DIFF
--- a/Models/PMF/Plant.cs
+++ b/Models/PMF/Plant.cs
@@ -397,7 +397,7 @@ namespace Models.PMF
             if (population > 0)
                 this.Population = population;
             else
-                this.Population = seeds;
+                this.Population = SowingData.Population = seeds;
 
             // Find cultivar and apply cultivar overrides.
             Cultivar cultivarDefinition = FindAllDescendants<Cultivar>().FirstOrDefault(c => c.IsKnownAs(SowingData.Cultivar));


### PR DESCRIPTION
This PR adds an additional assignment in Plant.Sow() to keep SowingParameters.Population synchronized with the 'seeds' parameter when it is present.

Another fix could be to replace `SowingParameters.Population` references with `IPlant.Population`, however I have not been able to fix the issue doing this. I found relevant references in models:
- `PMF/Structure/Tillering/C4LeafAreaM.cs`
- `PMF/Structure/Tillering/C4LeafArea.cs`
- `PMF/Structure/Tillering/FixedTillering.cs`

Resolves #7298