### PR TITLE
Fix to ensure properties without description attribute (e.g. SWCON)

### DIFF
--- a/Models/Core/ApsimFile/FileFormat.cs
+++ b/Models/Core/ApsimFile/FileFormat.cs
@@ -194,7 +194,7 @@
 
                         // Otherwise, only serialize if the property is inherited from
                         // Model or ModelCollectionFromResource.
-                        return member.DeclaringType.IsAssignableFrom(typeof(ModelCollectionFromResource));
+                        return typeof(ModelCollectionFromResource).IsAssignableFrom(member.DeclaringType);
                     };
                 }
 

--- a/Prototypes/SoilTemperature/SoilTemperature.apsimx
+++ b/Prototypes/SoilTemperature/SoilTemperature.apsimx
@@ -350,6 +350,36 @@
                   "CNCov": 0.8,
                   "DischargeWidth": 0.0,
                   "CatchmentArea": 0.0,
+                  "Thickness": [
+                    100.0,
+                    300.0,
+                    600.0,
+                    1000.0,
+                    1000.0,
+                    1000.0,
+                    1000.0,
+                    1000.0
+                  ],
+                  "SWCON": [
+                    0.9,
+                    0.9,
+                    0.9,
+                    0.6,
+                    0.6,
+                    0.6,
+                    0.6,
+                    0.6
+                  ],
+                  "KLAT": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
                   "ResourceName": "WaterBalance",
                   "Name": "SoilWater",
                   "Enabled": true,


### PR DESCRIPTION
are serialised to .apsimx. Resolves #7376 