### PR TITLE
Replace Bitmap and Image with Gdk.Pixbuf; replace SharpMap with Mapsui.

### DIFF
--- a/APSIM.Documentation/Program.cs
+++ b/APSIM.Documentation/Program.cs
@@ -32,6 +32,7 @@ namespace APSIM.Documentation
         {
             try
             {
+                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
                 // Get autodocs config - ie which models to document.
                 IEnumerable<IDocumentationTable> tables = new[]
                 {

--- a/APSIM.Interop/APSIM.Interop.csproj
+++ b/APSIM.Interop/APSIM.Interop.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="PdfSharpCore" Version="1.2.11" />
     <PackageReference Include="OxyPlot.Core" Version="2.1.0-Preview1" />
     <PackageReference Include="OxyPlot.SkiaSharp" Version="2.1.0-Preview1" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.0-preview.127" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="2.8.2-preview.127" />
   </ItemGroup>
 </Project>

--- a/APSIM.Interop/APSIM.Interop.csproj
+++ b/APSIM.Interop/APSIM.Interop.csproj
@@ -9,16 +9,14 @@
   <ItemGroup>
     <ProjectReference Include="../APSIM.Shared/APSIM.Shared.csproj" />
     <ProjectReference Include="../Models/Models.csproj" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
+    <PackageReference Include="CairoSharp" Version="3.24.24.38" />
+    <PackageReference Include="Mapsui" Version="3.0.2" />
     <PackageReference Include="Markdig" Version="0.22.1" />
     <PackageReference Include="MathNet.Numerics" Version="4.11.0" />
-    <PackageReference Include="Svg" Version="3.2.3" />
-    <PackageReference Include="SharpMap" Version="1.2.0" />
-    <PackageReference Include="SharpMap.Layers.BruTile" Version="1.2.0" />
     <PackageReference Include="ProjNET4GeoAPI" Version="1.4.1" />
     <EmbeddedResource Include="Resources\**" />
+    <PackageReference Include="SkiaSharp" Version="2.88.3" />
     <None Remove="Resources\Images\Swim-layers.png" />
-    <PackageReference Include="SkiaSharp" Version="2.88.0-preview.145" />
   </ItemGroup>
 
   <!-- .NET Core-specific references -->

--- a/APSIM.Interop/Documentation/Renderers/DirectedGraphTagRenderer.cs
+++ b/APSIM.Interop/Documentation/Renderers/DirectedGraphTagRenderer.cs
@@ -34,7 +34,7 @@ namespace APSIM.Interop.Documentation.Renderers
         /// <param name="width">Desired width of the image.</param>
         /// <param name="height">Desired height of the image.</param>
         /// <returns></returns>
-        private Image WriteToImage(DirectedGraph graph, int width, int height)
+        private Gdk.Pixbuf WriteToImage(DirectedGraph graph, int width, int height)
         {
             using (SkiaContext context = new SkiaContext((int)width, (int)height))
             {

--- a/APSIM.Interop/Documentation/Renderers/DirectedGraphTagRenderer.cs
+++ b/APSIM.Interop/Documentation/Renderers/DirectedGraphTagRenderer.cs
@@ -34,7 +34,7 @@ namespace APSIM.Interop.Documentation.Renderers
         /// <param name="width">Desired width of the image.</param>
         /// <param name="height">Desired height of the image.</param>
         /// <returns></returns>
-        private Gdk.Pixbuf WriteToImage(DirectedGraph graph, int width, int height)
+        private SkiaSharp.SKImage WriteToImage(DirectedGraph graph, int width, int height)
         {
             using (SkiaContext context = new SkiaContext((int)width, (int)height))
             {

--- a/APSIM.Interop/Drawing/Skia/SkiaContext.cs
+++ b/APSIM.Interop/Drawing/Skia/SkiaContext.cs
@@ -247,16 +247,17 @@ namespace APSIM.Interop.Drawing.Skia
         /// <summary>
         /// Save the current state of the drawing context to an image.
         /// </summary>
-        public Gdk.Pixbuf Save()
+        public SKImage Save()
         {
-            using (SKImage image = SKImage.FromBitmap(bitmap))
-            using (SKData data = image.Encode(SKEncodedImageFormat.Png, 100))
-            using (MemoryStream stream = new MemoryStream())
-            {
-                data.SaveTo(stream);
-                stream.Seek(0, SeekOrigin.Begin);
-                return new Gdk.Pixbuf(stream);
-            }
+            return SKImage.FromBitmap(bitmap);
+//            using (SKImage image = SKImage.FromBitmap(bitmap))
+//            using (SKData data = image.Encode(SKEncodedImageFormat.Png, 100))
+//            using (MemoryStream stream = new MemoryStream())
+//            {
+//                data.SaveTo(stream);
+//                stream.Seek(0, SeekOrigin.Begin);
+//                return new Gdk.Pixbuf(stream);
+//            }
         }
 
         /// <inheritdoc />

--- a/APSIM.Interop/Drawing/Skia/SkiaContext.cs
+++ b/APSIM.Interop/Drawing/Skia/SkiaContext.cs
@@ -250,14 +250,6 @@ namespace APSIM.Interop.Drawing.Skia
         public SKImage Save()
         {
             return SKImage.FromBitmap(bitmap);
-//            using (SKImage image = SKImage.FromBitmap(bitmap))
-//            using (SKData data = image.Encode(SKEncodedImageFormat.Png, 100))
-//            using (MemoryStream stream = new MemoryStream())
-//            {
-//                data.SaveTo(stream);
-//                stream.Seek(0, SeekOrigin.Begin);
-//                return new Gdk.Pixbuf(stream);
-//            }
         }
 
         /// <inheritdoc />

--- a/APSIM.Interop/Drawing/Skia/SkiaContext.cs
+++ b/APSIM.Interop/Drawing/Skia/SkiaContext.cs
@@ -247,7 +247,7 @@ namespace APSIM.Interop.Drawing.Skia
         /// <summary>
         /// Save the current state of the drawing context to an image.
         /// </summary>
-        public Image Save()
+        public Gdk.Pixbuf Save()
         {
             using (SKImage image = SKImage.FromBitmap(bitmap))
             using (SKData data = image.Encode(SKEncodedImageFormat.Png, 100))
@@ -255,7 +255,7 @@ namespace APSIM.Interop.Drawing.Skia
             {
                 data.SaveTo(stream);
                 stream.Seek(0, SeekOrigin.Begin);
-                return Image.FromStream(stream);
+                return new Gdk.Pixbuf(stream);
             }
         }
 

--- a/APSIM.Interop/Graphing/GraphExporter.cs
+++ b/APSIM.Interop/Graphing/GraphExporter.cs
@@ -45,7 +45,7 @@ namespace APSIM.Interop.Graphing
         /// <param name="graph">Graph to be exported.</param>
         /// <param name="width">Desired width of the image (in px).</param>
         /// <param name="height">Desired height of the image (in px).</param>
-        public Image Export(IGraph graph, double width, double height)
+        public Gdk.Pixbuf Export(IGraph graph, double width, double height)
         {
             return Export(ToPlotModel(graph), width, height);
         }
@@ -56,7 +56,7 @@ namespace APSIM.Interop.Graphing
         /// <param name="plot">Plot model to be exported.</param>
         /// <param name="width">Desired width of the image (in px).</param>
         /// <param name="height">Desired height of the image (in px).</param>
-        public Image Export(IPlotModel plot, double width, double height)
+        public Gdk.Pixbuf Export(IPlotModel plot, double width, double height)
         {
             using (Stream stream = new MemoryStream())
             {
@@ -66,7 +66,7 @@ namespace APSIM.Interop.Graphing
                 exporter.UseTextShaping = false;
                 exporter.Export(plot, stream);
                 stream.Seek(0, SeekOrigin.Begin);
-                return Image.FromStream(stream);
+                return new Gdk.Pixbuf(stream);
 
             }
         }

--- a/APSIM.Interop/Graphing/GraphExporter.cs
+++ b/APSIM.Interop/Graphing/GraphExporter.cs
@@ -45,7 +45,7 @@ namespace APSIM.Interop.Graphing
         /// <param name="graph">Graph to be exported.</param>
         /// <param name="width">Desired width of the image (in px).</param>
         /// <param name="height">Desired height of the image (in px).</param>
-        public Gdk.Pixbuf Export(IGraph graph, double width, double height)
+        public SkiaSharp.SKImage Export(IGraph graph, double width, double height)
         {
             return Export(ToPlotModel(graph), width, height);
         }
@@ -56,7 +56,7 @@ namespace APSIM.Interop.Graphing
         /// <param name="plot">Plot model to be exported.</param>
         /// <param name="width">Desired width of the image (in px).</param>
         /// <param name="height">Desired height of the image (in px).</param>
-        public Gdk.Pixbuf Export(IPlotModel plot, double width, double height)
+        public SkiaSharp.SKImage Export(IPlotModel plot, double width, double height)
         {
             using (Stream stream = new MemoryStream())
             {
@@ -66,8 +66,7 @@ namespace APSIM.Interop.Graphing
                 exporter.UseTextShaping = false;
                 exporter.Export(plot, stream);
                 stream.Seek(0, SeekOrigin.Begin);
-                return new Gdk.Pixbuf(stream);
-
+                return SkiaSharp.SKImage.FromEncodedData(stream);  
             }
         }
 

--- a/APSIM.Interop/Graphing/IGraphExporter.cs
+++ b/APSIM.Interop/Graphing/IGraphExporter.cs
@@ -15,7 +15,7 @@ namespace APSIM.Interop.Graphing
         /// <param name="graph">Graph to be converted.</param>
         /// <param name="width">Desired width of the image (in px).</param>
         /// <param name="height">Desired height of the image (in px).</param>
-        Gdk.Pixbuf Export(IGraph graph, double width, double height);
+        SkiaSharp.SKImage Export(IGraph graph, double width, double height);
 
         /// <summary>
         /// Export a plot model to an image.
@@ -23,7 +23,7 @@ namespace APSIM.Interop.Graphing
         /// <param name="plot">Plot model to be exported.</param>
         /// <param name="width">Desired width of the image (in px).</param>
         /// <param name="height">Desired height of the image (in px).</param>
-        Gdk.Pixbuf Export(IPlotModel plot, double width, double height);
+        SkiaSharp.SKImage Export(IPlotModel plot, double width, double height);
 
         /// <summary>
         /// Convert the given apsim graph to an oxyplot <see cref="PlotModel"/>.

--- a/APSIM.Interop/Graphing/IGraphExporter.cs
+++ b/APSIM.Interop/Graphing/IGraphExporter.cs
@@ -15,7 +15,7 @@ namespace APSIM.Interop.Graphing
         /// <param name="graph">Graph to be converted.</param>
         /// <param name="width">Desired width of the image (in px).</param>
         /// <param name="height">Desired height of the image (in px).</param>
-        Image Export(IGraph graph, double width, double height);
+        Gdk.Pixbuf Export(IGraph graph, double width, double height);
 
         /// <summary>
         /// Export a plot model to an image.
@@ -23,7 +23,7 @@ namespace APSIM.Interop.Graphing
         /// <param name="plot">Plot model to be exported.</param>
         /// <param name="width">Desired width of the image (in px).</param>
         /// <param name="height">Desired height of the image (in px).</param>
-        Image Export(IPlotModel plot, double width, double height);
+        Gdk.Pixbuf Export(IPlotModel plot, double width, double height);
 
         /// <summary>
         /// Convert the given apsim graph to an oxyplot <see cref="PlotModel"/>.

--- a/APSIM.Interop/Mapping/MapRenderer.cs
+++ b/APSIM.Interop/Mapping/MapRenderer.cs
@@ -1,23 +1,17 @@
-using System;
-using SharpMap;
-using MapTag = Models.Mapping.MapTag;
-using System.Drawing;
-using NetTopologySuite;
-using NetTopologySuite.Geometries;
-using SharpMap.Data.Providers;
-using SharpMap.Layers;
-using SharpMap.Styles;
-using System.Collections.Generic;
-using System.Linq;
-using GeoAPI;
-using GeoAPI.Geometries;
 using APSIM.Shared.Utilities;
-using ProjNet.CoordinateSystems;
-using SharpMap.CoordinateSystems;
-using ProjNet.CoordinateSystems.Transformations;
+using DocumentFormat.OpenXml.Wordprocessing;
+using GLib;
+using Mapsui;
+using Mapsui.Layers;
+using Mapsui.Projection;
+using Mapsui.Styles;
+using Mapsui.Utilities;
+using System;
+using System.Collections.Generic;
 using System.IO;
-using System.Text;
-using GeoAPI.CoordinateSystems.Transformations;
+using System.Linq;
+using System.Threading;
+using MapTag = Models.Mapping.MapTag;
 
 namespace APSIM.Interop.Mapping
 {
@@ -31,15 +25,6 @@ namespace APSIM.Interop.Mapping
         /// </summary>
         static MapRenderer()
         {
-            Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
-            GeometryServiceProvider.Instance = new NtsGeometryServices();
-            var coordFactory = new CoordinateSystemFactory(System.Text.Encoding.Unicode);
-            var css = new CoordinateSystemServices(coordFactory, new CoordinateTransformationFactory());
-            css.AddCoordinateSystem(3857, coordFactory.CreateFromWkt("PROJCS[\"WGS 84 / Pseudo-Mercator\", GEOGCS[\"WGS 84\", DATUM[\"WGS_1984\", SPHEROID[\"WGS 84\", 6378137, 298.257223563, AUTHORITY[\"EPSG\", \"7030\"]], AUTHORITY[\"EPSG\", \"6326\"]], PRIMEM[\"Greenwich\", 0, AUTHORITY[\"EPSG\", \"8901\"]], UNIT[\"degree\", 0.0174532925199433, AUTHORITY[\"EPSG\", \"9122\"]], AUTHORITY[\"EPSG\", \"4326\"]], UNIT[\"metre\", 1, AUTHORITY[\"EPSG\", \"9001\"]], PROJECTION[\"Mercator_1SP\"], PARAMETER[\"latitude_of_origin\", 0], PARAMETER[\"central_meridian\", 0], PARAMETER[\"scale_factor\", 1], PARAMETER[\"false_easting\", 0], PARAMETER[\"false_northing\", 0], AUTHORITY[\"EPSG\", \"3857\"]]"));
-            css.AddCoordinateSystem(4326, coordFactory.CreateFromWkt("GEOGCS[\"WGS 84\", DATUM[\"WGS_1984\", SPHEROID[\"WGS 84\", 6378137, 298.257223563, AUTHORITY[\"EPSG\", \"7030\"]], AUTHORITY[\"EPSG\", \"6326\"]], PRIMEM[\"Greenwich\", 0, AUTHORITY[\"EPSG\", \"8901\"]], UNIT[\"degree\", 0.0174532925199433, AUTHORITY[\"EPSG\", \"9122\"]], AUTHORITY[\"EPSG\", \"4326\"]]"));
-            Session.Instance.SetGeometryServices(GeoAPI.GeometryServiceProvider.Instance)
-                            .SetCoordinateSystemServices(css)
-                            .SetCoordinateSystemRepository(css);
         }
 
         /// <remarks>
@@ -48,34 +33,12 @@ namespace APSIM.Interop.Mapping
         /// specified? Where do we get the map? What projection do we use? These remarks are intended to 
         /// (slightly) clarify what is going on.
         /// 
-        /// We are using SharpMap to do the map rendering, and BruTile to fetch a suitable base map. The basemap 
+        /// We are using Mapsui to do the map rendering, which in turn uses BruTile to fetch a suitable base map. The basemap 
         /// tiles use a "projected" coordinate system, specifically EPSG 3857 (also known as Web Mercator); 
         /// the units in this system are (perhaps surpisingly) metres. However, the point data we wish to plot
         /// is expressed as latitude and longitude (using a "geographic" coordinate system, specifically EPSG 4326),
         /// with units of decimal degrees. Note that both are based on WGS84, so they have the same underlying
-        /// model of the shape of the earth, but use vastly different units. The two transformation objects defined 
-        /// below handle coordinate transformation.
-        /// 
-        /// An earlier version of this unit made a call to SharpMap.Converters.WellKnownText.SpatialReference.GetAllReferenceSystems
-        /// to obtain the co-ordinate systems. That call then attempted to generate a 3 MByte file with almost 4000 different
-        /// systems in it; we only needed 2. We can generate those we need from their WKT descriptions. If additions reference
-        /// systems are needed, their WKT descriptions should be available for download from spatialreference.org.
-        /// </remarks>
-        /// <summary>
-        /// Performs coordinate transformation from latitude/longitude (WGS84) to metres (WebMercator).
-        /// </summary>
-        private static readonly ICoordinateTransformation latLonToMetres = new
-                            CoordinateTransformationFactory().CreateFromCoordinateSystems(
-                                GeographicCoordinateSystem.WGS84,
-                                ProjectedCoordinateSystem.WebMercator);
-
-        /// <summary>
-        /// Performs coordinate transformation from  metres (WebMercator) to latitude/longitude (WGS84).
-        /// </summary>
-        private static readonly ICoordinateTransformation metresToLatLon = new
-                            CoordinateTransformationFactory().CreateFromCoordinateSystems(
-                                ProjectedCoordinateSystem.WebMercator,
-                                GeographicCoordinateSystem.WGS84);
+        /// model of the shape of the earth, but use vastly different units. 
 
         /// <summary>
         /// Indicates the ratio between steps when zooming.
@@ -83,67 +46,101 @@ namespace APSIM.Interop.Mapping
         private const double zoomStepFactor = 1.5;
 
         /// <summary>
-        /// Render the map as a <see cref="System.Drawing.Image"/>.
-        /// </summary>
-        /// <param name="map">Map tag to be rendered.</param>
-        /// <param name="renderer">PDF renderer to use for rendering the tag.</param>
-        public static Image ToImage(this MapTag map)
-        {
-            return map.ToSharpMap().GetMap();
-        }
-
-        /// <summary>
-        /// Render the map as a <see cref="System.Drawing.Image"/> of the specified size.
+        /// Render the map as a <see cref="Gdk.Pixbuf"/> of the specified size.
         /// </summary>
         /// <param name="map">Map tag to be rendered.</param>
         /// <param name="width">Width of the map in px.</param>
-        /// <param name="renderer">PDF renderer to use for rendering the tag.</param>
-        public static Image ToImage(this MapTag map, int width)
+        public static Gdk.Pixbuf ToImage(this MapTag map, int width)
         {
-            Map exported = map.ToSharpMap();
-            exported.Size = new Size(width, width);
-            return exported.GetMap();
+            Map exported = map.ToMapsuiMap();
+            Viewport viewport = new Viewport();
+            Mapsui.Geometries.Point centerMetric = Mapsui.Projection.SphericalMercator.FromLonLat(map.Center.Longitude, map.Center.Latitude);
+            viewport.SetCenter(centerMetric.X, centerMetric.Y);
+            viewport.SetSize(width, width);
+            // Compat check for old zoom units. Should really have used a converter...
+            double zoom = map.Zoom - 1.0;
+            if (zoom >= 60.0 || zoom < 0.0) // Convert any "old" zoom levels into whole-world maps
+                zoom = 0.0;
+            // map.Zoom = map.MaximumZoom / Math.Pow(MapRenderer.GetZoomStepFactor(), setValue);
+            double resolution = (78271.51696401953125 * 512 / width) / Math.Pow(MapRenderer.GetZoomStepFactor(), zoom);
+            viewport.SetResolution(resolution);
+
+            Gdk.Pixbuf result = null;
+            TileLayer osmLayer = exported.Layers.FindLayer("OpenStreetMap").FirstOrDefault() as TileLayer;
+
+            Mapsui.Fetcher.DataChangedEventHandler changedHandler = (s, e) =>
+            {
+                var layer = (TileLayer)s;
+                if (((!osmLayer.Busy && e.Error == null) || e.Error != null) && !e.Cancelled)
+                {
+                    if (e.Error != null)
+                    // Try to handle failure to fetch Open Street Map layer
+                    // by displaying the country outline layer instead
+                    {
+                        osmLayer.Enabled = false;
+                        Layer countryLayer = exported.Layers.FindLayer("Countries").FirstOrDefault() as Layer;
+                        if (countryLayer != null)
+                        {
+                            countryLayer.Enabled = true;
+                            countryLayer.RefreshData(viewport.Extent, viewport.Resolution, ChangeType.Discrete);
+                            // Give the "country" layer time to be loaded, if necessary.
+                            // Seven seconds should be way more than enough...
+                            int nSleeps = 0;
+                            while (countryLayer.Busy && nSleeps++ < 700)
+                                System.Threading.Thread.Sleep(10);
+                        }
+                    }
+                    MemoryStream bitmap = new Mapsui.Rendering.Skia.MapRenderer().RenderToBitmapStream(viewport, exported.Layers, exported.BackColor);
+                    bitmap.Seek(0, SeekOrigin.Begin);
+                    result = new Gdk.Pixbuf(bitmap);
+                }
+            };
+
+            if (osmLayer != null)
+            {
+                osmLayer.Enabled = true;
+                osmLayer.AbortFetch();
+                osmLayer.ClearCache();
+                osmLayer.DataChanged += changedHandler;
+                osmLayer.RefreshData(viewport.Extent, viewport.Resolution, ChangeType.Discrete);
+            }
+            // Allow ourselves up to 10 seconds to get a map.
+            int nSleeps = 0;
+            while (result == null && nSleeps++ < 1000)
+                System.Threading.Thread.Sleep(10);
+
+            osmLayer.DataChanged -= changedHandler;
+            return result;
         }
 
         /// <summary>
         /// Create a <see cref="Map"/> representing this map object.
         /// </summary>
         /// <param name="map">A map to be exported/rendered.</param>
-        public static Map ToSharpMap(this MapTag map)
+        public static Map ToMapsuiMap(this MapTag map)
         {
             Map result = InitMap();
 
-            GeometryFactory gf = new GeometryFactory(new PrecisionModel(), 4326);
-            List<IGeometry> locations = map.Markers.Select(c => gf.CreatePoint(new Coordinate(c.Longitude, c.Latitude))).ToList<IGeometry>();
-            VectorLayer markerLayer = new VectorLayer("Markers");
-            markerLayer.Style.Symbol = APSIM.Shared.Documentation.Image.LoadFromResource("Marker.png");
-            markerLayer.Style.SymbolOffset = new PointF(0, -16); // Offset so the point is marked by the tip of the symbol, not its center
-            markerLayer.DataSource = new GeometryProvider(locations);
-            markerLayer.CoordinateTransformation = latLonToMetres;
+            Mapsui.Layers.MemoryLayer markerLayer = new Mapsui.Layers.MemoryLayer("Markers")
+            {
+                Transformation = new MinimalTransformation(),
+                CRS = "EPSG:3857"
+            };
 
+            Stream markerStream = APSIM.Shared.Documentation.Image.GetStreamFromResource("Marker.png");
+            int bitmapId = BitmapRegistry.Instance.Register(markerStream);
+            markerLayer.Style = new SymbolStyle { BitmapId = bitmapId, SymbolScale = 1.0, SymbolOffset = new Offset(0.0, 0.5, true) };
+
+            List<Mapsui.Geometries.Point> locations = map.Markers.Select(c => Mapsui.Projection.SphericalMercator.FromLonLat(c.Longitude, c.Latitude)).ToList<Mapsui.Geometries.Point>();
+            markerLayer.DataSource = new Mapsui.Providers.MemoryProvider(locations)
+            {
+                CRS = "EPSG:3857"
+            };
             result.Layers.Add(markerLayer);
-
-            // Compat check for old zoom units. Should really have used a converter...
-            double zoom = map.Zoom - 1;
-            if (zoom >= 60)
-                zoom = 0;
-            result.Zoom = result.MaximumZoom / Math.Pow(zoomStepFactor, zoom);
-
-            Coordinate location = latLonToMetres.MathTransform.Transform(new Coordinate(map.Center.Longitude, map.Center.Latitude));
-            result.Center = location;
 
             return result;
         }
 
-        /// <summary>
-        /// Get a coordinate transformation to convert a latitude and longitude to metres.
-        /// </summary>
-        public static ICoordinateTransformation GetLatLonToMetres() => latLonToMetres;
-
-        /// <summary>
-        /// Get a coordinate transformation to convert metres into a latitude and longitude.
-        /// </summary>
-        public static ICoordinateTransformation GetMetresToLatLon() => metresToLatLon;
 
         /// <summary>
         /// Get the zoom step factor. This is the ratio of each zoom increment to
@@ -157,15 +154,20 @@ namespace APSIM.Interop.Mapping
         /// </summary>
         private static Map InitMap()
         {
-            var result = new SharpMap.Map();
-            result.BackColor = Color.LightBlue;
-            result.Center = new Coordinate(0, 0);
-            result.SRID = 3857;
+            Map result = new Map
+            {
+                CRS = "EPSG:3857",
+                Transformation = new MinimalTransformation()
+            };
+            result.BackColor = Mapsui.Styles.Color.FromString("LightBlue");
 
-            BruTile.Cache.FileCache fileCache = new BruTile.Cache.FileCache(Path.Combine(Path.GetTempPath(), "OSM Map Tiles"), "png", new TimeSpan(100, 0, 0, 0));
-            TileLayer baseLayer = new TileLayer(BruTile.Predefined.KnownTileSources.Create(BruTile.Predefined.KnownTileSource.OpenStreetMap, persistentCache: fileCache, userAgent: "APSIM Next Generation"), "OpenStreetMap");
-            result.BackgroundLayer.Add(baseLayer);
-            result.MaximumZoom = baseLayer.Envelope.Width;
+            Mapsui.Layers.TileLayer osmLayer = OpenStreetMap.CreateTileLayer("APSIM Next Generation");
+            if (osmLayer.TileSource is BruTile.Web.HttpTileSource)
+            {
+                BruTile.Cache.FileCache fileCache = new BruTile.Cache.FileCache(Path.Combine(Path.GetTempPath(), "OSM Map Tiles"), "png", new TimeSpan(100, 0, 0, 0));
+                (osmLayer.TileSource as BruTile.Web.HttpTileSource).PersistentCache = fileCache;
+            }
+            result.Layers.Add(osmLayer);
 
             // This layer is used only as a sort of backup in case the BruTile download times out
             // or is otherwise unavailable.
@@ -174,18 +176,26 @@ namespace APSIM.Interop.Mapping
             string shapeFileName = Path.Combine(apsimx, "ApsimNG", "Resources", "world", "countries.shp");
             if (File.Exists(shapeFileName))
             {
-                VectorLayer layWorld = new VectorLayer("Countries");
-                layWorld.DataSource = new ShapeFile(shapeFileName, true);
-                layWorld.Style = new VectorStyle();
-                layWorld.Style.EnableOutline = true;
-                // Color background = Colour.FromGtk(MainWidget.GetBackgroundColour(StateFlags.Normal));
-                // Color foreground = Colour.FromGtk(MainWidget.GetForegroundColour(StateFlags.Normal));
-                // layWorld.Style.Fill = new SolidBrush(background);
-                // layWorld.Style.Outline.Color = foreground;
-                layWorld.CoordinateTransformation = latLonToMetres;
-                result.BackgroundLayer.Insert(0, layWorld);
+                Mapsui.Layers.Layer layWorld = new Mapsui.Layers.Layer
+                {
+                    Name = "Countries",
+                    CRS = "EPSG:3857",
+                    Transformation = new MinimalTransformation()
+                };                
+                layWorld.DataSource = new Mapsui.Providers.Shapefile.ShapeFile(shapeFileName, true) 
+                { 
+                    CRS = "EPSG:4326" 
+                };
+                layWorld.Style = new Mapsui.Styles.VectorStyle
+                {
+                    Outline = new Mapsui.Styles.Pen { Color = Mapsui.Styles.Color.Black },
+                    Fill = new Mapsui.Styles.Brush { Color = Mapsui.Styles.Color.White }
+                };
+                layWorld.Style.Enabled = true;
+                layWorld.FetchingPostponedInMilliseconds = 1;
+                layWorld.Enabled = false;
+                result.Layers.Insert(0, layWorld);
             }
-
             return result;
         }
     }

--- a/APSIM.Interop/Mapping/MapRenderer.cs
+++ b/APSIM.Interop/Mapping/MapRenderer.cs
@@ -1,6 +1,5 @@
 using APSIM.Shared.Utilities;
 using DocumentFormat.OpenXml.Wordprocessing;
-using GLib;
 using Mapsui;
 using Mapsui.Layers;
 using Mapsui.Projection;
@@ -46,11 +45,11 @@ namespace APSIM.Interop.Mapping
         private const double zoomStepFactor = 1.5;
 
         /// <summary>
-        /// Render the map as a <see cref="Gdk.Pixbuf"/> of the specified size.
+        /// Render the map as a <see cref="SkiaSharp.SKImage"/> of the specified size.
         /// </summary>
         /// <param name="map">Map tag to be rendered.</param>
         /// <param name="width">Width of the map in px.</param>
-        public static Gdk.Pixbuf ToImage(this MapTag map, int width)
+        public static SkiaSharp.SKImage ToImage(this MapTag map, int width)
         {
             Map exported = map.ToMapsuiMap();
             Viewport viewport = new Viewport();
@@ -65,7 +64,7 @@ namespace APSIM.Interop.Mapping
             double resolution = (78271.51696401953125 * 512 / width) / Math.Pow(MapRenderer.GetZoomStepFactor(), zoom);
             viewport.SetResolution(resolution);
 
-            Gdk.Pixbuf result = null;
+            SkiaSharp.SKImage result = null;
             TileLayer osmLayer = exported.Layers.FindLayer("OpenStreetMap").FirstOrDefault() as TileLayer;
 
             Mapsui.Fetcher.DataChangedEventHandler changedHandler = (s, e) =>
@@ -92,7 +91,7 @@ namespace APSIM.Interop.Mapping
                     }
                     MemoryStream bitmap = new Mapsui.Rendering.Skia.MapRenderer().RenderToBitmapStream(viewport, exported.Layers, exported.BackColor);
                     bitmap.Seek(0, SeekOrigin.Begin);
-                    result = new Gdk.Pixbuf(bitmap);
+                    result = SkiaSharp.SKImage.FromEncodedData(bitmap);
                 }
             };
 

--- a/APSIM.Interop/Markdown/Renderers/Inlines/LinkInlineRenderer.cs
+++ b/APSIM.Interop/Markdown/Renderers/Inlines/LinkInlineRenderer.cs
@@ -37,7 +37,7 @@ namespace APSIM.Interop.Markdown.Renderers.Inlines
             string uri = link.GetDynamicUrl != null ? link.GetDynamicUrl() ?? link.Url : link.Url;
             if (link.IsImage)
             {
-                Gdk.Pixbuf image = GetImage(uri);
+                SkiaSharp.SKImage image = GetImage(uri);
                 // Technically, the image should be written to the same paragraph as any existing content.
                 // However, if the image is too large, I'm going to add it to its own paragraph.
                 // I'm defining "too large" as "taller than page height * 0.9".
@@ -75,7 +75,7 @@ namespace APSIM.Interop.Markdown.Renderers.Inlines
         /// Get the image specified by the given url.
         /// </summary>
         /// <param name="uri">Image URI.</param>
-        public virtual Gdk.Pixbuf GetImage(string uri)
+        public virtual SkiaSharp.SKImage GetImage(string uri)
         {
             return APSIM.Shared.Documentation.Image.LoadImage(uri, imageRelativePath);
         }

--- a/APSIM.Interop/Markdown/Renderers/Inlines/LinkInlineRenderer.cs
+++ b/APSIM.Interop/Markdown/Renderers/Inlines/LinkInlineRenderer.cs
@@ -37,7 +37,7 @@ namespace APSIM.Interop.Markdown.Renderers.Inlines
             string uri = link.GetDynamicUrl != null ? link.GetDynamicUrl() ?? link.Url : link.Url;
             if (link.IsImage)
             {
-                Image image = GetImage(uri);
+                Gdk.Pixbuf image = GetImage(uri);
                 // Technically, the image should be written to the same paragraph as any existing content.
                 // However, if the image is too large, I'm going to add it to its own paragraph.
                 // I'm defining "too large" as "taller than page height * 0.9".
@@ -75,7 +75,7 @@ namespace APSIM.Interop.Markdown.Renderers.Inlines
         /// Get the image specified by the given url.
         /// </summary>
         /// <param name="uri">Image URI.</param>
-        public virtual Image GetImage(string uri)
+        public virtual Gdk.Pixbuf GetImage(string uri)
         {
             return APSIM.Shared.Documentation.Image.LoadImage(uri, imageRelativePath);
         }

--- a/APSIM.Interop/Markdown/Renderers/PdfBuilder.cs
+++ b/APSIM.Interop/Markdown/Renderers/PdfBuilder.cs
@@ -535,7 +535,7 @@ namespace APSIM.Interop.Markdown.Renderers
         /// Append an image to the PDF document.
         /// </summary>
         /// <param name="image">Image to be appended.</param>
-        public void AppendImage(Image image)
+        public void AppendImage(Gdk.Pixbuf image)
         {
             AppendImage(image, GetLastParagraph());
         }
@@ -957,7 +957,7 @@ namespace APSIM.Interop.Markdown.Renderers
         /// </summary>
         /// <param name="image">Image to be appended.</param>
         /// <param name="paragraph">The paragraph to which the image should be appended.</param>
-        private void AppendImage(Image image, Paragraph paragraph)
+        private void AppendImage(Gdk.Pixbuf image, Paragraph paragraph)
         {
             // The image could potentially be too large. Therfore we read it,
             // adjust the size to fit the page better (if necessary), and add
@@ -971,8 +971,7 @@ namespace APSIM.Interop.Markdown.Renderers
             IImageSource imageSource = ImageSource.FromStream(Guid.NewGuid().ToString().Replace("-", ""), () =>
             {
                 image = ReadAndResizeImage(image, pageWidth, pageHeight);
-                Stream stream = new MemoryStream();
-                image.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
+                Stream stream = new MemoryStream(image.SaveToBuffer("png"));
                 stream.Seek(0, SeekOrigin.Begin);
                 return stream;
             });
@@ -1013,7 +1012,7 @@ namespace APSIM.Interop.Markdown.Renderers
         /// <param name="image">The image to be resized.</param>
         /// <param name="targetWidth">Max allowed width of the image in pixels.</param>
         /// <param name="targetHeight">Max allowed height of the image in pixels.</param>
-        private static Image ReadAndResizeImage(Image image, double targetWidth, double targetHeight)
+        private static Gdk.Pixbuf ReadAndResizeImage(Gdk.Pixbuf image, double targetWidth, double targetHeight)
         {
             if ( (targetWidth > 0 && image.Width > targetWidth) || (targetHeight > 0 && image.Height > targetHeight) )
                 image = ImageUtilities.ResizeImage(image, targetWidth, targetHeight);

--- a/APSIM.Interop/Markdown/Renderers/PdfBuilder.cs
+++ b/APSIM.Interop/Markdown/Renderers/PdfBuilder.cs
@@ -535,7 +535,7 @@ namespace APSIM.Interop.Markdown.Renderers
         /// Append an image to the PDF document.
         /// </summary>
         /// <param name="image">Image to be appended.</param>
-        public void AppendImage(Gdk.Pixbuf image)
+        public void AppendImage(SkiaSharp.SKImage image)
         {
             AppendImage(image, GetLastParagraph());
         }
@@ -957,7 +957,7 @@ namespace APSIM.Interop.Markdown.Renderers
         /// </summary>
         /// <param name="image">Image to be appended.</param>
         /// <param name="paragraph">The paragraph to which the image should be appended.</param>
-        private void AppendImage(Gdk.Pixbuf image, Paragraph paragraph)
+        private void AppendImage(SkiaSharp.SKImage image, Paragraph paragraph)
         {
             // The image could potentially be too large. Therfore we read it,
             // adjust the size to fit the page better (if necessary), and add
@@ -971,7 +971,7 @@ namespace APSIM.Interop.Markdown.Renderers
             IImageSource imageSource = ImageSource.FromStream(Guid.NewGuid().ToString().Replace("-", ""), () =>
             {
                 image = ReadAndResizeImage(image, pageWidth, pageHeight);
-                Stream stream = new MemoryStream(image.SaveToBuffer("png"));
+                Stream stream = new MemoryStream(image.Encode(SkiaSharp.SKEncodedImageFormat.Png, 100).ToArray());
                 stream.Seek(0, SeekOrigin.Begin);
                 return stream;
             });
@@ -1012,7 +1012,7 @@ namespace APSIM.Interop.Markdown.Renderers
         /// <param name="image">The image to be resized.</param>
         /// <param name="targetWidth">Max allowed width of the image in pixels.</param>
         /// <param name="targetHeight">Max allowed height of the image in pixels.</param>
-        private static Gdk.Pixbuf ReadAndResizeImage(Gdk.Pixbuf image, double targetWidth, double targetHeight)
+        private static SkiaSharp.SKImage ReadAndResizeImage(SkiaSharp.SKImage image, double targetWidth, double targetHeight)
         {
             if ( (targetWidth > 0 && image.Width > targetWidth) || (targetHeight > 0 && image.Height > targetHeight) )
                 image = ImageUtilities.ResizeImage(image, targetWidth, targetHeight);

--- a/APSIM.Interop/Utility/ImageUtilities.cs
+++ b/APSIM.Interop/Utility/ImageUtilities.cs
@@ -15,23 +15,15 @@ namespace APSIM.Interop.Utility
         /// <param name="image">The image to resize.</param>
         /// <param name="targetWidth">The width to aim for when rescaling.</param>
         /// <param name="targetHeight">The height to aim for when rescaling.</param>
-        public static Image ResizeImage(Image image, double targetWidth, double targetHeight)
+        public static Gdk.Pixbuf ResizeImage(Gdk.Pixbuf image, double targetWidth, double targetHeight)
         {
             // Determine scaling.
             double scale = Math.Min(targetWidth / image.Width, targetHeight / image.Height);
             var scaleWidth = (int)(image.Width * scale);
             var scaleHeight = (int)(image.Height * scale);
-            // var scaleRectangle = new Rectangle(((int)targetWidth - scaleWidth) / 2, ((int)targetHeight - scaleHeight) / 2, scaleWidth, scaleHeight);
-            var scaleRectangle = new Rectangle(0, 0, scaleWidth, scaleHeight);
 
             // Create a scaled image.
-            Bitmap scaledImage = new Bitmap((int)scaleWidth, (int)scaleHeight);
-            using (var graph = Graphics.FromImage(scaledImage))
-            {
-                graph.DrawImage(image, scaleRectangle);
-            }
-
-            return scaledImage;
+            return image.ScaleSimple(scaleWidth, scaleHeight, Gdk.InterpType.Bilinear);
         }
 
         /// <summary>

--- a/APSIM.Shared/APSIM.Shared.csproj
+++ b/APSIM.Shared/APSIM.Shared.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="DocumentFormat.OpenXml" Version="2.11.0" />
     <PackageReference Include="ExcelDataReader.DataSet" Version="3.6.0" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="7.5.0" />
+    <PackageReference Include="GtkSharp" Version="3.24.24.34" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
     <PackageReference Include="Docker.DotNet" Version="3.125.5" />

--- a/APSIM.Shared/APSIM.Shared.csproj
+++ b/APSIM.Shared/APSIM.Shared.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="7.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="SkiaSharp" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
     <PackageReference Include="Docker.DotNet" Version="3.125.5" />
   </ItemGroup>

--- a/APSIM.Shared/APSIM.Shared.csproj
+++ b/APSIM.Shared/APSIM.Shared.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="DocumentFormat.OpenXml" Version="2.11.0" />
     <PackageReference Include="ExcelDataReader.DataSet" Version="3.6.0" />
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="7.5.0" />
-    <PackageReference Include="GtkSharp" Version="3.24.24.34" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="SkiaSharp" Version="2.88.3" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
     <PackageReference Include="Docker.DotNet" Version="3.125.5" />
   </ItemGroup>

--- a/APSIM.Shared/Documentation/Image.cs
+++ b/APSIM.Shared/Documentation/Image.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using SkiaSharp;
 using Bitmap = System.Drawing.Bitmap;
 
 namespace APSIM.Shared.Documentation
@@ -19,11 +20,11 @@ namespace APSIM.Shared.Documentation
     /// </remarks>
     public class Image : ITag
     {
-        private Gdk.Pixbuf raster;
+        private SkiaSharp.SKImage raster;
         private string resourceName;
 
         /// <summary>The image to put into the doc.</summary>
-        public Gdk.Pixbuf GetRaster(string relativePath)
+        public SkiaSharp.SKImage GetRaster(string relativePath)
         {
             if (raster != null)
                 return raster;
@@ -36,7 +37,7 @@ namespace APSIM.Shared.Documentation
         /// </summary>
         /// <param name="uri">Image URI.</param>
         /// <param name="imageSearchPath">The path on which to search for an image with the given filename.</param>
-        public static Gdk.Pixbuf LoadImage(string uri, string imageSearchPath)
+        public static SkiaSharp.SKImage LoadImage(string uri, string imageSearchPath)
         {
             if (string.IsNullOrWhiteSpace(uri))
                 throw new InvalidOperationException("Unable to load image: resource name not specified");
@@ -59,9 +60,9 @@ namespace APSIM.Shared.Documentation
         /// Read an image from disk.
         /// </summary>
         /// <param name="fileName">Absolute path to the file on disk.</param>
-        public static Gdk.Pixbuf LoadFromFile(string fileName)
+        public static SkiaSharp.SKImage LoadFromFile(string fileName)
         {
-            return new Gdk.Pixbuf(fileName);
+            return SkiaSharp.SKImage.FromEncodedData(fileName);
         }
 
         /// <summary>
@@ -69,10 +70,10 @@ namespace APSIM.Shared.Documentation
         /// Will attempt to locate the resource in various assemblies.
         /// </summary>
         /// <param name="resourceName">Resource file name.</param>
-        public static Gdk.Pixbuf LoadFromResource(string resourceName)
+        public static SkiaSharp.SKImage LoadFromResource(string resourceName)
         {
             using (Stream stream = GetStreamFromResource(resourceName))
-                return new Gdk.Pixbuf(stream);
+                return SkiaSharp.SKImage.FromEncodedData(stream);
         }
 
         /// <summary>
@@ -117,7 +118,7 @@ namespace APSIM.Shared.Documentation
         /// Create an Image tag for a given image object.
         /// </summary>
         /// <param name="image">The image.</param>
-        public Image(Gdk.Pixbuf image) => raster = image;
+        public Image(SkiaSharp.SKImage image) => raster = image;
 
         /// <summary>
         /// Create an Image tag from a resource name. The resource name

--- a/APSIM.Shared/Documentation/Image.cs
+++ b/APSIM.Shared/Documentation/Image.cs
@@ -19,11 +19,11 @@ namespace APSIM.Shared.Documentation
     /// </remarks>
     public class Image : ITag
     {
-        private System.Drawing.Image raster;
+        private Gdk.Pixbuf raster;
         private string resourceName;
 
         /// <summary>The image to put into the doc.</summary>
-        public System.Drawing.Image GetRaster(string relativePath)
+        public Gdk.Pixbuf GetRaster(string relativePath)
         {
             if (raster != null)
                 return raster;
@@ -36,7 +36,7 @@ namespace APSIM.Shared.Documentation
         /// </summary>
         /// <param name="uri">Image URI.</param>
         /// <param name="imageSearchPath">The path on which to search for an image with the given filename.</param>
-        public static System.Drawing.Image LoadImage(string uri, string imageSearchPath)
+        public static Gdk.Pixbuf LoadImage(string uri, string imageSearchPath)
         {
             if (string.IsNullOrWhiteSpace(uri))
                 throw new InvalidOperationException("Unable to load image: resource name not specified");
@@ -59,12 +59,9 @@ namespace APSIM.Shared.Documentation
         /// Read an image from disk.
         /// </summary>
         /// <param name="fileName">Absolute path to the file on disk.</param>
-        public static System.Drawing.Image LoadFromFile(string fileName)
+        public static Gdk.Pixbuf LoadFromFile(string fileName)
         {
-            // Image.FromFile() will cause the file to be locked until the image is disposed of. 
-            // This workaround allows us to immediately release the lock on the file.
-            using (Bitmap bmp = new Bitmap(fileName))
-                return new Bitmap(bmp);
+            return new Gdk.Pixbuf(fileName);
         }
 
         /// <summary>
@@ -72,13 +69,20 @@ namespace APSIM.Shared.Documentation
         /// Will attempt to locate the resource in various assemblies.
         /// </summary>
         /// <param name="resourceName">Resource file name.</param>
-        public static System.Drawing.Image LoadFromResource(string resourceName)
+        public static Gdk.Pixbuf LoadFromResource(string resourceName)
         {
             using (Stream stream = GetStreamFromResource(resourceName))
-                return System.Drawing.Image.FromStream(stream);
+                return new Gdk.Pixbuf(stream);
         }
 
-        private static Stream GetStreamFromResource(string resourceName)
+        /// <summary>
+        /// Loads an image stream from the given resource name
+        /// Will attempt to locate the resource in various assemblies.
+        /// </summary>
+        /// <param name="resourceName">Name of the resource</param>
+        /// <returns>The resource as a stream</returns>
+        /// <exception cref="FileNotFoundException"></exception>
+        public static Stream GetStreamFromResource(string resourceName)
         {
             foreach (Assembly assembly in GetAssemblies())
             {
@@ -113,7 +117,7 @@ namespace APSIM.Shared.Documentation
         /// Create an Image tag for a given image object.
         /// </summary>
         /// <param name="image">The image.</param>
-        public Image(System.Drawing.Image image) => raster = image;
+        public Image(Gdk.Pixbuf image) => raster = image;
 
         /// <summary>
         /// Create an Image tag from a resource name. The resource name

--- a/ApsimNG/ApsimNG.csproj
+++ b/ApsimNG/ApsimNG.csproj
@@ -47,13 +47,10 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0-1.final" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="3.7.0-1.final" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0-1.final" />
-    <PackageReference Include="SharpMap" Version="1.2.0" />
-    <PackageReference Include="SharpMap.Layers.BruTile" Version="1.2.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0-preview.1.20120.5" />
     <PackageReference Include="System.Resources.Extensions" Version="5.0.0-preview.1.20120.5" />
     <PackageReference Include="ISO3166" Version="1.0.3" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.1" />
-    <PackageReference Include="ProjNET4GeoAPI" Version="1.4.1" />
     <PackageReference Include="Microsoft.Toolkit.Parsers" Version="6.1.1" />
     <PackageReference Include="Markdig" Version="0.22.1" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0.0" />

--- a/ApsimNG/Commands/RunCommand.cs
+++ b/ApsimNG/Commands/RunCommand.cs
@@ -93,7 +93,11 @@
                 explorerPresenter.MainPresenter.ShowMessage(string.Format("{0} complete [{1} sec]", jobName, e.ElapsedTime.TotalSeconds.ToString("#.00")), Simulation.MessageType.Information, false);
             // We don't need to display error messages now - they are displayed as they occur.
 
+#if NET6_0_OR_GREATER
+            if (!Configuration.Settings.Muted && OperatingSystem.IsWindows())
+#else
             if (!Configuration.Settings.Muted)
+#endif
             {
                 // Play a completion sound.
                 SoundPlayer player = new SoundPlayer();

--- a/ApsimNG/Interfaces/IGraphView.cs
+++ b/ApsimNG/Interfaces/IGraphView.cs
@@ -338,7 +338,7 @@
         /// <param name="bitmap">Bitmap to write to</param>
         /// <param name="r">Desired bitmap size.</param>
         /// <param name="legendOutside">Put legend outside of graph?</param>
-        void Export(ref Bitmap bitmap, Rectangle r, bool legendOutside);
+        void Export(out Gdk.Pixbuf bitmap, Rectangle r, bool legendOutside);
 
         /// <summary>
         /// Export the graph to the clipboard

--- a/ApsimNG/Interfaces/IMapView.cs
+++ b/ApsimNG/Interfaces/IMapView.cs
@@ -19,7 +19,7 @@ namespace UserInterface.Interfaces
         void ShowMap(List<Coordinate> coordinates, List<string> locNames, double zoom, Coordinate center);
 
         /// <summary>Export the map to an image.</summary>
-        System.Drawing.Image Export();
+        Gdk.Pixbuf Export();
 
         /// <summary>
         /// Get or set the zoom factor of the map

--- a/ApsimNG/Presenters/DirectedGraphPresenter.cs
+++ b/ApsimNG/Presenters/DirectedGraphPresenter.cs
@@ -45,11 +45,11 @@
         /// <summary>Export the view object to a file and return the file name</summary>
         public string ExportToPNG(string folder)
         {
-            Image image = view.Export();
+            Gdk.Pixbuf image = view.Export();
 
             
             string fileName = Path.ChangeExtension(Path.Combine(folder, Path.GetRandomFileName()), ".png");
-            image.Save(fileName, System.Drawing.Imaging.ImageFormat.Png);
+            image.Save(fileName, "png");
 
             return fileName;
         }

--- a/ApsimNG/Presenters/GraphPresenter.cs
+++ b/ApsimNG/Presenters/GraphPresenter.cs
@@ -181,13 +181,12 @@
             // The rectange numbers below are optimised for generation of PDF document
             // on a computer that has its display settings at 100%.
             Rectangle r = new Rectangle(0, 0, 600, 450);
-            Bitmap img = new Bitmap(r.Width, r.Height);
-
-            graphView.Export(ref img, r, true);
+            Gdk.Pixbuf img;
+            graphView.Export(out img, r, true);
 
             string path = graph.FullPath.Replace(".Simulations.", string.Empty);
             string fileName = Path.Combine(folder, path + ".png");
-            img.Save(fileName, System.Drawing.Imaging.ImageFormat.Png);
+            img.Save(fileName, "png");
 
             return fileName;
         }

--- a/ApsimNG/Presenters/MapPresenter.cs
+++ b/ApsimNG/Presenters/MapPresenter.cs
@@ -77,8 +77,8 @@
             string path = this.map.FullPath.Replace(".Simulations.", string.Empty);
             string fileName = Path.Combine(folder, path + ".png");
 
-            Image rawImage = this.view.Export();
-            rawImage.Save(fileName, System.Drawing.Imaging.ImageFormat.Png);
+            Gdk.Pixbuf rawImage = this.view.Export();
+            rawImage.Save(fileName, "png");
 
             return fileName;
         }

--- a/ApsimNG/Utility/Configuration.cs
+++ b/ApsimNG/Utility/Configuration.cs
@@ -117,8 +117,8 @@ namespace Utility
                 {
                     try
                     {
-                        Bitmap b = ApsimNG.Properties.Resources.ResourceManager.GetObject("ApsimSummary") as Bitmap;
-                        b.Save(summaryJpg);
+                        Gdk.Pixbuf b = Gdk.Pixbuf.LoadFromResource("Apsim1.png");
+                        b.Save(summaryJpg, "jpeg");
                     }
                     catch
                     {

--- a/ApsimNG/Views/DirectedGraphView.cs
+++ b/ApsimNG/Views/DirectedGraphView.cs
@@ -161,7 +161,7 @@
         }
 
         /// <summary>Export the view to the image</summary>
-        public System.Drawing.Image Export()
+        public Gdk.Pixbuf Export()
         {
 
             var window = new OffscreenWindow();
@@ -178,15 +178,7 @@
             window.ShowAll();
             while (GLib.MainContext.Iteration());
 
-            Gdk.Pixbuf screenshot = window.Pixbuf;
-            byte[] buffer = screenshot.SaveToBuffer("png");
-            window.Dispose();
-            using (MemoryStream stream = new MemoryStream(buffer))
-            {
-                System.Drawing.Bitmap bitmap = new Bitmap(stream);
-                return bitmap;
-            }
-
+            return window.Pixbuf;
         }
 
         /// <summary>The drawing canvas is being exposed to user.</summary>

--- a/ApsimNG/Views/GraphView.cs
+++ b/ApsimNG/Views/GraphView.cs
@@ -1244,18 +1244,14 @@
         /// <param name="bitmap">Bitmap to write to</param>
         /// <param name="r">Desired image size.</param>
         /// <param name="legendOutside">Put legend outside of graph?</param>
-        public void Export(ref Bitmap bitmap, Rectangle r, bool legendOutside)
+        public void Export(out Gdk.Pixbuf bitmap, Rectangle r, bool legendOutside)
         {
             MemoryStream stream = new MemoryStream();
             PngExporter pngExporter = new PngExporter();
             pngExporter.Width = r.Width;
             pngExporter.Height = r.Height;
             pngExporter.Export(plot1.Model, stream);
-            using (Graphics gfx = Graphics.FromImage(bitmap))
-            {
-                Bitmap newBitmap = new Bitmap(stream);
-                gfx.DrawImage(newBitmap, r);
-            }
+            bitmap = new Gdk.Pixbuf(stream);
         }
 
         /// <summary>

--- a/Tests/UnitTests/APSIMShared/StreamExtensionTests.cs
+++ b/Tests/UnitTests/APSIMShared/StreamExtensionTests.cs
@@ -7,7 +7,7 @@ using System.Text;
 namespace UnitTests.APSIMShared
 {
     /// <summary>
-    /// Unit tests for <see cref="StreamExtensions"/>.
+    /// Unit tests for <see cref="APSIM.Shared.Extensions.StreamExtensions"/>.
     /// </summary>
     [TestFixture]
     public class StreamExtensionTests
@@ -89,12 +89,12 @@ namespace UnitTests.APSIMShared
         [Test]
         public void TestArrayEquals()
         {
-            Assert.True(StreamExtensions.Equal(null, null));
-            Assert.False(StreamExtensions.Equal(new byte[0], null));
-            Assert.False(StreamExtensions.Equal(null, new byte[0]));
-            Assert.False(StreamExtensions.Equal(new byte[0], new byte[1]));
-            Assert.False(StreamExtensions.Equal(new byte[2] { 0, 1 }, new byte[2] { 0, 2 }));
-            Assert.True(StreamExtensions.Equal(new byte[2] { 64, 128 }, new byte[2] { 64, 128 }));
+            Assert.True(APSIM.Shared.Extensions.StreamExtensions.Equal(null, null));
+            Assert.False(APSIM.Shared.Extensions.StreamExtensions.Equal(new byte[0], null));
+            Assert.False(APSIM.Shared.Extensions.StreamExtensions.Equal(null, new byte[0]));
+            Assert.False(APSIM.Shared.Extensions.StreamExtensions.Equal(new byte[0], new byte[1]));
+            Assert.False(APSIM.Shared.Extensions.StreamExtensions.Equal(new byte[2] { 0, 1 }, new byte[2] { 0, 2 }));
+            Assert.True(APSIM.Shared.Extensions.StreamExtensions.Equal(new byte[2] { 64, 128 }, new byte[2] { 64, 128 }));
         }
 
         /// <summary>

--- a/Tests/UnitTests/Interop/Documentation/TagRenderers/GraphPageTagRendererTests.cs
+++ b/Tests/UnitTests/Interop/Documentation/TagRenderers/GraphPageTagRendererTests.cs
@@ -60,7 +60,7 @@ namespace UnitTests.Interop.Documentation.TagRenderers
         /// <summary>
         /// Our mock graph will use this image as its generated graph.
         /// </summary>
-        private static Image image;
+        private static Gdk.Pixbuf image;
 
         [SetUp]
         public void SetUp()
@@ -70,15 +70,15 @@ namespace UnitTests.Interop.Documentation.TagRenderers
             _ = document.AddSection().Elements;
             pdfBuilder = new PdfBuilder(document, PdfOptions.Default);
             pdfBuilder.UseTagRenderer(new MockTagRenderer());
-            image = new Bitmap(4, 4);
+            image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 4, 4), 0, 0, 4, 4);
 
             Mock<IGraph> mockGraph = new Mock<IGraph>();
             graph = mockGraph.Object;
 
             // Mock graph exporter - this will just return the image field of this class.
             Mock<IGraphExporter> mockExporter = new Mock<IGraphExporter>();
-            mockExporter.Setup<Image>(e => e.Export(It.IsAny<IGraph>(), It.IsAny<double>(), It.IsAny<double>())).Returns(() => image);
-            mockExporter.Setup<Image>(e => e.Export(It.IsAny<IPlotModel>(), It.IsAny<double>(), It.IsAny<double>())).Returns(() => image);
+            mockExporter.Setup<Gdk.Pixbuf>(e => e.Export(It.IsAny<IGraph>(), It.IsAny<double>(), It.IsAny<double>())).Returns(() => image);
+            mockExporter.Setup<Gdk.Pixbuf>(e => e.Export(It.IsAny<IPlotModel>(), It.IsAny<double>(), It.IsAny<double>())).Returns(() => image);
 
             renderer = new GraphPageTagRenderer(mockExporter.Object);
         }
@@ -108,7 +108,7 @@ namespace UnitTests.Interop.Documentation.TagRenderers
         {
             List<IGraph> graphs = new List<IGraph>(numGraphs);
             Mock<IGraphExporter> mockExporter = new Mock<IGraphExporter>();
-            List<Image> images = new List<Image>();
+            List<Gdk.Pixbuf> images = new List<Gdk.Pixbuf>();
             for (int i = 0; i < numGraphs; i++)
             {
                 // This is a little tricky because I want to have each graph
@@ -116,11 +116,11 @@ namespace UnitTests.Interop.Documentation.TagRenderers
                 // the intermediary plot model, and the graph exporter as well.
                 Mock<IGraph> mockGraph = new Mock<IGraph>();
                 IGraph graph = mockGraph.Object;
-                Image graphImage = CreateImage(i + 1);
+                Gdk.Pixbuf graphImage = CreateImage(i + 1);
                 Mock<IPlotModel> mockModel = new Mock<IPlotModel>();
                 IPlotModel graphModel = mockModel.Object;
                 mockExporter.Setup<IPlotModel>(e => e.ToPlotModel(graph)).Returns(() => graphModel);
-                mockExporter.Setup<Image>(e => e.Export(graphModel, It.IsAny<double>(), It.IsAny<double>())).Returns(() => graphImage);
+                mockExporter.Setup<Gdk.Pixbuf>(e => e.Export(graphModel, It.IsAny<double>(), It.IsAny<double>())).Returns(() => graphImage);
                 graphs.Add(graph);
                 images.Add(graphImage);
             }
@@ -281,9 +281,9 @@ namespace UnitTests.Interop.Documentation.TagRenderers
         /// Get a square image with the specified size.
         /// </summary>
         /// <param name="i">Image size (height and width) in px.</param>
-        private Image CreateImage(int i)
+        private Gdk.Pixbuf CreateImage(int i)
         {
-            return new Bitmap(i, i);
+            return new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, i, i), 0, 0, i, i);
         }
 
         /// <summary>
@@ -291,7 +291,7 @@ namespace UnitTests.Interop.Documentation.TagRenderers
         /// </summary>
         /// <param name="expected">Expected image.</param>
         /// <param name="actual">Actual image.</param>
-        private void AssertEqual(Image expected, MigraDocImage actual)
+        private void AssertEqual(Gdk.Pixbuf expected, MigraDocImage actual)
         {
             if (expected == null)
                 Assert.Null(actual);

--- a/Tests/UnitTests/Interop/Documentation/TagRenderers/GraphPageTagRendererTests.cs
+++ b/Tests/UnitTests/Interop/Documentation/TagRenderers/GraphPageTagRendererTests.cs
@@ -60,7 +60,7 @@ namespace UnitTests.Interop.Documentation.TagRenderers
         /// <summary>
         /// Our mock graph will use this image as its generated graph.
         /// </summary>
-        private static Gdk.Pixbuf image;
+        private static SkiaSharp.SKImage image;
 
         [SetUp]
         public void SetUp()
@@ -70,15 +70,15 @@ namespace UnitTests.Interop.Documentation.TagRenderers
             _ = document.AddSection().Elements;
             pdfBuilder = new PdfBuilder(document, PdfOptions.Default);
             pdfBuilder.UseTagRenderer(new MockTagRenderer());
-            image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 4, 4), 0, 0, 4, 4);
+            image = SkiaSharp.SKImage.Create(new SkiaSharp.SKImageInfo(4, 4));
 
             Mock<IGraph> mockGraph = new Mock<IGraph>();
             graph = mockGraph.Object;
 
             // Mock graph exporter - this will just return the image field of this class.
             Mock<IGraphExporter> mockExporter = new Mock<IGraphExporter>();
-            mockExporter.Setup<Gdk.Pixbuf>(e => e.Export(It.IsAny<IGraph>(), It.IsAny<double>(), It.IsAny<double>())).Returns(() => image);
-            mockExporter.Setup<Gdk.Pixbuf>(e => e.Export(It.IsAny<IPlotModel>(), It.IsAny<double>(), It.IsAny<double>())).Returns(() => image);
+            mockExporter.Setup<SkiaSharp.SKImage>(e => e.Export(It.IsAny<IGraph>(), It.IsAny<double>(), It.IsAny<double>())).Returns(() => image);
+            mockExporter.Setup<SkiaSharp.SKImage>(e => e.Export(It.IsAny<IPlotModel>(), It.IsAny<double>(), It.IsAny<double>())).Returns(() => image);
 
             renderer = new GraphPageTagRenderer(mockExporter.Object);
         }
@@ -108,7 +108,7 @@ namespace UnitTests.Interop.Documentation.TagRenderers
         {
             List<IGraph> graphs = new List<IGraph>(numGraphs);
             Mock<IGraphExporter> mockExporter = new Mock<IGraphExporter>();
-            List<Gdk.Pixbuf> images = new List<Gdk.Pixbuf>();
+            List<SkiaSharp.SKImage> images = new List<SkiaSharp.SKImage>();
             for (int i = 0; i < numGraphs; i++)
             {
                 // This is a little tricky because I want to have each graph
@@ -116,11 +116,11 @@ namespace UnitTests.Interop.Documentation.TagRenderers
                 // the intermediary plot model, and the graph exporter as well.
                 Mock<IGraph> mockGraph = new Mock<IGraph>();
                 IGraph graph = mockGraph.Object;
-                Gdk.Pixbuf graphImage = CreateImage(i + 1);
+                SkiaSharp.SKImage graphImage = CreateImage(i + 1);
                 Mock<IPlotModel> mockModel = new Mock<IPlotModel>();
                 IPlotModel graphModel = mockModel.Object;
                 mockExporter.Setup<IPlotModel>(e => e.ToPlotModel(graph)).Returns(() => graphModel);
-                mockExporter.Setup<Gdk.Pixbuf>(e => e.Export(graphModel, It.IsAny<double>(), It.IsAny<double>())).Returns(() => graphImage);
+                mockExporter.Setup<SkiaSharp.SKImage>(e => e.Export(graphModel, It.IsAny<double>(), It.IsAny<double>())).Returns(() => graphImage);
                 graphs.Add(graph);
                 images.Add(graphImage);
             }
@@ -281,9 +281,9 @@ namespace UnitTests.Interop.Documentation.TagRenderers
         /// Get a square image with the specified size.
         /// </summary>
         /// <param name="i">Image size (height and width) in px.</param>
-        private Gdk.Pixbuf CreateImage(int i)
+        private SkiaSharp.SKImage CreateImage(int i)
         {
-            return new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, i, i), 0, 0, i, i);
+            return SkiaSharp.SKImage.Create(new SkiaSharp.SKImageInfo(i, i));
         }
 
         /// <summary>
@@ -291,7 +291,7 @@ namespace UnitTests.Interop.Documentation.TagRenderers
         /// </summary>
         /// <param name="expected">Expected image.</param>
         /// <param name="actual">Actual image.</param>
-        private void AssertEqual(Gdk.Pixbuf expected, MigraDocImage actual)
+        private void AssertEqual(SkiaSharp.SKImage expected, MigraDocImage actual)
         {
             if (expected == null)
                 Assert.Null(actual);

--- a/Tests/UnitTests/Interop/Documentation/TagRenderers/GraphTagRendererTests.cs
+++ b/Tests/UnitTests/Interop/Documentation/TagRenderers/GraphTagRendererTests.cs
@@ -52,7 +52,7 @@ namespace UnitTests.Interop.Documentation.TagRenderers
         /// <summary>
         /// Our mock graph will use this image as its generated graph.
         /// </summary>
-        private static Gdk.Pixbuf image;
+        private static SkiaSharp.SKImage image;
 
         [SetUp]
         public void SetUp()
@@ -62,15 +62,15 @@ namespace UnitTests.Interop.Documentation.TagRenderers
             _ = document.AddSection().Elements;
             pdfBuilder = new PdfBuilder(document, PdfOptions.Default);
             pdfBuilder.UseTagRenderer(new MockTagRenderer());
-            image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 4, 4), 0, 0, 4, 4);
+            image = SkiaSharp.SKImage.Create(new SkiaSharp.SKImageInfo(4, 4));
 
             Mock<IGraph> mockGraph = new Mock<IGraph>();
             graph = mockGraph.Object;
 
             // Mock graph exporter - this will just return the image field of this class.
             Mock<IGraphExporter> mockExporter = new Mock<IGraphExporter>();
-            mockExporter.Setup<Gdk.Pixbuf>(e => e.Export(It.IsAny<IGraph>(), It.IsAny<double>(), It.IsAny<double>())).Returns(() => image);
-            mockExporter.Setup<Gdk.Pixbuf>(e => e.Export(It.IsAny<OxyPlot.IPlotModel>(), It.IsAny<double>(), It.IsAny<double>())).Returns(() => image);
+            mockExporter.Setup<SkiaSharp.SKImage>(e => e.Export(It.IsAny<IGraph>(), It.IsAny<double>(), It.IsAny<double>())).Returns(() => image);
+            mockExporter.Setup<SkiaSharp.SKImage>(e => e.Export(It.IsAny<OxyPlot.IPlotModel>(), It.IsAny<double>(), It.IsAny<double>())).Returns(() => image);
 
             renderer = new GraphTagRenderer(mockExporter.Object);
         }
@@ -146,7 +146,7 @@ namespace UnitTests.Interop.Documentation.TagRenderers
         public void TestExportedSize()
         {
             Mock<IGraphExporter> exporter = new Mock<IGraphExporter>();
-            exporter.Setup<Gdk.Pixbuf>(e => e.Export(It.IsAny<OxyPlot.IPlotModel>(), It.IsAny<double>(), It.IsAny<double>())).Returns<IGraph, double, double>((graph, width, height) =>
+            exporter.Setup<SkiaSharp.SKImage>(e => e.Export(It.IsAny<OxyPlot.IPlotModel>(), It.IsAny<double>(), It.IsAny<double>())).Returns<IGraph, double, double>((graph, width, height) =>
             {
                 // This should be the page width in px, with height calculated from an aspect ratio of 16:9.
                 // fixme: this isn't really the best way to verify this but it'll do for now.
@@ -165,7 +165,7 @@ namespace UnitTests.Interop.Documentation.TagRenderers
         /// </summary>
         /// <param name="expected">Expected image.</param>
         /// <param name="actual">Actual image.</param>
-        private void AssertEqual(Gdk.Pixbuf expected, MigraDocImage actual)
+        private void AssertEqual(SkiaSharp.SKImage expected, MigraDocImage actual)
         {
             if (expected == null)
                 Assert.Null(actual);

--- a/Tests/UnitTests/Interop/Documentation/TagRenderers/GraphTagRendererTests.cs
+++ b/Tests/UnitTests/Interop/Documentation/TagRenderers/GraphTagRendererTests.cs
@@ -52,7 +52,7 @@ namespace UnitTests.Interop.Documentation.TagRenderers
         /// <summary>
         /// Our mock graph will use this image as its generated graph.
         /// </summary>
-        private static Image image;
+        private static Gdk.Pixbuf image;
 
         [SetUp]
         public void SetUp()
@@ -62,15 +62,15 @@ namespace UnitTests.Interop.Documentation.TagRenderers
             _ = document.AddSection().Elements;
             pdfBuilder = new PdfBuilder(document, PdfOptions.Default);
             pdfBuilder.UseTagRenderer(new MockTagRenderer());
-            image = new Bitmap(4, 4);
+            image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 4, 4), 0, 0, 4, 4);
 
             Mock<IGraph> mockGraph = new Mock<IGraph>();
             graph = mockGraph.Object;
 
             // Mock graph exporter - this will just return the image field of this class.
             Mock<IGraphExporter> mockExporter = new Mock<IGraphExporter>();
-            mockExporter.Setup<Image>(e => e.Export(It.IsAny<IGraph>(), It.IsAny<double>(), It.IsAny<double>())).Returns(() => image);
-            mockExporter.Setup<Image>(e => e.Export(It.IsAny<OxyPlot.IPlotModel>(), It.IsAny<double>(), It.IsAny<double>())).Returns(() => image);
+            mockExporter.Setup<Gdk.Pixbuf>(e => e.Export(It.IsAny<IGraph>(), It.IsAny<double>(), It.IsAny<double>())).Returns(() => image);
+            mockExporter.Setup<Gdk.Pixbuf>(e => e.Export(It.IsAny<OxyPlot.IPlotModel>(), It.IsAny<double>(), It.IsAny<double>())).Returns(() => image);
 
             renderer = new GraphTagRenderer(mockExporter.Object);
         }
@@ -146,7 +146,7 @@ namespace UnitTests.Interop.Documentation.TagRenderers
         public void TestExportedSize()
         {
             Mock<IGraphExporter> exporter = new Mock<IGraphExporter>();
-            exporter.Setup<Image>(e => e.Export(It.IsAny<OxyPlot.IPlotModel>(), It.IsAny<double>(), It.IsAny<double>())).Returns<IGraph, double, double>((graph, width, height) =>
+            exporter.Setup<Gdk.Pixbuf>(e => e.Export(It.IsAny<OxyPlot.IPlotModel>(), It.IsAny<double>(), It.IsAny<double>())).Returns<IGraph, double, double>((graph, width, height) =>
             {
                 // This should be the page width in px, with height calculated from an aspect ratio of 16:9.
                 // fixme: this isn't really the best way to verify this but it'll do for now.
@@ -165,7 +165,7 @@ namespace UnitTests.Interop.Documentation.TagRenderers
         /// </summary>
         /// <param name="expected">Expected image.</param>
         /// <param name="actual">Actual image.</param>
-        private void AssertEqual(Image expected, MigraDocImage actual)
+        private void AssertEqual(Gdk.Pixbuf expected, MigraDocImage actual)
         {
             if (expected == null)
                 Assert.Null(actual);

--- a/Tests/UnitTests/Interop/Documentation/TagRenderers/ImageTagRendererTests.cs
+++ b/Tests/UnitTests/Interop/Documentation/TagRenderers/ImageTagRendererTests.cs
@@ -50,7 +50,7 @@ namespace UnitTests.Interop.Documentation.TagRenderers
         /// <summary>
         /// Our mock image tag will return this image.
         /// </summary>
-        private static Image image;
+        private static Gdk.Pixbuf image;
 
         [SetUp]
         public void SetUp()
@@ -60,7 +60,7 @@ namespace UnitTests.Interop.Documentation.TagRenderers
             _ = document.AddSection().Elements;
             pdfBuilder = new PdfBuilder(document, PdfOptions.Default);
             pdfBuilder.UseTagRenderer(new MockTagRenderer());
-            image = new Bitmap(4, 4);
+            image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 4, 4), 0, 0, 4, 4);
 
             imageTag = new ImageTag(image);
             renderer = new ImageTagRenderer();
@@ -134,7 +134,7 @@ namespace UnitTests.Interop.Documentation.TagRenderers
         /// </summary>
         /// <param name="expected">Expected image.</param>
         /// <param name="actual">Actual image.</param>
-        private void AssertEqual(Image expected, MigraDocImage actual)
+        private void AssertEqual(Gdk.Pixbuf expected, MigraDocImage actual)
         {
             if (expected == null)
                 Assert.Null(actual);

--- a/Tests/UnitTests/Interop/Documentation/TagRenderers/ImageTagRendererTests.cs
+++ b/Tests/UnitTests/Interop/Documentation/TagRenderers/ImageTagRendererTests.cs
@@ -50,7 +50,7 @@ namespace UnitTests.Interop.Documentation.TagRenderers
         /// <summary>
         /// Our mock image tag will return this image.
         /// </summary>
-        private static Gdk.Pixbuf image;
+        private static SkiaSharp.SKImage image;
 
         [SetUp]
         public void SetUp()
@@ -60,7 +60,7 @@ namespace UnitTests.Interop.Documentation.TagRenderers
             _ = document.AddSection().Elements;
             pdfBuilder = new PdfBuilder(document, PdfOptions.Default);
             pdfBuilder.UseTagRenderer(new MockTagRenderer());
-            image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 4, 4), 0, 0, 4, 4);
+            image = SkiaSharp.SKImage.Create(new SkiaSharp.SKImageInfo(4, 4));
 
             imageTag = new ImageTag(image);
             renderer = new ImageTagRenderer();
@@ -134,7 +134,7 @@ namespace UnitTests.Interop.Documentation.TagRenderers
         /// </summary>
         /// <param name="expected">Expected image.</param>
         /// <param name="actual">Actual image.</param>
-        private void AssertEqual(Gdk.Pixbuf expected, MigraDocImage actual)
+        private void AssertEqual(SkiaSharp.SKImage expected, MigraDocImage actual)
         {
             if (expected == null)
                 Assert.Null(actual);

--- a/Tests/UnitTests/Interop/Markdown/Renderers/Inlines/LinkInlineRendererTests.cs
+++ b/Tests/UnitTests/Interop/Markdown/Renderers/Inlines/LinkInlineRendererTests.cs
@@ -96,7 +96,7 @@ namespace UnitTests.Interop.Markdown.Renderers.Inlines
             string dynamicUri = "dynamic uri";
             inline.GetDynamicUrl = () => dynamicUri;
             inline.IsImage = true;
-            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 1, 1), 0, 0, 1, 1))
+            using (SkiaSharp.SKImage image = SkiaSharp.SKImage.Create(new SkiaSharp.SKImageInfo(1, 1)))
             {
                 Mock<LinkInlineRenderer> renderer = new Mock<LinkInlineRenderer>(null);
                 renderer.CallBase = true;
@@ -118,7 +118,7 @@ namespace UnitTests.Interop.Markdown.Renderers.Inlines
             inline.IsImage = true;
             Mock<LinkInlineRenderer> renderer = new Mock<LinkInlineRenderer>(null);
             renderer.CallBase = true;
-            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 1, 1), 0, 0, 1, 1))
+            using (SkiaSharp.SKImage image = SkiaSharp.SKImage.Create(new SkiaSharp.SKImageInfo(1, 1)))
             {
                 renderer.Setup(b => b.GetImage(It.IsAny<string>()))
                         .Callback<string>(uri => Assert.AreEqual(inline.Url, uri))
@@ -233,7 +233,7 @@ namespace UnitTests.Interop.Markdown.Renderers.Inlines
         {
             inline.IsImage = true;
             inline.AppendChild(new LiteralInline("caption"));
-            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 4, 4), 0, 0, 4, 4))
+            using (SkiaSharp.SKImage image = SkiaSharp.SKImage.Create(new SkiaSharp.SKImageInfo(4, 4)))
             {
                 Mock<LinkInlineRenderer> renderer = new Mock<LinkInlineRenderer>(null);
                 renderer.Setup(r => r.GetImage(It.IsAny<string>())).Returns(image);
@@ -254,7 +254,7 @@ namespace UnitTests.Interop.Markdown.Renderers.Inlines
         {
             pdfBuilder.AppendText("Not be in same paragraph as image", TextStyle.Normal);
             inline.IsImage = true;
-            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 4, 4), 0, 0, 4, 4))
+            using (SkiaSharp.SKImage image = SkiaSharp.SKImage.Create(new SkiaSharp.SKImageInfo(4, 4)))
             {
                 Mock<LinkInlineRenderer> renderer = new Mock<LinkInlineRenderer>(null);
                 renderer.CallBase = true;
@@ -273,7 +273,7 @@ namespace UnitTests.Interop.Markdown.Renderers.Inlines
             pdfBuilder.AppendText("Not be in same paragraph as image", TextStyle.Normal);
             inline.IsImage = true;
             int height = (int)(document.DefaultPageSetup.PageHeight.Point * 1.5);
-            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 2, height), 0, 0, 2, height))
+            using (SkiaSharp.SKImage image = SkiaSharp.SKImage.Create(new SkiaSharp.SKImageInfo(2, height)))
             {
                 Mock<LinkInlineRenderer> renderer = new Mock<LinkInlineRenderer>(null);
                 renderer.CallBase = true;
@@ -293,7 +293,7 @@ namespace UnitTests.Interop.Markdown.Renderers.Inlines
             pdfBuilder.AppendText("Not be in same paragraph as image", TextStyle.Normal);
             inline.IsImage = true;
             inline.AppendChild(new LiteralInline("Alt text"));
-            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 4, 4), 0, 0, 4, 4))
+            using (SkiaSharp.SKImage image = SkiaSharp.SKImage.Create(new SkiaSharp.SKImageInfo(4, 4)))
             {
                 Mock<LinkInlineRenderer> renderer = new Mock<LinkInlineRenderer>(null);
                 renderer.CallBase = true;
@@ -313,7 +313,7 @@ namespace UnitTests.Interop.Markdown.Renderers.Inlines
             Assert.AreEqual(0, pdfBuilder.FigureNumber);
             pdfBuilder.AppendText("Not be in same paragraph as image", TextStyle.Normal);
             inline.IsImage = true;
-            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 4, 4), 0, 0, 4, 4))
+            using (SkiaSharp.SKImage image = SkiaSharp.SKImage.Create(new SkiaSharp.SKImageInfo(4, 4)))
             {
                 Mock<LinkInlineRenderer> renderer = new Mock<LinkInlineRenderer>(null);
                 renderer.CallBase = true;
@@ -339,7 +339,7 @@ namespace UnitTests.Interop.Markdown.Renderers.Inlines
             builder.Setup(b => b.AppendText(altText, It.IsAny<TextStyle>())).Callback<string, TextStyle>((_, style) => Assert.AreEqual(TextStyle.Normal, style)).CallBase();
             builder.Setup(b => b.AppendText(It.IsNotIn(altText), It.IsAny<TextStyle>())).Callback<string, TextStyle>((_, style) => Assert.AreEqual(TextStyle.Strong, style)).CallBase();
 
-            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 4, 4), 0, 0, 4, 4))
+            using (SkiaSharp.SKImage image = SkiaSharp.SKImage.Create(new SkiaSharp.SKImageInfo(4, 4)))
             {
                 Mock<LinkInlineRenderer> renderer = new Mock<LinkInlineRenderer>(null);
                 renderer.CallBase = true;

--- a/Tests/UnitTests/Interop/Markdown/Renderers/Inlines/LinkInlineRendererTests.cs
+++ b/Tests/UnitTests/Interop/Markdown/Renderers/Inlines/LinkInlineRendererTests.cs
@@ -182,8 +182,12 @@ namespace UnitTests.Interop.Markdown.Renderers.Inlines
         public void TestImageFromLocalFile()
         {
             string fileName = Path.GetTempFileName();
-            Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 4, 4), 0, 0, 4, 4);
-            image.Save(fileName, "png");
+            SkiaSharp.SKImage image = SkiaSharp.SKImage.Create(new SkiaSharp.SKImageInfo(4, 4));
+            using (FileStream fileStream = new FileStream(fileName, FileMode.Create))
+            {
+                image.Encode().SaveTo(fileStream);
+                fileStream.Flush();
+            }
             try
             {
                 string imageName = Path.GetFileName(fileName);

--- a/Tests/UnitTests/Interop/Markdown/Renderers/Inlines/LinkInlineRendererTests.cs
+++ b/Tests/UnitTests/Interop/Markdown/Renderers/Inlines/LinkInlineRendererTests.cs
@@ -96,7 +96,7 @@ namespace UnitTests.Interop.Markdown.Renderers.Inlines
             string dynamicUri = "dynamic uri";
             inline.GetDynamicUrl = () => dynamicUri;
             inline.IsImage = true;
-            using (Image image = new Bitmap(1, 1))
+            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 1, 1), 0, 0, 1, 1))
             {
                 Mock<LinkInlineRenderer> renderer = new Mock<LinkInlineRenderer>(null);
                 renderer.CallBase = true;
@@ -118,7 +118,7 @@ namespace UnitTests.Interop.Markdown.Renderers.Inlines
             inline.IsImage = true;
             Mock<LinkInlineRenderer> renderer = new Mock<LinkInlineRenderer>(null);
             renderer.CallBase = true;
-            using (Image image = new Bitmap(1, 1))
+            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 1, 1), 0, 0, 1, 1))
             {
                 renderer.Setup(b => b.GetImage(It.IsAny<string>()))
                         .Callback<string>(uri => Assert.AreEqual(inline.Url, uri))
@@ -182,8 +182,8 @@ namespace UnitTests.Interop.Markdown.Renderers.Inlines
         public void TestImageFromLocalFile()
         {
             string fileName = Path.GetTempFileName();
-            Image image = new Bitmap(4, 4);
-            image.Save(fileName);
+            Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 4, 4), 0, 0, 4, 4);
+            image.Save(fileName, "png");
             try
             {
                 string imageName = Path.GetFileName(fileName);
@@ -233,7 +233,7 @@ namespace UnitTests.Interop.Markdown.Renderers.Inlines
         {
             inline.IsImage = true;
             inline.AppendChild(new LiteralInline("caption"));
-            using (Image image = new Bitmap(4, 4))
+            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 4, 4), 0, 0, 4, 4))
             {
                 Mock<LinkInlineRenderer> renderer = new Mock<LinkInlineRenderer>(null);
                 renderer.Setup(r => r.GetImage(It.IsAny<string>())).Returns(image);
@@ -254,7 +254,7 @@ namespace UnitTests.Interop.Markdown.Renderers.Inlines
         {
             pdfBuilder.AppendText("Not be in same paragraph as image", TextStyle.Normal);
             inline.IsImage = true;
-            using (Image image = new Bitmap(4, 4))
+            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 4, 4), 0, 0, 4, 4))
             {
                 Mock<LinkInlineRenderer> renderer = new Mock<LinkInlineRenderer>(null);
                 renderer.CallBase = true;
@@ -273,7 +273,7 @@ namespace UnitTests.Interop.Markdown.Renderers.Inlines
             pdfBuilder.AppendText("Not be in same paragraph as image", TextStyle.Normal);
             inline.IsImage = true;
             int height = (int)(document.DefaultPageSetup.PageHeight.Point * 1.5);
-            using (Image image = new Bitmap(2, height))
+            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 2, height), 0, 0, 2, height))
             {
                 Mock<LinkInlineRenderer> renderer = new Mock<LinkInlineRenderer>(null);
                 renderer.CallBase = true;
@@ -293,7 +293,7 @@ namespace UnitTests.Interop.Markdown.Renderers.Inlines
             pdfBuilder.AppendText("Not be in same paragraph as image", TextStyle.Normal);
             inline.IsImage = true;
             inline.AppendChild(new LiteralInline("Alt text"));
-            using (Image image = new Bitmap(4, 4))
+            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 4, 4), 0, 0, 4, 4))
             {
                 Mock<LinkInlineRenderer> renderer = new Mock<LinkInlineRenderer>(null);
                 renderer.CallBase = true;
@@ -313,7 +313,7 @@ namespace UnitTests.Interop.Markdown.Renderers.Inlines
             Assert.AreEqual(0, pdfBuilder.FigureNumber);
             pdfBuilder.AppendText("Not be in same paragraph as image", TextStyle.Normal);
             inline.IsImage = true;
-            using (Image image = new Bitmap(4, 4))
+            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 4, 4), 0, 0, 4, 4))
             {
                 Mock<LinkInlineRenderer> renderer = new Mock<LinkInlineRenderer>(null);
                 renderer.CallBase = true;
@@ -339,7 +339,7 @@ namespace UnitTests.Interop.Markdown.Renderers.Inlines
             builder.Setup(b => b.AppendText(altText, It.IsAny<TextStyle>())).Callback<string, TextStyle>((_, style) => Assert.AreEqual(TextStyle.Normal, style)).CallBase();
             builder.Setup(b => b.AppendText(It.IsNotIn(altText), It.IsAny<TextStyle>())).Callback<string, TextStyle>((_, style) => Assert.AreEqual(TextStyle.Strong, style)).CallBase();
 
-            using (Image image = new Bitmap(4, 4))
+            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 4, 4), 0, 0, 4, 4))
             {
                 Mock<LinkInlineRenderer> renderer = new Mock<LinkInlineRenderer>(null);
                 renderer.CallBase = true;

--- a/Tests/UnitTests/Interop/PdfBuilderTests.cs
+++ b/Tests/UnitTests/Interop/PdfBuilderTests.cs
@@ -81,7 +81,7 @@ namespace UnitTests.Interop
         {
             EnsureCanRenderTag(new SectionTag("title", new ITag[1] { new ParagraphTag("") }));
             EnsureCanRenderTag(new ParagraphTag("paragraph text"));
-            using (Image image = new Bitmap(2, 2))
+            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 2, 2), 0, 0, 2, 2))
                 EnsureCanRenderTag(new ImageTag(image));
             EnsureCanRenderTag(new TableTag(CreateTable()));
             EnsureCanRenderTag(CreateGraphTag());
