### PR TITLE
Stop innosetup showing error if source directory doesn't exist

### DIFF
--- a/Setup/apsimx.iss
+++ b/Setup/apsimx.iss
@@ -71,8 +71,8 @@ Source: ..\ApsimNG\Resources\world\*; DestDir: {app}\ApsimNG\Resources\world; Fl
 ;Sample files 
 Source: ..\Examples\*; DestDir: {app}\Examples; Flags: recursesubdirs
 Source: ..\Examples\*; DestDir: {autodocs}\Apsim\Examples; Flags: recursesubdirs
-Source: ..\Tests\UnderReview\*; DestDir: {app}\UnderReview; Flags: recursesubdirs
-Source: ..\Tests\UnderReview\*; DestDir: {autodocs}\Apsim\UnderReview; Flags: recursesubdirs
+Source: ..\Tests\UnderReview\*; DestDir: {app}\UnderReview; Flags: recursesubdirs; skipifsourcedoesntexist
+Source: ..\Tests\UnderReview\*; DestDir: {autodocs}\Apsim\UnderReview; Flags: recursesubdirs; skipifsourcedoesntexist
 
 [Tasks]
 Name: desktopicon; Description: Create a &desktop icon; GroupDescription: Additional icons:; Flags: unchecked


### PR DESCRIPTION
e.g. UnderReview. 

Resolves #7478