### PR TITLE
Fix ReflectionUtilities.Clone() when using a non-default AssemblyLoadContext

### DIFF
--- a/APSIM.Shared/Utilities/ReflectionUtilities.cs
+++ b/APSIM.Shared/Utilities/ReflectionUtilities.cs
@@ -10,6 +10,7 @@
     using System.IO;
     using System.Linq;
     using System.Reflection;
+    using System.Runtime.Loader;
     using System.Runtime.Serialization;
     using System.Runtime.Serialization.Formatters.Binary;
 
@@ -318,7 +319,7 @@
         /// <summary>
         /// Binary serialise the object and return the resulting stream.
         /// </summary>
-        public static Stream BinarySerialise(object source)
+        public static Stream BinarySerialise(object source, SerializationBinder binder = null)
         {
             if (source == null)
                 return null;
@@ -327,6 +328,7 @@
                 throw new ArgumentException("The type must be serializable.", "source");
 
             IFormatter formatter = new BinaryFormatter();
+            formatter.Binder = binder;
             Stream stream = new MemoryStream();
             formatter.Serialize(stream, source);
             return stream;
@@ -335,12 +337,13 @@
         /// <summary>
         /// Binary deserialise the specified stream and return the resulting object
         /// </summary>
-        public static object BinaryDeserialise(Stream stream)
+        public static object BinaryDeserialise(Stream stream, SerializationBinder binder = null)
         {
             if (stream == null)
                 return null;
 
             IFormatter formatter = new BinaryFormatter();
+            formatter.Binder = binder;
             return formatter.Deserialize(stream);
         }
 #pragma warning restore SYSLIB0011
@@ -546,9 +549,56 @@
         /// </summary>
         public static object Clone(object sourceObj)
         {
-            Stream stream = BinarySerialise(sourceObj);
+            CachingSerializationBinder binder = new CachingSerializationBinder();
+            Stream stream = BinarySerialise(sourceObj, binder);
             stream.Seek(0, SeekOrigin.Begin);
-            return BinaryDeserialise(stream);
+            return BinaryDeserialise(stream, binder);
+        }
+
+        /// <summary>
+        /// Custom SerializationBinder that records the assemblies seen during serialisation
+        /// and reuses them during deserialisation.
+        /// This is useful when working with assemblies from a non-default AssemblyLoadContext,
+        /// because BinaryFormatter cannot deserialise them otherwise.
+        /// </summary>
+        class CachingSerializationBinder : SerializationBinder
+        {
+            private Dictionary<string, Assembly> assemblyCache = new Dictionary<string, Assembly>();
+
+            public override void BindToName(Type serializedType, out string assemblyName, out string typeName)
+            {
+                assemblyName = serializedType.Assembly.FullName;
+                typeName = serializedType.FullName;
+                if (!assemblyCache.ContainsKey(assemblyName))
+                {
+                    assemblyCache[assemblyName] = serializedType.Assembly;
+                }
+                else
+                {
+                    if (assemblyCache[assemblyName] != serializedType.Assembly)
+                    {
+                        throw new FileLoadException(String.Format("Assemblies with the same name from different load contexts are not supported: '{0}'.", assemblyName));
+                    }
+                }
+            }
+
+            public override Type BindToType(string assemblyName, string typeName)
+            {
+                string qualifiedTypeName = String.Format("{0}, {1}", typeName, assemblyName);
+                return Type.GetType(qualifiedTypeName, assemblyResolver: ResolveAssembly, typeResolver: null);
+            }
+
+            private Assembly ResolveAssembly(AssemblyName assemblyName)
+            {
+                if (assemblyCache.ContainsKey(assemblyName.FullName))
+                {
+                    return assemblyCache[assemblyName.FullName];
+                }
+                else
+                {
+                    return AssemblyLoadContext.Default.LoadFromAssemblyName(assemblyName);
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Resolves #7464. (In short: Clone() breaks on assemblies from a non-default AssemblyLoadContext, because by default .NET's BinaryFormatter can only load assemblies from the default AssemblyLoadContext.)

---

Some comments on the implementation:

For general-purpose deserialization, there is no obvious way to specify the load context, because a composite object may contain objects from multiple assembly load contexts.

But in the special case of cloning (serialize-then-deserialize), there is an easy solution: cache the assemblies seen during serialization, and look them up in the cache during deserialization.

Resolving generic types can be complicated because the type arguments need to be resolved recursively, but fortunately the [overload of Type.GetType()](https://docs.microsoft.com/en-us/dotnet/api/system.type.gettype#system-type-gettype(system-string-system-func((system-reflection-assemblyname-system-reflection-assembly))-system-func((system-reflection-assembly-system-string-system-boolean-system-type)))) does the heavy lifting.