@@ -418,13 +418,13 @@ namespace UnitTests.Interop
         }
 
         /// <summary>
-        /// Ensure that <see cref="PdfBuilder.AppendImage(Image)"/> adds the
+        /// Ensure that <see cref="PdfBuilder.AppendImage(Gdk.Pixbuf)"/> adds the
         /// image into the document.
         /// </summary>
         [Test]
         public void TestAppendImage()
         {
-            using (Image image = new Bitmap(2, 2))
+            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 2, 2), 0, 0, 2, 2))
             {
                 builder.AppendImage(image);
                 Assert.AreEqual(1, doc.LastSection.Elements.Count);
@@ -458,7 +458,7 @@ namespace UnitTests.Interop
             // When setting the page width and height, convert from px to points.
             section.PageSetup.PageWidth =  Unit.FromPoint(pageWidth / pointsToPixels);
             section.PageSetup.PageHeight = Unit.FromPoint(pageHeight / pointsToPixels);
-            using (Image image = new Bitmap(imageWidth, imageHeight))
+            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, imageWidth, imageHeight), 0, 0, imageWidth, imageHeight))
             {
                 builder.AppendImage(image);
                 Paragraph paragraph = (Paragraph)doc.LastSection.Elements[0];
@@ -472,7 +472,7 @@ namespace UnitTests.Interop
         }
 
         /// <summary>
