### PR TITLE
Improve CroptimizR status output

### DIFF
--- a/Models/Optimisation/CroptimizR.cs
+++ b/Models/Optimisation/CroptimizR.cs
@@ -495,6 +495,7 @@ namespace Models.Optimisation
                 r.InstallPackages("remotes", "dplyr", "nloptr", "DiceDesign", "DBI", "cli");
                 r.InstallFromGithub("hol430/ApsimOnR", "SticsRPacks/CroptimizR");
 
+                Status = "Running Parameter Optimization";
 
                 // todo - capture stderr as well?
                 r.OutputReceived += OnOutputReceivedFromR;


### PR DESCRIPTION
This PR adds an additional status update when running CroptimizR with Docker disabled. Currently the status will display "Installing R packages" while the optimization process is running. This adds a "Running Parameter Optimization" status update when the optimization process starts. This matches the behavior of the status display when Docker is used.

Resolves #7343 