### PR TITLE
Catch exceptions caused by badly formed property values.

### DIFF
--- a/ApsimNG/Presenters/NewGridPresenter.cs
+++ b/ApsimNG/Presenters/NewGridPresenter.cs
@@ -124,8 +124,15 @@
         {
             if (CellChanged != null)
             {
-                SaveGridToModel();
-                CellChanged.Invoke(sender, colIndex, rowIndex);
+                try
+                {
+                    SaveGridToModel();
+                    CellChanged.Invoke(sender, colIndex, rowIndex);
+                }
+                catch (Exception err)
+                {
+                    explorerPresenter.MainPresenter.ShowError(err.ToString());
+                }
             }
         }
 


### PR DESCRIPTION
Working on #7392 

This doesn't address the core issue, but does help keep the GUI from crashing.