-        /// Ensure that <see cref="PdfBuilder.AppendImage(System.Drawing.Image)"/>
+        /// Ensure that <see cref="PdfBuilder.AppendImage(Gdk.Pixbuf)"/>
         /// adds the image at the end of the document, in an existing paragraph
         /// (if one exists).
         /// </summary>
@@ -480,7 +480,7 @@ namespace UnitTests.Interop
         public void TestAppendImageLocation()
         {
             doc.AddSection().AddParagraph("some text is already in the paragraph");
-            using (Image image = new Bitmap(2, 2))
+            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 2, 2), 0, 0, 2, 2))
                 builder.AppendImage(image);
             Assert.AreEqual(1, doc.LastSection.Elements.Count);
             Paragraph paragraph = (Paragraph)doc.LastSection.Elements[0];

--- a/Tests/UnitTests/Interop/PdfBuilderTests.cs
+++ b/Tests/UnitTests/Interop/PdfBuilderTests.cs
@@ -81,7 +81,7 @@ namespace UnitTests.Interop
         {
             EnsureCanRenderTag(new SectionTag("title", new ITag[1] { new ParagraphTag("") }));
             EnsureCanRenderTag(new ParagraphTag("paragraph text"));
-            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 2, 2), 0, 0, 2, 2))
+            using (SkiaSharp.SKImage image = SkiaSharp.SKImage.Create(new SkiaSharp.SKImageInfo(2, 2)))
                 EnsureCanRenderTag(new ImageTag(image));
             EnsureCanRenderTag(new TableTag(CreateTable()));
             EnsureCanRenderTag(CreateGraphTag());
