### PR TITLE
Improve table column width partitioning in autodocs

### DIFF
--- a/APSIM.Cli/Program.cs
+++ b/APSIM.Cli/Program.cs
@@ -109,7 +109,9 @@ namespace APSIM.Cli
                 string directory = Path.GetDirectoryName(file);
                 PdfWriter writer = new PdfWriter(new PdfOptions(directory, null));
                 IEnumerable<ITag> tags = options.ParamsDocs ? new ParamsInputsOutputs(model).Document() : model.Document();
-                writer.Write(pdfFile, tags);
+                // Make params/inputs/outputs docs landscape (they have some rather wide tables). Everything else, portrait.
+                bool vertical = !options.ParamsDocs;
+                writer.Write(pdfFile, tags, vertical);
             }
         }
 

--- a/APSIM.Interop/Documentation/PdfWriter.cs
+++ b/APSIM.Interop/Documentation/PdfWriter.cs
@@ -49,9 +49,9 @@ namespace APSIM.Interop.Documentation
         /// </summary>
         /// <param name="fileName">File name of the generated pdf.</param>
         /// <param name="tags">Tags to be converted to a PDF.</param>
-        public void Write(string fileName, IEnumerable<ITag> tags)
+        public void Write(string fileName, IEnumerable<ITag> tags, bool vertical = true)
         {
-            Document pdf = CreateStandardDocument();
+            Document pdf = CreateStandardDocument(vertical);
             PdfBuilder pdfRenderer = new PdfBuilder(pdf, options);
 
             Write(tags, pdfRenderer);


### PR DESCRIPTION
Resolves #7307 (as far as I can tell).

See commit messages for details. Wide tables should now be more readable, but they can still look odd if they are really wide, particularly in portrait documents. In the example below, the name, units, type, and settable columns can't actually be reasonably shrunk further because some cells further down contain long single words which can't be wrapped over multiple lines:

![agpryegrass-portrait](https://user-images.githubusercontent.com/36427516/185791234-fdbf0a0a-9c69-4b0c-892f-51c44b9353e4.png)

What I've done to work around this is make params/inputs/outputs documents landscape:

![agpryegrass-landscape](https://user-images.githubusercontent.com/36427516/185791240-313ba513-c525-4007-bcbd-c2327e6b37a9.png)

You might want to check that this is doing sensible things in other documents; I've not really tested this much - I only looked at AGPRyegrass (params/inputs/outputs) and AgPasture (standard).

Feel free to adapt/take/modify this as much as you want.