### PR TITLE
Fix PredictedObserved version upgrade

### DIFF
--- a/Models/Core/ApsimFile/Converter.cs
+++ b/Models/Core/ApsimFile/Converter.cs
@@ -4611,14 +4611,17 @@ namespace Models.Core.ApsimFile
         {
             foreach (JObject predictedObserved in JsonUtilities.ChildrenRecursively(root, "PredictedObserved"))
             {
-                for (int i = 3; i >= 1; --i)
-                {
-                    var key = "FieldName" + i + "UsedForMatch";
-                    var field = predictedObserved[key];
+                var field = predictedObserved["FieldName3UsedForMatch"];
+                if (!String.IsNullOrEmpty(field?.Value<string>()))
+                    predictedObserved["FieldName4UsedForMatch"] = field.Value<string>();
 
-                    if (!String.IsNullOrEmpty(field?.Value<string>()))
-                        predictedObserved["FieldName" + (i + 1) + "UsedForMatch"] = field.Value<string>();
-                }
+                field = predictedObserved["FieldName2UsedForMatch"];
+                if (!String.IsNullOrEmpty(field?.Value<string>()))
+                    predictedObserved["FieldName3UsedForMatch"] = field.Value<string>();
+
+                field = predictedObserved["FieldNameUsedForMatch"];
+                if (!String.IsNullOrEmpty(field?.Value<string>()))
+                    predictedObserved["FieldName2UsedForMatch"] = field.Value<string>();
 
                 predictedObserved["FieldNameUsedForMatch"] = "SimulationName";
             }

--- a/Models/Core/ApsimFile/Converter.cs
+++ b/Models/Core/ApsimFile/Converter.cs
@@ -4617,7 +4617,7 @@ namespace Models.Core.ApsimFile
                     var field = predictedObserved[key];
 
                     if (!String.IsNullOrEmpty(field?.Value<string>()))
-                        field["FieldName" + (i + 1) + "UsedForMatch"] = field.Value<string>();
+                        predictedObserved["FieldName" + (i + 1) + "UsedForMatch"] = field.Value<string>();
                 }
 
                 predictedObserved["FieldNameUsedForMatch"] = "SimulationName";

--- a/Models/Core/ApsimFile/Converter.cs
+++ b/Models/Core/ApsimFile/Converter.cs
@@ -4616,7 +4616,7 @@ namespace Models.Core.ApsimFile
                     var key = "FieldName" + i + "UsedForMatch";
                     var field = predictedObserved[key];
 
-                    if (predictedObserved.ContainsKey(key) && !field.Value<string>().Equals(""))
+                    if (!String.IsNullOrEmpty(field?.Value<string>()))
                         field["FieldName" + (i + 1) + "UsedForMatch"] = field.Value<string>();
                 }
 

--- a/Models/Core/ApsimFile/Converter.cs
+++ b/Models/Core/ApsimFile/Converter.cs
@@ -4611,17 +4611,16 @@ namespace Models.Core.ApsimFile
         {
             foreach (JObject predictedObserved in JsonUtilities.ChildrenRecursively(root, "PredictedObserved"))
             {
-                var fieldName3 = predictedObserved["FieldName3UsedForMatch"];
-                if (!string.IsNullOrEmpty(fieldName3.Value<string>()))
-                    predictedObserved["FieldName4UsedForMatch"] = fieldName3.Value<string>();
-                var fieldName2 = predictedObserved["FieldName2UsedForMatch"];
-                if (!string.IsNullOrEmpty(fieldName2.Value<string>()))
-                    predictedObserved["FieldName3UsedForMatch"] = fieldName2.Value<string>();
-                var fieldName1 = predictedObserved["FieldNameUsedForMatch"];
-                if (!string.IsNullOrEmpty(fieldName1.Value<string>()))
-                    predictedObserved["FieldName2UsedForMatch"] = fieldName1.Value<string>();
-                predictedObserved["FieldNameUsedForMatch"] = "SimulationName";
+                for (int i = 3; i >= 1; --i)
+                {
+                    var key = "FieldName" + i + "UsedForMatch";
+                    var field = predictedObserved[key];
 
+                    if (predictedObserved.ContainsKey(key) && !field.Value<string>().Equals(""))
+                        field["FieldName" + (i + 1) + "UsedForMatch"] = field.Value<string>();
+                }
+
+                predictedObserved["FieldNameUsedForMatch"] = "SimulationName";
             }
         }
 


### PR DESCRIPTION
This change updates the PredictedObserved version upgrade to avoid calling `JObject.Value` on null values, failing on the current standard toolbox.

The logic of this method should be consistent with previous behavior- the method is refactored into a loop.

Resolves #7608 