@@ -418,13 +418,13 @@ namespace UnitTests.Interop
         }
 
         /// <summary>
-        /// Ensure that <see cref="PdfBuilder.AppendImage(Gdk.Pixbuf)"/> adds the
+        /// Ensure that <see cref="PdfBuilder.AppendImage(SkiaSharp.SKImage)"/> adds the
         /// image into the document.
         /// </summary>
         [Test]
         public void TestAppendImage()
         {
-            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 2, 2), 0, 0, 2, 2))
+            using (SkiaSharp.SKImage image = SkiaSharp.SKImage.Create(new SkiaSharp.SKImageInfo(2, 2)))
             {
                 builder.AppendImage(image);
                 Assert.AreEqual(1, doc.LastSection.Elements.Count);
@@ -458,7 +458,7 @@ namespace UnitTests.Interop
             // When setting the page width and height, convert from px to points.
             section.PageSetup.PageWidth =  Unit.FromPoint(pageWidth / pointsToPixels);
             section.PageSetup.PageHeight = Unit.FromPoint(pageHeight / pointsToPixels);
-            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, imageWidth, imageHeight), 0, 0, imageWidth, imageHeight))
+            using (SkiaSharp.SKImage image = SkiaSharp.SKImage.Create(new SkiaSharp.SKImageInfo(imageWidth, imageHeight)))
             {
                 builder.AppendImage(image);
                 Paragraph paragraph = (Paragraph)doc.LastSection.Elements[0];
@@ -472,7 +472,7 @@ namespace UnitTests.Interop
         }
 
         /// <summary>
