### PR TITLE
Excel tav amp

### DIFF
--- a/APSIM.Shared/Utilities/ApsimTextFile.cs
+++ b/APSIM.Shared/Utilities/ApsimTextFile.cs
@@ -385,7 +385,7 @@ namespace APSIM.Shared.Utilities
 
             if (_excelData.Rows.Count != 0)
             {
-                data = _excelData;
+                data = _excelData.Copy();
             }
             //will I ever hit this without having any data???
 

--- a/APSIM.Shared/Utilities/ApsimTextFile.cs
+++ b/APSIM.Shared/Utilities/ApsimTextFile.cs
@@ -811,13 +811,19 @@ namespace APSIM.Shared.Utilities
         /// <summary>Return the current file position</summary>
         public long GetCurrentPosition()
         {
-            return inStreamReader.Position;
+            if (IsExcelFile)
+                return excelIndex;
+            else
+                return inStreamReader.Position;
         }
 
         /// <summary>Seek to the specified file position</summary>
         public void SeekToPosition(long position)
         {
-            inStreamReader.Seek(position, SeekOrigin.Begin);
+            if (IsExcelFile)
+                excelIndex = Convert.ToInt32(position);
+            else
+                inStreamReader.Seek(position, SeekOrigin.Begin);
         }
 
 


### PR DESCRIPTION
Resolves #7346. 

After clearing the null reference error, there was a bug in the UI where it would fail to draw the met component. This had to do with the DataTable owned by the ApsimTextFile reader being passed by reference to the Met UI component which would modify its columns without updating the headings in the reader, causing this component to fail. This was resolvable by giving the UI component a copy of the DataTable, rather than a reference, though a wiser approach may be add some setter methods to Weather.cs allowing the reader's heading and type arrays to be set so that we don't copy a large data table. 