### PR TITLE
Make sure "versionNumber" is defined when doing upgrade.

### DIFF
--- a/ApsimNG/Views/UpgradeView.cs
+++ b/ApsimNG/Views/UpgradeView.cs
@@ -318,6 +318,7 @@
 
                     Upgrade[] upgradeList = oldVersions.Active ? allUpgrades : upgrades;
                     Upgrade upgrade = upgradeList[selIndex];
+                    versionNumber = upgrade.ReleaseDate.ToString("yyyy.MM.dd.") + upgrade.Issue;
 
                     if ((Gtk.ResponseType)ViewBase.MasterView.ShowMsgDialog($"Are you sure you want to upgrade to version {upgrade.Version}?",
                                             "Are you sure?", MessageType.Question, ButtonsType.YesNo, window1) == Gtk.ResponseType.Yes)


### PR DESCRIPTION
Resolves #7312 

Note that the upgrade mechanism is broken for versions generated after late April 2022. Holders of those versions will need to download a new version manually.

I hope to soon add some additional changes to make use of HttpClient rather than the now-obsolete WebRequest API. This will be to partially address the changes needed for issue #7139.