### PR TITLE
Set PropagateNaturalHeight to true for model description in GUI

### DIFF
--- a/ApsimNG/Views/ExplorerView.cs
+++ b/ApsimNG/Views/ExplorerView.cs
@@ -99,6 +99,10 @@ namespace UserInterface.Views
                     if (descriptionView.MainWidget is ScrolledWindow scroller)
                         scroller.PropagateNaturalHeight = true;
                     rightHandView.PackStart(descriptionView.MainWidget, false, false, 0);
+                    // Let Gtk catch up with things; otherwise too much space
+                    // is allocated to the new description view. Is there a better way?
+                    while (Gtk.Application.EventsPending())
+                        Gtk.Application.RunIteration();
                 }
                 descriptionView.Text = description;
             }

--- a/ApsimNG/Views/ExplorerView.cs
+++ b/ApsimNG/Views/ExplorerView.cs
@@ -90,6 +90,14 @@ namespace UserInterface.Views
                 if (descriptionView == null)
                 {
                     descriptionView = new MarkdownView(this);
+                    // Set PropagateNaturalHeight to true, to ensure that the
+                    // scrolled window requests enough space to not require a
+                    // scrollbar by default. We could change MarkdownView to
+                    // always do this, but it's used in lots of other places, so
+                    // that may have unintended consequences and would require
+                    // more extensive testing.
+                    if (descriptionView.MainWidget is ScrolledWindow scroller)
+                        scroller.PropagateNaturalHeight = true;
                     rightHandView.PackStart(descriptionView.MainWidget, false, false, 0);
                 }
                 descriptionView.Text = description;


### PR DESCRIPTION
Resolves #7353.

It's perhaps not ideal to have this logic in ExplorerView. But I'm not sure of the implications of always setting this to true for all MarkdownView instances.