-        /// Ensure that <see cref="PdfBuilder.AppendImage(Gdk.Pixbuf)"/>
+        /// Ensure that <see cref="PdfBuilder.AppendImage(SkiaSharp.SKImage)"/>
         /// adds the image at the end of the document, in an existing paragraph
         /// (if one exists).
         /// </summary>
@@ -480,7 +480,7 @@ namespace UnitTests.Interop
         public void TestAppendImageLocation()
         {
             doc.AddSection().AddParagraph("some text is already in the paragraph");
-            using (Gdk.Pixbuf image = new Gdk.Pixbuf(new Cairo.ImageSurface(Cairo.Format.ARGB32, 2, 2), 0, 0, 2, 2))
+            using (SkiaSharp.SKImage image = SkiaSharp.SKImage.Create(new SkiaSharp.SKImageInfo(2, 2)))
                 builder.AppendImage(image);
             Assert.AreEqual(1, doc.LastSection.Elements.Count);
             Paragraph paragraph = (Paragraph)doc.LastSection.Elements[0];


### PR DESCRIPTION
Resolves #7469.

Eliminates use of Windows-based elements of System.Drawing.Common, by using Gdk.Pixbuf instead of Image or Bitmap. Also converts mapping from SharpMap to Mapsui. [Mapsui](https://mapsui.com) was developed from SharpMap, but uses SkiaSharp for its rendering, and is more actively maintained and updated. Map retrieval is done asynchronously, and uses the same Brutile cachinbg mechanism as did Sharpmap.