### PR TITLE
Fix broken links to the documentation website's "Contribute" section

### DIFF
--- a/Docs/content/Contribute/CLI/BringUpToDate.md
+++ b/Docs/content/Contribute/CLI/BringUpToDate.md
@@ -3,7 +3,7 @@ title: "4. Bring folder up to date"
 draft: false
 ---
 
-**NOTE:** Before you bring your folder up to date, you need to [commit or discard all files that you have added or modified](/development/contribute/cli/commit). If you don't do this you may get errors during the pull process outlined below.
+**NOTE:** Before you bring your folder up to date, you need to [commit or discard all files that you have added or modified](/contribute/cli/commit). If you don't do this you may get errors during the pull process outlined below.
 
 ## Pull
 

--- a/Docs/content/Contribute/SourceTree/GetSource.md
+++ b/Docs/content/Contribute/SourceTree/GetSource.md
@@ -40,6 +40,6 @@ You now need to create a link to your ApsimX fork that you created earlier.
 
 We suggest you name the remote repository the same as your GitHub user name, hence the need to enter it twice. The reason for linking to two repositories will become evident later. You ALWAYS **pull** from the ApsimX repository and **push** to your forked repository.
 
-At this point, you have all source code. If you wish to compile the code yourself, see [here](/development/contribute/compile/). If you don't wish to compile the code, you can run any of the examples/prototypes/test sets with the released version of apsim, but it will need to be up-to-date.
+At this point, you have all source code. If you wish to compile the code yourself, see [here](/contribute/compile/). If you don't wish to compile the code, you can run any of the examples/prototypes/test sets with the released version of apsim, but it will need to be up-to-date.
 
-After you have made some changes to the code or test sets, you will need to [commit your changes](/development/contribute/sourcetree/commit/).
+After you have made some changes to the code or test sets, you will need to [commit your changes](/contribute/sourcetree/commit/).

--- a/Docs/content/Contribute/SourceTree/_index.md
+++ b/Docs/content/Contribute/SourceTree/_index.md
@@ -4,7 +4,7 @@ draft: false
 weight: 20
 ---
 
-SourceTree is only available on Windows and OSX. If you are using Linux, version control will need to be managed [via the command line](/development/contribute/cli/)
+SourceTree is only available on Windows and OSX. If you are using Linux, version control will need to be managed [via the command line](/contribute/cli/)
 
 * [Get all source code from GitHub](/contribute/sourcetree/getsource)
 * [Commit changes to GIT (COMMIT)](/contribute/sourcetree/commit)

--- a/Docs/docfx/index.md
+++ b/Docs/docfx/index.md
@@ -24,7 +24,7 @@ Any recent PC with a minimum of 2Gb of RAM.
 
 Installers for Windows, MacOS, and (Debian) Linux are available [here](https://registration.apsim.info)
 
-Instructions for compiling from source are available [here](https://apsimnextgeneration.netlify.app/development/contribute/compile/)
+Instructions for compiling from source are available [here](https://apsimnextgeneration.netlify.app/contribute/compile/)
 
 ## Contributing
 
@@ -32,7 +32,7 @@ Any individual or organisation (a 3rd party outside of the AI) who uses APSIM mu
 
 Intellectual property rights in APSIM are retained by the AI. If a licensee makes any improvements to APSIM, the intellectual property rights to those improvements belong to the AI. This means that the AI can choose to make the improvements - including source code – and these improvements would then be made available to all licensed users. As part of the submission process, you are complying with this term as well as making it available to all licensed users. Any Improvements to APSIM are required to be unencumbered and the contributing party warrants that the IP being contributed does not and will not infringe any third party IPR rights.
 
-Please read our [guide](https://apsimnextgeneration.netlify.com/development/contribute/).
+Please read our [guide](https://apsimnextgeneration.netlify.app/contribute/).
 
 ## Publications 
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Any individual or organisation (a 3rd party outside of the AI) who uses APSIM mu
 
 Intellectual property rights in APSIM are retained by the AI. If a licensee makes any improvements to APSIM, the intellectual property rights to those improvements belong to the AI. This means that the AI can choose to make the improvements - including source code – and these improvements would then be made available to all licensed users. As part of the submission process, you are complying with this term as well as making it available to all licensed users. Any Improvements to APSIM are required to be unencumbered and the contributing party warrants that the IP being contributed does not and will not infringe any third party IPR rights.
 
-Please read our [guide](https://apsimnextgeneration.netlify.com/development/contribute/).
+Please read our [guide](https://apsimnextgeneration.netlify.app/contribute/).
 
 ## Publications 
 


### PR DESCRIPTION
The "Contribute" section was moved
from: https://apsimnextgeneration.netlify.app/development/contribute/*
to:   https://apsimnextgeneration.netlify.app/contribute/*
in #5629, and the old links return 404 Not Found.

Also change the domain name from "\*.netlify.com" to "\*.netlify.app" in a few places, since "\*.netlify.com" redirects to "\*.netlify.app".

Resolves #7468.