### PR TITLE
Use IClock instead of Clock consistently

### DIFF
--- a/Models/AgPasture/PastureSpecies.cs
+++ b/Models/AgPasture/PastureSpecies.cs
@@ -29,7 +29,7 @@ namespace Models.AgPasture
 
         /// <summary>Link to APSIM's Clock (provides time information).</summary>
         [Link]
-        private Clock myClock = null;
+        private IClock myClock = null;
 
         /// <summary>Link to the zone this pasture species resides in.</summary>
         [Link]
@@ -935,7 +935,7 @@ namespace Models.AgPasture
 
         /// <summary>Describes the FVPD function.</summary>
         [Units("0-1")]
-        public LinearInterpolationFunction FVPDFunction 
+        public LinearInterpolationFunction FVPDFunction
             = new LinearInterpolationFunction(x: new double[] { 0.0, 10.0, 50.0 },
                                               y: new double[] { 1.0, 1.0, 1.0 });
 
@@ -1427,7 +1427,7 @@ namespace Models.AgPasture
                 return dmTotal;
             }
         }
-        
+
         /// <summary>Dry matter weight of plant's leaves (kgDM/ha).</summary>
         [Units("kg/ha")]
         public double LeafWt
@@ -2732,7 +2732,7 @@ namespace Models.AgPasture
                     // Get the effective growth, after all limitations and senescence
                     DoActualGrowthAndAllocation();
 
-                    // Send detached material to other modules (litter to surfacesOM, roots to soilFOM) 
+                    // Send detached material to other modules (litter to surfacesOM, roots to soilFOM)
                     AddDetachedShootToSurfaceOM(detachedShootDM, detachedShootN);
                     Root.Dead.DetachBiomass(detachedRootDM, detachedRootN);
                     // TODO: currently only the roots at the main/home zone are considered, must add the other zones too
@@ -2867,7 +2867,7 @@ namespace Models.AgPasture
             double Pc_Daily = Pl_Daily * swardGreenCover*fractionGreenCover / LightExtinctionCoefficient;
 
             //  Carbon assimilation per leaf area (g C/m^2/day)
-            double carbonAssimilation = Pc_Daily * 0.001 * (12.0 / 44.0); // Convert from mgCO2 to gC           
+            double carbonAssimilation = Pc_Daily * 0.001 * (12.0 / 44.0); // Convert from mgCO2 to gC
 
             // Gross photosynthesis, converted to kg C/ha/day
             basePhotosynthesis = carbonAssimilation * 10.0; // convert from g/m2 to kg/ha (= 10000/1000)
@@ -3171,7 +3171,7 @@ namespace Models.AgPasture
 
             // Since changing the N uptake method from basic to defaultAPSIM the tolerances below
             // need to be changed from the default of 0.00001 to 0.0001. Not sure why but was getting
-            // mass balance errors on Jenkins (not my machine) when running 
+            // mass balance errors on Jenkins (not my machine) when running
             //    Examples\Tutorials\Sensitivity_MorrisMethod.apsimx
             // and
             //    Examples\Tutorials\Sensitivity_SobolMethod.apsimx
@@ -3492,7 +3492,7 @@ namespace Models.AgPasture
 
         /// <summary>Computes the fraction of new shoot DM that is allocated to leaves.</summary>
         /// <remarks>
-        /// This method is used to reduce the proportion of leaves as plants grow, this is used for species that 
+        /// This method is used to reduce the proportion of leaves as plants grow, this is used for species that
         ///  allocate proportionally more DM to stolon/stems when the whole plant's DM is high.
         /// To avoid too little allocation to leaves in case of grazing, the current leaf:stem ratio is evaluated
         ///  and used to modify the targeted value in a similar way as shoot:root ratio.
@@ -4084,7 +4084,7 @@ namespace Models.AgPasture
         /// Growth is limited if soil water content is above a given threshold (defined by MinimumWaterFreePorosity), which
         ///  will be the soil DUL is MinimumWaterFreePorosity is set to a negative value. When water content is greater than
         ///  this water-free porosity growth will be limited. The function is based on the cumulative water logging, which means
-        ///  that limitation are more severe if water logging conditions are persistent. Maximum increment in one day equals the 
+        ///  that limitation are more severe if water logging conditions are persistent. Maximum increment in one day equals the
         ///  SoilWaterSaturationFactor and cannot be greater than one. Recovery happens every if water content is below the full
         ///  saturation, and is proportional to the water-free porosity.
         /// </remarks>
@@ -4095,7 +4095,7 @@ namespace Models.AgPasture
             double mySWater = 0.0;  // actual soil water content
             double myWSat = 0.0;    // water content at saturation
             double myWMinP = 0.0;   // water content at minimum water-free porosity
-            double fractionLayer;   // fraction of layer with roots 
+            double fractionLayer;   // fraction of layer with roots
 
             // gather water status over the root zone
             for (int layer = 0; layer <= roots[0].BottomLayer; layer++)

--- a/Models/AgPasture/SimpleGrazing.cs
+++ b/Models/AgPasture/SimpleGrazing.cs
@@ -15,7 +15,7 @@ namespace Models.AgPasture
     using System.Linq;
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     [Serializable]
     [ViewName("UserInterface.Views.PropertyView")]
@@ -23,7 +23,7 @@ namespace Models.AgPasture
     [ValidParent(ParentType = typeof(Zone))]
     public class SimpleGrazing : Model
     {
-        [Link] Clock clock = null;
+        [Link] IClock clock = null;
         [Link] ISummary summary = null;
         [Link] Forages forages = null;
         [Link(ByName = true)] ISolute Urea = null;
@@ -77,7 +77,7 @@ namespace Models.AgPasture
         /// <summary>Invoked when urine is to be returned to soil.</summary>
         /// <remarks>
         /// This event provides a mechanism for another model to perform a
-        /// urine return to the soil. If no other model subscribes to this 
+        /// urine return to the soil. If no other model subscribes to this
         /// event then SimpleGrazing will do the urine return. This mechanism
         /// allows a urine patch model to work.
         /// </remarks>
@@ -163,7 +163,7 @@ namespace Models.AgPasture
         [Separator("Urine and Dung.")]
 
         [Description("Fraction of defoliated N going to soil. Remainder is exported as animal product or to lanes/camps (0-1).")]
-        public double[] FractionDefoliatedNToSoil { get; set; }   
+        public double[] FractionDefoliatedNToSoil { get; set; }
 
         /// <summary></summary>
         [Description("Proportion of excreted N going to dung (0-1). Yearly or 12 monthly values. Blank means use C:N ratio of dung.")]

--- a/Models/Agroforestry/TreeProxy.cs
+++ b/Models/Agroforestry/TreeProxy.cs
@@ -17,19 +17,19 @@ namespace Models.Agroforestry
 {
     /// <summary>
     /// A simple proxy for a full tree model is provided for use in agroforestry simulations.  It allows the user to directly specify the size and structural data for trees within the simulation rather than having to simulate complex tree development (e.g. tree canopy structure under specific pruning regimes).
-    /// 
+    ///
     /// Several parameters are required of the user to specify the state of trees within the simulation.  These include:
-    /// 
+    ///
     /// * Tree height (m)
     /// * Shade modifier with age (0-1)
     /// * Tree root radius (cm)
     /// * Shade at a range of distances from the trees (%)
     /// * Tree root length density at various depths and distances from the trees (cm/cm^3^)
     /// * Tree daily nitrogen demand (g/m2/day for tree zone area)
-    /// 
+    ///
     /// The model calculates diffusive nutrient uptake using the equations of [DeWilligen1994] as formulated in the model WANULCAS [WANULCAS2011] and modified to better represent nutrient buffering [smethurst1997paste;smethurst1999phase;van1990defining].
     /// Water uptake is calculated using an adaptation of the approach of [Meinkeetal1993] where the extraction coefficient is assumed to be proportional to root length density [Peakeetal2013].  The user specifies a value of the uptake coefficient at a base root length density of 1 cm/cm^3^ and spatial water uptake is scales using this value and the user-input of tree root length density.
-    /// 
+    ///
     /// </summary>
     [Serializable]
     [ViewName("UserInterface.Views.TreeProxyView")]
@@ -41,7 +41,7 @@ namespace Models.Agroforestry
         [Link]
         IWeather weather = null;
         [Link]
-        Clock clock = null;
+        IClock clock = null;
 
         /// <summary>
         /// Gets or sets the table data.
@@ -207,7 +207,7 @@ namespace Models.Agroforestry
                     if (zone == ZoneList.FirstOrDefault())
                         D += 0; // the tree is at distance 0
                     else
-                        D += (zone as RectangularZone).Width; 
+                        D += (zone as RectangularZone).Width;
                 }
                 else if (zone is CircularZone)
                     D += (zone as CircularZone).Width;
@@ -217,7 +217,7 @@ namespace Models.Agroforestry
                 if (zone == z)
                     return D;
             }
-        
+
             throw new ApsimXException(this, "Could not find zone called " + z.Name);
         }
 
@@ -239,7 +239,7 @@ namespace Models.Agroforestry
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="z"></param>
         /// <returns></returns>
@@ -263,7 +263,7 @@ namespace Models.Agroforestry
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="z"></param>
         /// <returns></returns>
@@ -278,7 +278,7 @@ namespace Models.Agroforestry
             {
                 rldInterp[i] = MathUtilities.LinearInterpReal(distInTH, rld.Keys.ToArray(), rldM.Row(i).ToArray(), out didInterp);
             }
-                       
+
             return rldInterp;
         }
 
@@ -292,7 +292,7 @@ namespace Models.Agroforestry
 
             for (int i = 2; i < Table.Count; i++)
             {
-                shade.Add(THCutoffs[i - 2], Convert.ToDouble(Table[i][0], 
+                shade.Add(THCutoffs[i - 2], Convert.ToDouble(Table[i][0],
                                                              System.Globalization.CultureInfo.InvariantCulture));
                 List<double> getRLDs = new List<double>();
                 for (int j = 3; j < Table[1].Count; j++)
@@ -357,7 +357,7 @@ namespace Models.Agroforestry
         /// Calculate water use on a per tree basis (L)
         /// </summary>
         [Units("L")]
-        public double IndividualTreeWaterUptake { 
+        public double IndividualTreeWaterUptake {
             get
             {
                 double TWU = 0;
@@ -382,7 +382,7 @@ namespace Models.Agroforestry
             get;
             private set;
         }
-        
+
         /// <summary>Called when [simulation commencing].</summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
@@ -418,7 +418,7 @@ namespace Models.Agroforestry
 
             List<ZoneWaterAndN> Uptakes = new List<ZoneWaterAndN>();
             double PotSWSupply = 0; // Total water supply (L)
-            
+
             foreach (ZoneWaterAndN Z in soilstate.Zones)
             {
                 foreach (Zone ZI in ZoneList)
@@ -447,7 +447,7 @@ namespace Models.Agroforestry
 
                         for (int i = 0; i <= SW.Length - 1; i++)
                         {
-                            Uptake.Water[i] = Math.Max(SW[i] - LL15mm[i],0.0) * BaseKL*RLD[i]; 
+                            Uptake.Water[i] = Math.Max(SW[i] - LL15mm[i],0.0) * BaseKL*RLD[i];
                             PotSWSupply += Uptake.Water[i] * ZI.Area * 10000;
                         }
                         Uptakes.Add(Uptake);
@@ -490,7 +490,7 @@ namespace Models.Agroforestry
 
             List<ZoneWaterAndN> Uptakes = new List<ZoneWaterAndN>();
             double PotNO3Supply = 0; // Total N supply (kg)
-            
+
             double NDemandkg = GetNDemandToday()*10 * treeZone.Area;
 
             foreach (ZoneWaterAndN Z in soilstate.Zones)
@@ -513,7 +513,7 @@ namespace Models.Agroforestry
                             }
 
                         double[] SW = Z.Water;
-                        
+
                         Uptake.NO3N = new double[SW.Length];
                         Uptake.NH4N = new double[SW.Length];
                         Uptake.Water = new double[SW.Length];
@@ -601,7 +601,7 @@ namespace Models.Agroforestry
                     }
                 }
             }
-            
+
         }
 
         /// <summary>

--- a/Models/CLEM/Activities/CropActivityManageProduct.cs
+++ b/Models/CLEM/Activities/CropActivityManageProduct.cs
@@ -28,7 +28,7 @@ namespace Models.CLEM.Activities
     public class CropActivityManageProduct: CLEMActivityBase, IValidatableObject, IHandlesActivityCompanionModels
     {
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
         [Link]
         private Simulation simulation = null;
         [Link]
@@ -85,7 +85,7 @@ namespace Models.CLEM.Activities
         public double PlantedMultiplier { get; set; }
 
         /// <summary>
-        /// Number of Trees per Hectare 
+        /// Number of Trees per Hectare
         /// </summary>
         [Description("Number of Trees (perHa) [0 if not a tree crop]")]
         [Required]
@@ -220,7 +220,7 @@ namespace Models.CLEM.Activities
             // look up tree until we find a parent to allow nested crop products for rotate vs mixed cropping/products
             parentManagementActivity = FindAncestor<CropActivityManageCrop>();
 
-            // Retrieve harvest data from the forage file for the entire run. 
+            // Retrieve harvest data from the forage file for the entire run.
             // only get entries where a harvest happened (Amtkg > 0)
             HarvestData = fileCrop.GetCropDataForEntireRun(parentManagementActivity.LinkedLandItem.SoilType, CropName,
                                                                clock.StartDate, clock.EndDate).Where(a => a.AmtKg > 0).OrderBy(a => a.Year * 100 + a.Month).ToList<CropDataType>();
@@ -278,7 +278,7 @@ namespace Models.CLEM.Activities
         private void OnCLEMStartOfTimeStepDoRotations(object sender, EventArgs e)
         {
             // rotate harvest if needed
-            if (rotationReady) 
+            if (rotationReady)
             {
                 parentManagementActivity.RotateCrop();
             }
@@ -293,7 +293,7 @@ namespace Models.CLEM.Activities
         private void OnCLEMStartOfTimeStep(object sender, EventArgs e)
         {
             harvests.current = null;
-            rotationReady = false;  
+            rotationReady = false;
             harvestOffset = (null, null, null, null);
             if (harvests.first == null)
             {
@@ -409,8 +409,8 @@ namespace Models.CLEM.Activities
         }
 
         /// <summary>
-        /// Function to calculate ecological indicators. 
-        /// By summing the monthly stocking rates so when you do yearly ecological calculation 
+        /// Function to calculate ecological indicators.
+        /// By summing the monthly stocking rates so when you do yearly ecological calculation
         /// you can get average monthly stocking rate for the whole year.
         /// </summary>
         /// <param name="sender">The sender.</param>
@@ -425,7 +425,7 @@ namespace Models.CLEM.Activities
             {
                 double area = (Parent as CropActivityManageCrop).Area * UnitsToHaConverter * 0.01;
 
-                // add this months stocking rate to running total 
+                // add this months stocking rate to running total
                 stockingRateSummed += PastureActivityManage.CalculateStockingRateRightNow(Resources.FindResourceGroup<RuminantHerd>(), StoreItemName, area);
 
                 //If it is time to do yearly calculation
@@ -647,7 +647,7 @@ namespace Models.CLEM.Activities
                 htmlWriter.Write($"\r\n<div class=\"activityentry\">Data is retrieved from {CLEMModel.DisplaySummaryValueSnippet(ModelNameFileCrop, "Resource not set", HTMLSummaryStyle.FileReader)}");
                 htmlWriter.Write($" using crop named {CLEMModel.DisplaySummaryValueSnippet(CropName)}");
                 htmlWriter.Write("</div>");
-                return htmlWriter.ToString(); 
+                return htmlWriter.ToString();
             }
         }
 

--- a/Models/CLEM/Activities/LabourActivityPayHired.cs
+++ b/Models/CLEM/Activities/LabourActivityPayHired.cs
@@ -27,7 +27,7 @@ namespace Models.CLEM.Activities
     public class LabourActivityPayHired : CLEMActivityBase, IValidatableObject, IHandlesActivityCompanionModels
     {
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
         private double amountToDo;
         private double amountToSkip;
         private string task = "";
@@ -212,7 +212,7 @@ namespace Models.CLEM.Activities
                 htmlWriter.Write("\r\n<div class=\"activityentry\">Pay all hired labour based on associated Fee components</div>");
                 return htmlWriter.ToString();
             }
-        } 
+        }
         #endregion
 
     }

--- a/Models/CLEM/Activities/ManureActivityCollectPaddock.cs
+++ b/Models/CLEM/Activities/ManureActivityCollectPaddock.cs
@@ -27,7 +27,7 @@ namespace Models.CLEM.Activities
     public class ManureActivityCollectPaddock: CLEMActivityBase, IHandlesActivityCompanionModels
     {
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
 
         private ProductStoreTypeManure manureStore;
         private ActivityCarryLimiter limiter;
@@ -176,7 +176,7 @@ namespace Models.CLEM.Activities
                 htmlWriter.Write("</div>");
                 return htmlWriter.ToString();
             }
-        } 
+        }
         #endregion
 
     }

--- a/Models/CLEM/Activities/PastureActivityCutAndCarry.cs
+++ b/Models/CLEM/Activities/PastureActivityCutAndCarry.cs
@@ -26,7 +26,7 @@ namespace Models.CLEM.Activities
     public class PastureActivityCutAndCarry : CLEMRuminantActivityBase, IHandlesActivityCompanionModels
     {
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
         private GrazeFoodStoreType pasture;
         private AnimalFoodStoreType foodstore;
         private ActivityCarryLimiter limiter;
@@ -92,7 +92,7 @@ namespace Models.CLEM.Activities
         {
             // activity is performed in CLEMDoCutAndCarry not CLEMGetResources
             this.AllocationStyle = ResourceAllocationStyle.Manual;
-            
+
             // get pasture
             pasture = Resources.FindResourceType<GrazeFoodStore, GrazeFoodStoreType>(this, PaddockName, OnMissingResourceActionTypes.ReportErrorAndStop, OnMissingResourceActionTypes.ReportErrorAndStop);
 
@@ -281,9 +281,9 @@ namespace Models.CLEM.Activities
                 htmlWriter.Write(" and carry to ");
                 htmlWriter.Write(CLEMModel.DisplaySummaryValueSnippet(AnimalFoodStoreName, "Store not set", HTMLSummaryStyle.Resource));
                 htmlWriter.Write("</div>");
-                return htmlWriter.ToString(); 
+                return htmlWriter.ToString();
             }
-        } 
+        }
         #endregion
 
     }

--- a/Models/CLEM/Activities/ResourceActivityManageExternal.cs
+++ b/Models/CLEM/Activities/ResourceActivityManageExternal.cs
@@ -28,7 +28,7 @@ namespace Models.CLEM.Activities
     public class ResourceActivityManageExternal : CLEMActivityBase, IHandlesActivityCompanionModels, IValidatableObject
     {
         [Link]
-        private readonly Clock clock = null;
+        private readonly IClock clock = null;
         private double[,] amountToDo;
         private double[,] valueToDo;
         private double[,] packetsToDo;
@@ -182,7 +182,7 @@ namespace Models.CLEM.Activities
                 {
                     var resource = allResources[item[fileResource.ResourceNameColumnName].ToString()];
                     if(resource.Item1 != null)
-                    { 
+                    {
                         // amount provided x any multiplier
                         double amount = Convert.ToDouble(item[fileResource.AmountColumnName], CultureInfo.InvariantCulture) * resource.Item2;
 
@@ -430,7 +430,7 @@ namespace Models.CLEM.Activities
                 htmlWriter.Write("</div>");
                 htmlWriter.Write("</div>");
 
-                return htmlWriter.ToString(); 
+                return htmlWriter.ToString();
             }
         }
 

--- a/Models/CLEM/Activities/RuminantActivityGrazeAll.cs
+++ b/Models/CLEM/Activities/RuminantActivityGrazeAll.cs
@@ -30,7 +30,7 @@ namespace Models.CLEM.Activities
     public class RuminantActivityGrazeAll : CLEMRuminantActivityBase, IValidatableObject
     {
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
 
         /// <summary>
         /// Number of hours grazed
@@ -159,9 +159,9 @@ namespace Models.CLEM.Activities
 
                 htmlWriter.Write("the maximum 8 hours each day</span>");
                 htmlWriter.Write("</div>");
-                return htmlWriter.ToString(); 
+                return htmlWriter.ToString();
             }
-        } 
+        }
         #endregion
 
     }

--- a/Models/CLEM/Activities/RuminantActivityGrazePasture.cs
+++ b/Models/CLEM/Activities/RuminantActivityGrazePasture.cs
@@ -35,7 +35,7 @@ namespace Models.CLEM.Activities
         /// Public so children can be dynamically created after links defined
         /// </summary>
         [Link]
-        public Clock Clock = null;
+        public IClock Clock = null;
 
         /// <summary>
         /// Number of hours grazed
@@ -189,9 +189,9 @@ namespace Models.CLEM.Activities
                     htmlWriter.Write(((HoursGrazed == 8) ? "" : "<span class=\"setvalue\">" + HoursGrazed.ToString("0.#") + "</span> hours of "));
                 htmlWriter.Write("the maximum 8 hours each day</span>");
                 htmlWriter.Write("</div>");
-                return htmlWriter.ToString(); 
+                return htmlWriter.ToString();
             }
-        } 
+        }
         #endregion
 
     }

--- a/Models/CLEM/Activities/RuminantActivityGrazePastureHerd.cs
+++ b/Models/CLEM/Activities/RuminantActivityGrazePastureHerd.cs
@@ -31,7 +31,7 @@ namespace Models.CLEM.Activities
         /// Public so children can be dynamically created after links defined
         /// </summary>
         [Link]
-        public Clock Clock = null;
+        public IClock Clock = null;
 
         private DateTime lastResourceRequest = new DateTime();
         private double totalPastureRequired = 0;
@@ -112,9 +112,9 @@ namespace Models.CLEM.Activities
         /// Potential intake limit
         /// </summary>
         [JsonIgnore]
-        public double PotentialIntakeLimit 
+        public double PotentialIntakeLimit
         {
-            get { return PotentialIntakePastureQualityLimiter * PotentialIntakePastureBiomassLimiter * PotentialIntakeGrazingTimeLimiter * GrazingCompetitionLimiter; } 
+            get { return PotentialIntakePastureQualityLimiter * PotentialIntakePastureBiomassLimiter * PotentialIntakeGrazingTimeLimiter * GrazingCompetitionLimiter; }
         }
 
         /// <summary>
@@ -195,7 +195,7 @@ namespace Models.CLEM.Activities
             double pastureDMD = GrazeFoodStoreModel.DMD;
             // Reduce potential intake based on pasture quality for the proportion consumed (zero legume).
             // TODO: check that this doesn't need to be performed for each breed based on how pasture taken
-            // this will still occur when grazing on improved, irrigated or crops. 
+            // this will still occur when grazing on improved, irrigated or crops.
             // CLEM does not allow grazing on two pastures in the month, whereas NABSA allowed irrigated pasture and supplemented with native for remainder needed.
             if (MathUtilities.IsGreaterThanOrEqual(0.8 - GrazeFoodStoreModel.IntakeTropicalQualityCoefficient - pastureDMD / 100, 0))
                 return 1 - GrazeFoodStoreModel.IntakeQualityCoefficient * (0.8 - GrazeFoodStoreModel.IntakeTropicalQualityCoefficient - pastureDMD / 100);
@@ -309,12 +309,12 @@ namespace Models.CLEM.Activities
                 // shortfall already takes into account competition (AdjustResourcesForActivity) and availability
                 double shortfall = (pastureRequest?.Provided??0) / totalPastureRequired;
 
-                // allocate to individuals in proportion to what they requested 
+                // allocate to individuals in proportion to what they requested
 
                 // current DMD and N of intake is stored in th DMD and N properties of this class as passed to GrazeFoodStoreType.Remove as AdditionalDetails with breed pool limits
                 foodDetails = new FoodResourcePacket()
                 {
-                    DMD = DMD, 
+                    DMD = DMD,
                     PercentN = N
                 };
 
@@ -450,9 +450,9 @@ namespace Models.CLEM.Activities
                     htmlWriter.Write(((HoursGrazed == 8) ? "" : "<span class=\"setvalue\">" + HoursGrazed.ToString("0.#") + "</span> hours of "));
                 htmlWriter.Write("the maximum 8 hours each day</span>");
                 htmlWriter.Write("</div>");
-                return htmlWriter.ToString(); 
+                return htmlWriter.ToString();
             }
-        } 
+        }
         #endregion
     }
 }

--- a/Models/CLEM/Activities/RuminantActivityGrow.cs
+++ b/Models/CLEM/Activities/RuminantActivityGrow.cs
@@ -33,7 +33,7 @@ namespace Models.CLEM.Activities
     public class RuminantActivityGrow : CLEMActivityBase
     {
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
 
         private GreenhouseGasesType methaneEmissions;
         private ProductStoreTypeManure manureStore;
@@ -195,12 +195,12 @@ namespace Models.CLEM.Activities
                         // Reference: Intake multiplier for lactating cow (M.Freer)
                         // double intakeMilkMultiplier = 1 + 0.57 * Math.Pow((dayOfLactation / 81.0), 0.7) * Math.Exp(0.7 * (1 - (dayOfLactation / 81.0)));
                         double intakeMilkMultiplier = 1 + ind.BreedParams.LactatingPotentialModifierConstantA * Math.Pow((dayOfLactation / ind.BreedParams.LactatingPotentialModifierConstantB), ind.BreedParams.LactatingPotentialModifierConstantC) * Math.Exp(ind.BreedParams.LactatingPotentialModifierConstantC * (1 - (dayOfLactation / ind.BreedParams.LactatingPotentialModifierConstantB)))*(1 - 0.5 + 0.5 * (ind.Weight/ind.NormalisedAnimalWeight));
-                        
+
                         // To make this flexible for sheep and goats, added three new Ruminant Coeffs
                         // Feeding standard values for Beef, Dairy suck, Dairy non-suck and sheep are:
                         // For 0.57 (A) use .42, .58, .85 and .69; for 0.7 (B) use 1.7, 0.7, 0.7 and 1.4, for 81 (C) use 62, 81, 81, 28
                         // added LactatingPotentialModifierConstantA, LactatingPotentialModifierConstantB and LactatingPotentialModifierConstantC
-                        // replaces (A), (B) and (C) 
+                        // replaces (A), (B) and (C)
                         potentialIntake *= intakeMilkMultiplier;
 
                         // calculate estimated milk production for time step here
@@ -219,7 +219,7 @@ namespace Models.CLEM.Activities
                         femaleind.MilkProducedThisTimeStep = 0;
                     }
                 }
-                
+
                 //TODO: option to restrict potential further due to stress (e.g. heat, cold, rain)
 
             }
@@ -393,7 +393,7 @@ namespace Models.CLEM.Activities
         }
 
         /// <summary>
-        /// Function to calculate manure production and place in uncollected manure pools of the "manure" resource in ProductResources 
+        /// Function to calculate manure production and place in uncollected manure pools of the "manure" resource in ProductResources
         /// This is called at the end of CLEMAnimalWeightGain so after intake determines and before deaths and sales.
         /// </summary>
         /// <param name="sender">The sender.</param>
@@ -421,7 +421,7 @@ namespace Models.CLEM.Activities
         private void CalculateEnergy(Ruminant ind, out double methaneProduced)
         {
             // all energy calculations are per day and multiplied at end to give monthly weight gain
-            
+
             // previously ind.MetabolicIntake / 30.4 - sure this was mistake
             double intakeDaily = ind.Intake / 30.4;
 
@@ -526,7 +526,7 @@ namespace Models.CLEM.Activities
 
                 // Reference: SCA p.24
                 // Reference p19 (1.20). Does not include MEgraze or Ecold, also skips M,
-                // 0.000082 is -0.03 Age in Years/365 for days 
+                // 0.000082 is -0.03 Age in Years/365 for days
                 energyMaintenance = ind.BreedParams.Kme * sme * (ind.BreedParams.EMaintCoefficient * Math.Pow(ind.Weight, 0.75) / km) * Math.Exp(-ind.BreedParams.EMaintExponent * maintenanceAge) + (ind.BreedParams.EMaintIntercept * energyMetablicFromIntake);
                 ind.EnergyBalance = energyMetablicFromIntake - energyMaintenance - energyMilk - energyFetus; // milk will be zero for non lactating individuals.
                 double feedingValue;
@@ -560,7 +560,7 @@ namespace Models.CLEM.Activities
             double mxwt = ind.StandardReferenceWeight * ind.BreedParams.MaximumSizeOfIndividual;
             newWt = Math.Min(newWt, mxwt);
             ind.Weight = newWt;
-            
+
             // sped up above using locals
             //ind.Weight += energyPredictedBodyMassChange;
             //ind.Weight = Math.Max(0.0, ind.Weight);
@@ -570,7 +570,7 @@ namespace Models.CLEM.Activities
             // Function based on Freer spreadsheet
             // methane is  0.02 * intakeDaily * ((13 + 7.52 * energyMetabolic) + energyMetablicFromIntake / energyMaintenance * (23.7 - 3.36 * energyMetabolic)); // MJ per day
             // methane is methaneProduced / 55.28 * 1000; // grams per day
-            
+
             // Charmely et al 2016 can be substituted by intercept = 0 and coefficient = 20.7
             methaneProduced = ind.BreedParams.MethaneProductionCoefficient * intakeDaily;
         }
@@ -690,9 +690,9 @@ namespace Models.CLEM.Activities
                 else
                     htmlWriter.Write($"<span class=\"resourcelink\">{MethaneStoreName}</span>");
                 htmlWriter.Write("</div>");
-                return htmlWriter.ToString(); 
+                return htmlWriter.ToString();
             }
-        } 
+        }
         #endregion
 
     }

--- a/Models/CLEM/Activities/RuminantActivityPredictiveStocking.cs
+++ b/Models/CLEM/Activities/RuminantActivityPredictiveStocking.cs
@@ -33,7 +33,7 @@ namespace Models.CLEM.Activities
     public class RuminantActivityPredictiveStocking: CLEMRuminantActivityBase, IHandlesActivityCompanionModels
     {
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
 
         private int numberToSkip = 0;
         private int numberToDo = 0;
@@ -349,11 +349,11 @@ namespace Models.CLEM.Activities
                 else
                     htmlWriter.Write("<span class=\"errorlink\">No month set");
                 htmlWriter.Write("</span></div>");
-                
+
                 htmlWriter.Write("\r\n<div class=\"activityentry\">The herd will be sold to maintain ");
                 htmlWriter.Write($"{CLEMModel.DisplaySummaryValueSnippet(FeedLowLimit, warnZero: true)} kg/ha at the end of this period");
                 htmlWriter.Write("</div>");
-                return htmlWriter.ToString(); 
+                return htmlWriter.ToString();
             }
         }
 

--- a/Models/CLEM/Activities/RuminantActivityPredictiveStockingENSO.cs
+++ b/Models/CLEM/Activities/RuminantActivityPredictiveStockingENSO.cs
@@ -31,7 +31,7 @@ namespace Models.CLEM.Activities
     public class RuminantActivityPredictiveStockingENSO: CLEMRuminantActivityBase, IHandlesActivityCompanionModels
     {
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
         private Relationship pastureToStockingChangeElNino { get; set; }
         private Relationship pastureToStockingChangeLaNina { get; set; }
 
@@ -470,7 +470,7 @@ namespace Models.CLEM.Activities
             }
 
             if (MathUtilities.IsPositive(destockDone + restockDone))
-            { 
+            {
                     SetStatusSuccessOrPartial(MathUtilities.FloatsAreEqual(destockToDo + restockToDo, destockDone + restockDone) == false);
 
                 // TODO wire up add report status as per Predictive stocking

--- a/Models/CLEM/Activities/RuminantActivityWean.cs
+++ b/Models/CLEM/Activities/RuminantActivityWean.cs
@@ -32,7 +32,7 @@ namespace Models.CLEM.Activities
     public class RuminantActivityWean: CLEMRuminantActivityBase, IHandlesActivityCompanionModels, IValidatableObject
     {
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
 
         private string grazeStore;
         private int numberToSkip = 0;
@@ -70,7 +70,7 @@ namespace Models.CLEM.Activities
         [System.ComponentModel.DefaultValue("Leave at current location")]
         [Required(AllowEmptyStrings = false, ErrorMessage = "Weaned individuals' location required")]
         public string GrazeFoodStoreName { get; set; }
-      
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -301,9 +301,9 @@ namespace Models.CLEM.Activities
 
                 htmlWriter.Write("</div>");
                 // ToDo: warn if natural weaning will take place
-                return htmlWriter.ToString(); 
+                return htmlWriter.ToString();
             }
-        } 
+        }
         #endregion
     }
 }

--- a/Models/CLEM/DataReaders/FilePasture.cs
+++ b/Models/CLEM/DataReaders/FilePasture.cs
@@ -16,8 +16,8 @@ namespace Models.CLEM
     /// Reads in pasture production and makes it available to other models.
     ///</summary>
     [Serializable]
-    [ViewName("UserInterface.Views.GridView")] 
-    [PresenterName("UserInterface.Presenters.PropertyPresenter")] 
+    [ViewName("UserInterface.Views.GridView")]
+    [PresenterName("UserInterface.Presenters.PropertyPresenter")]
     [Description("Specifies a pasture database file for native pasture used in the CLEM simulation")]
     [Version(1, 0, 2, "This component is no longer supported.\r\nUse the FileSQLitePasture reader for best performance.")]
     [Version(1, 0, 1, "")]
@@ -25,7 +25,7 @@ namespace Models.CLEM
     public class FilePasture : CLEMModel, IFilePasture
     {
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
 
         /// <summary>
         /// A reference to the text file reader object
@@ -75,8 +75,8 @@ namespace Models.CLEM
         /// The index of the year number column in the Pasture database
         /// This is NOT the actually date year, this is the number of
         /// years since the start of the pasture model run that generated the
-        /// pasture data. 
-        /// eg. it starts at 1 and goes up sequentially 
+        /// pasture data.
+        /// eg. it starts at 1 and goes up sequentially
         /// for however many years the pasture model run went for.
         /// </summary>
         private int yearNumIndex;
@@ -96,9 +96,9 @@ namespace Models.CLEM
         /// crop. Cut Number = 1 is the first harvest after planting
         /// and it goes up from there until it is pulled out and
         /// replanted.
-        /// nb. you may have multiple cuts in the one month so 
+        /// nb. you may have multiple cuts in the one month so
         /// year and month does not uniquely identify the monthly
-        /// yield data for that month. 
+        /// yield data for that month.
         /// We need to add up all the cuts within that month and use
         /// this as the monthly yield data for these crops.
         /// </summary>
@@ -118,7 +118,7 @@ namespace Models.CLEM
         /// <summary>
         /// The index of the by product 1 column in the Pasture database
         /// Crops can have by products that are produced as a consequence
-        /// of growing the crop. 
+        /// of growing the crop.
         /// This is the amount of the first by product of this crop
         /// Eg. straw from growing wheat grain.
         /// nb. THIS IS NOT REALLY USED BY PASTURES
@@ -128,10 +128,10 @@ namespace Models.CLEM
         /// <summary>
         /// The index of the by product 2 (second) column in the Pasture database
         /// Crops can have by products that are produced as a consequence
-        /// of growing the crop. 
+        /// of growing the crop.
         /// This is the amount of the second by product of this crop
         /// Eg. grain husks from growing wheat grain.
-        /// nb. THIS IS NOT REALLY USED BY PASTURES. 
+        /// nb. THIS IS NOT REALLY USED BY PASTURES.
         /// </summary>
         private int bp2Index;
 
@@ -204,7 +204,7 @@ namespace Models.CLEM
         public string FileName { get; set; }
 
         /// <summary>
-        /// Gets or sets the full file name (with path). The user interface uses this. 
+        /// Gets or sets the full file name (with path). The user interface uses this.
         /// </summary>
         [JsonIgnore]
         public string FullFileName
@@ -281,14 +281,14 @@ namespace Models.CLEM
         /// <summary>
         /// Provides an error message to display if something is wrong.
         /// Used by the UserInterface to give a warning of what is wrong
-        /// 
-        /// When the user selects a file using the browse button in the UserInterface 
+        ///
+        /// When the user selects a file using the browse button in the UserInterface
         /// and the file can not be displayed for some reason in the UserInterface.
         /// </summary>
         public string ErrorMessage = string.Empty;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <returns></returns>
         public DataTable GetTable()
@@ -393,7 +393,7 @@ namespace Models.CLEM
 
         /// <summary>
         /// Finds the closest Stocking Rate Category in the Pasture database for a given Stocking Rate.
-        /// The Pasture database does not have every stocking rate. 
+        /// The Pasture database does not have every stocking rate.
         /// Each Pasture database has its own set of stocking rate value categories
         /// Need to find the closest the stocking rate category in the Pasture database for this stocking rate.
         /// It will find the category with the next largest value to the actual stocking rate.
@@ -406,7 +406,7 @@ namespace Models.CLEM
             //https://stackoverflow.com/questions/41277957/get-closest-value-in-an-array
             //https://msdn.microsoft.com/en-us/library/2cy9f6wb(v=vs.110).aspx
             Array.Sort(distinctStkRates);
-            int index = Array.BinarySearch(distinctStkRates, stockingRate); 
+            int index = Array.BinarySearch(distinctStkRates, stockingRate);
             double category = (index < 0) ? distinctStkRates[~index] : distinctStkRates[index];
             return category;
         }
@@ -484,7 +484,7 @@ namespace Models.CLEM
             int region, string soil, double grassBasalArea, double landCondition, double stockingRate)
         {
             string errormessageStart = "Problem with Pasture database file." + System.Environment.NewLine
-                        + "For Region: " + region + ", Soil: " + soil 
+                        + "For Region: " + region + ", Soil: " + soil
                         + ", GrassBA: " + grassBasalArea + ", LandCon: " + landCondition + ", StkRate: " + stockingRate + System.Environment.NewLine;
 
             if (clock.EndDate == clock.Today)
@@ -495,7 +495,7 @@ namespace Models.CLEM
             foreach (PastureDataType month in filtered)
             {
                 if ((tempdate.Year != month.Year) || (tempdate.Month != month.Month))
-                    throw new ApsimXException(this, errormessageStart 
+                    throw new ApsimXException(this, errormessageStart
                         + "Missing entry for Year: " + month.Year + " and Month: " + month.Month);
                 tempdate = tempdate.AddMonths(1);
             }
@@ -518,7 +518,7 @@ namespace Models.CLEM
         /// <param name="year"></param>
         /// <param name="month"></param>
         /// <returns>CropDataType containg the crop data for this month</returns>
-        public PastureDataType GetMonthsPastureData(int region, int soil, int forageNo, int grassBasalArea, int landCondition, int stockingRate, 
+        public PastureDataType GetMonthsPastureData(int region, int soil, int forageNo, int grassBasalArea, int landCondition, int stockingRate,
                                          int year, int month)
         {
             object[] keyVals = new Object[8];
@@ -734,9 +734,9 @@ namespace Models.CLEM
                         htmlWriter.Write("Using <span class=\"filelink\">" + FileName + "</span>");
                 }
                 htmlWriter.Write("\r\n</div>");
-                return htmlWriter.ToString(); 
+                return htmlWriter.ToString();
             }
-        } 
+        }
         #endregion
     }
 
@@ -757,7 +757,7 @@ namespace Models.CLEM
         public int Soil;
 
         /// <summary>
-        /// Forage Number 
+        /// Forage Number
         /// nb. This column is to be ignored.
         /// </summary>
         public int ForageNo;
@@ -843,7 +843,7 @@ namespace Models.CLEM
         public double Runoff;
 
         /// <summary>
-        /// Combine Year and Month to create a DateTime. 
+        /// Combine Year and Month to create a DateTime.
         /// Day is set to the 1st of the month.
         /// </summary>
         public DateTime CutDate;

--- a/Models/CLEM/DataReaders/FilePricing.cs
+++ b/Models/CLEM/DataReaders/FilePricing.cs
@@ -19,7 +19,7 @@ namespace Models.CLEM
     ///<summary>
     /// Reads in external pricing input data and adjusts resource pricing as specified through simulation.
     ///</summary>
-    ///    
+    ///
     ///<remarks>
     ///</remarks>
     [Serializable]
@@ -34,7 +34,7 @@ namespace Models.CLEM
     public class FilePricing : CLEMModel, IValidatableObject
     {
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
 
         /// <summary>
         /// Gets or sets the file name. Should be relative filename where possible.
@@ -69,7 +69,7 @@ namespace Models.CLEM
         private List<IResourcePricing> pricingComonentsFound;
 
         /// <summary>
-        /// Gets or sets the full file name (with path). 
+        /// Gets or sets the full file name (with path).
         /// The Commands.ChangeProperty() uses this property to change the model.
         /// This is done after the user changes the file using the browse button in the View.
         /// </summary>
@@ -115,7 +115,7 @@ namespace Models.CLEM
                 throw new ApsimXException(this, errorMsg);
             }
 
-            // get all pricing component names 
+            // get all pricing component names
             // put in a list that provides a link to the object so we can use this to set values
             var resources = FindAllAncestors<Zone>().FirstOrDefault();
             if (resources != null)
@@ -126,7 +126,7 @@ namespace Models.CLEM
                 Sort = $"{DateColumnName} ASC"
             };
             priceFileAsRows = dataView.ToTable().Rows;
-            
+
             UpdatePricingToDate(clock.StartDate.Year, clock.StartDate.Month);
         }
 
@@ -150,7 +150,7 @@ namespace Models.CLEM
         private void OnCLEMStartOfTimeStep(object sender, EventArgs e)
         {
             // update all pricing this timestep
-            // use last price provided for timestep 
+            // use last price provided for timestep
             UpdatePricingToDate(clock.Today.Year, clock.Today.Month);
         }
 
@@ -185,8 +185,8 @@ namespace Models.CLEM
         /// <summary>
         /// Provides an error message to display if something is wrong.
         /// Used by the UserInterface to give a warning of what is wrong
-        /// 
-        /// When the user selects a file using the browse button in the UserInterface 
+        ///
+        /// When the user selects a file using the browse button in the UserInterface
         /// and the file can not be displayed for some reason in the UserInterface.
         /// </summary>
         [JsonIgnore]

--- a/Models/CLEM/Extras/RainfallShuffler.cs
+++ b/Models/CLEM/Extras/RainfallShuffler.cs
@@ -17,8 +17,8 @@ namespace Models.CLEM
     ///<remarks>
     ///</remarks>
     [Serializable]
-    [ViewName("UserInterface.Views.GridView")] 
-    [PresenterName("UserInterface.Presenters.PropertyPresenter")] 
+    [ViewName("UserInterface.Views.GridView")]
+    [PresenterName("UserInterface.Presenters.PropertyPresenter")]
     [ValidParent(ParentType = typeof(FileSQLitePasture))]
     [Description("Shuffle rainfall years for reading pasture data as proxy for randomised rainfall")]
     [Version(1, 0, 1, "")]
@@ -27,7 +27,7 @@ namespace Models.CLEM
     public class RainfallShuffler: CLEMModel, IValidatableObject
     {
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
 
         /// <summary>
         /// Month for the start of rainfall/growth season
@@ -142,7 +142,7 @@ namespace Models.CLEM
                 htmlWriter.Write("\r\n<div class=\"activityentry\">");
                 htmlWriter.Write("\r\n<div class=\"warningbanner\">WARNING: Rainfall years are being shuffled as a proxy for stochastic rainfall variation in this simulation.<br />This is an advance feature provided for particular projects.</div>");
                 htmlWriter.Write("\r\n</div>");
-                return htmlWriter.ToString(); 
+                return htmlWriter.ToString();
             }
         }
 

--- a/Models/CLEM/Resources/Finance.cs
+++ b/Models/CLEM/Resources/Finance.cs
@@ -9,7 +9,7 @@ namespace Models.CLEM.Resources
 {
     ///<summary>
     /// Parent model of finance models.
-    ///</summary> 
+    ///</summary>
     [Serializable]
     [ViewName("UserInterface.Views.PropertyView")]
     [PresenterName("UserInterface.Presenters.PropertyPresenter")]
@@ -20,7 +20,7 @@ namespace Models.CLEM.Resources
     public class Finance : ResourceBaseWithTransactions
     {
         [Link]
-        Clock Clock = null;
+        IClock Clock = null;
 
         /// <summary>
         /// Currency used
@@ -68,7 +68,7 @@ namespace Models.CLEM.Resources
             }
             htmlWriter.Write("</div>");
             return htmlWriter.ToString();
-        } 
+        }
 
         #endregion
 

--- a/Models/CLEM/Resources/GrazeFoodStoreFertilityLimiter.cs
+++ b/Models/CLEM/Resources/GrazeFoodStoreFertilityLimiter.cs
@@ -22,7 +22,7 @@ namespace Models.CLEM.Resources
     public class GrazeFoodStoreFertilityLimiter: CLEMModel
     {
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
 
         private double annualNUsed = 0;
         private GrazeFoodStoreType parentPasture;
@@ -77,7 +77,7 @@ namespace Models.CLEM.Resources
         /// </summary>
         /// <param name="newGrowthKgHa">The amount of new growth in this month (kg per ha)</param>
         /// <returns>The proportion of new grass nitrogen content to assign</returns>
-        public double GetProportionNitrogenLimited(double newGrowthKgHa) 
+        public double GetProportionNitrogenLimited(double newGrowthKgHa)
         {
             // calculate proportion of new growth above the cutoff to adjust N reduction accordingly
             double nRequired = newGrowthKgHa * parentPasture.GreenNitrogen / 100;
@@ -179,9 +179,9 @@ namespace Models.CLEM.Resources
                     htmlWriter.Write("or <b>(B)</b> Add a ActivityMonthRangeTimer below to reduce nitrogen content in specified months");
                     htmlWriter.Write("\r\n</div>");
                 }
-                return htmlWriter.ToString(); 
+                return htmlWriter.ToString();
             }
-        } 
+        }
         #endregion
     }
 }

--- a/Models/CLEM/Resources/Labour.cs
+++ b/Models/CLEM/Resources/Labour.cs
@@ -14,7 +14,7 @@ namespace Models.CLEM.Resources
 {
     ///<summary>
     /// Parent model of Labour Person models.
-    ///</summary> 
+    ///</summary>
     [Serializable]
     [ViewName("UserInterface.Views.PropertyView")]
     [PresenterName("UserInterface.Presenters.PropertyPresenter")]
@@ -25,7 +25,7 @@ namespace Models.CLEM.Resources
     public class Labour: ResourceBaseWithTransactions, IValidatableObject, IHandlesActivityCompanionModels
     {
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
 
         private List<string> warningsMultipleEntry = new List<string>();
         private List<string> warningsNotFound = new List<string>();
@@ -259,7 +259,7 @@ namespace Models.CLEM.Resources
         {
             List<LabourType> checkList = new List<LabourType>() { labour };
             if (labour.LabourAvailability != null)
-            {                
+            {
                 // check labour availability still ok
                 if (!(labour.LabourAvailability as IFilterGroup).Filter(checkList).Any())
                     labour.LabourAvailability = null;
@@ -286,7 +286,7 @@ namespace Models.CLEM.Resources
 
                     throw new ApsimXException(this, msg);
                 }
-            }            
+            }
         }
 
         /// <summary>Age individuals</summary>
@@ -346,7 +346,7 @@ namespace Models.CLEM.Resources
             {
                 // search through RuminantPriceGroups for first match with desired purchase or sale flag
                 foreach (LabourPriceGroup item in PayList.FindAllChildren<LabourPriceGroup>())
-                    if (item.Filter(ind))                    
+                    if (item.Filter(ind))
                         return item.Value;
 
                 // no price match found.
@@ -376,7 +376,7 @@ namespace Models.CLEM.Resources
                 LabourPriceGroup matchCriteria = null;
                 foreach (LabourPriceGroup priceGroup in PayList.FindAllChildren<LabourPriceGroup>())
                 {
-                    if (priceGroup.Filter(ind) && matchIndividual == null)                    
+                    if (priceGroup.Filter(ind) && matchIndividual == null)
                         matchIndividual = priceGroup;
 
                     // check that pricing item meets the specified criteria.
@@ -478,7 +478,7 @@ namespace Models.CLEM.Resources
                 }
                 htmlWriter.Write("</table>");
                 htmlWriter.Write("</div></div>");
-                return htmlWriter.ToString(); 
+                return htmlWriter.ToString();
             }
         }
 

--- a/Models/CLEM/Timers/ActivityTimerDateRange.cs
+++ b/Models/CLEM/Timers/ActivityTimerDateRange.cs
@@ -30,7 +30,7 @@ namespace Models.CLEM.Timers
     public class ActivityTimerDateRange : CLEMModel, IActivityTimer, IActivityPerformedNotifier
     {
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
 
         /// <summary>
         /// Start date of period to perform activities
@@ -39,7 +39,7 @@ namespace Models.CLEM.Timers
         [System.ComponentModel.DefaultValue(typeof(DateTime), "1/1/1900")]
         [Required]
         public DateTime StartDate { get; set; }
-        
+
         /// <summary>
         /// End date of period to perform activities
         /// </summary>
@@ -161,7 +161,7 @@ namespace Models.CLEM.Timers
                 htmlWriter.Write("</div>");
                 if (!this.Enabled & !FormatForParentControl)
                     htmlWriter.Write(" - DISABLED!");
-                return htmlWriter.ToString(); 
+                return htmlWriter.ToString();
             }
         }
 
@@ -181,9 +181,9 @@ namespace Models.CLEM.Timers
                     htmlWriter.Write(this.Name);
                 htmlWriter.Write($"</div>");
                 htmlWriter.Write("\r\n<div class=\"filterborder clearfix\" style=\"opacity: " + SummaryOpacity(FormatForParentControl).ToString() + "\">");
-                return htmlWriter.ToString(); 
+                return htmlWriter.ToString();
             }
-        } 
+        }
         #endregion
 
     }

--- a/Models/CLEM/Timers/ActivityTimerMonthRange.cs
+++ b/Models/CLEM/Timers/ActivityTimerMonthRange.cs
@@ -32,7 +32,7 @@ namespace Models.CLEM.Timers
     public class ActivityTimerMonthRange: CLEMModel, IActivityTimer, IActivityPerformedNotifier
     {
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
 
         private int startMonth;
         private int endMonth;
@@ -155,7 +155,7 @@ namespace Models.CLEM.Timers
                 htmlWriter.Write("</div>");
                 if (!this.Enabled & !FormatForParentControl)
                     htmlWriter.Write(" - DISABLED!");
-                return htmlWriter.ToString(); 
+                return htmlWriter.ToString();
             }
         }
 
@@ -175,9 +175,9 @@ namespace Models.CLEM.Timers
                     htmlWriter.Write(this.Name);
                 htmlWriter.Write($"</div>");
                 htmlWriter.Write("\r\n<div class=\"filterborder clearfix\" style=\"opacity: " + SummaryOpacity(FormatForParentControl).ToString() + "\">");
-                return htmlWriter.ToString(); 
+                return htmlWriter.ToString();
             }
-        } 
+        }
         #endregion
     }
 }

--- a/Models/CLEM/Timers/ActivityTimerResourceLevel.cs
+++ b/Models/CLEM/Timers/ActivityTimerResourceLevel.cs
@@ -30,7 +30,7 @@ namespace Models.CLEM.Timers
         [Link]
         private ResourcesHolder resources = null;
 
-        [Link] Clock clock = null;
+        [Link] IClock clock = null;
 
         double amountAtFirstCheck;
         DateTime checkDate = DateTime.Now;
@@ -195,7 +195,7 @@ namespace Models.CLEM.Timers
                 htmlWriter.Write("</div>");
                 if (!this.Enabled & !FormatForParentControl)
                     htmlWriter.Write(" - DISABLED!");
-                return htmlWriter.ToString(); 
+                return htmlWriter.ToString();
             }
         }
 
@@ -215,9 +215,9 @@ namespace Models.CLEM.Timers
                     htmlWriter.Write(this.Name);
                 htmlWriter.Write($"</div>");
                 htmlWriter.Write("\r\n<div class=\"filterborder clearfix\" style=\"opacity: " + SummaryOpacity(FormatForParentControl).ToString() + "\">");
-                return htmlWriter.ToString(); 
+                return htmlWriter.ToString();
             }
-        } 
+        }
         #endregion
 
     }

--- a/Models/CLEM/ZoneCLEM.cs
+++ b/Models/CLEM/ZoneCLEM.cs
@@ -32,7 +32,7 @@ namespace Models.CLEM
         [Link]
         private Summary summary = null;
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
         private string wholeSimulationSummaryFile = "";
 
         /// <summary>
@@ -145,7 +145,7 @@ namespace Models.CLEM
         [EventSubscribe("Completed")]
         private void OnCompleted(object sender, EventArgs e)
         {
-            // if auto create summary 
+            // if auto create summary
             if (AutoCreateDescriptiveSummary)
             {
                 if (!File.Exists(wholeSimulationSummaryFile))
@@ -284,10 +284,10 @@ namespace Models.CLEM
             IModel simulation = model.FindAncestor<Simulation>();
             var summary = simulation.FindDescendant<Summary>();
 
-            // get all validations 
+            // get all validations
             ReportErrors(model, summary.GetMessages(simulation.Name)?.Where(a => a.Severity == MessageType.Error && a.Text.StartsWith("Invalid parameter ")));
 
-            // get all other errors 
+            // get all other errors
             ReportErrors(model, summary.GetMessages(simulation.Name)?.Where(a => a.Severity == MessageType.Error && !a.Text.StartsWith("Invalid parameter ")));
 
         }
@@ -486,10 +486,10 @@ namespace Models.CLEM
 
                 foreach (CLEMModel cm in this.FindAllChildren<CLEMModel>())
                     htmlWriter.Write(cm.GetFullSummary(cm, CurrentAncestorList, "", markdown2Html));
-                
+
                 CurrentAncestorList = null;
 
-                return htmlWriter.ToString(); 
+                return htmlWriter.ToString();
             }
         }
 

--- a/Models/Climate/ControlledEnvironment.cs
+++ b/Models/Climate/ControlledEnvironment.cs
@@ -20,7 +20,7 @@ namespace Models.Climate
         /// A link to the clock model.
         /// </summary>
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
         /// <summary>
         /// Gets the start date of the weather file
         /// </summary>
@@ -92,7 +92,7 @@ namespace Models.Climate
         [Description("Solar Radiation")]
         [Units("MJ/m2/d")]
         public double Radn { get; set; }
-		
+
         /// <summary>
         /// Gets or sets the Pan Evaporation (mm) (Class A pan)
         /// </summary>

--- a/Models/Climate/SlopeEffectsOnWeather.cs
+++ b/Models/Climate/SlopeEffectsOnWeather.cs
@@ -8,7 +8,7 @@ namespace Models.Climate
     /// </summary>
     /// <remarks>
     /// - This include routines to modify the incoming solar radiation as well as minimum and maximum air temperatures;
-    /// - Adjusts for rainfall, vp, and windspeed, can be also done, but these are simply relative changes supplied by the user, not calculated. 
+    /// - Adjusts for rainfall, vp, and windspeed, can be also done, but these are simply relative changes supplied by the user, not calculated.
     /// - Calculations happens on PreparingNewWeatherData event and take also into account the latitude of the site (read from the weather model).
     /// + References:
     ///     Allen, R.G.; Pereira, L.S.; Raes, D.; and Smith, M., 1998. Crop evapotranspiration: guidelines for computing crop water requirements. Irrigation and Drainage Paper No. 56, FAO, Rome, Italy. 300 p.
@@ -27,7 +27,7 @@ namespace Models.Climate
     {
         /// <summary>Link to APSIM's clock model.</summary>
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
 
         /// <summary>Link to APSIM's weather file.</summary>
         [Link]
@@ -395,7 +395,7 @@ namespace Models.Climate
             // Sky clearness index - following typical approach (Boland et al., 2008; Dervishi and Mahdavi, 2012)
             ClearnessIndex = Math.Min(1.0, Math.Max(0.0, weather.Radn / ExtraterrestrialRadn));
 
-            // Diffuse radiation fraction - same approach as Boland et al. (2008), equivalent to Allen et al. (2006) 
+            // Diffuse radiation fraction - same approach as Boland et al. (2008), equivalent to Allen et al. (2006)
             DiffuseRadnFraction = 1.0 / (1.0 + Math.Exp(A_diffuseRadn + (B_diffuseRadn * ClearnessIndex)));
 
             if (zone.Slope > epsilon)

--- a/Models/Climate/Weather.cs
+++ b/Models/Climate/Weather.cs
@@ -25,7 +25,7 @@
         /// A link to the clock model.
         /// </summary>
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
 
         /// <summary>
         /// A reference to the text file reader object
@@ -148,7 +148,7 @@
         public string FileName { get; set; }
 
         /// <summary>
-        /// Gets or sets the full file name (with path). The user interface uses this. 
+        /// Gets or sets the full file name (with path). The user interface uses this.
         /// </summary>
         [JsonIgnore]
         public string FullFileName
@@ -432,19 +432,19 @@
         public DailyMetDataFromFile TomorrowsMetData { get; set; }
 
         /// <summary>First date of summer.</summary>
-        [JsonIgnore] 
+        [JsonIgnore]
         public string FirstDateOfSummer { get; set; } = "1-dec";
 
         /// <summary>First date of autumn / fall.</summary>
-        [JsonIgnore] 
+        [JsonIgnore]
         public string FirstDateOfAutumn { get; set; } = "1-mar";
 
         /// <summary>First date of winter.</summary>
-        [JsonIgnore] 
+        [JsonIgnore]
         public string FirstDateOfWinter { get; set; } = "1-jun";
 
         /// <summary>First date of spring.</summary>
-        [JsonIgnore] 
+        [JsonIgnore]
         public string FirstDateOfSpring { get; set; } = "1-sep";
 
         /// <summary>
@@ -601,7 +601,7 @@
         {
             if (this.reader != null)
                 this.reader.Close();
-            this.reader = null;            
+            this.reader = null;
         }
 
         /// <summary>
@@ -646,7 +646,7 @@
             { // Move everything forward a day
                 YesterdaysMetData = TodaysMetData;
                 TodaysMetData = TomorrowsMetData;
-                
+
                 if (clock.Today == clock.EndDate && clock.EndDate == reader.LastDate)
                     TomorrowsMetData = TodaysMetData;
                 else
@@ -665,7 +665,7 @@
             this.DayLength = TodaysMetData.DayLength;
             if (co2Index != -1)
                 CO2 = TodaysMetData.CO2;
-            
+
             if (this.PreparingNewWeatherData != null)
                 this.PreparingNewWeatherData.Invoke(this, new EventArgs());
 
@@ -675,13 +675,13 @@
                 if (clock.Today.DayOfYear < WinterSolsticeDOY)
                 {
                     if (DateTime.IsLeapYear(clock.Today.Year-1))
-                        DaysSinceWinterSolstice = 366 - WinterSolsticeDOY + clock.Today.DayOfYear;  
+                        DaysSinceWinterSolstice = 366 - WinterSolsticeDOY + clock.Today.DayOfYear;
                     else
-                        DaysSinceWinterSolstice = 365 - WinterSolsticeDOY + clock.Today.DayOfYear; 
+                        DaysSinceWinterSolstice = 365 - WinterSolsticeDOY + clock.Today.DayOfYear;
                 }
                 else
                     DaysSinceWinterSolstice = clock.Today.DayOfYear - WinterSolsticeDOY;
-                    
+
                 First = false;
             }
 
@@ -900,7 +900,7 @@
                 }
                 else
                 {
-                    if (this.reader.IsExcelFile != true) 
+                    if (this.reader.IsExcelFile != true)
                         this.reader.SeekToDate(this.reader.FirstDate);
                 }
 
@@ -948,7 +948,7 @@
                 this.reader.AddConstant("tav", tav.ToString(CultureInfo.InvariantCulture), string.Empty, string.Empty); // add a new constant
             else
                 this.reader.SetConstant("tav", tav.ToString(CultureInfo.InvariantCulture));
- 
+
             if (this.reader.Constant("amp") == null)
                 this.reader.AddConstant("amp", amp.ToString(CultureInfo.InvariantCulture), string.Empty, string.Empty); // add a new constant
             else

--- a/Models/Climate/WeatherSampler.cs
+++ b/Models/Climate/WeatherSampler.cs
@@ -17,8 +17,8 @@
     /// <remarks>
     /// Parameters / inputs
     ///     * read in a met file
-    ///     * parameter setting the 'start' of the year as dd-mmm-yyyy (e.g. "01-jun-3000") where the 
-    ///     dd-mmm part sets the start of all sampling years and the full dd-mmm-yyyy sets the start 
+    ///     * parameter setting the 'start' of the year as dd-mmm-yyyy (e.g. "01-jun-3000") where the
+    ///     dd-mmm part sets the start of all sampling years and the full dd-mmm-yyyy sets the start
     ///     date of the simulation (end date is the start plus the number of years listed below)
     ///     * read in either:
     ///         - a list of years in order to sample (e.g. "1997,2014,2000"); or
@@ -27,11 +27,11 @@
     ///     * ? an add-on to the existing met file?
     ///     * needs to be able to be used as a factor in an experiment
     /// What it does
-    ///     * sets the (fake) start date of the simulation (here 01-jun-3000) along with the weather data 
+    ///     * sets the (fake) start date of the simulation (here 01-jun-3000) along with the weather data
     ///     to be used with the "sampling_date" (here the first one would be 01-jun-1997 for example) being outputable
-    ///     * leap years - ignores 29-feb in the sampling data and pads an extra final day in the year if needed 
+    ///     * leap years - ignores 29-feb in the sampling data and pads an extra final day in the year if needed
     ///     (want the same weather regardless of the simulation year - hope that makes sense!)
-    ///     * in the example above, by the time the simulation gets to 31-may-3001, sampling_date is 31-may-1998. 
+    ///     * in the example above, by the time the simulation gets to 31-may-3001, sampling_date is 31-may-1998.
     ///     Then on simulation date 01-jun-3001 the sampling_date is 01-jun-2014. Equivalent behaviour for
     ///     randomly generated weather years.
     /// </remarks>
@@ -51,7 +51,7 @@
         private int currentYearIndex;
 
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
 
         /// <summary>Type of randomiser enum for drop down.</summary>
         public enum RandomiserTypeEnum
@@ -117,7 +117,7 @@
 
         /// <summary>The end date of the weather file.</summary>
         public DateTime EndDate { get; set; }
-        
+
         /// <summary>The maximum temperature (oc).</summary>
         [Units("°C")]
         [JsonIgnore]
@@ -266,7 +266,7 @@
                 // Make sure user has entered number of years.
                 if (NumYears <= 0)
                     throw new Exception("The number of years to sample from the weather file hasn't been speciifed.");
-                
+
                 // Determine the year range to sample from.
                 var firstYearToSampleFrom = firstDateInFile.Year;
                 var lastYearToSampleFrom = lastDateInFile.Year - 1;
@@ -320,7 +320,7 @@
             MinT = Convert.ToDouble(data.Rows[currentRowIndex]["MinT"]);
             Radn = Convert.ToDouble(data.Rows[currentRowIndex]["Radn"]);
             Rain = Convert.ToDouble(data.Rows[currentRowIndex]["Rain"]);
-            if (data.Columns.Contains("VP")) 
+            if (data.Columns.Contains("VP"))
                 VP = Convert.ToDouble(data.Rows[currentRowIndex]["VP"]);
             if (data.Columns.Contains("Wind"))
                 Wind = Convert.ToDouble(data.Rows[currentRowIndex]["Wind"]);

--- a/Models/Core/Simulation.cs
+++ b/Models/Core/Simulation.cs
@@ -94,7 +94,7 @@ namespace Models.Core
         {
             get
             {
-                Clock c = this.FindChild<Clock>();
+                IClock c = this.FindChild<IClock>();
                 if (c == null)
                     return 0;
                 else
@@ -267,8 +267,8 @@ namespace Models.Core
         /// <summary>
         /// Runs the simulation on the current thread and waits for the simulation
         /// to complete before returning to caller. Simulation is NOT cloned before
-        /// running. Use instance of Runner to get more options for running a 
-        /// simulation or groups of simulations. 
+        /// running. Use instance of Runner to get more options for running a
+        /// simulation or groups of simulations.
         /// </summary>
         /// <param name="cancelToken">Is cancellation pending?</param>
         public void Run(CancellationTokenSource cancelToken = null)
@@ -276,7 +276,7 @@ namespace Models.Core
             IsRunning = true;
             Exception simulationError = null;
 
-            // If the cancelToken is null then give it a default one. This can happen 
+            // If the cancelToken is null then give it a default one. This can happen
             // when called from the unit tests.
             if (cancelToken == null)
                 cancelToken = new CancellationTokenSource();

--- a/Models/Functions/AccumulateByDate.cs
+++ b/Models/Functions/AccumulateByDate.cs
@@ -26,7 +26,7 @@ namespace Models.Functions
 
         /// <summary>The Clock</summary>
         [Link]
-        Clock clock = null;
+        IClock clock = null;
 
         /// <summary>The start date</summary>
         [Description("Date to start accumulation dd-mmm")]

--- a/Models/Functions/HourlyInterpolation.cs
+++ b/Models/Functions/HourlyInterpolation.cs
@@ -106,9 +106,9 @@ namespace Models.Functions
     }
 
     /// <summary>
-    /// Firstly 3-hourly estimates of air temperature (Ta) are interpolated 
-    /// using the method of [jones_ceres-maize:_1986] which assumes a sinusoidal temperature 
-    /// pattern between Tmax and Tmin.  
+    /// Firstly 3-hourly estimates of air temperature (Ta) are interpolated
+    /// using the method of [jones_ceres-maize:_1986] which assumes a sinusoidal temperature
+    /// pattern between Tmax and Tmin.
     /// </summary>
     [Serializable]
     [Description("A value is calculated at 3-hourly estimates using air temperature based on daily max and min temperatures\n\n" +
@@ -179,14 +179,14 @@ namespace Models.Functions
     }
 
     /// <summary>
-    /// Firstly hourly estimates of air temperature (Ta) are interpolated from Tmax, Tmin and daylength (d) 
-    /// using the method of [Goudriaan1994].  
-    /// During sunlight hours Ta is calculated each hour using a 
-    /// sinusoidal curve fitted to Tmin and Tmax . 
-    /// After sunset Ta is calculated as an exponential decline from Ta at sunset 
+    /// Firstly hourly estimates of air temperature (Ta) are interpolated from Tmax, Tmin and daylength (d)
+    /// using the method of [Goudriaan1994].
+    /// During sunlight hours Ta is calculated each hour using a
+    /// sinusoidal curve fitted to Tmin and Tmax .
+    /// After sunset Ta is calculated as an exponential decline from Ta at sunset
     /// to the Tmin at sunrise the next day.
-    /// The hour (Th) of sunrise is calculated as Th = 12 − d/2 and Ta is assumed 
-    /// to equal Tmin at this time.  Tmax is reached when Th equals 13.5. 
+    /// The hour (Th) of sunrise is calculated as Th = 12 − d/2 and Ta is assumed
+    /// to equal Tmin at this time.  Tmax is reached when Th equals 13.5.
     /// </summary>
     [Serializable]
     [Description("calculating the hourly temperature based on Tmax, Tmin and daylength")]
@@ -306,7 +306,7 @@ namespace Models.Functions
         /// Link to the clock object
         /// </summary>
         [Link]
-        protected Clock clock = null;
+        protected IClock clock = null;
 
         /// <summary>The type of variable for sub-daily values</summary>
         [JsonIgnore]

--- a/Models/Functions/PhotoperiodDeltaFunction.cs
+++ b/Models/Functions/PhotoperiodDeltaFunction.cs
@@ -23,7 +23,7 @@ namespace Models.Functions
 
         /// <summary>The clock</summary>
         [Link]
-        protected Clock Clock = null;
+        protected IClock Clock = null;
 
         /// <summary>The twilight</summary>
         [Description("Twilight")]

--- a/Models/Functions/PhotoperiodFunction.cs
+++ b/Models/Functions/PhotoperiodFunction.cs
@@ -30,7 +30,7 @@ namespace Models.Functions
 
         /// <summary>The clock.</summary>
         [Link]
-        protected Clock Clock = null;
+        protected IClock Clock = null;
 
         /// <summary>The twilight angle.</summary>
         [Description("Twilight angle")]

--- a/Models/Functions/SupplyFunctions/CanopyPhotosynthesis.cs
+++ b/Models/Functions/SupplyFunctions/CanopyPhotosynthesis.cs
@@ -33,7 +33,7 @@ namespace Models.Functions.SupplyFunctions
         public Weather Weather = null;
         /// <summary>The Weather file</summary>
         [Link]
-        public Clock Clock = null;
+        public IClock Clock = null;
 
         /// <summary>Link to the hourly photosynthesis model </summary>
         [Link]
@@ -80,7 +80,7 @@ namespace Models.Functions.SupplyFunctions
         ///Reference:1. Wang,Enli. xxxx.
         ///%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% </summary>
         public double DailyCanopyGrossPhotosythesis(double LAI, double Latitude, int Day,
-                                                double Radn, double Tmax, double Tmin, double CO2, 
+                                                double Radn, double Tmax, double Tmin, double CO2,
                                                 double DifFr,
                                                 double Fact)
         {
@@ -208,7 +208,7 @@ namespace Models.Functions.SupplyFunctions
                                                       Weather.CO2,
                                                       Weather.DiffuseFraction,
                                                       1.0) * 30 / 44 * 0.1;
-                //30/44 converts CO2 to CH2O, 0.1 converts from kg/ha to g/m2                      
+                //30/44 converts CO2 to CH2O, 0.1 converts from kg/ha to g/m2
 
             }
             return GrossPhotosynthesis;

--- a/Models/G_Range/G_Range.cs
+++ b/Models/G_Range/G_Range.cs
@@ -29,7 +29,7 @@ namespace Models
         private ISummary summary = null;
 
         [Link]
-        private Clock Clock = null;
+        private IClock Clock = null;
 
         [Link]
         private IWeather Weather = null;
@@ -82,7 +82,7 @@ namespace Models
                 // So what should be used for deadStanding? Looks like it uses 2.5, even though I suspect
                 // for shrub and tree facets, the deadStandingCarbon will be mostly woody.
                 mass.MetabolicWt = (leafCarbon[Facet.herb] + leafCarbon[Facet.shrub] + leafCarbon[Facet.tree]) * 2.5;
-                mass.StructuralWt = (fineBranchCarbon[Facet.shrub] + fineBranchCarbon[Facet.tree]) * 2.0 + 
+                mass.StructuralWt = (fineBranchCarbon[Facet.shrub] + fineBranchCarbon[Facet.tree]) * 2.0 +
                                     (deadStandingCarbon[Facet.herb] + deadStandingCarbon[Facet.shrub] + deadStandingCarbon[Facet.tree]) * 2.5;
                 mass.MetabolicN = leafNitrogen[Facet.herb] + leafNitrogen[Facet.shrub] + leafNitrogen[Facet.tree];
                 mass.StructuralN = fineBranchNitrogen[Facet.shrub] + fineBranchNitrogen[Facet.tree] +
@@ -292,7 +292,7 @@ namespace Models
 
         /// <summary>
         /// Woody part constants
-        /// Woody parts, leaf, fine root, fine branch, large wood, and coarse root    
+        /// Woody parts, leaf, fine root, fine branch, large wood, and coarse root
         /// </summary>
         public static class WoodyPart
         {
@@ -410,10 +410,10 @@ namespace Models
         /// This is the number of individuals in a 1 km^2 area
         /// </summary>
         [JsonIgnore]
-        public double[] totalPopulation { get; private set; } = new double[nLayers]; 
+        public double[] totalPopulation { get; private set; } = new double[nLayers];
 
         /// <summary>
-        /// Bare cover stored, rather than continually summing the three facets. 
+        /// Bare cover stored, rather than continually summing the three facets.
         /// </summary>
         [Units("0-1")]
         [JsonIgnore]
@@ -435,7 +435,7 @@ namespace Models
         public double precip { get { return globe.precip; } }
 
         /// <summary>
-        /// Average maximum temperature for the current month 
+        /// Average maximum temperature for the current month
         /// Exposed here for reporting purposes
         /// </summary>
         [Units("C")]
@@ -443,7 +443,7 @@ namespace Models
         public double maxTemp { get { return globe.maxTemp; } }
 
         /// <summary>
-        /// Average minimum temperature for the current month 
+        /// Average minimum temperature for the current month
         /// Exposed here for reporting purposes
         /// </summary>
         [Units("C")]
@@ -529,7 +529,7 @@ namespace Models
         /// </summary>
         [Units("g/m^2")]
         [JsonIgnore]
-        public double[] nLeached { get; private set; } = new double[nDefSoilLayers]; 
+        public double[] nLeached { get; private set; } = new double[nDefSoilLayers];
 
         private double[] asmos = new double[nDefSoilLayers];     // Used in summing water
         private double[] amov = new double[nDefSoilLayers];      // Used in summing water movement
@@ -549,7 +549,7 @@ namespace Models
         /// Water available to plants, available for growth =(1) [0 in C#], survival(2) [1 in C#], and in the two top layers(3) [2 in C#]
         /// </summary>
         [JsonIgnore]
-        public double[] waterAvailable { get; private set; }  = new double[3]; 
+        public double[] waterAvailable { get; private set; }  = new double[3];
 
         /// <summary>
         /// Annual actual evapotranspiration
@@ -685,7 +685,7 @@ namespace Models
         /// Carbon to nitrogen ratio, SURFACE, SOIL
         /// </summary>
         [JsonIgnore]
-        public double[] carbonNitrogenRatio { get; private set; } = new double[2]; 
+        public double[] carbonNitrogenRatio { get; private set; } = new double[2];
 
         /// <summary>
         /// Soil organic matter carbon, surface and soil  g/m2(SOM1C in Century)
@@ -751,7 +751,7 @@ namespace Models
         public double[] abovegroundPotProduction { get; private set; } = new double[nLayers];
 
         /// <summary>
-        /// BIOMASS, Calculate total potential production, in g/m2 with all the corrections in place. 
+        /// BIOMASS, Calculate total potential production, in g/m2 with all the corrections in place.
         /// </summary>
         [Units("g/m^2")]
         [JsonIgnore]
@@ -1009,7 +1009,7 @@ namespace Models
         /// </summary>
         [Units("g/m^2")]
         [JsonIgnore]
-        public double[] litterStructuralCarbon { get; private set; } = new double[2];   
+        public double[] litterStructuralCarbon { get; private set; } = new double[2];
 
         /// <summary>
         /// Litter metabolic carbon at the surface(1)[0 in C#] and in the soil(2)[1 in C#]  (METCIS, or in Savanna, SMETCIS)
@@ -1233,7 +1233,7 @@ namespace Models
 
         // private int largeErrorCount;  // The count of cells being reset because their values were very very large
         // private int negErrorCount;    // The count of cell being reset because values were below zero
-       
+
         // Additional output variables added for convenience in the Apsim context - EJZ
         /// <summary>
         /// Herbaceous facet aboveground net primary production
@@ -1353,12 +1353,12 @@ namespace Models
             [Description("Temperate deciduous forest and woodland")]
             TemperateDecid,
             /// <summary>
-            /// BOREAL EVERGREEN FOREST / WOODLAND 
+            /// BOREAL EVERGREEN FOREST / WOODLAND
             /// </summary>
             [Description("Boreal evergreen forest and woodland")]
             BorealEGreen,
             /// <summary>
-            /// BOREAL DECIDUOUS FOREST / WOODLAND 
+            /// BOREAL DECIDUOUS FOREST / WOODLAND
             /// </summary>
             [Description("Boreal deciduous forest and woodland")]
             BorealDecid,
@@ -1398,7 +1398,7 @@ namespace Models
             [Description("Desert")]
             Desert,
             /// <summary>
-            /// POLAR DESERT / ROCK / ICE 
+            /// POLAR DESERT / ROCK / ICE
             /// </summary>
             [Description("Polar desert")]
             PolarDesert
@@ -1450,7 +1450,7 @@ namespace Models
         private double[] partBasedDeathRate = new double[nFacets];
 
         /// <summary>
-        /// Gets or sets the full file name (with path). The user interface uses this. 
+        /// Gets or sets the full file name (with path). The user interface uses this.
         /// </summary>
         [JsonIgnore]
         public string FullDatabaseName
@@ -1814,7 +1814,7 @@ namespace Models
 
         /// <summary>
         /// Processes that are required each year, prior to any process-based simulation steps.
-        /// 
+        ///
         /// Transcoded from Misc_Material.f95
         /// </summary>
         private void EachYear()
@@ -1856,7 +1856,7 @@ namespace Models
             }
 
 
-            // Clearing -out the shrub_carbon and tree_carbon variables, such that they represent the contribution of new carbon            
+            // Clearing -out the shrub_carbon and tree_carbon variables, such that they represent the contribution of new carbon
             // to woody parts for the year in question.
             for (int iPart = 0; iPart < nWoodyParts; iPart++)
             {
@@ -1941,11 +1941,11 @@ namespace Models
               // I prefer not to use the external files of G-Range, especially as the Weather component is already intended as
               // a provider of information on CO2 levels.
 
-            // In G-Range, a value of 0.8 is the baseline value for co2EffectOnProduction, 
+            // In G-Range, a value of 0.8 is the baseline value for co2EffectOnProduction,
             // and is what G-Range uses for dates prior to 2007. They have the value going up to around 1.0 in 2066 under the rcp85 scenario,
             // which is around 800 ppm. Boone et al. 2017 reference equation 10 of Pan et al. (1998):
             // 1 + (1.25 - 1)/(log10(2)) * (log10(CO2 / 350))
-            // But actually use something a bit different, indicating 2006 CO2 levels as a baseline, without giving details. 
+            // But actually use something a bit different, indicating 2006 CO2 levels as a baseline, without giving details.
             // I can get close to their values with the following:
             double co2 = Math.Max(Weather.CO2, 380.0);
             double co2Effect = 0.8 + (0.19 / Math.Log10(2.0)) * Math.Log10(co2 / 380.0);
@@ -1984,7 +1984,7 @@ namespace Models
         /// values aren't exceeding a very large value, or moving negative.  Errors will cause tallying of counts of errors,
         /// both spatially and per entry.That said, they won't be stored spatially for each individual entry, as that
         /// would almost double memory.
-        /// 
+        ///
         /// This routine includes a simple assignment of grazing fraction.That logic is placed here to allow for it to
         /// be made more dynamic in the future.
         /// </summary>

--- a/Models/IClock.cs
+++ b/Models/IClock.cs
@@ -7,8 +7,9 @@
     {
         /// <summary>Simulation date.</summary>
         DateTime Today { get; }
-
         /// <summary>Returns the current fraction of the overall simulation which has been completed</summary>
         double FractionComplete { get;  }
+        DateTime StartDate { get; }
+        DateTime EndDate { get; }
     }
 }

--- a/Models/IClock.cs
+++ b/Models/IClock.cs
@@ -9,7 +9,9 @@
         DateTime Today { get; }
         /// <summary>Returns the current fraction of the overall simulation which has been completed</summary>
         double FractionComplete { get;  }
+        /// <summary>Simulation start date.</summary>
         DateTime StartDate { get; }
+        /// <summary>Simulation end date.</summary>
         DateTime EndDate { get; }
     }
 }

--- a/Models/Lifecycle/Infestation.cs
+++ b/Models/Lifecycle/Infestation.cs
@@ -8,7 +8,7 @@
     using static Models.LifeCycle.LifeCyclePhase;
 
     /// <summary>
-    /// Sets and infestation event for Lifecycle model.  
+    /// Sets and infestation event for Lifecycle model.
     /// </summary>
     [Serializable]
     [ViewName("UserInterface.Views.PropertyView")]
@@ -18,12 +18,12 @@
     {
         /// <summary> Clock </summary>
         [Link]
-        public Clock Clock = null;
+        public IClock Clock = null;
 
         /// <summary>Sets the type of infestation event</summary>
         [Description("Select the type of infestation event")]
         public InfestationType TypeOfInfestation { get; set; }
-        
+
         /// <summary>Options for types of infestation</summary>
         public enum InfestationType
         {
@@ -89,7 +89,7 @@
         }
 
         /// <summary>At the start of the simulation find the infesting lifecycle and phase</summary>
-        /// <param name="sender"></param> 
+        /// <param name="sender"></param>
         /// <param name="e"></param>
         [EventSubscribe("StartOfSimulation")]
         private void OnStartOfSimulation(object sender, EventArgs e)

--- a/Models/Log.cs
+++ b/Models/Log.cs
@@ -14,7 +14,7 @@ namespace Models
     public class Log : Model
     {
         [Link]
-        Clock Clock = null;
+        IClock Clock = null;
 
         [Link]
         Simulation Simulation = null;

--- a/Models/Management/Operations.cs
+++ b/Models/Management/Operations.cs
@@ -61,7 +61,7 @@ namespace Models
     public class Operations : Model
     {
         /// <summary>The clock</summary>
-        [Link] Clock Clock = null;
+        [Link] IClock Clock = null;
 
         /// <summary>Gets or sets the schedule.</summary>
         /// <value>The schedule.</value>

--- a/Models/MicroClimate/MicroClimate.cs
+++ b/Models/MicroClimate/MicroClimate.cs
@@ -8,7 +8,7 @@
     using System.Linq;
 
     /// <summary>
-    /// The module MICROMET, described here, has been developed to allow the calculation of 
+    /// The module MICROMET, described here, has been developed to allow the calculation of
     /// potential transpiration for multiple competing canopies that can be either layered or intermingled.
     /// </summary>
     [Serializable]
@@ -20,7 +20,7 @@
     {
         /// <summary>The clock</summary>
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
 
         /// <summary>The weather</summary>
         [Link]
@@ -284,7 +284,7 @@
         ///<summary> Calculate the short wave radiation balance for strip crop system</summary>
         private void CalculateStripZoneShortWaveRadiation()
         {
-            
+
             MicroClimateZone tallest;
             MicroClimateZone shortest;
             if (microClimatesZones[0].DeltaZ.Sum()> microClimatesZones[1].DeltaZ.Sum())
@@ -303,7 +303,7 @@
             double Wt = (tallest.Zone as Zones.RectangularZone).Width*1000;    // Width of tallest crop zone
             foreach (MicroClimateCanopy c in tallest.Canopies)
             {
-               
+
                 if ((c.Canopy.Height - c.Canopy.Depth) > 0  && c.Canopy.Width > Wt)
                     TallestIsTree = true;
 
@@ -368,7 +368,7 @@
                 double It = 1 - Tt - Ta;                                    // Interception by the trees
                 double St = Tt * Wt / CWt;                                  // Transmission to the soil in the tree zone
                 double IaOl = Tt * WaOl / CWt * (1 - Math.Exp(-Ka * LAIa)); // Interception by the alley canopy below the overlap of the trees
-                double IaOp = Ta * (1 - Math.Exp(-Ka * LAIa));              // Interception by the alley canopy in the gaps between tree canopy 
+                double IaOp = Ta * (1 - Math.Exp(-Ka * LAIa));              // Interception by the alley canopy in the gaps between tree canopy
                 double Ia = IaOl + IaOp;                                    // Interception by the alley canopy
                 double SaOl = Tt * WaOl / CWt * (Math.Exp(-Ka * LAIa));     // Transmission to the soil beneigth the alley canopy under the tree canopy
                 double SaOp = Ta * (Math.Exp(-Ka * LAIa));                  // Transmission to the soil beneigth the alley canopy in the open
@@ -390,7 +390,7 @@
                 {
                     if (double.IsNaN(Rint))
                         throw new Exception("Bad Radiation Value in Light partitioning");
-                    Rint = Rin; 
+                    Rint = Rin;
                     for (int j = 0; j <= treeZone.Canopies.Count - 1; j++)
                         treeZone.Canopies[j].Rs[i] = Rint * MathUtilities.Divide(treeZone.Canopies[j].Ftot[i] * treeZone.Canopies[j].Ktot, treeZone.layerKtot[i], 0.0);
                     Rin -= Rint;
@@ -405,7 +405,7 @@
                 {
                     if (double.IsNaN(Rint))
                         throw new Exception("Bad Radiation Value in Light partitioning");
-                    Rint = Rin; 
+                    Rint = Rin;
                     for (int j = 0; j <= alleyZone.Canopies.Count - 1; j++)
                         alleyZone.Canopies[j].Rs[i] = Rint * MathUtilities.Divide(alleyZone.Canopies[j].Ftot[i] * alleyZone.Canopies[j].Ktot, alleyZone.layerKtot[i], 0.0);
                     Rin -= Rint;
@@ -498,7 +498,7 @@
             {
                 double Ht = vine.DeltaZ.Sum();                // Height of tree canopy
 
-                double CDt = vine.Canopies[0].Canopy.Depth / 1000;         // Depth of tree canopy    
+                double CDt = vine.Canopies[0].Canopy.Depth / 1000;         // Depth of tree canopy
                 double CBHt = Ht - CDt;                                    // Base hight of the tree canopy
                 double Ha = alley.DeltaZ.Sum();               // Height of alley canopy
                 if ((Ha > CBHt) & (vine.DeltaZ.Length > 1))
@@ -556,7 +556,7 @@
 
                 //double fb = fhomo * (1 - W) + fcompr * W;  //light interception by the vine row
 
-                double Soilt = SRb * Ft;                   // Transmission to the soil below tallest strip        
+                double Soilt = SRb * Ft;                   // Transmission to the soil below tallest strip
 
                 double Intttop = ftop;   // Interception by the top layer of the tallest strip (ie light intercepted in tallest strip above height of shortest strip)
 

--- a/Models/MicroClimate/MicroClimateZone.cs
+++ b/Models/MicroClimate/MicroClimateZone.cs
@@ -21,7 +21,7 @@
     public class MicroClimateZone
     {
         /// <summary>The clock model.</summary>
-        private Clock clock;
+        private IClock clock;
 
         /// <summary>Solar radiation.</summary>
         private double Radn;
@@ -172,7 +172,7 @@
         /// <param name="clockModel">The clock model.</param>
         /// <param name="zoneModel">The zone model.</param>
         /// <param name="minHeightDiffForNewLayer">Minimum canopy height diff for new layer.</param>
-        public MicroClimateZone(Clock clockModel, Zone zoneModel, double minHeightDiffForNewLayer)
+        public MicroClimateZone(IClock clockModel, Zone zoneModel, double minHeightDiffForNewLayer)
         {
             clock = clockModel;
             Zone = zoneModel;

--- a/Models/PMF/OilPalm/OilPalm.cs
+++ b/Models/PMF/OilPalm/OilPalm.cs
@@ -77,7 +77,7 @@ namespace Models.PMF.OilPalm
                 }
             }
         }
-        
+
         /// <summary>Gets the maximum LAI (m^2/m^2)</summary>
         public double LAITotal { get { return LAI; } }
 
@@ -92,7 +92,7 @@ namespace Models.PMF.OilPalm
 
         /// <summary>Gets the canopy depth (mm)</summary>
         public double Depth { get { return 10000; } }
-        
+
         /// <summary>Gets the width of the canopy (mm).</summary>
         public double Width{ get { return 0; } }
 
@@ -143,7 +143,7 @@ namespace Models.PMF.OilPalm
         public string plant_status = "out";
         /// <summary>The clock</summary>
         [Link]
-        Clock Clock = null;
+        IClock Clock = null;
         /// <summary>The met data</summary>
         [Link]
         IWeather MetData = null;
@@ -513,7 +513,7 @@ namespace Models.PMF.OilPalm
         [Units("g/g")]
         IFunction BunchOilConversionFactor = null;
         /// <summary>The ripe bunch water content</summary>
-        [Link(Type = LinkType.Child, ByName = true)] 
+        [Link(Type = LinkType.Child, ByName = true)]
         [Description("This function returns the fractional contribution of water to fresh bunch mass.")]
         [Units("g/g")]
         IFunction RipeBunchWaterContent = null;
@@ -591,7 +591,7 @@ namespace Models.PMF.OilPalm
         public double UnderstoryNFixation { get; set; }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [Serializable]
         public class RootType
@@ -605,7 +605,7 @@ namespace Models.PMF.OilPalm
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [Serializable]
         public class FrondType
@@ -621,7 +621,7 @@ namespace Models.PMF.OilPalm
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [Serializable]
         public class BunchType
@@ -769,7 +769,7 @@ namespace Models.PMF.OilPalm
             for (int i = 0; i < (int)InitialFrondNumber.Value() + 60; i++)
             {
                 BunchType B = new BunchType();
-                if (i>40) 
+                if (i>40)
                    B.FemaleFraction =  FemaleFlowerFraction.Value();
                 else
                     B.FemaleFraction = 0;
@@ -1074,8 +1074,8 @@ namespace Models.PMF.OilPalm
             if (Fr > 1.0)
                 Excess = DMAvailable - (TotBunchDMD + TotFrondDMD + StemDMD);
 
-            //why is this here? -JF 
-            if (Age > 10 && Fr < 1) 
+            //why is this here? -JF
+            if (Age > 10 && Fr < 1)
             { }
 
             BunchGrowth = 0; // zero the daily value before incrementally building it up again with today's growth of individual bunches
@@ -1107,7 +1107,7 @@ namespace Models.PMF.OilPalm
 
             };
 
-            StemGrowth = StemDMD * Fr;// +Excess; 
+            StemGrowth = StemDMD * Fr;// +Excess;
             StemMass += StemGrowth;
 
             CarbonStress = Fr;
@@ -1240,8 +1240,8 @@ namespace Models.PMF.OilPalm
 
             double StemNDemand = StemGrowth * StemNConcentration.Value() / 100.0 * 10.0;  // factor of 10 to convert g/m2 to kg/ha
             double RootNDemand = Math.Max(0.0, (RootMass * RootNConcentration.Value() / 100.0 - RootN)) * 10.0;  // kg/ha
-            double FrondNDemand = Math.Max(0.0, (FrondMass * FrondMaximumNConcentration.Value() / 100.0 - FrondN)) * 10.0;  // kg/ha 
-            double BunchNDemand = Math.Max(0.0, (BunchMass * BunchNConcentration.Value() / 100.0 - BunchN)) * 10.0;  // kg/ha 
+            double FrondNDemand = Math.Max(0.0, (FrondMass * FrondMaximumNConcentration.Value() / 100.0 - FrondN)) * 10.0;  // kg/ha
+            double BunchNDemand = Math.Max(0.0, (BunchMass * BunchNConcentration.Value() / 100.0 - BunchN)) * 10.0;  // kg/ha
 
             Ndemand = StemNDemand + FrondNDemand + RootNDemand + BunchNDemand;  //kg/ha
 

--- a/Models/PMF/Organs/LeafCohort.cs
+++ b/Models/PMF/Organs/LeafCohort.cs
@@ -16,9 +16,9 @@ namespace Models.PMF.Organs
     /// A leaf cohort model
     /// </summary>
     /// <remarks>
-    /// 
+    ///
     /// @startuml
-    /// Initialized -> Appeared: Appearance 
+    /// Initialized -> Appeared: Appearance
     /// Appeared -> Expanded: GrowthDuration
     /// Expanded -> Senescing: LagDuration
     /// Senescing -> Senesced: SenescenceDuration
@@ -35,12 +35,12 @@ namespace Models.PMF.Organs
     /// Appeared -> Detached: IsAppeared
     /// Initialized -> Detached: IsInitialised
     /// @enduml
-    /// 
+    ///
     /// Leaf death
     /// ------------------------
-    /// The leaf area, structural biomass and structural nitrogen of 
+    /// The leaf area, structural biomass and structural nitrogen of
     /// green (live) parts is subtracted by a fraction.
-    /// 
+    ///
     /// </remarks>
     [Serializable]
     [ViewName("UserInterface.Views.PropertyView")]
@@ -71,7 +71,7 @@ namespace Models.PMF.Organs
 
         /// <summary>The clock</summary>
         [Link]
-        public Clock Clock = null;
+        public IClock Clock = null;
 
         [Link]
         private ISurfaceOrganicMatter SurfaceOrganicMatter = null;
@@ -529,7 +529,7 @@ namespace Models.PMF.Organs
             get
             {
                 if (IsNotSenescing && (ShadeInducedSenRate == 0.0) && (StorageFraction > 0))
-                    // Assuming a leaf will have no demand if it is senescing and will have no demand if it is is shaded conditions.  Also if there is 
+                    // Assuming a leaf will have no demand if it is senescing and will have no demand if it is is shaded conditions.  Also if there is
                     return Math.Max(0.0, LuxaryNConc*(LiveStart.StructuralWt + LiveStart.MetabolicWt
                                                       + PotentialStructuralDMAllocation + PotentialMetabolicDMAllocation) -
                                          Live.StorageN);
@@ -705,7 +705,7 @@ namespace Models.PMF.Organs
             Detached = new Biomass();
             Removed = new Biomass();
         }
-        
+
         /// <summary>Returns a clone of this object</summary>
         /// <returns></returns>
         public virtual LeafCohort Clone()
@@ -813,7 +813,7 @@ namespace Models.PMF.Organs
             //Reduce leaf Population in Cohort due to plant mortality
             double startPopulation = CohortPopulation;
 
-            
+
             if (Structure.ProportionPlantMortality > 0)
                 CohortPopulation -= CohortPopulation * Structure.ProportionPlantMortality;
 
@@ -943,10 +943,10 @@ namespace Models.PMF.Organs
             //Fixme.  Live.Nonstructural should probably be included in DM supply for leaf growth also
             double deltaActualArea = Math.Min(DeltaStressConstrainedArea, DeltaCarbonConstrainedArea);
 
-            
+
             //Fixme.  Live.Storage should probably be included in DM supply for leaf growth also
             LiveArea += deltaActualArea;
-            
+
             //Senessing leaf area
             double areaSenescing = LiveArea*SenescedFrac;
             double areaSenescingN = 0;
@@ -984,7 +984,7 @@ namespace Models.PMF.Organs
 
             Live.StorageN -= Math.Max(0.0,
                 StorageNSenescing - StorageNReallocated - StorageNRetrasnlocated);
-            //Dont Senesess todays Storage N if it was retranslocated or reallocated 
+            //Dont Senesess todays Storage N if it was retranslocated or reallocated
             Dead.StorageN += Math.Max(0.0,
                 StorageNSenescing - StorageNReallocated - StorageNRetrasnlocated);
 
@@ -1122,7 +1122,7 @@ namespace Models.PMF.Organs
                 double lsn = 0;
                 for (int i = 0; i < ApexCohort.GroupAge.Length; i++)
                 {
-                    
+
                     if (i == 0)
                     {
                         _lagDuration = LagDuration;

--- a/Models/PMF/Phenology/Phases/DAWSPhase.cs
+++ b/Models/PMF/Phenology/Phases/DAWSPhase.cs
@@ -25,7 +25,7 @@ namespace Models.PMF.Phen
         Weather met = null;
 
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
 
         //2. Private and protected fields
         //-----------------------------------------------------------------------------------------------------------------
@@ -74,7 +74,7 @@ namespace Models.PMF.Phen
                         StartDAWS = 366 - met.WinterSolsticeDOY + clock.Today.DayOfYear -1;
                     else
                         StartDAWS = 365 - met.WinterSolsticeDOY + clock.Today.DayOfYear -1;
-                } 
+                }
                 else
                     StartDAWS = clock.Today.DayOfYear - met.WinterSolsticeDOY;
 

--- a/Models/PMF/Phenology/Phases/EmergingPhase.cs
+++ b/Models/PMF/Phenology/Phases/EmergingPhase.cs
@@ -11,8 +11,8 @@ using System.Text;
 namespace Models.PMF.Phen
 {
     /// <summary>
-    /// This phase goes from a start stage to an end stage and simulates time to 
-    /// emergence as a function of sowing depth.  
+    /// This phase goes from a start stage to an end stage and simulates time to
+    /// emergence as a function of sowing depth.
     /// Progress toward emergence is driven by a thermal time accumulation child function.
     /// </summary>
     [Serializable]
@@ -28,7 +28,7 @@ namespace Models.PMF.Phen
         Phenology phenology = null;
 
         [Link]
-        Clock clock = null;
+        IClock clock = null;
 
         [Link]
         Plant plant = null;
@@ -62,7 +62,7 @@ namespace Models.PMF.Phen
 
         /// <summary>Thermal time target to end this phase.</summary>
         [JsonIgnore]
-        public double Target { get; set; } 
+        public double Target { get; set; }
 
         /// <summary>Thermal time for this time-step.</summary>
         public double TTForTimeStep { get; set; }

--- a/Models/PMF/Phenology/Phases/GerminatingPhase.cs
+++ b/Models/PMF/Phenology/Phases/GerminatingPhase.cs
@@ -13,7 +13,7 @@ namespace Models.PMF.Phen
 {
     /// <summary>
     /// This phase goes from a start stage to an end stage and assumes
-    /// germination will be reached on the day after sowing or the first day 
+    /// germination will be reached on the day after sowing or the first day
     /// thereafter when the extractable soil water at sowing depth is greater than zero."
     /// </summary>
     [Serializable]
@@ -39,7 +39,7 @@ namespace Models.PMF.Phen
         private Phenology phenology = null;
 
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
 
         // 2. Private and protected fields
         //-----------------------------------------------------------------------------------------------------------------

--- a/Models/Report/DateReportFrequency.cs
+++ b/Models/Report/DateReportFrequency.cs
@@ -48,7 +48,7 @@ namespace Models
         /// <param name="e">Event arguments</param>
         private void OnDoReport(object sender, EventArgs e)
         {
-            Clock clock = sender as Clock;
+            IClock clock = sender as IClock;
             if (DateUtilities.DatesAreEqual(dateString, clock.Today))
                 report.DoOutput();
         }

--- a/Models/Resources/Scripts/CSharpBooleanExpressionTemplate.cs
+++ b/Models/Resources/Scripts/CSharpBooleanExpressionTemplate.cs
@@ -14,7 +14,7 @@ namespace Models
     [Serializable]
     public class Script : Model, IBooleanFunction
     {
-        [Link] Clock Clock = null;
+        [Link] IClock Clock = null;
 
         /// <summary>Gets the value of the function.</summary>
         public bool Value()

--- a/Models/Resources/Scripts/CSharpExpressionTemplate.cs
+++ b/Models/Resources/Scripts/CSharpExpressionTemplate.cs
@@ -14,7 +14,7 @@ namespace Models
     [Serializable]
     public class Script : Model, IFunction
     {
-        [Link] Clock Clock = null;
+        [Link] IClock Clock = null;
 
         /// <summary>Gets the value of the function.</summary>
         public double Value(int arrayIndex = -1)

--- a/Models/Soils/MultiPoreWater/WEIRDO.cs
+++ b/Models/Soils/MultiPoreWater/WEIRDO.cs
@@ -160,7 +160,7 @@ namespace Models.Soils
         /// <summary>Plant available water CAPACITY (DUL-LL15).</summary>
         [Units("mm")]
         [Display(Format = "N0", ShowTotal = true)]
-        [JsonIgnore] 
+        [JsonIgnore]
         public double[] PAWCmm { get { return MathUtilities.Multiply(PAWC, soilPhysical.Thickness); } }
 
         /// <summary>Plant available water SW-LL15 (mm/mm).</summary>
@@ -272,7 +272,7 @@ namespace Models.Soils
         ///<summary> Who knows</summary>
         [JsonIgnore]
         public double WinterU { get; set; }
-        
+
         ///<summary> Who knows</summary>
         public void SetWater_frac(double[] New_SW) { }
         ///<summary> Who knows</summary>
@@ -298,7 +298,7 @@ namespace Models.Soils
         [Link]
         private Evapotranspiration ET = null;
         [Link]
-        private Clock Clock = null;
+        private IClock Clock = null;
         [Link(IsOptional = true)]
         Plant Plant = null;
         [Link]
@@ -618,11 +618,11 @@ namespace Models.Soils
             }
 
             SetSoilProperties(); //Calls a function that applies soil parameters to calculate and set the properties for the soil
-           
+
             Hourly = new HourlyData();
             SubHourly = new SubHourlyData();
             ProfileSaturation = MathUtilities.Sum(SaturatedWaterDepth);
-            
+
             if (ReportDetail) { DoDetailReport("Initialisation", 0, 0); }
 
             //Check the soil water content initialisation is legit
@@ -684,8 +684,8 @@ namespace Models.Soils
             {
                 //If duration of precipitation is less than an hour and the rate is high, set up sub hourly timestep
                 int TimeStepSplits = 1;
-                bool SplitTimeStep = ((((IrrigationDuration>0.0)&&(IrrigationDuration < 1.0)) 
-                                   || ((Met.RainfallHours > 0.0)&&(Met.RainfallHours < 1.0))) 
+                bool SplitTimeStep = ((((IrrigationDuration>0.0)&&(IrrigationDuration < 1.0))
+                                   || ((Met.RainfallHours > 0.0)&&(Met.RainfallHours < 1.0)))
                                    && (Hourly.Rainfall[h] + Hourly.Irrigation[h] > 0.5));
                 if (SplitTimeStep)
                 {//Drop the time step to 6min for this hour while water is going on at a high rate
@@ -1010,7 +1010,7 @@ namespace Models.Soils
             Pond -= PondEvapHourly;
             EvaporationHourly -= PondEvapHourly;
             double EsRemaining = EvaporationHourly;
-            for (int c = 0; (c < PoreCompartments && EsRemaining > 0); c++) //If Evaopration demand not satisified by pond, evaporate from largest pores first. 
+            for (int c = 0; (c < PoreCompartments && EsRemaining > 0); c++) //If Evaopration demand not satisified by pond, evaporate from largest pores first.
             {
                 double PoreEvapHourly = Math.Min(EsRemaining, Pores[0][c].WaterDepth);
                 EsRemaining -= PoreEvapHourly;
@@ -1157,7 +1157,7 @@ namespace Models.Soils
 
         #region Internal Properties and Methods
         /// <summary>
-        /// Goes through all profile and pore properties and updates their values using soil parameters.  
+        /// Goes through all profile and pore properties and updates their values using soil parameters.
         /// Must be called after any soil parameters are chagned if the effect of the changes is to work correctly.
         /// </summary>
         private void SetSoilProperties()
@@ -1211,7 +1211,7 @@ namespace Models.Soils
                     Theta[l][c] = Pores[l][c].ThetaUpper;
                 }
             }
-            
+
         }
         private double CalcResidueInterception(double Precipitation)
         {
@@ -1250,7 +1250,7 @@ namespace Models.Soils
         }
 
         /// <summary>
-        /// Utility to sum the specified propertie from all pore compartments in the pore layer input 
+        /// Utility to sum the specified propertie from all pore compartments in the pore layer input
         /// </summary>
         /// <param name="Compartments"></param>
         /// <param name="Property"></param>
@@ -1304,13 +1304,13 @@ namespace Models.Soils
                 Irrig = SubHourly.Irrigation[Subh];
                 Drain = SubHourly.Drainage[Subh];
             }
-            double WaterIn = InitialProfileWater + InitialPondDepth + InitialResidueWater 
+            double WaterIn = InitialProfileWater + InitialPondDepth + InitialResidueWater
                              + Rain + Irrig;
             double ProfileWaterAtCalcEnd = MathUtilities.Sum(SWmm);
             //double WaterExtraction = MathUtilities.Sum(HourlyWaterExtraction);
             double WaterOut = ProfileWaterAtCalcEnd + Pond + ResidueWater + Drain;
             if (Math.Abs(WaterIn - WaterOut) > FloatingPointTolerance)
-                throw new Exception(this + " " + Process + " calculations are violating mass balance");           
+                throw new Exception(this + " " + Process + " calculations are violating mass balance");
         }
         /// <summary>
         /// Function to update profile summary values
@@ -1358,7 +1358,7 @@ namespace Models.Soils
             {//Step through each layer and set roof factor.
                 if (Plant.Root.LengthDensity[l] > 0)
                 {
-                    
+
                     RootLengthDensity[l] = Plant.Root.LengthDensity[l];
                     for (int c = PoreCompartments - 2; c >= 0; c--)//PoreCompartments-2 disregards the cohorts that is less than ll15
                     {
@@ -1377,7 +1377,7 @@ namespace Models.Soils
 
                 bool DidInterpolate;
                 double Factor = MathUtilities.LinearInterpReal(Pores[l][5].RelativeWaterContent, X, Y, out DidInterpolate);
-               
+
                 for (int c = PoreCompartments - 1; c >= 0; c--)
                 {
                     Pores[l][c].RepelancyFactor = Factor;

--- a/Models/Soils/NutrientPatching/NutrientPatchManager.cs
+++ b/Models/Soils/NutrientPatching/NutrientPatchManager.cs
@@ -18,11 +18,11 @@ namespace Models.Soils.NutrientPatching
     public class NutrientPatchManager : Model, INutrient, INutrientPatchManager
     {
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
 
         [Link]
         private IPhysical soilPhysical = null;
-        
+
         [Link]
         private ISummary summary = null;
 
@@ -59,7 +59,7 @@ namespace Models.Soils.NutrientPatching
         /// <summary>Layer thickness to consider when N partition between patches is BasedOnSoilConcentration (mm).</summary>
         [Units("mm")]
         public double LayerForNPartition { get; set; } = -99;
-        
+
         /// <summary>The inert pool.</summary>
         public INutrientPool Inert { get { return SumNutrientPools(patches.Select(patch => patch.Nutrient.Inert)); } }
 
@@ -95,7 +95,7 @@ namespace Models.Soils.NutrientPatching
 
         /// <summary>The Urea pool.</summary>
         public ISolute Urea { get { return SumSolutes(patches.Select(patch => patch.Nutrient.Urea)); } }
-        
+
         /// <summary>The NO3 pool.</summary>
         public double[] NO3ForEachPatch { get { return TotalSoluteForEachPatch(patches.Select(patch => patch.Nutrient.NO3)); } }
 
@@ -409,7 +409,7 @@ namespace Models.Soils.NutrientPatching
         }
 
         /// <summary>
-        /// For each patch, sum all layers of a solute. 
+        /// For each patch, sum all layers of a solute.
         /// </summary>
         /// <param name="solutes">The list of solutes</param>
         /// <returns>A single total solute for each patch.</returns>
@@ -546,7 +546,7 @@ namespace Models.Soils.NutrientPatching
                             Result[k][layer] = (incomingDelta[layer] * partitionWeight[k]) / patches[k].RelativeArea;
                     }
                     else
-                    { 
+                    {
                         // there is no incoming solute for this layer
                         for (int k = 0; k < patches.Count; k++)
                             Result[k][layer] = 0.0;

--- a/Models/Soils/SoilNitrogen/SoilNitrogen.Variables.cs
+++ b/Models/Soils/SoilNitrogen/SoilNitrogen.Variables.cs
@@ -26,7 +26,7 @@ namespace Models.Soils
 
         /// <summary>Link to APSIM's Clock (time information).</summary>
         [Link]
-        public Clock Clock = null;
+        public IClock Clock = null;
 
         /// <summary>Link to APSIM's WeatherFile (weather data).</summary>
         [Link]
@@ -1733,7 +1733,7 @@ namespace Models.Soils
 
         #region Values for soil mineral N
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 10000.0)]
         [Units("mg/kg")]
@@ -1762,7 +1762,7 @@ namespace Models.Soils
             }
         }
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 10000.0)]
         [Units("mg/kg")]
@@ -1791,7 +1791,7 @@ namespace Models.Soils
             }
         }
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [Bounds(Lower = 0.0, Upper = 10000.0)]
         [Units("mg/kg")]
@@ -2519,7 +2519,7 @@ namespace Models.Soils
             double[] deltaN = new double[value.Length];
             for (int layer = 0; layer < Math.Min(nLayers, value.Length); layer++)
                 deltaN[layer] = value[layer] - nh4[layer];
-            
+
             SetNH4Delta(callingModelType, deltaN);
         }
 

--- a/Models/Soils/SoilTemp/CERESSoilTemperature.cs
+++ b/Models/Soils/SoilTemp/CERESSoilTemperature.cs
@@ -23,14 +23,14 @@ namespace Models.Soils
         IWeather weather = null;
 
         [Link]
-        Clock clock = null;
+        IClock clock = null;
 
         /// <summary>The water balance model</summary>
         [Link]
         ISoilWater waterBalance = null;
 
         /// <summary>Access the soil physical properties.</summary>
-        [Link] 
+        [Link]
         private IPhysical soilPhysical = null;
 
         #region Parameters and inputs provided by the user or APSIM
@@ -173,7 +173,7 @@ namespace Models.Soils
                 alx = ang * _today.AddDays(-(int)sth_hot).DayOfYear;
 
             // RCichota: had to cast nth_hot and sth_hot to integer due to differences in how DayOfYear are handled in here as compared to the fortran version
-            //  there was a one day offset for sth_hot. Ex.:  
+            //  there was a one day offset for sth_hot. Ex.:
             //  if today = 1-Jan and sht_hot = 382.625, fortran gives day of year = 349, while here, without casting, we get 348
 
             if (alx < 0.0 || alx > 6.31)
@@ -253,8 +253,8 @@ namespace Models.Soils
         private double DampDepth()
         {
             // + Purpose
-            //      Now get the temperature damping depth. 
-            //       This is a function of the average soil bulk density and the amount of water above the lower limit. 
+            //      Now get the temperature damping depth.
+            //       This is a function of the average soil bulk density and the amount of water above the lower limit.
 
             //+  Notes
             //     241091 consulted Brian Wall.  For soil temperature an estimate of the water content of the total profile is required,

--- a/Models/Soils/SoilTemp/SoilTemperature.cs
+++ b/Models/Soils/SoilTemp/SoilTemperature.cs
@@ -24,13 +24,13 @@
         private IWeather weather = null;
 
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
 
         [Link]
         private MicroClimate microClimate = null;
 
         [Link]
-        private Physical physical = null;
+        private IPhysical physical = null;
 
         [Link]
         ISoilWater waterBalance = null;

--- a/Models/Stock/AnimalGroup.cs
+++ b/Models/Stock/AnimalGroup.cs
@@ -15,16 +15,16 @@ namespace Models.GrazPlan
     public class AnimalGroup
     {
         /// <summary>
-        /// AnimalsDynamicGlb differentiates between the "static" version of the      
-        /// model used in GrazFeed and the "dynamic" version used elsewhere           
+        /// AnimalsDynamicGlb differentiates between the "static" version of the
+        /// model used in GrazFeed and the "dynamic" version used elsewhere
         /// </summary>
         private const bool animalsDynamicGlb = true;
-       
+
         /// <summary>
-        /// 
+        ///
         /// </summary>
         private const int latePregLength = 42;
-        
+
         /// <summary>
         /// Depth of wool left after shearing (cm)
         /// </summary>
@@ -36,7 +36,7 @@ namespace Models.GrazPlan
 
         /// <summary>The clock model.</summary>
         [NonSerialized]
-        private Clock clock;
+        private IClock clock;
 
         /// <summary>The parent stock list</summary>
         [NonSerialized]
@@ -46,7 +46,7 @@ namespace Models.GrazPlan
         /// Paramters of the animal mated to
         /// </summary>
         private Genotype matedToGenotypeParameters;
-        
+
         /// <summary>
         /// Distribution of ages
         /// </summary>
@@ -56,7 +56,7 @@ namespace Models.GrazPlan
         /// All weights in kg
         /// </summary>
         private double totalWeight;
-        
+
         /// <summary>
         /// Greasy fleece weight (including stubble)
         /// </summary>
@@ -66,17 +66,17 @@ namespace Models.GrazPlan
         /// Lactation status
         /// </summary>
         private GrazType.LactType lactStatus;
-        
+
         /// <summary>
         /// Number of foetuses
         /// </summary>
         private int numberFoetuses;
-        
+
         /// <summary>
         /// Number of offspring
         /// </summary>
         private int numberOffspring;
-        
+
         /// <summary>
         /// Previous offspring
         /// </summary>
@@ -91,19 +91,19 @@ namespace Models.GrazPlan
         /// Day in the mating cycle; -1 if not mating
         /// </summary>
         private int mateCycle;
-        
+
         /// <summary>
         /// Days left in joining period
         /// </summary>
         private int daysToMate;
-        
+
         /// <summary>
         /// Days since conception
         /// </summary>
         private int foetalAge;
 
         /// <summary>
-        /// Base weight 42 days before parturition   
+        /// Base weight 42 days before parturition
         /// </summary>
         private double midLatePregWeight;
 
@@ -111,7 +111,7 @@ namespace Models.GrazPlan
         /// Highest previous weight (kg)
         /// </summary>
         private double maxPrevWeight;
-        
+
         /// <summary>
         /// Hair or fleece depth (cm)
         /// </summary>
@@ -121,7 +121,7 @@ namespace Models.GrazPlan
         /// Phosphorus in base weight (kg)
         /// </summary>
         private double basePhosphorusWeight;
-        
+
         /// <summary>
         /// Sulphur in base weight (kg)
         /// </summary>
@@ -131,79 +131,79 @@ namespace Models.GrazPlan
         /// Weight of these animals at birth (kg)
         /// </summary>
         private double birthWeight;
-        
+
         /// <summary>
         /// Normal weight (kg)
         /// </summary>
         private double normalWeight;
-        
+
         /// <summary>
         /// Days since parturition (if lactating)
         /// </summary>
         private int daysLactating;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         private double milkPhosphorusProduction;
-        
+
         /// <summary>
-        /// 
+        ///
         /// </summary>
         private double milkSulphurProduction;
 
         /// <summary>
-        /// Proportion of potential milk production  
+        /// Proportion of potential milk production
         /// </summary>
         private double proportionOfMaxMilk;
-        
+
         /// <summary>
-        /// Scales max. intake etc for underweight in lactating animals  
+        /// Scales max. intake etc for underweight in lactating animals
         /// </summary>
         private double lactationAdjustment;
-        
+
         /// <summary>
-        /// 
+        ///
         /// </summary>
         private double lactationRatio;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         private double dryOffTime;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         private double feedingLevel;
-        
+
         /// <summary>
-        /// 
+        ///
         /// </summary>
         private double startFU;
-        
+
         /// <summary>
-        /// Fraction of base weight gain from solid intake. 
+        /// Fraction of base weight gain from solid intake.
         /// </summary>
         private double baseWeightGainSolid;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         private double[] netSupplementDMI;
-        
+
         /// <summary>
         /// Sub time step value
         /// </summary>
         private double[] timeStepNetSupplementDMI;
-        
+
         /// <summary>
         /// Chill index
         /// </summary>
         private double chillIndex;
-        
+
         /// <summary>
-        /// 
+        ///
         /// </summary>
         private double implantEffect;
 
@@ -238,9 +238,9 @@ namespace Models.GrazPlan
                            int Number,
                            int AgeD,
                            double LiveWt,
-                           double GFW,                   // NB this is a *fleece* weight             
+                           double GFW,                   // NB this is a *fleece* weight
                            MyRandom RandomFactory,
-                           Clock clockModel,
+                           IClock clockModel,
                            IWeather weatherModel,
                            StockList stockListModel,
                            bool bTakeParams = false)
@@ -263,7 +263,7 @@ namespace Models.GrazPlan
         /// <param name="clockModel">The clock model.</param>
         /// <param name="weatherModel">The weather model.</param>
         public AnimalGroup(AnimalGroup Parents, double LiveWt,
-                           Clock clockModel,
+                           IClock clockModel,
                            IWeather weatherModel)
         {
             clock = clockModel;
@@ -295,7 +295,7 @@ namespace Models.GrazPlan
             for (int i = 0; i < 2; i++)
                 this.PastIntakeRate[i] = new GrazType.GrazingOutputs();
 
-            ComputeSRW();                                                              // Must do this after assigning a value to Mothers  
+            ComputeSRW();                                                              // Must do this after assigning a value to Mothers
             CalculateWeights();
         }
 
@@ -363,7 +363,7 @@ namespace Models.GrazPlan
         public double BaseWeight { get; set; }
 
         /// <summary>
-        /// Gets or sets the fleece-free, conceptus-free weight, but including the wool stubble        
+        /// Gets or sets the fleece-free, conceptus-free weight, but including the wool stubble
         /// </summary>
         [Units("kg")]
         public double EmptyShornWeight
@@ -433,7 +433,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Gets or sets the stage of pregnancy. Days since conception. 
+        /// Gets or sets the stage of pregnancy. Days since conception.
         /// </summary>
         [Units("d")]
         public int Pregnancy
@@ -497,7 +497,7 @@ namespace Models.GrazPlan
         public AnimalOutput AnimalState { get; set; } = new AnimalOutput();
 
         /// <summary>
-        /// Gets or sets the steepness code (1-2) of the paddock 
+        /// Gets or sets the steepness code (1-2) of the paddock
         /// </summary>
         [Units("1-2")]
         public double PaddSteep { get; set; }
@@ -567,7 +567,7 @@ namespace Models.GrazPlan
         /// RDP factor
         /// </summary>
         [Units("0-1")]
-        public double[] RDPFactor = new double[2];      // [0..1] 
+        public double[] RDPFactor = new double[2];      // [0..1]
 
         /// <summary>
         /// Index is to forage-within-paddock
@@ -602,7 +602,7 @@ namespace Models.GrazPlan
         // Management events .............................................
 
         /// <summary>
-        ///  Commence joining                                                          
+        ///  Commence joining
         /// </summary>
         /// <param name="maleParams"></param>
         /// <param name="matingPeriod"></param>
@@ -652,7 +652,7 @@ namespace Models.GrazPlan
 
                 if (this.Young.MaleNo == 0)
                 {
-                    // Divide the male from the female lambs or calves                              
+                    // Divide the male from the female lambs or calves
                     femaleYoung = this.Young;
                     maleYoung = null;
                 }
@@ -677,21 +677,21 @@ namespace Models.GrazPlan
                 if (femaleYoung != null)
                     femaleYoung.ReproState = GrazType.ReproType.Empty;
 
-                this.Young = null;                                                                      // Detach weaners from their mothers        
+                this.Young = null;                                                                      // Detach weaners from their mothers
                 this.previousOffspring = this.numberOffspring;
                 this.numberOffspring = this.previousOffspring;
 
-                if (weanMales)                                                                          // Export the weaned lambs or calves        
+                if (weanMales)                                                                          // Export the weaned lambs or calves
                     this.ExportWeaners(ref maleYoung, ref weanedOff);
                 if (weanFemales)
                     this.ExportWeaners(ref femaleYoung, ref weanedOff);
 
-                if (!weanMales)                                                                         // Export ewes or cows which still have     
-                    this.SplitMothers(ref maleYoung, totalYoung, malePropn, ref newGroups);             // lambs or calves                        
+                if (!weanMales)                                                                         // Export ewes or cows which still have
+                    this.SplitMothers(ref maleYoung, totalYoung, malePropn, ref newGroups);             // lambs or calves
                 if (!weanFemales)
                     this.SplitMothers(ref femaleYoung, totalYoung, 1.0 - malePropn, ref newGroups);
 
-                if (this.Genotype.Animal == GrazType.AnimalType.Sheep)                                   // Sheep don't continue lactation           
+                if (this.Genotype.Animal == GrazType.AnimalType.Sheep)                                   // Sheep don't continue lactation
                     this.SetLactation(0);
 
                 this.numberOffspring = 0;
@@ -721,7 +721,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// End lactation in cows whose calves have already been weaned               
+        /// End lactation in cows whose calves have already been weaned
         /// </summary>
         public void DryOff()
         {
@@ -1016,7 +1016,7 @@ namespace Models.GrazPlan
             int Total2;
 
 
-            if ((NoFoetuses != otherGrp.NoFoetuses)                                   // Necessary conditions for merging         
+            if ((NoFoetuses != otherGrp.NoFoetuses)                                   // Necessary conditions for merging
                || (NoOffspring != otherGrp.NoOffspring)
                || ((mothers == null) && (ReproState != otherGrp.ReproState))
                || (lactStatus != otherGrp.lactStatus))
@@ -1025,8 +1025,8 @@ namespace Models.GrazPlan
             Total1 = NoAnimals;
             Total2 = otherGrp.NoAnimals;
 
-            MaleNo += otherGrp.MaleNo;                                       // Take weighted averages of all            
-            FemaleNo += otherGrp.FemaleNo;                                     // appropriate fields                       
+            MaleNo += otherGrp.MaleNo;                                       // Take weighted averages of all
+            FemaleNo += otherGrp.FemaleNo;                                     // appropriate fields
             ages.Merge(otherGrp.ages);
             AgeDays = ages.MeanAge();
 
@@ -1167,11 +1167,11 @@ namespace Models.GrazPlan
                 }
                 else if (this.NoOffspring == 2)
                 {
-                    numToSplit = Convert.ToInt32(Math.Min(this.Young.MaleNo, this.Young.FemaleNo), CultureInfo.InvariantCulture) / 2;   // One male, one female                     
-                    if (((this.Young.FemaleNo - numToSplit) % 2) != 0)  //if odd                                                        // Ensures Young.FemaleNo (and hence        
-                        numToSplit++;                                                                                                   // Young.MaleNo) is even after the call   
-                    this.SplitNumbers(ref newGroups, numToSplit, numToSplit, numToSplit);                                               // to SplitBySex                          
-                    numToSplit = this.Young.FemaleNo / 2;                                                                               // Twin females                             
+                    numToSplit = Convert.ToInt32(Math.Min(this.Young.MaleNo, this.Young.FemaleNo), CultureInfo.InvariantCulture) / 2;   // One male, one female
+                    if (((this.Young.FemaleNo - numToSplit) % 2) != 0)  //if odd                                                        // Ensures Young.FemaleNo (and hence
+                        numToSplit++;                                                                                                   // Young.MaleNo) is even after the call
+                    this.SplitNumbers(ref newGroups, numToSplit, numToSplit, numToSplit);                                               // to SplitBySex
+                    numToSplit = this.Young.FemaleNo / 2;                                                                               // Twin females
                     this.SplitNumbers(ref newGroups, numToSplit, 0, 2 * numToSplit);
                 }
             }
@@ -1179,7 +1179,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Is an animal group similar enough to another for them to be merged?       
+        /// Is an animal group similar enough to another for them to be merged?
         /// </summary>
         /// <param name="animalGrp">An animal group</param>
         /// <returns></returns>
@@ -1225,8 +1225,8 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Sets the value of MaxPrevWeight using current base weight, age and a      
-        /// (relative) body condition. Intended for use with young animals.           
+        /// Sets the value of MaxPrevWeight using current base weight, age and a
+        /// (relative) body condition. Intended for use with young animals.
         /// </summary>
         /// <param name="bodyCondition"></param>
         public void SetConditionAtWeight(double bodyCondition)
@@ -1267,8 +1267,8 @@ namespace Models.GrazPlan
                 newOffset = newGroups.Count;
             else
                 newOffset = 0;
-            if (mothers == null)                                                    // Deaths must be done before age is        
-                Kill(chillIndex, ref newGroups);                                          //   incremented                           
+            if (mothers == null)                                                    // Deaths must be done before age is
+                Kill(chillIndex, ref newGroups);                                          //   incremented
 
             if (YoungStopSuckling())
                 Lactation = 0;
@@ -1306,29 +1306,29 @@ namespace Models.GrazPlan
                             KillEndPreg(ref newGroups);
                         else if (foetalAge >= Genotype.Gestation)
                         {
-                            Lactation = 1;                                // Create lambs or calves                   
+                            Lactation = 1;                                // Create lambs or calves
                             NoOffspring = NoFoetuses;
                             Young.BaseWeight = FoetalWeight - Young.woolWt;
                             Young.maxPrevWeight = Young.BaseWeight;
-                            Pregnancy = 0;                                // End pregnancy                            
+                            Pregnancy = 0;                                // End pregnancy
                         }
                     break;
             }
         }
 
         /// <summary>
-        /// Routine to compute the potential intake of a group of animals.  The       
-        /// result is stored as TheAnimals.IntakeLimit.  A variety of other fields   
-        /// of TheAnimals are also updated: the normal weight, mature normal weight, 
-        /// highest previous weight (in young animals), relative size and relative    
-        /// condition.                                                                
+        /// Routine to compute the potential intake of a group of animals.  The
+        /// result is stored as TheAnimals.IntakeLimit.  A variety of other fields
+        /// of TheAnimals are also updated: the normal weight, mature normal weight,
+        /// highest previous weight (in young animals), relative size and relative
+        /// condition.
         /// </summary>
         public void CalculateIntakeLimit()
         {
-            double lactTime;                                                               // Scaled days since birth of young         
-            double weightLoss;                                                              // Mean daily weight loss during lactation  
-                                                                                            // as a proportion of SRW                 
-            double criticalLoss;                                                            // Threshold value of WeightLoss            
+            double lactTime;                                                               // Scaled days since birth of young
+            double weightLoss;                                                              // Mean daily weight loss during lactation
+                                                                                            // as a proportion of SRW
+            double criticalLoss;                                                            // Threshold value of WeightLoss
             double tempDiff;
             double tempAmpl;
             double belowLCT;
@@ -1340,9 +1340,9 @@ namespace Models.GrazPlan
             int lactNum;
             double shapeParam;
 
-            CalculateWeights();                                                             // Compute size and condition               
+            CalculateWeights();                                                             // Compute size and condition
 
-            if (BodyCondition > 1.0)  // and (LactStatus <> Lactating) then  // No longer exclude lactating females. See bug#2223 
+            if (BodyCondition > 1.0)  // and (LactStatus <> Lactating) then  // No longer exclude lactating females. See bug#2223
                 condFactor = BodyCondition * (this.Genotype.IntakeC[20] - BodyCondition) / (this.Genotype.IntakeC[20] - 1.0);
             else
                 condFactor = 1.0;
@@ -1355,7 +1355,7 @@ namespace Models.GrazPlan
 
             if (this.weather.MinT < this.AnimalState.LowerCritTemp)
             {
-                // Integrate sinusoidal temperature function over the part below LCT       
+                // Integrate sinusoidal temperature function over the part below LCT
                 tempDiff = this.weather.MeanT - this.AnimalState.LowerCritTemp;
                 tempAmpl = 0.5 * (this.weather.MaxT - this.weather.MinT);
                 X = Math.Acos(Math.Max(-1.0, Math.Min(1.0, tempDiff / tempAmpl)));
@@ -1365,15 +1365,15 @@ namespace Models.GrazPlan
             else
                 heatFactor = 1.0;
 
-            if (this.weather.MinT >= this.Genotype.IntakeC[7])                                 // High temperatures depress intake         
+            if (this.weather.MinT >= this.Genotype.IntakeC[7])                                 // High temperatures depress intake
                 heatFactor = heatFactor * (1.0 - this.Genotype.IntakeC[5] * StdMath.DIM(this.weather.MeanT, this.Genotype.IntakeC[6]));
             if (this.lactStatus != GrazType.LactType.Lactating)
                 this.lactationAdjustment = 1.0;
 #pragma warning disable 162 // unreachable code
-            else if (!animalsDynamicGlb)                                                        // In the dynamic model, LactAdjust is a    
-            {                                                                                   // state variable computed in the         
-                weightLoss = RelativeSize * StdMath.XDiv(BirthCondition - BodyCondition,               // lactation routine; for GrazFeed, it is 
-                                             daysLactating);                                    // estimated with these equations         
+            else if (!animalsDynamicGlb)                                                        // In the dynamic model, LactAdjust is a
+            {                                                                                   // state variable computed in the
+                weightLoss = RelativeSize * StdMath.XDiv(BirthCondition - BodyCondition,               // lactation routine; for GrazFeed, it is
+                                             daysLactating);                                    // estimated with these equations
                 criticalLoss = Genotype.IntakeC[14] * Math.Exp(-Math.Pow(Genotype.IntakeC[13] * daysLactating, 2));
                 if (weightLoss > criticalLoss)
                     this.lactationAdjustment = (1.0 - Genotype.IntakeC[12] * weightLoss / Genotype.IntakeC[13]);
@@ -1447,9 +1447,9 @@ namespace Models.GrazPlan
             double[,] seedRI = new double[GrazType.MaxPlantSpp + 1, 3];
             double suppRI = 0;
 
-            // Do this before resetting AnimalState!    
-            if ((!animalsDynamicGlb || (this.AnimalState.ME_Intake.Total == 0.0) || (this.WaterLogging == 0.0) || (this.PaddSteep > 1.0)))    // Waterlogging effect only on level ground 
-                waterLogScalar = 1.0;                                                 // The published model assumes WaterLog=0   
+            // Do this before resetting AnimalState!
+            if ((!animalsDynamicGlb || (this.AnimalState.ME_Intake.Total == 0.0) || (this.WaterLogging == 0.0) || (this.PaddSteep > 1.0)))    // Waterlogging effect only on level ground
+                waterLogScalar = 1.0;                                                 // The published model assumes WaterLog=0
             else if ((this.AnimalState.EnergyUse.Gain == 0.0) || (this.AnimalState.Efficiency.Gain == 0.0))
                 waterLogScalar = 1.0;
             else
@@ -1458,13 +1458,13 @@ namespace Models.GrazPlan
                 waterLogScalar = StdMath.DIM(1.0, maintMEIScalar * WaterLogging);
             }
 
-            if (reset)                                                                  // First time step of the day?              
+            if (reset)                                                                  // First time step of the day?
                 this.ResetGrazing();
 
             this.timeStepState = new AnimalOutput();
 
             this.CalculateRelIntake(this, deltaT, feedSuppFirst,
-                                waterLogScalar,                                       // The published model assumes WaterLog=0   
+                                waterLogScalar,                                       // The published model assumes WaterLog=0
                                 ref herbageRI, ref seedRI, ref suppRI);
             this.DescribeTheDiet(ref herbageRI, ref seedRI, ref suppRI, ref this.timeStepState);
             this.UpdateAnimalState(deltaT, feedSuppFirst, suppRI);
@@ -1500,18 +1500,18 @@ namespace Models.GrazPlan
 
             if (this.Animal == GrazType.AnimalType.Sheep)
                 this.ApplyWoolGrowth();
-            this.ComputePhosphorus();                                                       // These must be done after DeltaFleeceWt   
-            this.ComputeSulfur();                                                           // is known                               
+            this.ComputePhosphorus();                                                       // These must be done after DeltaFleeceWt
+            this.ComputeSulfur();                                                           // is known
             this.ComputeAshAlk();
 
-            this.totalWeight = this.BaseWeight + this.ConceptusWt();                    // TotalWeight is meant to be the weight    
-            if (this.Animal == GrazType.AnimalType.Sheep)                               // "on the scales", including conceptus   
-                this.totalWeight = this.totalWeight + this.woolWt;                      // and/or fleece.                         
+            this.totalWeight = this.BaseWeight + this.ConceptusWt();                    // TotalWeight is meant to be the weight
+            if (this.Animal == GrazType.AnimalType.Sheep)                               // "on the scales", including conceptus
+                this.totalWeight = this.totalWeight + this.woolWt;                      // and/or fleece.
             this.AnimalState.IntakeLimitLegume = this.PotIntake * (1.0 + this.Genotype.GrazeC[2] * this.Herbage.LegumePropn);
         }
 
         /// <summary>
-        /// Test whether intake of RDP matches the requirement for RDP.               
+        /// Test whether intake of RDP matches the requirement for RDP.
         /// </summary>
         /// <returns></returns>
         public double RDPIntakeFactor()
@@ -1573,8 +1573,8 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Records state information prior to the grazing and nutrition calculations     
-        /// so that it can be restored if there is an RDP insufficiency.                
+        /// Records state information prior to the grazing and nutrition calculations
+        /// so that it can be restored if there is an RDP insufficiency.
         /// </summary>
         /// <param name="animalInfo"></param>
         public void StoreStateInfo(ref AnimalStateInfo animalInfo)
@@ -1591,7 +1591,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Restores state information about animal groups if there is an RDP insufficiency.                                                              
+        /// Restores state information about animal groups if there is an RDP insufficiency.
         /// </summary>
         /// <param name="animalInfo"></param>
         public void RevertStateInfo(AnimalStateInfo animalInfo)
@@ -1627,32 +1627,32 @@ namespace Models.GrazPlan
         {
             const double CLASSWIDTH = 0.1;
 
-            double[] availFeed = new double[GrazType.DigClassNo + 2]; // 1..DigClassNo+1   // Grazeable DM in each quality class    
-            double[] heightRatio = new double[GrazType.DigClassNo + 2];                    // "Height ratio"                        
-            double legume;                                                                 // Legume fraction                       
+            double[] availFeed = new double[GrazType.DigClassNo + 2]; // 1..DigClassNo+1   // Grazeable DM in each quality class
+            double[] heightRatio = new double[GrazType.DigClassNo + 2];                    // "Height ratio"
+            double legume;                                                                 // Legume fraction
             double legumeTrop;                                                             // Legume tropicality }
-            double selectFactor;                                                           // SF, adjusted for legume content       
-            double[] relQ = new double[GrazType.DigClassNo + 2];                           // Function of herbage class digestib'ty 
-            double suppRelQ;                                                               // Function of supplement digestibility  
+            double selectFactor;                                                           // SF, adjusted for legume content
+            double[] relQ = new double[GrazType.DigClassNo + 2];                           // Function of herbage class digestib'ty
+            double suppRelQ;                                                               // Function of supplement digestibility
             double suppFWPerHead;
             double suppDWPerHead;
             double totalFeed;
 
             double OMD_Supp;
-            double proteinFactor;                                                          // DOM/protein and lactation factors for 
-            double milkFactor;                                                             // modifying substitution rate         
+            double proteinFactor;                                                          // DOM/protein and lactation factors for
+            double milkFactor;                                                             // modifying substitution rate
             double substSuppRelQ;
 
             double[] relIntake = new double[GrazType.DigClassNo + 2];
             double suppEntry;
-            double fillRemaining;                                                          // Proportion of maximum relative fill  that is yet to be satisfied         
-            bool suppRemains;                                                              // TRUE if the animals have yet to select a supplement that is present        
+            double fillRemaining;                                                          // Proportion of maximum relative fill  that is yet to be satisfied
+            bool suppRemains;                                                              // TRUE if the animals have yet to select a supplement that is present
             double legumeAdjust;
             int speciesIdx,
             classIdx,
             ripeIdx;
 
-            // Start by aggregating herbage and seed into selection classes              
+            // Start by aggregating herbage and seed into selection classes
             for (classIdx = 1; classIdx <= GrazType.DigClassNo; classIdx++)
             {
                 availFeed[classIdx] = theAnimals.Herbage.Herbage[classIdx].Biomass;
@@ -1688,14 +1688,14 @@ namespace Models.GrazPlan
             suppFWPerHead = theAnimals.RationFed.TotalAmount;
             suppDWPerHead = suppFWPerHead * theAnimals.IntakeSupplement.DMPropn;
 
-            herbageRI = new double[GrazType.DigClassNo + 1];                                // Sundry initializations                
+            herbageRI = new double[GrazType.DigClassNo + 1];                                // Sundry initializations
             seedRI = new double[GrazType.MaxPlantSpp + 1, GrazType.RIPE + 1];
             suppRelIntake = 0.0;
             relIntake = new double[GrazType.DigClassNo + 2];
 
-            selectFactor = (1.0 - legume * (1.0 - legumeTrop)) * theAnimals.Herbage.SelectFactor;         // Herbage relative quality calculation  
+            selectFactor = (1.0 - legume * (1.0 - legumeTrop)) * theAnimals.Herbage.SelectFactor;         // Herbage relative quality calculation
             for (classIdx = 1; classIdx <= GrazType.DigClassNo; classIdx++)
-                relQ[classIdx] = 1.0 - theAnimals.Genotype.GrazeC[3] * StdMath.DIM(theAnimals.Genotype.GrazeC[1] - selectFactor, theAnimals.Herbage.Herbage[classIdx].Digestibility); // Eq. 21 
+                relQ[classIdx] = 1.0 - theAnimals.Genotype.GrazeC[3] * StdMath.DIM(theAnimals.Genotype.GrazeC[1] - selectFactor, theAnimals.Herbage.Herbage[classIdx].Digestibility); // Eq. 21
             relQ[GrazType.DigClassNo + 1] = 1;                                             // fixes range check error. Set this to the value that was calc'd when range check error was in place
 
             suppRemains = (suppFWPerHead > GrazType.VerySmall);                           // Compute relative quality of supplement (if present)
@@ -1761,11 +1761,11 @@ namespace Models.GrazPlan
                     classIdx++;
                 }
 
-                // Still supplement left? 
+                // Still supplement left?
                 if (suppRemains)
                     this.EatSupplement(theAnimals, timeStepLength, suppDWPerHead, theAnimals.IntakeSupplement, suppRelQ, false, ref suppRelIntake, ref fillRemaining);
 
-                legumeAdjust = theAnimals.Genotype.GrazeC[2] * StdMath.Sqr(1.0 - fillRemaining) * legume;         // Adjustment to intake rate for waterlogging and legume content        
+                legumeAdjust = theAnimals.Genotype.GrazeC[2] * StdMath.Sqr(1.0 - fillRemaining) * legume;         // Adjustment to intake rate for waterlogging and legume content
                 for (classIdx = 1; classIdx <= GrazType.DigClassNo; classIdx++)
                     relIntake[classIdx] = relIntake[classIdx] * waterLogScalar * (1.0 + legumeAdjust);
             }
@@ -1788,9 +1788,9 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Feasible range of weights for a given age and (relative) body condition   
-        /// This weight range is a consequence of the normal weight function          
-        /// (AnimalGroup.NormalWeightFunc)                                           
+        /// Feasible range of weights for a given age and (relative) body condition
+        /// This weight range is a consequence of the normal weight function
+        /// (AnimalGroup.NormalWeightFunc)
         /// </summary>
         /// <param name="reprod"></param>
         /// <param name="ageDays">Age in days</param>
@@ -1816,7 +1816,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Returns the number of male and female animals  
+        /// Returns the number of male and female animals
         /// which are aged greater than a number of days
         /// </summary>
         /// <param name="ageDays">Days of age</param>
@@ -1830,7 +1830,7 @@ namespace Models.GrazPlan
         // ------------------ Private model logic ------------------
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="classAttr"></param>
         /// <param name="netClassIntake"></param>
@@ -1875,30 +1875,30 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        ///  DescribeTheDiet                                                           
-        /// Calculate the following for each applicable component of the diet         
-        /// (herbage, supplement and milk):                                             
-        ///   - Dry weight of intake             - Intake of ME                       
-        ///   - Weight of protein in the intake  - Intake of P                        
-        ///   - Digestibility                    - Intake of S                        
-        ///   - Digestible organic matter (DOM)  - Concentration of protein           
-        ///   - ME:DM ratio                                                           
-        /// These results are all stored in the TimeStepState static variable for     
-        /// reference by other routines.                                              
+        ///  DescribeTheDiet
+        /// Calculate the following for each applicable component of the diet
+        /// (herbage, supplement and milk):
+        ///   - Dry weight of intake             - Intake of ME
+        ///   - Weight of protein in the intake  - Intake of P
+        ///   - Digestibility                    - Intake of S
+        ///   - Digestible organic matter (DOM)  - Concentration of protein
+        ///   - ME:DM ratio
+        /// These results are all stored in the TimeStepState static variable for
+        /// reference by other routines.
         /// </summary>
         /// <param name="herbageRI">"Relative intakes" of each herbage digestibility class</param>
         /// <param name="seedRI">"Relative intakes" of seeds</param>
         /// <param name="suppRI">"Relative intakes" of supplement</param>
         /// <param name="timeStepState"></param>
         private void DescribeTheDiet(
-                                   ref double[] herbageRI,         
-                                   ref double[,] seedRI,           
-                                   ref double suppRI,                                             
+                                   ref double[] herbageRI,
+                                   ref double[,] seedRI,
+                                   ref double suppRI,
                                    ref AnimalOutput timeStepState)
         {
             GrazType.IntakeRecord suppInput = new GrazType.IntakeRecord();
             double gutPassage;
-            double supp_ME2DM;                                              // Used to compute ME_2_DM.Supp          
+            double supp_ME2DM;                                              // Used to compute ME_2_DM.Supp
             int species, classIdx, ripeIdx, idx;
 
             for (classIdx = 1; classIdx <= GrazType.DigClassNo; classIdx++)
@@ -1908,7 +1908,7 @@ namespace Models.GrazPlan
                 for (ripeIdx = GrazType.UNRIPE; ripeIdx <= GrazType.RIPE; ripeIdx++)
                     timeStepState.IntakePerHead.Seed[species, ripeIdx] = this.PotIntake * seedRI[species, ripeIdx];
             }
-            timeStepState.PaddockIntake = new GrazType.IntakeRecord();              // Summarise herbage+seed intake         
+            timeStepState.PaddockIntake = new GrazType.IntakeRecord();              // Summarise herbage+seed intake
             for (classIdx = 1; classIdx <= GrazType.DigClassNo; classIdx++)
                 this.AddDietElement(ref this.Herbage.Herbage[classIdx], timeStepState.IntakePerHead.Herbage[classIdx], ref timeStepState.PaddockIntake);
             for (species = 1; species <= GrazType.MaxPlantSpp; species++)
@@ -1921,14 +1921,14 @@ namespace Models.GrazPlan
             if (timeStepState.PaddockIntake.Biomass == 0.0) // i.e. less than fTrivialIntake
                 timeStepState.IntakePerHead = new GrazType.GrazingOutputs();
 
-            timeStepState.SuppIntake = new GrazType.IntakeRecord();                 // Summarise supplement intake           
+            timeStepState.SuppIntake = new GrazType.IntakeRecord();                 // Summarise supplement intake
             supp_ME2DM = 0.0;
             if ((this.RationFed.TotalAmount > 0.0) && (suppRI * this.PotIntake > 0.0))
             {
                 // The supplements must be treated separately because of the non-linearity in the gut passage term
-                for (idx = 0; idx <= this.RationFed.Count - 1; idx++)                                 
-                {                                                                   
-                    suppInput.Digestibility = this.RationFed[idx].DMDigestibility;           
+                for (idx = 0; idx <= this.RationFed.Count - 1; idx++)
+                {
+                    suppInput.Digestibility = this.RationFed[idx].DMDigestibility;
                     suppInput.CrudeProtein = this.RationFed[idx].CrudeProt;
                     suppInput.Degradability = this.RationFed[idx].DegProt;
                     suppInput.PhosContent = this.RationFed[idx].Phosphorus;
@@ -1946,7 +1946,7 @@ namespace Models.GrazPlan
                 }
 
                 this.SummariseIntakeRecord(ref timeStepState.SuppIntake);
-                if (timeStepState.SuppIntake.Biomass == 0.0) 
+                if (timeStepState.SuppIntake.Biomass == 0.0)
                 {
                     // i.e. less than fTrivialIntake
                     for (idx = 0; idx <= this.RationFed.Count - 1; idx++)
@@ -1960,19 +1960,19 @@ namespace Models.GrazPlan
                 for (idx = 0; idx <= this.RationFed.Count - 1; idx++)
                     this.timeStepNetSupplementDMI[idx] = 0.0;
 
-            timeStepState.DM_Intake.Herbage = timeStepState.PaddockIntake.Biomass;                                  // Dry matter intakes                    
+            timeStepState.DM_Intake.Herbage = timeStepState.PaddockIntake.Biomass;                                  // Dry matter intakes
             timeStepState.DM_Intake.Supp = timeStepState.SuppIntake.Biomass;
             timeStepState.DM_Intake.Solid = timeStepState.DM_Intake.Herbage + timeStepState.DM_Intake.Supp;
-            timeStepState.DM_Intake.Total = timeStepState.DM_Intake.Solid;                                          // Milk doesn't count for DM intake      
+            timeStepState.DM_Intake.Total = timeStepState.DM_Intake.Solid;                                          // Milk doesn't count for DM intake
 
-            timeStepState.Digestibility.Herbage = timeStepState.PaddockIntake.Digestibility;                        // Digestibilities                       
+            timeStepState.Digestibility.Herbage = timeStepState.PaddockIntake.Digestibility;                        // Digestibilities
             timeStepState.Digestibility.Supp = timeStepState.SuppIntake.Digestibility;
             timeStepState.Digestibility.Solid = StdMath.XDiv(
                                            timeStepState.Digestibility.Supp * timeStepState.DM_Intake.Supp +
                                            timeStepState.Digestibility.Herbage * timeStepState.DM_Intake.Herbage,
                                            timeStepState.DM_Intake.Solid);
 
-            if (this.lactStatus == GrazType.LactType.Suckling)                                                                         
+            if (this.lactStatus == GrazType.LactType.Suckling)
             {
                 // Milk terms
                 timeStepState.CP_Intake.Milk = this.mothers.MilkProtein / this.NoOffspring;
@@ -1988,7 +1988,7 @@ namespace Models.GrazPlan
                 timeStepState.ME_Intake.Milk = 0.0;
             }
 
-            timeStepState.CP_Intake.Herbage = timeStepState.PaddockIntake.Biomass * timeStepState.PaddockIntake.CrudeProtein;   // Crude protein intakes and contents    
+            timeStepState.CP_Intake.Herbage = timeStepState.PaddockIntake.Biomass * timeStepState.PaddockIntake.CrudeProtein;   // Crude protein intakes and contents
             timeStepState.CP_Intake.Supp = timeStepState.SuppIntake.Biomass * timeStepState.SuppIntake.CrudeProtein;
             timeStepState.CP_Intake.Solid = timeStepState.CP_Intake.Herbage + timeStepState.CP_Intake.Supp;
             timeStepState.CP_Intake.Total = timeStepState.CP_Intake.Solid + timeStepState.CP_Intake.Milk;
@@ -1996,18 +1996,18 @@ namespace Models.GrazPlan
             timeStepState.ProteinConc.Supp = timeStepState.SuppIntake.CrudeProtein;
             timeStepState.ProteinConc.Solid = StdMath.XDiv(timeStepState.CP_Intake.Solid, timeStepState.DM_Intake.Solid);
 
-            timeStepState.Phos_Intake.Herbage = timeStepState.PaddockIntake.Biomass * timeStepState.PaddockIntake.PhosContent;  // Phosphorus intakes                    
+            timeStepState.Phos_Intake.Herbage = timeStepState.PaddockIntake.Biomass * timeStepState.PaddockIntake.PhosContent;  // Phosphorus intakes
             timeStepState.Phos_Intake.Supp = 0.0;
             timeStepState.Phos_Intake.Solid = timeStepState.Phos_Intake.Herbage + timeStepState.Phos_Intake.Supp;
             timeStepState.Phos_Intake.Total = timeStepState.Phos_Intake.Solid + timeStepState.Phos_Intake.Milk;
 
-            timeStepState.Sulf_Intake.Herbage = timeStepState.PaddockIntake.Biomass * timeStepState.PaddockIntake.SulfContent;  // Sulphur intakes                       
+            timeStepState.Sulf_Intake.Herbage = timeStepState.PaddockIntake.Biomass * timeStepState.PaddockIntake.SulfContent;  // Sulphur intakes
             timeStepState.Sulf_Intake.Supp = 0.0;
             timeStepState.Sulf_Intake.Solid = timeStepState.Sulf_Intake.Herbage + timeStepState.Sulf_Intake.Supp;
             timeStepState.Sulf_Intake.Total = timeStepState.Sulf_Intake.Solid + timeStepState.Sulf_Intake.Milk;
 
-            timeStepState.ME_2_DM.Herbage = GrazType.HerbageE2DM * timeStepState.Digestibility.Herbage - 2.0;                   // Metabolizable energy intakes and contents     
-            timeStepState.ME_2_DM.Supp = supp_ME2DM;                                                                                                        
+            timeStepState.ME_2_DM.Herbage = GrazType.HerbageE2DM * timeStepState.Digestibility.Herbage - 2.0;                   // Metabolizable energy intakes and contents
+            timeStepState.ME_2_DM.Supp = supp_ME2DM;
             timeStepState.ME_Intake.Supp = timeStepState.ME_2_DM.Supp * timeStepState.DM_Intake.Supp;
             timeStepState.ME_Intake.Herbage = timeStepState.ME_2_DM.Herbage * timeStepState.DM_Intake.Herbage;
             timeStepState.ME_Intake.Solid = timeStepState.ME_Intake.Herbage + timeStepState.ME_Intake.Supp;
@@ -2016,7 +2016,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Compute RDP intake and requirement for a given MEI and feeding level      
+        /// Compute RDP intake and requirement for a given MEI and feeding level
         /// </summary>
         /// <param name="intakeScale"></param>
         /// <param name="feedingLevel"></param>
@@ -2024,18 +2024,18 @@ namespace Models.GrazPlan
         /// <param name="rdpi"></param>
         /// <param name="rdpr"></param>
         /// <param name="udpis"></param>
-        private void ComputeRDP(double intakeScale,            // Assumed scaling factor for intake        
-                                  double feedingLevel,                     // Assumed feeding level                    
+        private void ComputeRDP(double intakeScale,            // Assumed scaling factor for intake
+                                  double feedingLevel,                     // Assumed feeding level
                                   ref Diet corrDg,
                                   ref double rdpi, ref double rdpr,
                                   ref Diet udpis)
         {
             Diet RDPIs;
-            double suppFME_Intake;                                                                      // Fermentable ME intake of supplement      
+            double suppFME_Intake;                                                                      // Fermentable ME intake of supplement
             int idx;
 
-            corrDg.Herbage = this.AnimalState.PaddockIntake.Degradability                               // Correct the protein degradability        
-                              * (1.0 - (Genotype.DgProtC[1] - this.Genotype.DgProtC[2] * this.AnimalState.Digestibility.Herbage)// for feeding level                     
+            corrDg.Herbage = this.AnimalState.PaddockIntake.Degradability                               // Correct the protein degradability
+                              * (1.0 - (Genotype.DgProtC[1] - this.Genotype.DgProtC[2] * this.AnimalState.Digestibility.Herbage)// for feeding level
                                        * Math.Max(feedingLevel, 0.0));
             corrDg.Supp = this.AnimalState.SuppIntake.Degradability
                               * (1.0 - this.Genotype.DgProtC[3] * Math.Max(feedingLevel, 0.0));
@@ -2043,57 +2043,57 @@ namespace Models.GrazPlan
             RDPIs.Herbage = intakeScale * this.AnimalState.CP_Intake.Herbage * this.AnimalState.CorrDgProt.Herbage;
             RDPIs.Supp = intakeScale * this.AnimalState.CP_Intake.Supp * this.AnimalState.CorrDgProt.Supp;
             RDPIs.Solid = RDPIs.Herbage + RDPIs.Supp;
-            RDPIs.Milk = 0.0;                                                                           // This neglects any degradation of milk    
-            udpis.Herbage = intakeScale * this.AnimalState.CP_Intake.Herbage - RDPIs.Herbage;           // CPI late in lactation when the rumen   
-            udpis.Supp = intakeScale * this.AnimalState.CP_Intake.Supp - RDPIs.Supp;                    // has begun to develop                   
+            RDPIs.Milk = 0.0;                                                                           // This neglects any degradation of milk
+            udpis.Herbage = intakeScale * this.AnimalState.CP_Intake.Herbage - RDPIs.Herbage;           // CPI late in lactation when the rumen
+            udpis.Supp = intakeScale * this.AnimalState.CP_Intake.Supp - RDPIs.Supp;                    // has begun to develop
             udpis.Milk = this.AnimalState.CP_Intake.Milk;
             udpis.Solid = udpis.Herbage + udpis.Supp;
             rdpi = RDPIs.Solid + RDPIs.Milk;
 
-            suppFME_Intake = StdMath.DIM(intakeScale * this.AnimalState.ME_Intake.Supp,                 // Fermentable ME intake of supplement      
-                                   GrazType.ProteinE2DM * udpis.Supp);                                  // leaves out the ME derived from         
-            for (idx = 0; idx <= RationFed.Count - 1; idx++)                                            // undegraded protein and oils            
+            suppFME_Intake = StdMath.DIM(intakeScale * this.AnimalState.ME_Intake.Supp,                 // Fermentable ME intake of supplement
+                                   GrazType.ProteinE2DM * udpis.Supp);                                  // leaves out the ME derived from
+            for (idx = 0; idx <= RationFed.Count - 1; idx++)                                            // undegraded protein and oils
                 suppFME_Intake = StdMath.DIM(suppFME_Intake,
                                        GrazType.FatE2DM * RationFed[idx].EtherExtract * intakeScale * netSupplementDMI[idx]);
 
-            rdpr = (this.Genotype.DgProtC[4] + this.Genotype.DgProtC[5] * (1.0 - Math.Exp(-this.Genotype.DgProtC[6] * (feedingLevel + 1.0))))       // RDP requirement                          
+            rdpr = (this.Genotype.DgProtC[4] + this.Genotype.DgProtC[5] * (1.0 - Math.Exp(-this.Genotype.DgProtC[6] * (feedingLevel + 1.0))))       // RDP requirement
                     * (intakeScale * this.AnimalState.ME_Intake.Herbage
                         * (1.0 + Genotype.DgProtC[7] * (weather.Latitude / 40.0)
                                             * Math.Sin(GrazEnv.DAY2RAD * clock.Today.DayOfYear)) + suppFME_Intake);
         }
-        
+
         /// <summary>
-        /// Set the standard reference weight of a group of animals based on breed  
-        /// and sex                                                                   
+        /// Set the standard reference weight of a group of animals based on breed
+        /// and sex
         /// </summary>
         private void ComputeSRW()
         {
-            double SRW;                                                             // Breed standard reference weight (i.e.    
+            double SRW;                                                             // Breed standard reference weight (i.e.
                                                                                     // normal weight of a mature, empty female)
 
-            if (mothers != null)                                                    // For lambs and calves, take both parents' 
-                SRW = Genotype.BreedSRW;     // 0.5 * (BreedSRW + MaleSRW)           // breed SRW's into account               
+            if (mothers != null)                                                    // For lambs and calves, take both parents'
+                SRW = Genotype.BreedSRW;     // 0.5 * (BreedSRW + MaleSRW)           // breed SRW's into account
             else
                 SRW = Genotype.BreedSRW;
 
-            if (MaleNo == 0)                                                       // Now take into account different SRWs of  
-                standardReferenceWeight = SRW;                                                     // males and females and different        
-            else                                                                    // scalars for entire and castrated males 
+            if (MaleNo == 0)                                                       // Now take into account different SRWs of
+                standardReferenceWeight = SRW;                                                     // males and females and different
+            else                                                                    // scalars for entire and castrated males
                 standardReferenceWeight = SRW * StdUnits.StdMath.XDiv(FemaleNo + MaleNo * Genotype.SRWScalars[(int)ReproState],       // TODO: check this
                                         FemaleNo + MaleNo);
         }
 
         /// <summary>
-        /// Reference birth weight, adjusted for number of foetuses and relative size 
+        /// Reference birth weight, adjusted for number of foetuses and relative size
         /// </summary>
         /// <returns></returns>
         private double BirthWeightForSize()
         {
             return this.Genotype.StdBirthWt(NoFoetuses) * ((1.0 - this.Genotype.PregC[4]) + this.Genotype.PregC[4] * RelativeSize);
         }
-        
+
         /// <summary>
-        ///  "Normal weight" of the foetus and the weight of the conceptus in pregnant animals.         
+        ///  "Normal weight" of the foetus and the weight of the conceptus in pregnant animals.
         /// </summary>
         /// <returns>The normal weight</returns>
         private double FoetalNormWt()
@@ -2105,7 +2105,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Gompertz function, constrained to give f(A)=1.0                              
+        /// Gompertz function, constrained to give f(A)=1.0
         /// </summary>
         /// <param name="t"></param>
         /// <param name="a"></param>
@@ -2118,7 +2118,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Weight of the conceptus, i.e. foetus(es) plus uterus etc                  
+        /// Weight of the conceptus, i.e. foetus(es) plus uterus etc
         /// </summary>
         /// <returns>Conceptus weight</returns>
         private double ConceptusWt()
@@ -2130,9 +2130,9 @@ namespace Models.GrazPlan
             else
                 return 0.0;
         }
-       
+
         /// <summary>
-        /// Normal weight equation                                                 
+        /// Normal weight equation
         /// </summary>
         /// <param name="ageDays"></param>
         /// <param name="maxOldWt"></param>
@@ -2143,25 +2143,25 @@ namespace Models.GrazPlan
             double fMaxNormWt;
 
             fMaxNormWt = MaxNormWtFunc(standardReferenceWeight, birthWeight, ageDays, Genotype);
-            if (maxOldWt < fMaxNormWt)                                           // Delayed deveopment of frame size         
+            if (maxOldWt < fMaxNormWt)                                           // Delayed deveopment of frame size
                 return weighting * fMaxNormWt + (1.0 - weighting) * maxOldWt;
             else
                 return fMaxNormWt;
         }
-        
+
         /// <summary>
-        /// Calculate normal weight, size and condition of a group of animals.      
+        /// Calculate normal weight, size and condition of a group of animals.
         /// </summary>
         private void CalculateWeights()
         {
-            maxPrevWeight = Math.Max(BaseWeight, maxPrevWeight);                             // Store the highest weight reached to date 
+            maxPrevWeight = Math.Max(BaseWeight, maxPrevWeight);                             // Store the highest weight reached to date
             normalWeight = NormalWeightFunc(AgeDays, maxPrevWeight, Genotype.GrowthC[3]);
             RelativeSize = normalWeight / standardReferenceWeight;
             BodyCondition = BaseWeight / normalWeight;
         }
-        
+
         /// <summary>
-        /// Compute coat depth from GFW and fibre diameter                              
+        /// Compute coat depth from GFW and fibre diameter
         /// </summary>
         private void CalculateCoatDepth()
         {
@@ -2180,8 +2180,8 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// In sheep, the coat depth is used to set the total wool weight (this is the  
-        /// way that shearing is done)                                                  
+        /// In sheep, the coat depth is used to set the total wool weight (this is the
+        /// way that shearing is done)
         /// </summary>
         /// <param name="coatDepth">Coat depth for which a greasy wool weight is to be calculated (cm)</param>
         /// <returns>Wool weight</returns>
@@ -2206,7 +2206,7 @@ namespace Models.GrazPlan
         /// <returns>Conception rates</returns>
         private double[] GetConceptionRates()
         {
-            const double STD_LATITUDE = -35.0;      // Latitude (in degrees) for which the DayLengthConst[] parameters are set    
+            const double STD_LATITUDE = -35.0;      // Latitude (in degrees) for which the DayLengthConst[] parameters are set
             int iDOY;
             double fDLFactor;
             double fPropn;
@@ -2217,8 +2217,8 @@ namespace Models.GrazPlan
             iDOY = clock.Today.DayOfYear;
             fDLFactor = (1.0 - Math.Sin(GrazEnv.DAY2RAD * (iDOY + 10)))
                          * Math.Sin(GrazEnv.DEG2RAD * weather.Latitude) / Math.Sin(GrazEnv.DEG2RAD * STD_LATITUDE);
-            for (N = 1; N <= Genotype.MaxYoung; N++)                              // First we calculate the proportion of   
-            {                                                                    // females with at least N young          
+            for (N = 1; N <= Genotype.MaxYoung; N++)                              // First we calculate the proportion of
+            {                                                                    // females with at least N young
                 if (Genotype.ConceiveSigs[N][0] < 5.0)
                     fPropn = StdMath.DIM(1.0, Genotype.DayLengthConst[N] * fDLFactor)
                               * StdMath.SIG(RelativeSize * BodyCondition, Genotype.ConceiveSigs[N]);
@@ -2268,8 +2268,8 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Used in createYoung() to set up the genotypic parameters of the lambs     
-        /// or calves that are about to be born/created.                              
+        /// Used in createYoung() to set up the genotypic parameters of the lambs
+        /// or calves that are about to be born/created.
         /// </summary>
         /// <returns></returns>
         private Genotype ConstructOffspringParams()
@@ -2283,7 +2283,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        ///  Carry out one cycle's worth of conceptions                                
+        ///  Carry out one cycle's worth of conceptions
         /// </summary>
         /// <param name="newGroups"></param>
         private void Conceive(ref List<AnimalGroup> newGroups)
@@ -2332,7 +2332,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Mortality submodel                                                        
+        /// Mortality submodel
         /// </summary>
         /// <param name="chill"></param>
         /// <param name="newGroups"></param>
@@ -2365,8 +2365,8 @@ namespace Models.GrazPlan
 
             else if ((Young != null) && (femaleLosses + YoungLosses > 0))
             {
-                if (femaleLosses > 0)                                               // For now, unweaned young of dying animals 
-                {                                                                   //   die with them                       
+                if (femaleLosses > 0)                                               // For now, unweaned young of dying animals
+                {                                                                   //   die with them
                     DeadGroup = Split(femaleLosses, false, Diffs, NODIFF);
                     YoungToKill = StdMath.IDIM(YoungLosses, DeadGroup.Young.NoAnimals);
                     DeadGroup = null;
@@ -2374,8 +2374,8 @@ namespace Models.GrazPlan
                 else
                     YoungToKill = YoungLosses;
 
-                if (YoungToKill > 0)                                                // Any further young to kill are removed as 
-                {                                                                   //   evenly as possible from their mothers  
+                if (YoungToKill > 0)                                                // Any further young to kill are removed as
+                {                                                                   //   evenly as possible from their mothers
                     if (FemaleNo > 0)
                         LoseYoung(this, YoungToKill / FemaleNo);
                     if (YoungToKill % FemaleNo > 0)
@@ -2385,12 +2385,12 @@ namespace Models.GrazPlan
                         CheckAnimList(ref newGroups);
                         newGroups.Add(SplitGroup);
                     }
-                } //// _ IF (YoungToKill > 0) 
-            } //// ELSE IF (Young <> NIL) and (NoLosses + YoungLosses > 0) 
+                } //// _ IF (YoungToKill > 0)
+            } //// ELSE IF (Young <> NIL) and (NoLosses + YoungLosses > 0)
         }
 
         /// <summary>
-        /// Decrease the number of young by N per mother                               
+        /// Decrease the number of young by N per mother
         /// </summary>
         /// <param name="animalGrp"></param>
         /// <param name="number">Number of animals</param>
@@ -2434,7 +2434,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Pregnancy toxaemia and dystokia                                           
+        /// Pregnancy toxaemia and dystokia
         /// </summary>
         /// <param name="newGroups">The new groups</param>
         private void KillEndPreg(ref List<AnimalGroup> newGroups)
@@ -2445,10 +2445,10 @@ namespace Models.GrazPlan
             int numLosses;
 
             if ((Animal == GrazType.AnimalType.Sheep) && (foetalAge == Genotype.Gestation - 1))
-                if (NoFoetuses == 1)                                                    // Calculate loss of young due to           
-                {                                                                       // dystokia and move the corresponding      
-                    DystokiaRate = StdMath.SIG((FoetalWeight / Genotype.StdBirthWt(1)) *     // number of mothers into a new animal      
-                                           Math.Max(RelativeSize, 1.0),                         // group                                    
+                if (NoFoetuses == 1)                                                    // Calculate loss of young due to
+                {                                                                       // dystokia and move the corresponding
+                    DystokiaRate = StdMath.SIG((FoetalWeight / Genotype.StdBirthWt(1)) *     // number of mothers into a new animal
+                                           Math.Max(RelativeSize, 1.0),                         // group
                                          Genotype.DystokiaSigs);
                     numLosses = randFactory.RndPropn(FemaleNo, DystokiaRate);
                     if (numLosses > 0)
@@ -2458,21 +2458,21 @@ namespace Models.GrazPlan
                         CheckAnimList(ref newGroups);
                         newGroups.Add(DystGroup);
                     } ////  IF (NoLosses > 0)
-                } //// IF (NoYoung = 1) 
+                } //// IF (NoYoung = 1)
 
-                else if (NoFoetuses >= 2)                                          // Deaths of sheep with multiple young      
-                {                                                                  // due to pregnancy toxaemia              
+                else if (NoFoetuses >= 2)                                          // Deaths of sheep with multiple young
+                {                                                                  // due to pregnancy toxaemia
                     ToxaemiaRate = StdMath.SIG((midLatePregWeight - BaseWeight) / normalWeight,
                                          Genotype.ToxaemiaSigs);
                     numLosses = randFactory.RndPropn(FemaleNo, ToxaemiaRate);
                     Deaths += numLosses;
                     if (numLosses > 0)
                         Split(numLosses, false, NODIFF, NODIFF);
-                } //// ELSE IF (NoFoetuses >= 2) 
+                } //// ELSE IF (NoFoetuses >= 2)
         }
 
         /// <summary>
-        /// Automatic end to lactation in response to reduced milk production         
+        /// Automatic end to lactation in response to reduced milk production
         /// </summary>
         /// <returns></returns>
         private bool YoungStopSuckling()
@@ -2496,7 +2496,7 @@ namespace Models.GrazPlan
             else
                 return 0;
         }
-        
+
         /// <summary>
         /// TODO: check that this function returns changed values
         /// </summary>
@@ -2510,9 +2510,9 @@ namespace Models.GrazPlan
                 ag.woolWt = ag.woolWt + x * diffs.FleeceWt;
             ag.standardReferenceWeight = ag.standardReferenceWeight + x * diffs.StdRefWt;
             ag.CalculateWeights();
-            ag.totalWeight = ag.BaseWeight + ag.ConceptusWt();                            // TotalWeight is meant to be the weight  
-            if (Genotype.Animal == GrazType.AnimalType.Sheep)                              // "on the scales", including conceptus   
-                ag.totalWeight = ag.totalWeight + ag.woolWt;                              // and/or fleece.                         
+            ag.totalWeight = ag.BaseWeight + ag.ConceptusWt();                            // TotalWeight is meant to be the weight
+            if (Genotype.Animal == GrazType.AnimalType.Sheep)                              // "on the scales", including conceptus
+                ag.totalWeight = ag.totalWeight + ag.woolWt;                              // and/or fleece.
         }
 
         /// <summary>
@@ -2530,7 +2530,7 @@ namespace Models.GrazPlan
             if ((numberMales > MaleNo) || (numberFemales > FemaleNo))
                 throw new Exception("AnimalGroup: Error in SplitSex method");
 
-            AnimalGroup Result = Copy();                                                 // Create the new animal group              
+            AnimalGroup Result = Copy();                                                 // Create the new animal group
             if ((numberMales == MaleNo) && (numberFemales == FemaleNo))
             {
                 MaleNo = 0;
@@ -2539,12 +2539,12 @@ namespace Models.GrazPlan
             }
             else
             {
-                PropnGoing = StdMath.XDiv(numberMales + numberFemales, MaleNo + FemaleNo);        // Adjust weights etc                       
+                PropnGoing = StdMath.XDiv(numberMales + numberFemales, MaleNo + FemaleNo);        // Adjust weights etc
                 AdjustRecords(this, -PropnGoing, diffs);
                 AdjustRecords(Result, 1.0 - PropnGoing, diffs);
 
-                Result.MaleNo = numberMales;                                                 // Set up numbers in the two groups and     
-                Result.FemaleNo = numberFemales;                                             // split up the age list                  
+                Result.MaleNo = numberMales;                                                 // Set up numbers in the two groups and
+                Result.FemaleNo = numberFemales;                                             // split up the age list
                 Result.ages = this.ages.Split(numberMales, numberFemales, byAge);
                 Result.AgeDays = Result.ages.MeanAge();
 
@@ -2607,7 +2607,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Weight of fleece that would be cut if the animals were shorn (kg greasy) 
+        /// Weight of fleece that would be cut if the animals were shorn (kg greasy)
         /// </summary>
         /// <returns></returns>
         private double GetFleeceCutWt()
@@ -2625,7 +2625,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Total weight of wool including stubble (kg greasy)                        
+        /// Total weight of wool including stubble (kg greasy)
         /// </summary>
         /// <param name="woolWeight"></param>
         private void SetWoolWt(double woolWeight)
@@ -2646,7 +2646,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// In sheep, the coat depth is used to set the total wool weight 
+        /// In sheep, the coat depth is used to set the total wool weight
         /// </summary>
         /// <param name="newCoatDepth">New coat depth (cm)</param>
         private void SetCoatDepth(double newCoatDepth)
@@ -2682,16 +2682,16 @@ namespace Models.GrazPlan
             {
                 if (p == 0)
                 {
-                    ReproState = GrazType.ReproType.Empty;                         // Don't re-set the base weight here as     
-                    foetalAge = 0;                                                  // this is usually used at birth, where   
-                    FoetalWeight = 0.0;                                                 // the conceptus is lost                  
+                    ReproState = GrazType.ReproType.Empty;                         // Don't re-set the base weight here as
+                    foetalAge = 0;                                                  // this is usually used at birth, where
+                    FoetalWeight = 0.0;                                                 // the conceptus is lost
                     midLatePregWeight = 0.0;
                     SetNoFoetuses(0);
                     mateCycle = -1;
                 }
                 else if (p != 0)
                 {
-                    OldLiveWt = LiveWeight;                                              // Store live weight                        
+                    OldLiveWt = LiveWeight;                                              // Store live weight
                     if (p >= Genotype.Gestation - latePregLength)
                         ReproState = GrazType.ReproType.LatePreg;
                     else
@@ -2701,10 +2701,10 @@ namespace Models.GrazPlan
                         SetNoFoetuses(1);
                     mateCycle = -1;
                     daysToMate = 0;
-                    for (Idx = 1; Idx <= 3; Idx++)                                         // This piece of code estimates the weight  
-                    {                                                                      // of the foetus and implicitly the       
-                        ConditionFactor = (BodyCondition - 1.0)                                // conceptus while keeping the live       
-                                           * FoetalNormWt() / Genotype.StdBirthWt(NoFoetuses);   // weight constant                        
+                    for (Idx = 1; Idx <= 3; Idx++)                                         // This piece of code estimates the weight
+                    {                                                                      // of the foetus and implicitly the
+                        ConditionFactor = (BodyCondition - 1.0)                                // conceptus while keeping the live
+                                           * FoetalNormWt() / Genotype.StdBirthWt(NoFoetuses);   // weight constant
                         if (BodyCondition >= 1.0)
                             FoetalWeight = FoetalNormWt() * (1.0 + ConditionFactor);
                         else
@@ -2720,7 +2720,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="l"></param>
         private void SetLactation(int l)
@@ -2731,15 +2731,15 @@ namespace Models.GrazPlan
             {
                 if (l == 0)
                 {
-                    lactStatus = GrazType.LactType.Dry;                                     // Set this before calling setDryoffTime()  
+                    lactStatus = GrazType.LactType.Dry;                                     // Set this before calling setDryoffTime()
                     if (Young == null)
                         SetDryoffTime(daysLactating, 0, previousOffspring);
-                    else                                                                    // This happens when self-weaning occurs    
+                    else                                                                    // This happens when self-weaning occurs
                     {
                         SetDryoffTime(daysLactating, 0, NoOffspring);
                         Young.lactStatus = GrazType.LactType.Dry;
                     }
-                    daysLactating = 0;                                                      // ConditionAtBirthing, PropnOfMaxMilk and  
+                    daysLactating = 0;                                                      // ConditionAtBirthing, PropnOfMaxMilk and
                 }                                                                           // LactAdjust are left at their final values
                 else
                 {
@@ -2788,8 +2788,8 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        ///  On creation, lambs and calves are always suckling their mothers. This may 
-        /// change in the course of a simulation (see the YoungStopSuckling function) 
+        ///  On creation, lambs and calves are always suckling their mothers. This may
+        /// change in the course of a simulation (see the YoungStopSuckling function)
         /// </summary>
         /// <param name="value"></param>
         private void SetNoOffspring(int value)
@@ -2798,7 +2798,7 @@ namespace Models.GrazPlan
 
             if (value != NoOffspring)
             {
-                iDaysLact = Lactation;                                                 // Store the current stage of lactation     
+                iDaysLact = Lactation;                                                 // Store the current stage of lactation
                 Lactation = 0;
                 if (Young != null)
                 {
@@ -2811,14 +2811,14 @@ namespace Models.GrazPlan
                 if (value == 0)
                     Young = null;
                 else if (value <= Genotype.MaxYoung)
-                    SetLactation(iDaysLact);                                            // This creates a new group of (suckling) lambs or calves  
-            }                                                                                                   
+                    SetLactation(iDaysLact);                                            // This creates a new group of (suckling) lambs or calves
+            }
         }
 
         /// <summary>
-        /// Return the total faecal carbon and nitrogen an urine nitrogen produced by 
-        /// a group of animals.  The values are in kilograms, not kg/head (i.e. they  
-        /// are totalled over all animals in the group)                               
+        /// Return the total faecal carbon and nitrogen an urine nitrogen produced by
+        /// a group of animals.  The values are in kilograms, not kg/head (i.e. they
+        /// are totalled over all animals in the group)
         /// </summary>
         /// <returns></returns>
         private GrazType.DM_Pool GetOrgFaeces()
@@ -2952,7 +2952,7 @@ namespace Models.GrazPlan
 
         //TODO: Test this function
         /// <summary>
-        /// Get the age class 
+        /// Get the age class
         /// </summary>
         /// <returns></returns>
         private GrazType.AgeType GetAgeClass()
@@ -3016,7 +3016,7 @@ namespace Models.GrazPlan
         /// <returns></returns>
         private double GetDSEs()
         {
-            const double DSE_REF_MEI = 8.8;                     // ME intake corresponding to 1.0 dry sheep 
+            const double DSE_REF_MEI = 8.8;                     // ME intake corresponding to 1.0 dry sheep
             double Result;
             double MEIPerHead;
 
@@ -3033,7 +3033,7 @@ namespace Models.GrazPlan
         /// </summary>
         /// <returns></returns>
         private double GetCFW() { return FleeceCutWeight * Genotype.WoolC[3]; }
-        
+
         /// <summary>
         /// CleanFleeceGrowth
         /// </summary>
@@ -3088,8 +3088,8 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// GrowthCurve calculates MaxNormalWt (see below) for an animal with the   
-        /// default birth weight.                                                   
+        /// GrowthCurve calculates MaxNormalWt (see below) for an animal with the
+        /// default birth weight.
         /// </summary>
         /// <param name="srw"></param>
         /// <param name="bw"></param>
@@ -3107,7 +3107,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Normal weight as a function of age and sex                                
+        /// Normal weight as a function of age and sex
         /// </summary>
         /// <param name="ageDays"></param>
         /// <param name="reprdType"></param>
@@ -3139,7 +3139,7 @@ namespace Models.GrazPlan
                                  int number,
                                  int age,
                                  double liveWeight,
-                                 double gfw,                   // NB this is a *fleece* weight             
+                                 double gfw,                   // NB this is a *fleece* weight
                                  MyRandom randomFactory,
                                  bool takeParams = false)
         {
@@ -3166,14 +3166,14 @@ namespace Models.GrazPlan
             implantEffect = 1.0;
             IntakeModifier = 1.0;
 
-            AgeDays = age;                                                          // Age of the animals                       
+            AgeDays = age;                                                          // Age of the animals
             ages = new AgeList(randFactory);
             ages.Input(age, MaleNo, FemaleNo);
 
             RationFed = new SupplementRation();
             IntakeSupplement = new FoodSupplement();
 
-            mateCycle = -1;                                                          // Not recently mated                       
+            mateCycle = -1;                                                          // Not recently mated
 
             LiveWeight = liveWeight;
             birthWeight = Math.Min(Genotype.StdBirthWt(1), BaseWeight);
@@ -3181,8 +3181,8 @@ namespace Models.GrazPlan
 
             if (Animal == GrazType.AnimalType.Sheep)
             {
-                FibreDiam = Genotype.MaxFleeceDiam;                                   // Calculation of FleeceCutWeight depends   
-                FleeceCutWeight = gfw;                                                // on the values of NormalWt & WoolMicron 
+                FibreDiam = Genotype.MaxFleeceDiam;                                   // Calculation of FleeceCutWeight depends
+                FleeceCutWeight = gfw;                                                // on the values of NormalWt & WoolMicron
 
                 fWoolAgeFactor = Genotype.WoolC[5] + (1.0 - Genotype.WoolC[5]) * (1.0 - Math.Exp(-Genotype.WoolC[12] * AgeDays));
                 GreasyFleeceGrowth = Genotype.FleeceRatio * standardReferenceWeight * fWoolAgeFactor / 365.0;
@@ -3196,8 +3196,8 @@ namespace Models.GrazPlan
             else
                 SetMaxPrevWt(BaseWeight);
 
-            BirthCondition = BodyCondition;                                         // These terms affect the calculation of  
-            proportionOfMaxMilk = 1.0;                                                    // potential intake                     
+            BirthCondition = BodyCondition;                                         // These terms affect the calculation of
+            proportionOfMaxMilk = 1.0;                                                    // potential intake
             lactationAdjustment = 1.0;
 
             basePhosphorusWeight = BaseWeight * Genotype.PhosC[9];
@@ -3215,12 +3215,12 @@ namespace Models.GrazPlan
         private double AverageField(int total1, int total2, double field1, double field2)
         {
             if (total1 + total2 > 0)
-                return (field1 * total1 + field2 * total2) / (total1 + total2);    // The result of the averaging process goes "into place"                      
+                return (field1 * total1 + field2 * total2) / (total1 + total2);    // The result of the averaging process goes "into place"
             return field1;
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="maleScale"></param>
         /// <param name="numMale"></param>
@@ -3271,7 +3271,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Wood-type function, scaled to give a maximum of 1.0 at time Tmax          
+        /// Wood-type function, scaled to give a maximum of 1.0 at time Tmax
         /// </summary>
         /// <param name="t"></param>
         /// <param name="tmax"></param>
@@ -3283,7 +3283,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Inverse of the WOOD function, evaluated iteratively                       
+        /// Inverse of the WOOD function, evaluated iteratively
         /// </summary>
         /// <param name="y"></param>
         /// <param name="tmax"></param>
@@ -3300,13 +3300,13 @@ namespace Models.GrazPlan
                 result = tmax;
             else
             {
-                if (!declining)                                                   // Initial guess                            
+                if (!declining)                                                   // Initial guess
                     x1 = Math.Min(0.99, y);
                 else
                     x1 = Math.Max(1.01, Math.Exp(b * (1.0 - y)));
 
                 bool more = true;
-                do                                                                 // Newton-Raphson solution                   
+                do                                                                 // Newton-Raphson solution
                 {
                     x0 = x1;
                     x1 = x0 - (1.0 - y / WOOD(x0, 1.0, b)) * x0 / (b * (1.0 - x0));
@@ -3345,8 +3345,8 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Used in GrazFeed to initialise the state variables for which yesterday's  
-        /// value must be known in order to get today's calculation                   
+        /// Used in GrazFeed to initialise the state variables for which yesterday's
+        /// value must be known in order to get today's calculation
         /// </summary>
         /// <param name="prevGroup"></param>
         private void SetUpForYesterday(AnimalGroup prevGroup)
@@ -3380,7 +3380,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="full"></param>
         /// <param name="fullDenom"></param>
@@ -3492,7 +3492,7 @@ namespace Models.GrazPlan
                 this.UpdateIntakeRecord(ref this.AnimalState.PaddockIntake, this.timeStepState.PaddockIntake, timeStep);
                 this.UpdateIntakeRecord(ref this.AnimalState.SuppIntake, this.timeStepState.SuppIntake, suppTS);
 
-                // compute these averages *before* cumulating DM_Intake & CP_Intake 
+                // compute these averages *before* cumulating DM_Intake & CP_Intake
 
                 this.UpdateDietAve(ref this.AnimalState.Digestibility, this.AnimalState.DM_Intake,
                                this.timeStepState.Digestibility, this.timeStepState.DM_Intake,
@@ -3525,21 +3525,21 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Compute proportional contribution of diet components (milk, fodder and      
-        /// supplement) and the efficiencies of energy use                            
-        /// This procedure corresponds to section 5 of the model specification        
+        /// Compute proportional contribution of diet components (milk, fodder and
+        /// supplement) and the efficiencies of energy use
+        /// This procedure corresponds to section 5 of the model specification
         /// </summary>
         private void Efficiencies()
         {
-            double herbageEfficiency;                                                       // Efficiencies for gain from herbage &     
-            double suppEfficiency;                                                          // supplement intake                      
+            double herbageEfficiency;                                                       // Efficiencies for gain from herbage &
+            double suppEfficiency;                                                          // supplement intake
 
             this.AnimalState.DietPropn.Milk = StdMath.XDiv(this.AnimalState.ME_Intake.Milk, this.AnimalState.ME_Intake.Total);
             this.AnimalState.DietPropn.Solid = 1.0 - this.AnimalState.DietPropn.Milk;
             this.AnimalState.DietPropn.Supp = this.AnimalState.DietPropn.Solid * StdMath.XDiv(this.AnimalState.ME_Intake.Supp, this.AnimalState.ME_Intake.Solid);
             this.AnimalState.DietPropn.Herbage = this.AnimalState.DietPropn.Solid - this.AnimalState.DietPropn.Supp;
 
-            if (this.AnimalState.ME_Intake.Total < GrazType.VerySmall)                             
+            if (this.AnimalState.ME_Intake.Total < GrazType.VerySmall)
             {
                 // Efficiencies of various uses of ME
                 this.AnimalState.Efficiency.Maint = this.Genotype.EfficC[4];
@@ -3565,15 +3565,15 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Basal metabolism routine.  Outputs (EnergyUse.Metab,EnergyUse.Maint,      
-        /// ProteinUse.Maint) are stored in AnimalState.                              
+        /// Basal metabolism routine.  Outputs (EnergyUse.Metab,EnergyUse.Maint,
+        /// ProteinUse.Maint) are stored in AnimalState.
         /// </summary>
         private void ComputeMaintenance()
         {
             double metabScale;
-            double grazeMoved_KM;       // Distance walked during grazing (km)      
-            double eatingEnergy;        // Energy requirement for grazing           
-            double movingEnergy;        // Energy requirement for movement          
+            double grazeMoved_KM;       // Distance walked during grazing (km)
+            double eatingEnergy;        // Energy requirement for grazing
+            double movingEnergy;        // Energy requirement for movement
             double endoUrineN;
 
             if (this.lactStatus == GrazType.LactType.Suckling)
@@ -3582,13 +3582,13 @@ namespace Models.GrazPlan
                 metabScale = 1.0 + this.Genotype.MaintC[15];
             else
                 metabScale = 1.0;
-            this.AnimalState.EnergyUse.Metab = metabScale * this.Genotype.MaintC[2] * Math.Pow(this.BaseWeight, 0.75) // Basal metabolism                         
+            this.AnimalState.EnergyUse.Metab = metabScale * this.Genotype.MaintC[2] * Math.Pow(this.BaseWeight, 0.75) // Basal metabolism
                                * Math.Max(Math.Exp(-this.Genotype.MaintC[3] * this.AgeDays), this.Genotype.MaintC[4]);
 
-            eatingEnergy = this.Genotype.MaintC[6] * this.BaseWeight * this.AnimalState.DM_Intake.Herbage             // Work of eating fibrous diets             
+            eatingEnergy = this.Genotype.MaintC[6] * this.BaseWeight * this.AnimalState.DM_Intake.Herbage             // Work of eating fibrous diets
                                          * StdMath.DIM(this.Genotype.MaintC[7], this.AnimalState.Digestibility.Herbage);
 
-            if (Herbage.TotalGreen > 100.0)                                                                      // Energy requirement for movement          
+            if (Herbage.TotalGreen > 100.0)                                                                      // Energy requirement for movement
                 grazeMoved_KM = 1.0 / (this.Genotype.MaintC[8] * this.Herbage.TotalGreen + this.Genotype.MaintC[9]);
             else if (Herbage.TotalDead > 100.0)
                 grazeMoved_KM = 1.0 / (this.Genotype.MaintC[8] * this.Herbage.TotalDead + this.Genotype.MaintC[9]);
@@ -3603,7 +3603,7 @@ namespace Models.GrazPlan
                                + this.Genotype.MaintC[1] * this.AnimalState.ME_Intake.Total;
             this.feedingLevel = this.AnimalState.ME_Intake.Total / this.AnimalState.EnergyUse.Maint - 1.0;
 
-            //// ...........................................................................  MAINTENANCE PROTEIN REQUIREMENT          
+            //// ...........................................................................  MAINTENANCE PROTEIN REQUIREMENT
 
             this.AnimalState.EndoFaeces.Nu[(int)GrazType.TOMElement.n] = (this.Genotype.MaintC[10] * this.AnimalState.DM_Intake.Solid + this.Genotype.MaintC[11] * this.AnimalState.ME_Intake.Milk) / GrazType.N2Protein;
 
@@ -3612,7 +3612,7 @@ namespace Models.GrazPlan
                 endoUrineN = (this.Genotype.MaintC[12] * Math.Log(this.BaseWeight) - this.Genotype.MaintC[13]) / GrazType.N2Protein;
                 this.AnimalState.DermalNLoss = this.Genotype.MaintC[14] * Math.Pow(this.BaseWeight, 0.75) / GrazType.N2Protein;
             }
-            else  
+            else
             {
                 // sheep
                 endoUrineN = (this.Genotype.MaintC[12] * this.BaseWeight + this.Genotype.MaintC[13]) / GrazType.N2Protein;
@@ -3622,7 +3622,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="isRoughage"></param>
         /// <param name="cp"></param>
@@ -3656,20 +3656,20 @@ namespace Models.GrazPlan
             this.AnimalState.UDP_Intake = UDPIntakes.Solid + UDPIntakes.Milk;
             dgCorrect = StdMath.XDiv(this.AnimalState.CorrDgProt.Supp, this.AnimalState.SuppIntake.Degradability);
 
-            this.AnimalState.MicrobialCP = this.Genotype.ProtC[6] * this.AnimalState.RDP_Reqd;                       // Microbial crude protein synthesis        
+            this.AnimalState.MicrobialCP = this.Genotype.ProtC[6] * this.AnimalState.RDP_Reqd;                       // Microbial crude protein synthesis
 
             DUDP.Milk = Genotype.ProtC[5];
             DUDP.Herbage = DUDPFunc(true, this.AnimalState.ProteinConc.Herbage, this.AnimalState.CorrDgProt.Herbage, 0.0);
             DUDP.Supp = 0.0;
             for (idx = 0; idx <= RationFed.Count - 1; idx++)
-                DUDP.Supp = DUDP.Supp + StdMath.XDiv(this.netSupplementDMI[idx], this.AnimalState.DM_Intake.Supp)        // Fraction of net supplement intake        
-                                          * this.DUDPFunc(this.RationFed[idx].IsRoughage,                           // DUDP of this part of the ration          
+                DUDP.Supp = DUDP.Supp + StdMath.XDiv(this.netSupplementDMI[idx], this.AnimalState.DM_Intake.Supp)        // Fraction of net supplement intake
+                                          * this.DUDPFunc(this.RationFed[idx].IsRoughage,                           // DUDP of this part of the ration
                                                       this.RationFed[idx].CrudeProt,
                                                       this.RationFed[idx].DegProt * dgCorrect,
                                                       this.RationFed[idx].ADIP2CP);
 
-            this.AnimalState.DPLS_MCP = this.Genotype.ProtC[7] * this.AnimalState.MicrobialCP;                            // DPLS from microbial crude protein        
-            this.AnimalState.DPLS_Milk = DUDP.Milk * UDPIntakes.Milk;                                                    // Store DPLS from milk separately          
+            this.AnimalState.DPLS_MCP = this.Genotype.ProtC[7] * this.AnimalState.MicrobialCP;                            // DPLS from microbial crude protein
+            this.AnimalState.DPLS_Milk = DUDP.Milk * UDPIntakes.Milk;                                                    // Store DPLS from milk separately
             this.AnimalState.DPLS = DUDP.Herbage * UDPIntakes.Herbage
                             + DUDP.Supp * UDPIntakes.Supp
                             + this.AnimalState.DPLS_Milk
@@ -3679,17 +3679,17 @@ namespace Models.GrazPlan
             else
                 this.AnimalState.UDP_Dig = DUDP.Herbage;
 
-            this.AnimalState.OrgFaeces.DM = this.AnimalState.DM_Intake.Solid * (1.0 - this.AnimalState.Digestibility.Solid);       // Faecal DM & N:                           
-            this.AnimalState.OrgFaeces.Nu[(int)GrazType.TOMElement.n] = ((1.0 - DUDP.Herbage) * UDPIntakes.Herbage       //   Undigested UDP                         
+            this.AnimalState.OrgFaeces.DM = this.AnimalState.DM_Intake.Solid * (1.0 - this.AnimalState.Digestibility.Solid);       // Faecal DM & N:
+            this.AnimalState.OrgFaeces.Nu[(int)GrazType.TOMElement.n] = ((1.0 - DUDP.Herbage) * UDPIntakes.Herbage       //   Undigested UDP
                                + (1.0 - DUDP.Supp) * UDPIntakes.Supp
                                + (1.0 - DUDP.Milk) * UDPIntakes.Milk
-                               + Genotype.ProtC[8] * this.AnimalState.MicrobialCP)                                        //   Undigested MCP                         
-                               / GrazType.N2Protein + this.AnimalState.EndoFaeces.Nu[(int)GrazType.TOMElement.n];        //   Endogenous component                   
+                               + Genotype.ProtC[8] * this.AnimalState.MicrobialCP)                                        //   Undigested MCP
+                               / GrazType.N2Protein + this.AnimalState.EndoFaeces.Nu[(int)GrazType.TOMElement.n];        //   Endogenous component
             this.AnimalState.InOrgFaeces.Nu[(int)GrazType.TOMElement.n] = 0.0;
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="t"></param>
         /// <param name="a"></param>
@@ -3702,20 +3702,20 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Requirements for pregnancy:                                               
-        ///   'Normal' weight of foetus is calculated from its age, maturity of       
-        ///   the mother and her no. of young and is adjusted for mother's            
-        ///   condition. The "FoetalWt" field of TheAnimals^ is updated here, as      
-        ///   are the "EnergyUse.Preg" and "ProteinUse.Preg" fields of TimeStepState   
+        /// Requirements for pregnancy:
+        ///   'Normal' weight of foetus is calculated from its age, maturity of
+        ///   the mother and her no. of young and is adjusted for mother's
+        ///   condition. The "FoetalWt" field of TheAnimals^ is updated here, as
+        ///   are the "EnergyUse.Preg" and "ProteinUse.Preg" fields of TimeStepState
         /// </summary>
         private void ComputePregnancy()
         {
-            double birthWt;                                         // Reference birth weight (kg)              
-            double birthConceptus;                                  // Reference value of conceptus weight at birth  
-            double foetalNWt;                                       // Normal weight of foetus (kg)             
-            double foetalNGrowth;                                   // Normal growth rate of foetus (kg/day)    
-            double conditionFactor;                                 // Effect of maternal condition on foetal growth 
-            double foetalCondition;                                 // Foetal body condition                    
+            double birthWt;                                         // Reference birth weight (kg)
+            double birthConceptus;                                  // Reference value of conceptus weight at birth
+            double foetalNWt;                                       // Normal weight of foetus (kg)
+            double foetalNGrowth;                                   // Normal growth rate of foetus (kg/day)
+            double conditionFactor;                                 // Effect of maternal condition on foetal growth
+            double foetalCondition;                                 // Foetal body condition
             double prevConceptusWt;
 
             prevConceptusWt = this.ConceptusWt();
@@ -3745,29 +3745,29 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Requirements for lactation:                                             
-        ///   The potential production of milk on the particular day of lactation,  
-        ///   expressed as the ME value of the milk for the young, is predicted     
-        ///   from a Wood-type function, scaled for the absolute and relative size  
-        ///   of the mother, her condition at parturition and the no. of young.     
-        ///   If ME intake is inadequate for potential production, yield is reduced 
-        ///   by a proportion of the energy deficit.                                
+        /// Requirements for lactation:
+        ///   The potential production of milk on the particular day of lactation,
+        ///   expressed as the ME value of the milk for the young, is predicted
+        ///   from a Wood-type function, scaled for the absolute and relative size
+        ///   of the mother, her condition at parturition and the no. of young.
+        ///   If ME intake is inadequate for potential production, yield is reduced
+        ///   by a proportion of the energy deficit.
         /// </summary>
         private void ComputeLactation()
         {
-            double potMilkMJ;                                                               // Potential production of milk (MP')       
-            double maxMilkMJ;                                                               // Milk prodn after energy deficit (MP'')   
+            double potMilkMJ;                                                               // Potential production of milk (MP')
+            double maxMilkMJ;                                                               // Milk prodn after energy deficit (MP'')
             double energySurplus;
             double availMJ;
             double availRatio;
             double availDays;
-            double condFactor;                                                              // Function of condition affecting milk     
-                                                                                            // vs body reserves partition (CFlact)    
-            double milkLimit;                                                               // Max. milk consumption by young (kg/hd)   
-            double dayRatio;                                                                // Today's value of Milk_MJProd:PotMilkMJ   
+            double condFactor;                                                              // Function of condition affecting milk
+                                                                                            // vs body reserves partition (CFlact)
+            double milkLimit;                                                               // Max. milk consumption by young (kg/hd)
+            double dayRatio;                                                                // Today's value of Milk_MJProd:PotMilkMJ
 
             condFactor = 1.0 - this.Genotype.IntakeC[15] + this.Genotype.IntakeC[15] * BirthCondition;
-            if (this.NoSuckling() > 0)                                                      // Potential milk production in MJ          
+            if (this.NoSuckling() > 0)                                                      // Potential milk production in MJ
                 potMilkMJ = this.Genotype.PeakLactC[this.NoSuckling()]
                              * Math.Pow(this.standardReferenceWeight, 0.75) * this.RelativeSize
                              * condFactor * this.lactationAdjustment
@@ -3775,13 +3775,13 @@ namespace Models.GrazPlan
             else
                 potMilkMJ = this.Genotype.LactC[5] * this.Genotype.LactC[6] * this.Genotype.PeakMilk // peakmilk must have a value
                              * condFactor * this.lactationAdjustment
-                             * this.WOOD(this.daysLactating + this.Genotype.LactC[1], this.Genotype.LactC[2], this.Genotype.LactC[4]); 
+                             * this.WOOD(this.daysLactating + this.Genotype.LactC[1], this.Genotype.LactC[2], this.Genotype.LactC[4]);
 
             energySurplus = this.AnimalState.ME_Intake.Total - this.AnimalState.EnergyUse.Maint - this.AnimalState.EnergyUse.Preg;
             availMJ = Genotype.LactC[5] * this.AnimalState.Efficiency.Lact * energySurplus;
-            availRatio = availMJ / potMilkMJ;                                               // Effects of available energy, stage of    
-            availDays = Math.Max(daysLactating, availRatio / (2.0 * Genotype.LactC[22]));    // lactation and body condition on        
-            maxMilkMJ = potMilkMJ * this.Genotype.LactC[7]                                        // milk production                        
+            availRatio = availMJ / potMilkMJ;                                               // Effects of available energy, stage of
+            availDays = Math.Max(daysLactating, availRatio / (2.0 * Genotype.LactC[22]));    // lactation and body condition on
+            maxMilkMJ = potMilkMJ * this.Genotype.LactC[7]                                        // milk production
                                          / (1.0 + Math.Exp(this.Genotype.LactC[19] - this.Genotype.LactC[20] * availRatio
                                                        - this.Genotype.LactC[21] * availDays * (availRatio - this.Genotype.LactC[22] * availDays)
                                                        + this.Genotype.LactC[23] * BodyCondition * (availRatio - this.Genotype.LactC[24] * BodyCondition)));
@@ -3792,9 +3792,9 @@ namespace Models.GrazPlan
                              * Math.Pow(this.Young.BaseWeight, 0.75)
                              * (this.Genotype.LactC[12] + this.Genotype.LactC[13] * Math.Exp(-this.Genotype.LactC[14] * daysLactating));
                 MilkEnergy = Math.Min(maxMilkMJ, milkLimit);                              // Milk_MJ_Prodn becomes less than MaxMilkMJ
-                proportionOfMaxMilk = MilkEnergy / milkLimit;                                  // when the young are not able to consume 
-            }                                                                               // the amount of milk the mothers are     
-            else                                                                            // capable of producing                   
+                proportionOfMaxMilk = MilkEnergy / milkLimit;                                  // when the young are not able to consume
+            }                                                                               // the amount of milk the mothers are
+            else                                                                            // capable of producing
             {
                 MilkEnergy = maxMilkMJ;
                 proportionOfMaxMilk = 1.0;
@@ -3821,9 +3821,9 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Wool production is calculated from the intake of ME, except that used   
-        /// for pregnancy and lactation, and from the intake of undegraded dietary  
-        /// protein. N.B. that the stored fleece weights are on a greasy basis      
+        /// Wool production is calculated from the intake of ME, except that used
+        /// for pregnancy and lactation, and from the intake of undegraded dietary
+        /// protein. N.B. that the stored fleece weights are on a greasy basis
         /// </summary>
         /// <param name="dplsAdjust"></param>
         private void ComputeWool(double dplsAdjust)
@@ -3831,8 +3831,8 @@ namespace Models.GrazPlan
             double AgeFactor;
             double DayLenFactor;
             double ME_Avail_Wool;
-            double DPLS_To_CFW;                   // kg CFW grown per kg available DPLS       
-            double ME_To_CFW;                     // kg CFW grown per kg available ME         
+            double DPLS_To_CFW;                   // kg CFW grown per kg available DPLS
+            double ME_To_CFW;                     // kg CFW grown per kg available ME
             double DayCFWGain;
 
             AgeFactor = this.Genotype.WoolC[5] + (1.0 - this.Genotype.WoolC[5]) * (1.0 - Math.Exp(-this.Genotype.WoolC[12] * this.AgeDays));
@@ -3845,12 +3845,12 @@ namespace Models.GrazPlan
             DayCFWGain = Math.Min(DPLS_To_CFW * this.AnimalState.DPLS_Avail_Wool, ME_To_CFW * ME_Avail_Wool);
 #pragma warning disable 162 //unreachable code
             if (animalsDynamicGlb)
-                this.AnimalState.ProteinUse.Wool = (1 - this.Genotype.WoolC[4]) * (this.Genotype.WoolC[3] * this.GreasyFleeceGrowth) +            // Smoothed wool growth                     
+                this.AnimalState.ProteinUse.Wool = (1 - this.Genotype.WoolC[4]) * (this.Genotype.WoolC[3] * this.GreasyFleeceGrowth) +            // Smoothed wool growth
                                    this.Genotype.WoolC[4] * DayCFWGain;
             else
                 this.AnimalState.ProteinUse.Wool = DayCFWGain;
 #pragma warning restore 162
-            this.AnimalState.EnergyUse.Wool = this.Genotype.WoolC[1] * StdMath.DIM(this.AnimalState.ProteinUse.Wool, this.Genotype.WoolC[2] * this.RelativeSize) /      // Energy use for fleece                    
+            this.AnimalState.EnergyUse.Wool = this.Genotype.WoolC[1] * StdMath.DIM(this.AnimalState.ProteinUse.Wool, this.Genotype.WoolC[2] * this.RelativeSize) /      // Energy use for fleece
                                this.Genotype.WoolC[3];
         }
 
@@ -3864,13 +3864,13 @@ namespace Models.GrazPlan
             double diamPower;
             double gain_Length;
 
-            this.GreasyFleeceGrowth = this.AnimalState.ProteinUse.Wool / this.Genotype.WoolC[3];                // Convert clean to greasy fleece           
+            this.GreasyFleeceGrowth = this.AnimalState.ProteinUse.Wool / this.Genotype.WoolC[3];                // Convert clean to greasy fleece
             this.woolWt = this.woolWt + this.GreasyFleeceGrowth;
-            this.AnimalState.TotalWoolEnergy = this.Genotype.WoolC[1] * this.GreasyFleeceGrowth;                // Reporting only                           
+            this.AnimalState.TotalWoolEnergy = this.Genotype.WoolC[1] * this.GreasyFleeceGrowth;                // Reporting only
 
             // Changed to always TRUE for use with AgLab API, since we want to
             // be able to report the change in coat depth
-            if (true) // AnimalsDynamicGlb  then                                                        // This section deals with fibre diameter   
+            if (true) // AnimalsDynamicGlb  then                                                        // This section deals with fibre diameter
             {
                 ageFactor = this.Genotype.WoolC[5] + (1.0 - this.Genotype.WoolC[5]) * (1.0 - Math.Exp(-this.Genotype.WoolC[12] * this.AgeDays));
                 potCleanGain = (this.Genotype.WoolC[3] * this.Genotype.FleeceRatio * this.standardReferenceWeight) * ageFactor / 365;
@@ -3882,13 +3882,13 @@ namespace Models.GrazPlan
                 if (BaseWeight <= 0)
                     throw new Exception("Base weight is zero or less for " + this.NoAnimals.ToString() + " " + GetBreed() + " animals aged " + this.AgeDays.ToString() + " days");
                 if (this.DayFibreDiam > 0.0)
-                    gain_Length = 100.0 * 4.0 / Math.PI * this.AnimalState.ProteinUse.Wool /              // Computation of fibre diameter assumes    
-                                           (this.Genotype.WoolC[10] * this.Genotype.WoolC[11] *             // that the day's growth is cylindrical   
-                                             this.Genotype.ChillC[1] * Math.Pow(this.BaseWeight, 2.0 / 3.0) *   // in shape                               
+                    gain_Length = 100.0 * 4.0 / Math.PI * this.AnimalState.ProteinUse.Wool /              // Computation of fibre diameter assumes
+                                           (this.Genotype.WoolC[10] * this.Genotype.WoolC[11] *             // that the day's growth is cylindrical
+                                             this.Genotype.ChillC[1] * Math.Pow(this.BaseWeight, 2.0 / 3.0) *   // in shape
                                              StdMath.Sqr(this.DayFibreDiam * 1E-6));
                 else
                     gain_Length = 0.0;
-                this.FibreDiam = StdMath.XDiv(this.coatDepth * this.FibreDiam +                      // Running average fibre diameter           
+                this.FibreDiam = StdMath.XDiv(this.coatDepth * this.FibreDiam +                      // Running average fibre diameter
                                            gain_Length * this.DayFibreDiam,
                                          coatDepth + gain_Length);
                 this.coatDepth = this.coatDepth + gain_Length;
@@ -3897,30 +3897,30 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Chilling routine.                                                       
+        /// Chilling routine.
         /// Energy use in maintaining body temperature is computed in 2-hour blocks.
-        /// Although the "day" in the animal model runs from 9 am, we first compute 
-        /// the value of the insulation and the lower critical temperature in the   
-        /// middle of the night (i.e. at the time of minimum temperature).  Even    
-        /// though wind increases during the day, the minimum value of the          
-        /// Insulation variable will be no less than half the value of Insulation   
-        /// at this time for any reasonable value of wind speed; we can therefore   
-        /// put a bound on LCT.                                                     
+        /// Although the "day" in the animal model runs from 9 am, we first compute
+        /// the value of the insulation and the lower critical temperature in the
+        /// middle of the night (i.e. at the time of minimum temperature).  Even
+        /// though wind increases during the day, the minimum value of the
+        /// Insulation variable will be no less than half the value of Insulation
+        /// at this time for any reasonable value of wind speed; we can therefore
+        /// put a bound on LCT.
         /// </summary>
         private void ComputeChilling()
         {
             const double Sin60 = 0.8660254;
             double[] HourSines = { 0, 0.5, Sin60, 1.0, Sin60, 0.5, 0.0, -0.5, -Sin60, -1.0, -Sin60, -0.5, 0.0 }; //[1..12]
-            double SurfaceArea;                                                            // Surface area of animal, sq m             
-            double BodyRadius;                                                             // Radius of body, cm                       
-            double Factor1, Factor2;                                                       // Function of body radius and coat depth   
+            double SurfaceArea;                                                            // Surface area of animal, sq m
+            double BodyRadius;                                                             // Radius of body, cm
+            double Factor1, Factor2;                                                       // Function of body radius and coat depth
             double Factor3, WetFactor;
             double HeatPerArea;
             double LCT_Base;
-            double PropnClearSky;                                                          // Proportion of night with clear sky       
+            double PropnClearSky;                                                          // Proportion of night with clear sky
             double TissueInsulation;
             double Insulation;
-            double LCT;                                                                    // Lower critical temp. for a 2-hour period 
+            double LCT;                                                                    // Lower critical temp. for a 2-hour period
             double EnergyRate;
 
             double AveTemp, TempRange;
@@ -3928,7 +3928,7 @@ namespace Models.GrazPlan
             double Temp2Hr, Wind2Hr;
             int Time;
 
-            this.AnimalState.Therm0HeatProdn = this.AnimalState.ME_Intake.Total            // Thermoneutral heat production            
+            this.AnimalState.Therm0HeatProdn = this.AnimalState.ME_Intake.Total            // Thermoneutral heat production
                            - this.AnimalState.Efficiency.Preg * this.AnimalState.EnergyUse.Preg
                            - this.AnimalState.Efficiency.Lact * this.AnimalState.EnergyUse.Lact
                            - this.AnimalState.Efficiency.Gain * (this.AnimalState.ME_Intake.Total - this.AnimalState.EnergyUse.Maint - this.AnimalState.EnergyUse.Preg - this.AnimalState.EnergyUse.Lact)
@@ -3937,22 +3937,22 @@ namespace Models.GrazPlan
             BodyRadius = this.Genotype.ChillC[2] * Math.Pow(this.normalWeight, 1.0 / 3.0);
 
 
-            // Means and amplitudes for temperature and windrun     
-            AveTemp = 0.5 * (weather.MaxT + weather.MinT);                                                          
+            // Means and amplitudes for temperature and windrun
+            AveTemp = 0.5 * (weather.MaxT + weather.MinT);
             TempRange = (weather.MaxT - weather.MinT) / 2.0;
-            AveWind = 0.4 * weather.Wind;                                               // 0.4 corrects wind to animal height       
+            AveWind = 0.4 * weather.Wind;                                               // 0.4 corrects wind to animal height
             WindRange = 0.35 * AveWind;
-            PropnClearSky = 0.7 * Math.Exp(-0.25 * weather.Rain);                   // Equation J.4                             
+            PropnClearSky = 0.7 * Math.Exp(-0.25 * weather.Rain);                   // Equation J.4
 
 
             TissueInsulation = Genotype.ChillC[3] * Math.Min(1.0, 0.4 + 0.02 * AgeDays) *    // Reduce tissue insulation for animals under 1 month old
-                                            (Genotype.ChillC[4] + (1.0 - Genotype.ChillC[4]) * BodyCondition);    // Tissue insulation calculated as a fn     
-                                                                                                            // of species and body condition          
-            Factor1 = BodyRadius / (BodyRadius + CoatDepth);                                // These factors are used in equation J.8   
+                                            (Genotype.ChillC[4] + (1.0 - Genotype.ChillC[4]) * BodyCondition);    // Tissue insulation calculated as a fn
+                                                                                                            // of species and body condition
+            Factor1 = BodyRadius / (BodyRadius + CoatDepth);                                // These factors are used in equation J.8
             Factor2 = BodyRadius * Math.Log(1.0 / Factor1);
             WetFactor = this.Genotype.ChillC[5] + (1.0 - this.Genotype.ChillC[5]) *
                                             Math.Exp(-this.Genotype.ChillC[6] * weather.Rain / CoatDepth);
-            HeatPerArea = this.AnimalState.Therm0HeatProdn / SurfaceArea;                   // These factors are used in equation J.10  
+            HeatPerArea = this.AnimalState.Therm0HeatProdn / SurfaceArea;                   // These factors are used in equation J.10
             LCT_Base = this.Genotype.ChillC[11] - HeatPerArea * TissueInsulation;
             Factor3 = HeatPerArea / (HeatPerArea - this.Genotype.ChillC[12]);
 
@@ -3963,12 +3963,12 @@ namespace Models.GrazPlan
                 Temp2Hr = AveTemp + TempRange * HourSines[Time];
                 Wind2Hr = AveWind + WindRange * HourSines[Time];
 
-                Insulation = WetFactor *                                                    // External insulation due to hair cover or 
-                              (Factor1 / (Genotype.ChillC[7] + Genotype.ChillC[8] * Math.Sqrt(Wind2Hr)) +     // fleece is calculated from Blaxter (1977)      
-                               Factor2 * (Genotype.ChillC[9] - Genotype.ChillC[10] * Math.Sqrt(Wind2Hr)));                                     
+                Insulation = WetFactor *                                                    // External insulation due to hair cover or
+                              (Factor1 / (Genotype.ChillC[7] + Genotype.ChillC[8] * Math.Sqrt(Wind2Hr)) +     // fleece is calculated from Blaxter (1977)
+                               Factor2 * (Genotype.ChillC[9] - Genotype.ChillC[10] * Math.Sqrt(Wind2Hr)));
 
                 LCT = LCT_Base + (this.Genotype.ChillC[12] - HeatPerArea) * Insulation;
-                if ((Time >= 7) && (Time <= 11) && (Temp2Hr > 10.0))                        // Night-time, i.e. 7 pm to 5 am            
+                if ((Time >= 7) && (Time <= 11) && (Temp2Hr > 10.0))                        // Night-time, i.e. 7 pm to 5 am
                     LCT = LCT + PropnClearSky * this.Genotype.ChillC[13] * Math.Exp(-Genotype.ChillC[14] * StdMath.Sqr(StdMath.DIM(Temp2Hr, Genotype.ChillC[15])));
 
                 EnergyRate = SurfaceArea * StdMath.DIM(LCT, Temp2Hr)
@@ -3982,29 +3982,29 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Computes the efficiency of energy use for weight change.  This routine  
-        /// is called twice if chilling energy use is computed                      
+        /// Computes the efficiency of energy use for weight change.  This routine
+        /// is called twice if chilling energy use is computed
         /// </summary>
         private void AdjustKGain()
         {
             if (this.AnimalState.ME_Intake.Total < this.AnimalState.EnergyUse.Maint + this.AnimalState.EnergyUse.Preg + this.AnimalState.EnergyUse.Lact)
-            {                                                                                                           // Efficiency of energy use for weight change     
+            {                                                                                                           // Efficiency of energy use for weight change
                 if (lactStatus == GrazType.LactType.Lactating)
-                    this.AnimalState.Efficiency.Gain = this.AnimalState.Efficiency.Lact / this.Genotype.EfficC[10];                     // Lactating animals in -ve energy balance 
+                    this.AnimalState.Efficiency.Gain = this.AnimalState.Efficiency.Lact / this.Genotype.EfficC[10];                     // Lactating animals in -ve energy balance
                 else
-                    this.AnimalState.Efficiency.Gain = this.AnimalState.Efficiency.Maint / this.Genotype.EfficC[11];                    // Dry animals in -ve energy balance        
+                    this.AnimalState.Efficiency.Gain = this.AnimalState.Efficiency.Maint / this.Genotype.EfficC[11];                    // Dry animals in -ve energy balance
             }
             else if (lactStatus == GrazType.LactType.Lactating)
-                this.AnimalState.Efficiency.Gain = this.Genotype.EfficC[9] * this.AnimalState.Efficiency.Lact;                          // Lactating animals in +ve energy balance  
+                this.AnimalState.Efficiency.Gain = this.Genotype.EfficC[9] * this.AnimalState.Efficiency.Lact;                          // Lactating animals in +ve energy balance
         }
 
         /// <summary>
-        /// The remaining surplus of net energy is converted to weight gain in a      
-        /// logistic function dependent on the relative size of the animal.           
+        /// The remaining surplus of net energy is converted to weight gain in a
+        /// logistic function dependent on the relative size of the animal.
         /// </summary>
         private void ComputeGain()
         {
-            double Eff_DPLS;                                                               // Efficiency of DPLS use                   
+            double Eff_DPLS;                                                               // Efficiency of DPLS use
             double DPLS_Used;
             double[] GainSigs = new double[2];
             double fGainSize;
@@ -4019,11 +4019,11 @@ namespace Models.GrazPlan
             this.AnimalState.EnergyUse.Gain = this.AnimalState.Efficiency.Gain * (this.AnimalState.ME_Intake.Total - (this.AnimalState.EnergyUse.Maint + this.AnimalState.EnergyUse.Preg + this.AnimalState.EnergyUse.Lact))
                              - this.AnimalState.EnergyUse.Wool;
 
-            Eff_DPLS = this.Genotype.GainC[2] / (1.0 + (this.Genotype.GainC[2] / this.Genotype.GainC[3] - 1.0) *               // Efficiency of use of protein from milk   
-                                                StdMath.XDiv(this.AnimalState.DPLS_Milk, this.AnimalState.DPLS));           // is higher than from solid sources      
+            Eff_DPLS = this.Genotype.GainC[2] / (1.0 + (this.Genotype.GainC[2] / this.Genotype.GainC[3] - 1.0) *               // Efficiency of use of protein from milk
+                                                StdMath.XDiv(this.AnimalState.DPLS_Milk, this.AnimalState.DPLS));           // is higher than from solid sources
             DPLS_Used = (this.AnimalState.ProteinUse.Maint + this.AnimalState.ProteinUse.Preg + this.AnimalState.ProteinUse.Lact) / Eff_DPLS;
-            if (Animal == GrazType.AnimalType.Sheep)                                                                        // Efficiency of use of protein for wool is 
-                DPLS_Used = DPLS_Used + this.AnimalState.ProteinUse.Wool / Genotype.GainC[1];                                // 0.6 regardless of source               
+            if (Animal == GrazType.AnimalType.Sheep)                                                                        // Efficiency of use of protein for wool is
+                DPLS_Used = DPLS_Used + this.AnimalState.ProteinUse.Wool / Genotype.GainC[1];                                // 0.6 regardless of source
             this.AnimalState.ProteinUse.Gain = Eff_DPLS * (this.AnimalState.DPLS - DPLS_Used);
 
 
@@ -4033,7 +4033,7 @@ namespace Models.GrazPlan
             SizeFactor1 = StdMath.SIG(fGainSize, GainSigs);
             SizeFactor2 = StdMath.RAMP(fGainSize, this.Genotype.GainC[6], this.Genotype.GainC[7]);
 
-            this.AnimalState.GainEContent = this.Genotype.GainC[8]                                             // Generalization of the SCA equations      
+            this.AnimalState.GainEContent = this.Genotype.GainC[8]                                             // Generalization of the SCA equations
                                - SizeFactor1 * (this.Genotype.GainC[9] - this.Genotype.GainC[10] * (this.feedingLevel - 1.0))
                                + SizeFactor2 * this.Genotype.GainC[11] * (this.BodyCondition - 1.0);
             this.AnimalState.GainPContent = this.Genotype.GainC[12]
@@ -4047,10 +4047,10 @@ namespace Models.GrazPlan
 
             NetProtein = this.AnimalState.ProteinUse.Gain - this.AnimalState.GainPContent * this.AnimalState.EnergyUse.Gain / this.AnimalState.GainEContent;
 
-            if ((NetProtein < 0) && (this.AnimalState.ProteinUse.Lact > GrazType.VerySmall))                // Deficiency of protein, i.e. protein is   
-            {                                                                                               //  more limiting than ME                  
-                MilkScalar = Math.Max(0.0, 1.0 + Genotype.GainC[16] * NetProtein /                           // Redirect protein from milk to weight change    
-                                                                this.AnimalState.ProteinUse.Lact);                                           
+            if ((NetProtein < 0) && (this.AnimalState.ProteinUse.Lact > GrazType.VerySmall))                // Deficiency of protein, i.e. protein is
+            {                                                                                               //  more limiting than ME
+                MilkScalar = Math.Max(0.0, 1.0 + Genotype.GainC[16] * NetProtein /                           // Redirect protein from milk to weight change
+                                                                this.AnimalState.ProteinUse.Lact);
                 this.AnimalState.EnergyUse.Gain = this.AnimalState.EnergyUse.Gain + (1.0 - MilkScalar) * MilkEnergy;
                 this.AnimalState.ProteinUse.Gain = this.AnimalState.ProteinUse.Gain + (1.0 - MilkScalar) * this.AnimalState.ProteinUse.Lact;
                 NetProtein = this.AnimalState.ProteinUse.Gain - this.AnimalState.GainPContent * this.AnimalState.EnergyUse.Gain / this.AnimalState.GainEContent;
@@ -4068,11 +4068,11 @@ namespace Models.GrazPlan
                 this.AnimalState.EnergyUse.Gain = this.AnimalState.EnergyUse.Gain + Genotype.GainC[17] * this.AnimalState.GainEContent *
                                                     NetProtein / this.AnimalState.GainPContent;
 
-            if ((this.AnimalState.ProteinUse.Gain < 0) && (Animal == GrazType.AnimalType.Sheep))                    // If protein is being catabolised, it can  
-            {                                                                                                       // be utilized to increase wool growth    
-                PrevWoolEnergy = this.AnimalState.EnergyUse.Wool;                                                   // Maintain the energy balance by           
-                ComputeWool(Math.Abs(this.AnimalState.ProteinUse.Gain));                                           // transferring any extra energy use for  
-                this.AnimalState.EnergyUse.Gain = this.AnimalState.EnergyUse.Gain - (this.AnimalState.EnergyUse.Wool - PrevWoolEnergy);  // wool out of weight change              
+            if ((this.AnimalState.ProteinUse.Gain < 0) && (Animal == GrazType.AnimalType.Sheep))                    // If protein is being catabolised, it can
+            {                                                                                                       // be utilized to increase wool growth
+                PrevWoolEnergy = this.AnimalState.EnergyUse.Wool;                                                   // Maintain the energy balance by
+                ComputeWool(Math.Abs(this.AnimalState.ProteinUse.Gain));                                           // transferring any extra energy use for
+                this.AnimalState.EnergyUse.Gain = this.AnimalState.EnergyUse.Gain - (this.AnimalState.EnergyUse.Wool - PrevWoolEnergy);  // wool out of weight change
             }
 
             EmptyBodyGain = this.AnimalState.EnergyUse.Gain / this.AnimalState.GainEContent;
@@ -4083,24 +4083,24 @@ namespace Models.GrazPlan
             this.AnimalState.ProteinUse.Total = this.AnimalState.ProteinUse.Maint + this.AnimalState.ProteinUse.Gain +
                                  this.AnimalState.ProteinUse.Preg + this.AnimalState.ProteinUse.Lact +
                                  this.AnimalState.ProteinUse.Wool;
-            this.AnimalState.Urine.Nu[(int)GrazType.TOMElement.n] = StdMath.DIM(this.AnimalState.CP_Intake.Total / GrazType.N2Protein,   // Urinary loss of N                        
-                                      (this.AnimalState.ProteinUse.Total - this.AnimalState.ProteinUse.Maint) / GrazType.N2Protein       // This is retention of N                 
-                                      + this.AnimalState.OrgFaeces.Nu[(int)GrazType.TOMElement.n]                                   // This is other excretion                
+            this.AnimalState.Urine.Nu[(int)GrazType.TOMElement.n] = StdMath.DIM(this.AnimalState.CP_Intake.Total / GrazType.N2Protein,   // Urinary loss of N
+                                      (this.AnimalState.ProteinUse.Total - this.AnimalState.ProteinUse.Maint) / GrazType.N2Protein       // This is retention of N
+                                      + this.AnimalState.OrgFaeces.Nu[(int)GrazType.TOMElement.n]                                   // This is other excretion
                                       + this.AnimalState.InOrgFaeces.Nu[(int)GrazType.TOMElement.n]
                                       + this.AnimalState.DermalNLoss);
         }
 
         /// <summary>
-        /// Usage of and mass balance for phosphorus                                  
-        /// * Only a proportion of the phosphorus intake is absorbed (available).     
-        /// * There are endogenous losses of P which will appear in the excreta       
-        ///   regardless of intake.                                                   
-        /// * P content of the day's conceptus growth varies with stage of pregnancy. 
-        /// * P contents of milk and wool are constants.                              
-        /// * P usage in liveweight change is computed to try and maintain body P     
-        ///   content at PhosC[9].                                                    
-        /// * All P is excreted in faeces, but some is organic and the rest is        
-        ///   inorganic.  Organic P excretion is a constant proportion of DMI.        
+        /// Usage of and mass balance for phosphorus
+        /// * Only a proportion of the phosphorus intake is absorbed (available).
+        /// * There are endogenous losses of P which will appear in the excreta
+        ///   regardless of intake.
+        /// * P content of the day's conceptus growth varies with stage of pregnancy.
+        /// * P contents of milk and wool are constants.
+        /// * P usage in liveweight change is computed to try and maintain body P
+        ///   content at PhosC[9].
+        /// * All P is excreted in faeces, but some is organic and the rest is
+        ///   inorganic.  Organic P excretion is a constant proportion of DMI.
         /// </summary>
         private void ComputePhosphorus()
         {
@@ -4136,7 +4136,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Usage of and mass balance for sulphur                                     
+        /// Usage of and mass balance for sulphur
         /// </summary>
         private void ComputeSulfur()
         {
@@ -4165,11 +4165,11 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Proton balance                                                            
+        /// Proton balance
         /// </summary>
         private void ComputeAshAlk()
         {
-            double intakeMoles;                                                             // These are all on a per-head basis        
+            double intakeMoles;                                                             // These are all on a per-head basis
             double accumMoles;
 
             intakeMoles = this.AnimalState.PaddockIntake.AshAlkalinity * this.AnimalState.PaddockIntake.Biomass
@@ -4183,7 +4183,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="animalList"></param>
         private void CheckAnimList(ref List<AnimalGroup> animalList)
@@ -4191,7 +4191,7 @@ namespace Models.GrazPlan
             if (animalList == null)
                 animalList = new List<AnimalGroup>();
         }
-        
+
         /// <summary>
         /// Export the animal group
         /// </summary>
@@ -4208,7 +4208,7 @@ namespace Models.GrazPlan
                 weanedOff.Add(weanedGroup);
             }
         }
-        
+
         /// <summary>
         /// Export the group with young
         /// </summary>
@@ -4228,22 +4228,22 @@ namespace Models.GrazPlan
 
         /// <summary>
         /// In the case where only one sex of lambs has been weaned, re-constitute
-        /// groups of mothers with unweaned lambs or calves.                      
-        /// For example, if male lambs have been weaned (bDoFemales=TRUE), then:  
-        /// - if pre-weaning lambs/ewe = 1, 100% of the ewe lambs become singles  
-        /// - if pre-weaning lambs/ewe = 2, 50% of the ewe lambs become singles   
-        ///                                 50% remain as twins                   
-        /// - if pre-weaning lambs/ewe = 3, 25% of the ewe lambs become singles   
-        ///                                 50% become twins                      
-        ///                                 25% remain as triplets                
-        /// * We then have to round the numbers of lambs (or calves) that remain  
-        ///   twins or triplets down so that they have an integer number of       
-        ///   mothers.                                                            
-        /// * In order to conserve animals numbers, the number remaining as       
-        ///   singles is done by difference                                       
-        /// * The re-constituted groups of mothers are sent off to the NewGroups  
-        ///   list, leaving Self as the group of mothers whach has had all its    
-        ///   offspring weaned                                                    
+        /// groups of mothers with unweaned lambs or calves.
+        /// For example, if male lambs have been weaned (bDoFemales=TRUE), then:
+        /// - if pre-weaning lambs/ewe = 1, 100% of the ewe lambs become singles
+        /// - if pre-weaning lambs/ewe = 2, 50% of the ewe lambs become singles
+        ///                                 50% remain as twins
+        /// - if pre-weaning lambs/ewe = 3, 25% of the ewe lambs become singles
+        ///                                 50% become twins
+        ///                                 25% remain as triplets
+        /// * We then have to round the numbers of lambs (or calves) that remain
+        ///   twins or triplets down so that they have an integer number of
+        ///   mothers.
+        /// * In order to conserve animals numbers, the number remaining as
+        ///   singles is done by difference
+        /// * The re-constituted groups of mothers are sent off to the NewGroups
+        ///   list, leaving Self as the group of mothers whach has had all its
+        ///   offspring weaned
         /// </summary>
         /// <param name="youngGroup"></param>
         /// <param name="totalYoung"></param>
@@ -4309,7 +4309,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Integration of the age-dependent mortality function                       
+        /// Integration of the age-dependent mortality function
         /// </summary>
         /// <param name="overDays">Number of days</param>
         /// <returns>Integrated value</returns>
@@ -4418,7 +4418,7 @@ namespace Models.GrazPlan
                 suppRelFill = 0.0;
             else
             {
-                if (eatenFirst)                                                     // Relative fill of supplement           
+                if (eatenFirst)                                                     // Relative fill of supplement
                     suppRelFill = Math.Min(fracUnsat,
                                           suppDWPerHead / (theAnimals.PotIntake * suppRQ));
                 else
@@ -4439,7 +4439,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// "Relative fill" of pasture [F(d)]                                     
+        /// "Relative fill" of pasture [F(d)]
         /// </summary>
         /// <param name="theAnimals">The animal group</param>
         /// <param name="fu"></param>
@@ -4459,14 +4459,14 @@ namespace Models.GrazPlan
 
             double result;
 
-            // Equation numbers refer to June 2008 revision of Freer, Moore, and Donnelly 
-            heightFactor = Math.Max(0.0, (1.0 - theAnimals.Genotype.GrazeC[12]) + theAnimals.Genotype.GrazeC[12] * hr);       // Eq. 18 : HF 
-            sizeFactor = 1.0 + StdMath.DIM(theAnimals.Genotype.GrazeC[7], theAnimals.RelativeSize);                                  // Eq. 19 : ZF 
-            scaledFeed = heightFactor * sizeFactor * classFeed;                                                             // Part of Eqs. 16, 16 : HF * ZF * B 
-            propnFactor = 1.0 + theAnimals.Genotype.GrazeC[13] * StdMath.XDiv(classFeed, totalFeed);                         // Part of Eqs. 16, 17 : 1 + Cr13 * Phi 
-            rateTerm = 1.0 - Math.Exp(-propnFactor * theAnimals.Genotype.GrazeC[4] * scaledFeed);                            // Eq. 16 
-            timeTerm = 1.0 + theAnimals.Genotype.GrazeC[5] * Math.Exp(-propnFactor * Math.Pow(theAnimals.Genotype.GrazeC[6] * scaledFeed, 2)); // Eq. 17 
-            result = fu * rateTerm * timeTerm;                                                                              // Eq. 14 
+            // Equation numbers refer to June 2008 revision of Freer, Moore, and Donnelly
+            heightFactor = Math.Max(0.0, (1.0 - theAnimals.Genotype.GrazeC[12]) + theAnimals.Genotype.GrazeC[12] * hr);       // Eq. 18 : HF
+            sizeFactor = 1.0 + StdMath.DIM(theAnimals.Genotype.GrazeC[7], theAnimals.RelativeSize);                                  // Eq. 19 : ZF
+            scaledFeed = heightFactor * sizeFactor * classFeed;                                                             // Part of Eqs. 16, 16 : HF * ZF * B
+            propnFactor = 1.0 + theAnimals.Genotype.GrazeC[13] * StdMath.XDiv(classFeed, totalFeed);                         // Part of Eqs. 16, 17 : 1 + Cr13 * Phi
+            rateTerm = 1.0 - Math.Exp(-propnFactor * theAnimals.Genotype.GrazeC[4] * scaledFeed);                            // Eq. 16
+            timeTerm = 1.0 + theAnimals.Genotype.GrazeC[5] * Math.Exp(-propnFactor * Math.Pow(theAnimals.Genotype.GrazeC[6] * scaledFeed, 2)); // Eq. 17
+            result = fu * rateTerm * timeTerm;                                                                              // Eq. 14
 
             return result;
         }
@@ -4496,7 +4496,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Weighted average of two values                                            
+        /// Weighted average of two values
         /// </summary>
         /// <param name="x1"></param>
         /// <param name="y1"></param>

--- a/Models/Stock/StockList.cs
+++ b/Models/Stock/StockList.cs
@@ -14,30 +14,30 @@
 
 
     /// <summary>
-    /// StockList is primarily a list of AnimalGroups. Each animal group has a     
-    /// "current paddock" (function getInPadd() ) and a "group tag" (function getTag()      
-    /// associated with it. The correspondences between these and the animal         
-    /// groups must be maintained.                                                   
-    /// -                                                                               
-    /// In addition, the class maintains two other lists:                            
-    /// FPaddockInfo  holds paddock-specific information.  Animal groups are        
-    ///                 related to the members of FPaddockInfo by the FPaddockNos     
-    ///                 array.                                                        
-    /// FSwardInfo    holds the herbage availabilities and amounts removed from     
-    ///                 each sward (i.e. all components which respond to the          
-    ///                 call for "sward2stock").  The animal groups never refer to    
-    ///                 this information directly; instead, the TStockList.Dynamics   
-    ///                 method (1) aggregates the availability in each sward into     
-    ///                 a paddock-level total, and (2) once the grazing logic has     
-    ///                 been executed it also allocates the amounts removed between   
-    ///                 the various swards.  Swards are allocated to paddocks on      
-    ///                 the basis of their FQDN's.                                    
-    /// -                                                                              
-    ///  N.B. The use of a fixed-length array for priorities and paddock numbers      
-    ///       limits the number of animal groups that can be stored in this           
-    ///       implementation.                                                         
-    ///  N.B. The At property is 1-offset.  In many of the management methods, an     
-    ///       index of 0 denotes "do to all groups".                                  
+    /// StockList is primarily a list of AnimalGroups. Each animal group has a
+    /// "current paddock" (function getInPadd() ) and a "group tag" (function getTag()
+    /// associated with it. The correspondences between these and the animal
+    /// groups must be maintained.
+    /// -
+    /// In addition, the class maintains two other lists:
+    /// FPaddockInfo  holds paddock-specific information.  Animal groups are
+    ///                 related to the members of FPaddockInfo by the FPaddockNos
+    ///                 array.
+    /// FSwardInfo    holds the herbage availabilities and amounts removed from
+    ///                 each sward (i.e. all components which respond to the
+    ///                 call for "sward2stock").  The animal groups never refer to
+    ///                 this information directly; instead, the TStockList.Dynamics
+    ///                 method (1) aggregates the availability in each sward into
+    ///                 a paddock-level total, and (2) once the grazing logic has
+    ///                 been executed it also allocates the amounts removed between
+    ///                 the various swards.  Swards are allocated to paddocks on
+    ///                 the basis of their FQDN's.
+    /// -
+    ///  N.B. The use of a fixed-length array for priorities and paddock numbers
+    ///       limits the number of animal groups that can be stored in this
+    ///       implementation.
+    ///  N.B. The At property is 1-offset.  In many of the management methods, an
+    ///       index of 0 denotes "do to all groups".
     /// </summary>
     [Serializable]
     public class StockList
@@ -48,7 +48,7 @@
         private const double MONTH2DAY = 365.25 / 12;
 
         /// <summary>
-        /// Converts animal mass into "dse"s for trampling purposes                     
+        /// Converts animal mass into "dse"s for trampling purposes
         /// </summary>
         private const double WEIGHT2DSE = 0.02;
 
@@ -56,13 +56,13 @@
         private readonly Stock parentStockModel = null;
 
         /// <summary>The clock model.</summary>
-        private readonly Clock clock;
+        private readonly IClock clock;
 
         /// <summary>The weather model.</summary>
         private readonly IWeather weather;
 
         /// <summary>
-        /// stock[0] is kept for use as temporary storage         
+        /// stock[0] is kept for use as temporary storage
         /// </summary>
         private AnimalGroup[] stock = new AnimalGroup[0];
 
@@ -73,7 +73,7 @@
         /// <param name="clockModel">The clock model.</param>
         /// <param name="weatherModel">The weather model.</param>
         /// <param name="paddocksInSimulation">The paddocks in the simulation.</param>
-        public StockList(Stock stockModel, Clock clockModel, IWeather weatherModel, List<Zone> paddocksInSimulation)
+        public StockList(Stock stockModel, IClock clockModel, IWeather weatherModel, List<Zone> paddocksInSimulation)
         {
             parentStockModel = stockModel;
             ForagesAll = new ForageProviders();
@@ -81,7 +81,7 @@
             clock = clockModel;
             weather = weatherModel;
 
-            Array.Resize(ref this.stock, 1);                                          // Set aside temporary storage           
+            Array.Resize(ref this.stock, 1);                                          // Set aside temporary storage
             Paddocks = new List<PaddockInfo>();
 
             Paddocks.Add(new PaddockInfo());
@@ -96,7 +96,7 @@
                 var forages = stockModel.FindInScope<Forages>();
                 if (forages == null)
                     throw new Exception("No forages component found in simulation.");
-                
+
                 foreach (var forage in forages.ModelsWithDigestibleBiomass.Where(m => m.Zone == zone))
                     ForagesAll.AddProvider(newPadd, zone.Name, zone.Name + "." + forage.Name, 0, 0, forage);
             }
@@ -121,15 +121,15 @@
         public ForageProviders ForagesAll { get; }
 
         /// <summary>
-        /// Combine sufficiently-similar groups of animals and delete empty ones         
+        /// Combine sufficiently-similar groups of animals and delete empty ones
         /// </summary>
         private void Merge()
         {
             int idx, jdx;
             AnimalGroup animalGroup;
 
-            // Remove empty groups                   
-            for (idx = 1; idx <= this.Count(); idx++)                                                     
+            // Remove empty groups
+            for (idx = 1; idx <= this.Count(); idx++)
             {
                 if ((stock[idx] != null) && (stock[idx].NoAnimals == 0))
                 {
@@ -138,7 +138,7 @@
             }
 
             // Merge similar groups
-            for (idx = 1; idx <= this.Count() - 1; idx++)                                                                     
+            for (idx = 1; idx <= this.Count() - 1; idx++)
             {
                 for (jdx = idx + 1; jdx <= this.Count(); jdx++)
                 {
@@ -154,8 +154,8 @@
                 }
             }
 
-            // Pack the lists and priority array.      
-            for (idx = this.Count(); idx >= 1; idx--)                                              
+            // Pack the lists and priority array.
+            for (idx = this.Count(); idx >= 1; idx--)
             {
                 if (stock[idx] == null)
                     this.Delete(idx);
@@ -163,8 +163,8 @@
         }
 
         /// <summary>
-        /// Records state information prior to the grazing and nutrition calculations      
-        /// so that it can be restored if there is an RDP insufficiency.                 
+        /// Records state information prior to the grazing and nutrition calculations
+        /// so that it can be restored if there is an RDP insufficiency.
         /// </summary>
         /// <param name="posIdx">Index in stock list</param>
         private void StoreInitialState(int posIdx)
@@ -175,10 +175,10 @@
         }
 
         /// <summary>
-        /// Restores state information about animal groups if there is an RDP            
-        /// insufficiency. Also alters the intake limit.                                 
-        /// * Assumes that stock[*].fRDPFactor[] has ben populated - see the            
-        ///   computeNutritiion() method.                                                
+        /// Restores state information about animal groups if there is an RDP
+        /// insufficiency. Also alters the intake limit.
+        /// * Assumes that stock[*].fRDPFactor[] has ben populated - see the
+        ///   computeNutritiion() method.
         /// </summary>
         /// <param name="posIdx">Index in stock list</param>
         private void RevertInitialState(int posIdx)
@@ -194,10 +194,10 @@
         }
 
         /// <summary>
-        /// 1. Sets the livestock inputs (other than forage and supplement amounts) for    
-        ///    animal groups occupying the paddock denoted by aPaddock.                  
-        /// 2. Sets up the amounts of herbage available to each animal group from each   
-        ///    forage (for animal groups and forages in the paddock denoted by aPaddock).  
+        /// 1. Sets the livestock inputs (other than forage and supplement amounts) for
+        ///    animal groups occupying the paddock denoted by aPaddock.
+        /// 2. Sets up the amounts of herbage available to each animal group from each
+        ///    forage (for animal groups and forages in the paddock denoted by aPaddock).
         /// </summary>
         /// <param name="posIdx">Index in stock list</param>
         private void SetInitialStockInputs(int posIdx)
@@ -211,7 +211,7 @@
 
             group.PaddSteep = paddock.Steepness;
             group.WaterLogging = paddock.Waterlog;
-            group.RationFed.Assign(paddock.SuppInPadd);                              // fTotalAmount will be overridden       
+            group.RationFed.Assign(paddock.SuppInPadd);                              // fTotalAmount will be overridden
 
             // ensure young are fed
             if (group.Young != null)
@@ -252,11 +252,11 @@
                 GrazType.addGrazingInputs(jdx + 1, this.stock[posIdx].StepForageInputs[jdx], ref this.stock[posIdx].PaddockInputs);
 
             group.Herbage.CopyFrom(this.stock[posIdx].PaddockInputs);
-            group.RationFed.Assign(paddock.SuppInPadd);                               // fTotalAmount will be overridden       
+            group.RationFed.Assign(paddock.SuppInPadd);                               // fTotalAmount will be overridden
 
             if (paddock.SummedPotIntake > 0.0)
-                propn = group.PotIntake / paddock.SummedPotIntake;                  // This is the proportion of the total   
-            else                                                                        // supplement that one animal gets     
+                propn = group.PotIntake / paddock.SummedPotIntake;                  // This is the proportion of the total
+            else                                                                        // supplement that one animal gets
                 propn = 0.0;
 
             group.RationFed.TotalAmount = propn * StdMath.DIM(paddock.SuppInPadd.TotalAmount, paddock.SuppRemovalKG);
@@ -274,8 +274,8 @@
         }
 
         /// <summary>
-        /// Limits the length of a grazing sub-step so that no more than MAX_CONSUMPTION 
-        /// of the herbage is consumed.                                                  
+        /// Limits the length of a grazing sub-step so that no more than MAX_CONSUMPTION
+        /// of the herbage is consumed.
         /// </summary>
         /// <param name="paddock">The paddock</param>
         /// <returns>The step length</returns>
@@ -292,8 +292,8 @@
             double removalTime;
             int classIdx;
 
-            posn = 1;                                                                  // Find the first animal group occupying 
-            while ((posn <= this.Count()) && (stock[posn].PaddOccupied != paddock))    // this paddock                         
+            posn = 1;                                                                  // Find the first animal group occupying
+            while ((posn <= this.Count()) && (stock[posn].PaddOccupied != paddock))    // this paddock
                 posn++;
 
             if ((posn > this.Count()) || (paddock.Area <= 0.0))
@@ -441,10 +441,10 @@
             if (stock[posIdx].Young != null)
                 stock[posIdx].Young.CompleteGrowth(this.stock[posIdx].RDPFactor[1]);
         }
- 
+
         /// <summary>
-        /// Add a group of animals to the list                                           
-        /// Returns the group index of the group that was added. 0->n                    
+        /// Add a group of animals to the list
+        /// Returns the group index of the group that was added. 0->n
         /// </summary>
         /// <param name="animalGroup">Animal group</param>
         /// <param name="paddInfo">The paddock information</param>
@@ -467,7 +467,7 @@
         }
 
         /// <summary>
-        /// Returns the group index of the group that was added. 0->n                    
+        /// Returns the group index of the group that was added. 0->n
         /// </summary>
         /// <param name="animalInits">The animal data</param>
         /// <returns>The index of the new animal group</returns>
@@ -557,7 +557,7 @@
         }
 
         /// <summary>
-        ///  * N.B. posn is 1-offset; stock list is effectively also a 1-offset array        
+        ///  * N.B. posn is 1-offset; stock list is effectively also a 1-offset array
         /// </summary>
         /// <param name="posn">In all methods, posn is 1-offset</param>
         public void Delete(int posn)
@@ -572,12 +572,12 @@
 
                 for (idx = posn + 1; idx <= count; idx++)
                     this.stock[idx - 1] = this.stock[idx];
-                Array.Resize(ref this.stock, count);                                               // Leave stock[0] as temporary storage  
+                Array.Resize(ref this.stock, count);                                               // Leave stock[0] as temporary storage
             }
         }
 
         /// <summary>
-        /// Only groups 1 to Length()-1 are counted                                    
+        /// Only groups 1 to Length()-1 are counted
         /// </summary>
         /// <returns>The number of items in the stock list</returns>
         public int Count()
@@ -618,7 +618,7 @@
         }
 
         /// <summary>
-        /// Advance the list by one time step.  All the input properties should be set first                                                                        
+        /// Advance the list by one time step.  All the input properties should be set first
         /// </summary>
         public void Dynamics()
         {
@@ -645,29 +645,29 @@
 
             // Aging, birth, deaths etc. Animal groups may appear in the NewGroups list as a result of processes such as lamb deaths
             n = this.Count();
-            for (idx = 1; idx <= n; idx++)                                                  
-            {                                                                               
-                newGroups = null;                                                            
+            for (idx = 1; idx <= n; idx++)
+            {
+                newGroups = null;
                 stock[idx].Age(1, ref newGroups);
 
-                // Ensure the new young have climate data                             
-                this.Add(newGroups, stock[idx].PaddOccupied, stock[idx].Tag);       // The new groups are added back onto    
-                newGroups = null;                                                           // the main list                       
+                // Ensure the new young have climate data
+                this.Add(newGroups, stock[idx].PaddOccupied, stock[idx].Tag);       // The new groups are added back onto
+                newGroups = null;                                                           // the main list
             }
 
-            this.Merge();                                                                        // Merge any similar animal groups       
+            this.Merge();                                                                        // Merge any similar animal groups
 
-            // Now run the grazing and nutrition models. This process is quite involved...                         
-            for (idx = 1; idx <= this.Count(); idx++)                                       
+            // Now run the grazing and nutrition models. This process is quite involved...
+            for (idx = 1; idx <= this.Count(); idx++)
             {
-                this.StoreInitialState(idx);                                                     
+                this.StoreInitialState(idx);
                 this.ComputeIntakeLimit(stock[idx]);
                 stock[idx].ResetGrazing();
             }
 
-            // Compute the total potential intake (used to distribute supplement between groups of animals)         
-            for (paddIdx = 0; paddIdx <= this.Paddocks.Count() - 1; paddIdx++)              
-            {                                                                               
+            // Compute the total potential intake (used to distribute supplement between groups of animals)
+            for (paddIdx = 0; paddIdx <= this.Paddocks.Count() - 1; paddIdx++)
+            {
                 thePaddock = this.Paddocks[paddIdx];
                 totPotIntake = 0.0;
 
@@ -681,17 +681,17 @@
                 thePaddock.SummedPotIntake = totPotIntake;
             }
 
-            // We loop over paddocks and then over animal groups within a paddock so that we can take account of herbage 
-            for (paddIdx = 0; paddIdx <= this.Paddocks.Count() - 1; paddIdx++)                       
-            {                                                                               
+            // We loop over paddocks and then over animal groups within a paddock so that we can take account of herbage
+            for (paddIdx = 0; paddIdx <= this.Paddocks.Count() - 1; paddIdx++)
+            {
                 thePaddock = this.Paddocks[paddIdx];
-                                                   
-                // removal & its effect on intake      
-                iterator = 1;                                                                  // This loop handles RDP insufficiency   
+
+                // removal & its effect on intake
+                iterator = 1;                                                                  // This loop handles RDP insufficiency
                 done = false;
                 while (!done)
                 {
-                    timeValue = 0.0;                                                            // Variable-length substeps for grazing  
+                    timeValue = 0.0;                                                            // Variable-length substeps for grazing
 
                     while (timeValue < 1.0 - EPS)
                     {
@@ -701,9 +701,9 @@
 
                         delta = Math.Min(this.ComputeStepLength(thePaddock), 1.0 - timeValue);
 
-                        // Compute rate of grazing for this substep                             
-                        for (idx = 1; idx <= this.Count(); idx++)                           
-                            if (stock[idx].PaddOccupied == thePaddock)                             
+                        // Compute rate of grazing for this substep
+                        for (idx = 1; idx <= this.Count(); idx++)
+                            if (stock[idx].PaddOccupied == thePaddock)
                                 this.ComputeGrazing(idx, timeValue, delta, thePaddock.FeedSuppFirst);
 
                         this.ComputeRemoval(thePaddock, delta);
@@ -711,26 +711,26 @@
                         timeValue = timeValue + delta;
                     } // _ grazing sub-steps loop _
 
-                    // Nutrition submodel here...            
+                    // Nutrition submodel here...
                     RDP = 1.0;
-                    for (idx = 1; idx <= this.Count(); idx++)                               
+                    for (idx = 1; idx <= this.Count(); idx++)
                         if (stock[idx].PaddOccupied == thePaddock)
                             this.ComputeNutrition(idx, ref RDP);
 
                     // Maximum of 2 iterations in the RDP loop
-                    if (iterator == 2)                                                                                         
-                        done = true;                                                       
+                    if (iterator == 2)
+                        done = true;
                     else
                     {
-                        done = (RDP == 1.0);                                              // Is there an animal group in this paddock with an RDP insufficiency?  
-                        if (!done)                                                         
+                        done = (RDP == 1.0);                                              // Is there an animal group in this paddock with an RDP insufficiency?
+                        if (!done)
                         {
                             thePaddock.ZeroRemoval();
 
                             // If so, we have to revert the state of the animal group ready for the second iteration.
-                            for (idx = 1; idx <= this.Count(); idx++)                       
+                            for (idx = 1; idx <= this.Count(); idx++)
                                 if (stock[idx].PaddOccupied == thePaddock)
-                                    this.RevertInitialState(idx);                                                   
+                                    this.RevertInitialState(idx);
                         }
                     }
 
@@ -811,24 +811,24 @@
             if (srcExcretion.Defaecations > 0.0)
             {
                 destExcretion.DefaecationVolume = this.WeightedMean(
-                                                                    destExcretion.DefaecationVolume, 
+                                                                    destExcretion.DefaecationVolume,
                                                                     srcExcretion.DefaecationVolume,
-                                                                    destExcretion.Defaecations, 
+                                                                    destExcretion.Defaecations,
                                                                     srcExcretion.Defaecations);
-                destExcretion.DefaecationArea = this.WeightedMean( 
-                                                                    destExcretion.DefaecationArea, 
+                destExcretion.DefaecationArea = this.WeightedMean(
+                                                                    destExcretion.DefaecationArea,
                                                                     srcExcretion.DefaecationArea,
-                                                                    destExcretion.Defaecations, 
+                                                                    destExcretion.Defaecations,
                                                                     srcExcretion.Defaecations);
                 destExcretion.DefaecationEccentricity = this.WeightedMean(
-                                                                            destExcretion.DefaecationEccentricity, 
+                                                                            destExcretion.DefaecationEccentricity,
                                                                             srcExcretion.DefaecationEccentricity,
-                                                                            destExcretion.Defaecations, 
+                                                                            destExcretion.Defaecations,
                                                                             srcExcretion.Defaecations);
                 destExcretion.FaecalNO3Propn = this.WeightedMean(
-                                                                    destExcretion.FaecalNO3Propn, 
+                                                                    destExcretion.FaecalNO3Propn,
                                                                     srcExcretion.FaecalNO3Propn,
-                                                                    destExcretion.InOrgFaeces.Nu[(int)GrazType.TOMElement.n], 
+                                                                    destExcretion.InOrgFaeces.Nu[(int)GrazType.TOMElement.n],
                                                                     srcExcretion.InOrgFaeces.Nu[(int)GrazType.TOMElement.n]);
                 destExcretion.Defaecations = destExcretion.Defaecations + srcExcretion.Defaecations;
 
@@ -839,19 +839,19 @@
             if (srcExcretion.Urinations > 0.0)
             {
                 destExcretion.UrinationVolume = this.WeightedMean(
-                                                                    destExcretion.UrinationVolume, 
+                                                                    destExcretion.UrinationVolume,
                                                                     srcExcretion.UrinationVolume,
-                                                                    destExcretion.Urinations, 
+                                                                    destExcretion.Urinations,
                                                                     srcExcretion.Urinations);
                 destExcretion.UrinationArea = this.WeightedMean(
-                                                                    destExcretion.UrinationArea, 
+                                                                    destExcretion.UrinationArea,
                                                                     srcExcretion.UrinationArea,
-                                                                    destExcretion.Urinations, 
+                                                                    destExcretion.Urinations,
                                                                     srcExcretion.Urinations);
                 destExcretion.dUrinationEccentricity = this.WeightedMean(
-                                                                            destExcretion.dUrinationEccentricity, 
+                                                                            destExcretion.dUrinationEccentricity,
                                                                             srcExcretion.dUrinationEccentricity,
-                                                                            destExcretion.Urinations, 
+                                                                            destExcretion.Urinations,
                                                                             srcExcretion.Urinations);
                 destExcretion.Urinations = destExcretion.Urinations + srcExcretion.Urinations;
 
@@ -860,18 +860,18 @@
         }
 
         /// <summary>
-        /// Parameters:                                                               
-        /// OrgFaeces    kg/ha  Excretion of organic matter in faeces                 
-        /// InorgFaeces  kg/ha  Excretion of inorganic nutrients in faeces            
-        /// Urine        kg/ha  Excretion of nutrients in urine                       
-        /// -                                                                          
-        /// Note:  TAnimalGroup.OrgFaeces returns the OM faecal excretion in kg, and  
-        ///        is the total of mothers and young where appropriate; similarly for   
-        ///        TAnimalGroup.InorgFaeces and TAnimalGroup.Urine.                   
-        ///        TAnimalGroup.FaecalAA and TAnimalGroup.UrineAAN return weighted    
-        ///        averages over mothers and young where appropriate. As a result we  
-        ///        don't need to concern ourselves with unweaned young in this        
-        ///        particular calculation except when computing PatchFract.           
+        /// Parameters:
+        /// OrgFaeces    kg/ha  Excretion of organic matter in faeces
+        /// InorgFaeces  kg/ha  Excretion of inorganic nutrients in faeces
+        /// Urine        kg/ha  Excretion of nutrients in urine
+        /// -
+        /// Note:  TAnimalGroup.OrgFaeces returns the OM faecal excretion in kg, and
+        ///        is the total of mothers and young where appropriate; similarly for
+        ///        TAnimalGroup.InorgFaeces and TAnimalGroup.Urine.
+        ///        TAnimalGroup.FaecalAA and TAnimalGroup.UrineAAN return weighted
+        ///        averages over mothers and young where appropriate. As a result we
+        ///        don't need to concern ourselves with unweaned young in this
+        ///        particular calculation except when computing PatchFract.
         /// </summary>
         /// <param name="thePadd">Paddock</param>
         /// <param name="excretion">The excretion info</param>
@@ -909,8 +909,8 @@
         }
 
         /// <summary>
-        /// Return the reproductive status of the group as a string.  These strings   
-        /// are compatible with the ParseRepro routine.                               
+        /// Return the reproductive status of the group as a string.  These strings
+        /// are compatible with the ParseRepro routine.
         /// </summary>
         /// <param name="idx">Index of the group</param>
         /// <param name="useYoung">For the young</param>
@@ -943,8 +943,8 @@
         }
 
         /// <summary>
-        /// GrowthCurve calculates MaxNormalWt (see below) for an animal with the   
-        /// default birth weight.                                                   
+        /// GrowthCurve calculates MaxNormalWt (see below) for an animal with the
+        /// default birth weight.
         /// </summary>
         /// <param name="srw">Standard reference weight</param>
         /// <param name="bw">Birth weight</param>
@@ -1173,8 +1173,8 @@
                         for (cohortIdx = cohortsInfo.MinYears; cohortIdx <= cohortsInfo.MaxYears; cohortIdx++)
                         {
                             pregRate = this.GetOffspringRates(
-                                                        mainGenotype, 
-                                                        latitude, 
+                                                        mainGenotype,
+                                                        latitude,
                                                         mateDOY,
                                                         ageInfoList[cohortIdx].AgeAtMating,
                                                         ageInfoList[cohortIdx].SizeAtMating,
@@ -1187,7 +1187,7 @@
                                 ageInfoList[cohortIdx].Numbers[0, 0] -= shiftNumber[preg];
                             }
                         }
-                    } // if (iDaysPreg > 0) and (fFoetuses > 0.0)  
+                    } // if (iDaysPreg > 0) and (fFoetuses > 0.0)
 
                     // Numbers with each number of suckling young
                     // Different logic for sheep and cattle:
@@ -1265,18 +1265,18 @@
                                 }
                                 while (Math.Abs(trialOffspring - cohortsInfo.Offspring) >= 1.0E-5); // until (Abs(fTrialOffspring-CohortsInfo.fOffspring) < 1.0E-5);
                             }
-                        } // fitting lactation rate to a condition 
+                        } // fitting lactation rate to a condition
 
                         // Compute final offspring rates and numbers
                         for (cohortIdx = cohortsInfo.MinYears; cohortIdx <= cohortsInfo.MaxYears; cohortIdx++)
                         {
                             lactRate = this.GetOffspringRates(
-                                                            mainGenotype, 
-                                                            latitude, 
+                                                            mainGenotype,
+                                                            latitude,
                                                             mateDOY,
                                                             ageInfoList[cohortIdx].AgeAtMating,
                                                             ageInfoList[cohortIdx].SizeAtMating,
-                                                            condition, 
+                                                            condition,
                                                             chillIndex);
                             for (preg = 0; preg <= 3; preg++)
                             {
@@ -1290,7 +1290,7 @@
                             }
                         }
                     } // _ lactating animals _
-                } // _ female animals 
+                } // _ female animals
 
                 // Construct the animal groups from the numbers and cohort-specific information
                 animalInits.Genotype = cohortsInfo.Genotype;
@@ -1355,7 +1355,7 @@
                         }
                     }
                 }
-            } // if CohortsInfo.iNumber > 0 
+            } // if CohortsInfo.iNumber > 0
         }
 
         /// <summary>
@@ -1391,27 +1391,27 @@
                         liveWeight = liveWeight + animalInfo.GFW;
                 }
 
-                // Construct a new group of animals.     
+                // Construct a new group of animals.
                 newGroup = new AnimalGroup(
                                             agenotype,
-                                            animalInfo.Repro,                         // Repro should be Empty, Castrated or 
-                                            animalInfo.Number,                        // Male; pregnancy is handled with the 
-                                            animalInfo.AgeDays,                       // Preg  field.                        
+                                            animalInfo.Repro,                         // Repro should be Empty, Castrated or
+                                            animalInfo.Number,                        // Male; pregnancy is handled with the
+                                            animalInfo.AgeDays,                       // Preg  field.
                                             liveWeight,
                                             animalInfo.GFW,
                                             parentStockModel.randFactory,
                                             clock, weather, this);
 
                 // Adjust the condition score if it has been given
-                if ((animalInfo.CondScore > 0.0) && (animalInfo.LiveWt > 0.0))        
-                {                                                                                                
+                if ((animalInfo.CondScore > 0.0) && (animalInfo.LiveWt > 0.0))
+                {
                     bodyCondition = StockUtilities.CondScore2Condition(animalInfo.CondScore);
                     newGroup.WeightRangeForCond(
-                                                animalInfo.Repro, 
+                                                animalInfo.Repro,
                                                 animalInfo.AgeDays,
-                                                bodyCondition, 
+                                                bodyCondition,
                                                 newGroup.Genotype,
-                                                ref lowBaseWeight, 
+                                                ref lowBaseWeight,
                                                 ref highBaseWeight);
 
                     if ((newGroup.BaseWeight >= lowBaseWeight) && (newGroup.BaseWeight <= highBaseWeight))
@@ -1428,25 +1428,25 @@
                 }
 
                 // ensure lactating sheep have young. Cattle can be purchased lactating with no calf
-                if ((animalInfo.Lact > 0) && (newGroup.Animal == GrazType.AnimalType.Sheep)) 
+                if ((animalInfo.Lact > 0) && (newGroup.Animal == GrazType.AnimalType.Sheep))
                     animalInfo.NYoung = Math.Max(1, animalInfo.NYoung);
 
                 // females will be empty to this point
                 if (newGroup.ReproState == GrazType.ReproType.Empty)
                 {
-                    // Use TAnimalGroup's property interface to set up pregnancy and lactation.  
-                    if (animalInfo.MatedTo != string.Empty)                                      
-                        newGroup.MatedTo = parentStockModel.Genotypes.Get(animalInfo.MatedTo);            
+                    // Use TAnimalGroup's property interface to set up pregnancy and lactation.
+                    if (animalInfo.MatedTo != string.Empty)
+                        newGroup.MatedTo = parentStockModel.Genotypes.Get(animalInfo.MatedTo);
                     newGroup.Pregnancy = animalInfo.Preg;
                     newGroup.Lactation = animalInfo.Lact;
 
-                    // NYoung denotes the number of *suckling* young in lactating cows, which isn't quite the same as the YoungNo property                    
+                    // NYoung denotes the number of *suckling* young in lactating cows, which isn't quite the same as the YoungNo property
                     if ((newGroup.Animal == GrazType.AnimalType.Cattle)
-                       && (animalInfo.Lact > 0) && (animalInfo.NYoung == 0))            
-                    {                                                                   
-                        weanList = null;                                                
-                        newGroup.Wean(true, true, ref weanList, ref weanList);          
-                        weanList = null; 
+                       && (animalInfo.Lact > 0) && (animalInfo.NYoung == 0))
+                    {
+                        weanList = null;
+                        newGroup.Wean(true, true, ref weanList, ref weanList);
+                        weanList = null;
                     }
                     else if (animalInfo.NYoung > 0)
                     {
@@ -1467,29 +1467,29 @@
                             newGroup.NoOffspring = animalInfo.NYoung;
                     }
 
-                    // Lamb/calf weights and lamb fleece weights are optional.               
-                    if (newGroup.Young != null)                                              
-                    {                                                                   
+                    // Lamb/calf weights and lamb fleece weights are optional.
+                    if (newGroup.Young != null)
+                    {
                         if (this.IsGiven(animalInfo.YoungWt))
                             newGroup.Young.LiveWeight = animalInfo.YoungWt;
                         if (this.IsGiven(animalInfo.YoungGFW))
                             newGroup.Young.FleeceCutWeight = animalInfo.YoungGFW;
                     }
-                } // if (ReproState = Empty) 
+                } // if (ReproState = Empty)
 
-                paddNo = 0;                                                                          // Newly bought animals have tag # zero and go in the first named paddock.  
-                while ((paddNo < this.Paddocks.Count()) && (this.Paddocks[paddNo].Name == string.Empty))   
+                paddNo = 0;                                                                          // Newly bought animals have tag # zero and go in the first named paddock.
+                while ((paddNo < this.Paddocks.Count()) && (this.Paddocks[paddNo].Name == string.Empty))
                     paddNo++;
                 if (paddNo >= this.Paddocks.Count())
                     paddNo = 0;
                 result = this.Add(newGroup, this.Paddocks[paddNo], 0);
-            } // if AnimalInfo.Number > 0 
+            } // if AnimalInfo.Number > 0
             return result;
         }
 
         /// <summary>
-        /// See the notes to the Castrate method; but weaning is even further         
-        /// complicated because males and/or females may be weaned.                   
+        /// See the notes to the Castrate method; but weaning is even further
+        /// complicated because males and/or females may be weaned.
         /// </summary>
         /// <param name="groupIdx">The animal group index</param>
         /// <param name="number">The number of animals</param>
@@ -1499,12 +1499,12 @@
         {
             number = Math.Max(number, 0);
 
-            // Only iterate through groups present at the start of the routine            
+            // Only iterate through groups present at the start of the routine
             int n = Count();
-            for (int idx = 1; idx <= n; idx++)                                                  
+            for (int idx = 1; idx <= n; idx++)
             {
-                // Group Idx, or all groups if 0         
-                if (((groupIdx == 0) || (groupIdx == idx)) && (stock[idx] != null))       
+                // Group Idx, or all groups if 0
+                if (((groupIdx == 0) || (groupIdx == idx)) && (stock[idx] != null))
                     number = number - Wean(stock[idx], number, weanFemales, weanMales);
             }
         }
@@ -1521,7 +1521,7 @@
         {
             if (group.Young != null)
             {
-                // Establish the number of lambs/calves to wean from this group of mothers  
+                // Establish the number of lambs/calves to wean from this group of mothers
                 int numToWean = 0;
                 if (weanMales && weanFemales)
                     numToWean = Math.Min(number, group.Young.NoAnimals);
@@ -1534,7 +1534,7 @@
                 {
                     if (numToWean == number)
                     {
-                        // If there are more lambs/calves present than are to be weaned, split the excess off                       
+                        // If there are more lambs/calves present than are to be weaned, split the excess off
                         int mothersToWean;
                         if (weanMales && weanFemales)
                             mothersToWean = Convert.ToInt32(Math.Round((double)numToWean / group.NoOffspring), CultureInfo.InvariantCulture);
@@ -1544,7 +1544,7 @@
                             this.Split(group, mothersToWean);
                     }
 
-                    // Carry out the weaning process. N.B. the weaners appear in the same      
+                    // Carry out the weaning process. N.B. the weaners appear in the same
                     // paddock as their mothers and with the same tag
                     List<AnimalGroup> newGroups = null;
                     group.Wean(weanFemales, weanMales, ref newGroups, ref newGroups);
@@ -1557,8 +1557,8 @@
         }
 
         /// <summary>
-        /// Ends lactation in cows that have already had their calves weaned.  
-        /// The event has no effect on other animals.                                                   
+        /// Ends lactation in cows that have already had their calves weaned.
+        /// The event has no effect on other animals.
         /// </summary>
         /// <param name="groups">Groups</param>
         /// <param name="number">Number of animals</param>
@@ -1566,8 +1566,8 @@
         {
             number = Math.Max(number, 0);
 
-            // Only iterate through groups present at the start of the routine   
-            foreach (var group in groups)                                                        
+            // Only iterate through groups present at the start of the routine
+            foreach (var group in groups)
             {
                 if (group.Lactation > 0)
                 {
@@ -1584,10 +1584,10 @@
         }
 
         /// <summary>
-        /// Break an animal group up in various ways; by number, by age, by weight    
-        /// or by sex of lambs/calves.  The new group(s) have the same priority and   
-        /// paddock as the original.  SplitWeight assumes a distribution of weights   
-        /// around the group average.                                                 
+        /// Break an animal group up in various ways; by number, by age, by weight
+        /// or by sex of lambs/calves.  The new group(s) have the same priority and
+        /// paddock as the original.  SplitWeight assumes a distribution of weights
+        /// around the group average.
         /// </summary>
         /// <param name="groupIdx">The animal group index</param>
         /// <param name="numToKeep">Number to keep</param>
@@ -1597,10 +1597,10 @@
         }
 
         /// <summary>
-        /// Break an animal group up in various ways; by number, by age, by weight    
-        /// or by sex of lambs/calves.  The new group(s) have the same priority and   
-        /// paddock as the original.  SplitWeight assumes a distribution of weights   
-        /// around the group average.                                                 
+        /// Break an animal group up in various ways; by number, by age, by weight
+        /// or by sex of lambs/calves.  The new group(s) have the same priority and
+        /// paddock as the original.  SplitWeight assumes a distribution of weights
+        /// around the group average.
         /// </summary>
         /// <param name="group">The animal group to split.</param>
         /// <param name="numToKeep">Number of animals to keep.</param>
@@ -1650,12 +1650,12 @@
         /// <returns>The new groups that were created.</returns>
         public IEnumerable<AnimalGroup> SplitByWeight(double splitWt, IEnumerable<AnimalGroup> groups)
         {
-            const double varRatio = 0.10;      // Coefficient of variation of LW (0-1)       
+            const double varRatio = 0.10;      // Coefficient of variation of LW (0-1)
             const int NOSTEPS = 20;
 
             var newGroups = new List<AnimalGroup>();
             foreach (var srcGroup in groups)
-            { 
+            {
                 int numAnimals = srcGroup.NoAnimals;
                 double liveWt = srcGroup.LiveWeight;
 
@@ -1673,20 +1673,20 @@
 
                 if (numToRemove > 0)
                 {
-                    DifferenceRecord diffs = new DifferenceRecord() { StdRefWt = srcGroup.NODIFF.StdRefWt, BaseWeight = srcGroup.NODIFF.BaseWeight, FleeceWt = srcGroup.NODIFF.FleeceWt };            
+                    DifferenceRecord diffs = new DifferenceRecord() { StdRefWt = srcGroup.NODIFF.StdRefWt, BaseWeight = srcGroup.NODIFF.BaseWeight, FleeceWt = srcGroup.NODIFF.FleeceWt };
                     if (numToRemove < numAnimals)
                     {
-                        // This computation gives us the mean live weight of animals which are    
-                        // lighter than the weight threshold. We are integrating over a truncated 
-                        // normal distribution, using the differences between successive      
-                        // evaluations of the CumNormal function                            
-                        double rightSD = -5.0;                                             
-                        double stepWidth = (splitSD - rightSD) / NOSTEPS;                  
-                        double removeLW = 0.0;                                             
-                        double prevCum = 0.0;                                              
-                        for (int idx = 1; idx <= NOSTEPS; idx++)                        
-                        {                                                           
-                            rightSD = rightSD + stepWidth;                          
+                        // This computation gives us the mean live weight of animals which are
+                        // lighter than the weight threshold. We are integrating over a truncated
+                        // normal distribution, using the differences between successive
+                        // evaluations of the CumNormal function
+                        double rightSD = -5.0;
+                        double stepWidth = (splitSD - rightSD) / NOSTEPS;
+                        double removeLW = 0.0;
+                        double prevCum = 0.0;
+                        for (int idx = 1; idx <= NOSTEPS; idx++)
+                        {
+                            rightSD = rightSD + stepWidth;
                             double currCum = StdMath.CumNormal(rightSD);
                             removeLW = removeLW + ((currCum - prevCum) * liveWt * (1.0 + varRatio * (rightSD - 0.5 * stepWidth)));
                             prevCum = currCum;
@@ -1732,7 +1732,7 @@
         }
 
         /// <summary>
-        /// Sorting is done using the one-offset stock array                            
+        /// Sorting is done using the one-offset stock array
         /// </summary>
         public void Sort()
         {
@@ -1742,19 +1742,19 @@
         /// <summary>A stock tag comparer.</summary>
         private class TagComparer : IComparer<AnimalGroup>
         {
-            public int Compare(AnimalGroup x, AnimalGroup y) 
+            public int Compare(AnimalGroup x, AnimalGroup y)
             {
                 if (x == null)
                     return 0;
                 else if (y == null)
                     return 1;
-                else 
-                    return x.Tag.CompareTo(y.Tag); 
-            } 
+                else
+                    return x.Tag.CompareTo(y.Tag);
+            }
         }
 
         /// <summary>
-        /// Converts a ReproductiveType to a ReproType. 
+        /// Converts a ReproductiveType to a ReproType.
         /// </summary>
         /// <param name="reproType">The keyword to match</param>
         /// <param name="repro">The reproduction record</param>
@@ -1777,7 +1777,7 @@
         }
 
         /// <summary>
-        /// Tests for a non-MISSING, non-zero value                                      
+        /// Tests for a non-MISSING, non-zero value
         /// </summary>
         /// <param name="x">The test value</param>
         /// <returns>True if this is not a missing value</returns>
@@ -1803,7 +1803,7 @@
         }
 
         /// <summary>
-        /// Utility routines for manipulating the DM_Pool type.  AddDMPool adds the   
+        /// Utility routines for manipulating the DM_Pool type.  AddDMPool adds the
         /// contents of two pools together
         /// </summary>
         /// <param name="pool1">DM pool 1</param>
@@ -1825,7 +1825,7 @@
         }
 
         /// <summary>
-        /// MultiplyDMPool scales the contents of a pool                                                                 
+        /// MultiplyDMPool scales the contents of a pool
         /// </summary>
         /// <param name="srcPool">The dm pool to scale</param>
         /// <param name="scale">The scale</param>
@@ -1859,7 +1859,7 @@
         private double[] GetOffspringRates(Genotype parameters, double latitude, int mateDOY, int ageDays, double matingSize, double condition, double chillIndex = 0.0)
         {
             const double NO_CYCLES = 2.5;
-            const double STD_LATITUDE = -35.0;             // Latitude (in degrees) for which the DayLengthConst[] parameters are set    
+            const double STD_LATITUDE = -35.0;             // Latitude (in degrees) for which the DayLengthConst[] parameters are set
             double[] result;
             double[] conceptions = new double[4];
             double emptyPropn;
@@ -1913,8 +1913,8 @@
         }
 
         /// <summary>
-        /// Add( TAnimalList, TPaddockInfo, integer, integer )                           
-        /// Private variant. Adds all members of a TAnimalList back into the stock list  
+        /// Add( TAnimalList, TPaddockInfo, integer, integer )
+        /// Private variant. Adds all members of a TAnimalList back into the stock list
         /// </summary>
         /// <param name="animalList">The source animal list</param>
         /// <param name="paddInfo">The paddock info</param>
@@ -1927,7 +1927,7 @@
                 for (idx = 0; idx <= animalList.Count - 1; idx++)
                 {
                     this.Add(animalList[idx], paddInfo, tagNo);
-                    animalList[idx] = null;                           // Detach the animal group from the TAnimalList                              
+                    animalList[idx] = null;                           // Detach the animal group from the TAnimalList
                 }
         }
 
@@ -1954,10 +1954,10 @@
             };
             if (!this.ParseRepro(stockInfo.Sex, ref purchaseInfo.Repro))
                 throw new Exception("Event BUY does not support sex='" + stockInfo.Sex + "'");
-            if (purchaseInfo.Preg > 0) 
+            if (purchaseInfo.Preg > 0)
                 purchaseInfo.NYoung = Math.Max(1, purchaseInfo.NYoung);
-            if ((purchaseInfo.Lact == 0) || (purchaseInfo.YoungWt == 0.0))                              // Can't use MISSING as default owing    
-                purchaseInfo.YoungWt = StdMath.DMISSING;                                                // to double-to-single conversion      
+            if ((purchaseInfo.Lact == 0) || (purchaseInfo.YoungWt == 0.0))                              // Can't use MISSING as default owing
+                purchaseInfo.YoungWt = StdMath.DMISSING;                                                // to double-to-single conversion
 
             if (purchaseInfo.Number > 0)
             {

--- a/Models/Stock/stock.cs
+++ b/Models/Stock/stock.cs
@@ -16,82 +16,82 @@ namespace Models.GrazPlan
     /// <summary>
     /// # Stock
     /// The STOCK component encapsulates the GRAZPLAN animal biology model, as described in [FREER1997].
-    /// 
+    ///
     /// [The GrazPlan animal model technical description](https://grazplan.csiro.au/wp-content/uploads/2007/08/TechPaperMay12.pdf)
-    /// 
+    ///
     /// Animals may be of different genotypes. In particular, sheep and cattle may be represented within a single STOCK instance.
-    /// 
+    ///
     /// Usually a single STOCK module is added to an AusFarm simulation, at the top level in the
     /// module hierarchy.
-    /// 
+    ///
     /// In a grazing system, however, there may be a variety of different classes of livestock. Animals
     /// may be of different genotypes (including both sheep and cattle); may be males, females or
     /// castrates; are likely to have a range of different ages; and females may be pregnant and/or
     /// lactating. The set of classes of livestock can change over time as animals enter or leave the
     /// system, are mated, give birth or are weaned. Further, animals that are otherwise similar may be
     /// placed in different paddocks, where their growth rates may differ.
-    /// 
+    ///
     /// ![The list of animal groups at a particular time during a hypothetical simulation containing a STOCK module. Group 1 is distinct from the others because it has a different genotype and sex. Groups 2 and 3 are distinct because they are in different age classes (yearling vs mature). Groups 2 and 4 are distinct because they are in different reproductive states (pregnant vs lactating). Note how the unweaned lambs are associated with their mothers.](StockGroupsExample.png)
-    /// 
+    ///
     /// In the STOCK component, this complexity is handled by representing the set of animals in a
     /// simulated system as a list of animal groups (Figure 2.1). The members of each animal group
     /// have the same genotype and age class, but may have a range of ages (for example, an animal
     /// group containing mature animals may include four-year-old, five-year-old and six-year-old
     /// stock). The members of each animal group also have the same stage of pregnancy and/or
     /// lactation; the same number of suckling offspring; and occupy the same paddock.
-    /// 
+    ///
     /// The set of animal groups changes as animals enter and leave the simulation, and as
     /// physiological events such as maturation, mating, birth or weaning take place. Animal groups
     /// that become sufficiently similar are merged into a single group. The state of any unweaned
     /// lambs or calves is stored alongside that of their mothers; at weaning, the male and female
     /// weaners are transferred into two new animal groups within the main list.
-    /// 
+    ///
     /// In addition to the biological state variables that describe the animals, each animal group has
     /// four attributes that are of particular interest when writing management scripts.
-    /// 
+    ///
     /// **Index**
-    /// 
+    ///
     /// Each animal group has a unique, internally-assigned integer index, starting at 1.
     /// Because the set of groups present in a component instance is dynamic, the index
     /// number associated with a particular group of animals can – and usually does – change
     /// over time. This dynamic numbering scheme has consequences for the way that animals
     /// of a particular kind must be located when writing management scripts.
-    /// 
+    ///
     /// **Paddock**
-    /// 
+    ///
     /// Each animal group is also assigned a paddock. The forage and supplementary feed
     /// available to a group of animals are determined by the paddock it occupies. Paddocks are
     /// referred to by name in the STOCK component:
-    /// 
+    ///
     /// * To set the paddock occupied by an animal group, use the **Move** event.
     /// * To determine the paddock occupied by an animal group, use the **Paddock** variable.
-    /// 
+    ///
     /// It is the user’s responsibility to ensure that paddock names correspond to PADDOCK
     /// modules or other sources of necessary driving variables.
-    /// 
+    ///
     /// **Tag Value**
-    /// 
+    ///
     /// Each animal group also has a user-assigned tag value that takes an integer value. Tag
     /// values have two purposes:
-    /// 
+    ///
     /// * They can be used to manage distinct groups of animals in a common fashion. For
     /// example, all lactating ewes might be assigned the same tag value, and then all
     /// animals with this tag value might undergo the same supplementary feeding regime.
     /// * If tag values are assigned sequentially (starting at 1), they can be used to generate
     /// summary variables. For example, **WeightTag[1]** gives the average live weight
     /// of all animals in groups with a tag value of 1.
-    /// 
+    ///
     /// Note that animal groups with different tag values are never merged, even if they are
     /// otherwise similar.
-    /// 
+    ///
     /// * To set the tag value of an animal group, use the **Tag** method.
     /// * To determine the tag value of an animal group, use the **TagNo** variable.
-    /// 
+    ///
     ///  **Merging groups of similar animals**
-    ///  
+    ///
     /// Animal groups that become sufficiently similar are merged into a single group.
     /// Animals are similar if all these are the same:
-    /// 
+    ///
     /// * Occupy the same paddock
     /// * Reproduction status (Castrated, Male, Empty, Early Preg,  Late Preg)
     /// * Number of foetuses
@@ -145,7 +145,7 @@ namespace Models.GrazPlan
         /// The simulation clock
         /// </summary>
         [Link]
-        private Clock systemClock = null;
+        private IClock systemClock = null;
 
         /// <summary>
         /// The simulation weather component
@@ -3807,12 +3807,12 @@ namespace Models.GrazPlan
 
         #region Management methods ============================================
         // ............................................................................
-        // Management methods                                                         
+        // Management methods
         // ............................................................................
 
         /// <summary>
-        /// Causes a set of related age cohorts of animals to enter the simulation. 
-        /// Each age cohort may contain animals that are pregnant and/or lactating, in which case distributions of numbers of foetuses and/or suckling offspring are computed automatically. 
+        /// Causes a set of related age cohorts of animals to enter the simulation.
+        /// Each age cohort may contain animals that are pregnant and/or lactating, in which case distributions of numbers of foetuses and/or suckling offspring are computed automatically.
         /// This event is primarily intended to simplify the initialisation of flocks and herds in simulations.
         /// </summary>
         /// <param name="animals">The animal data</param>
@@ -3948,7 +3948,7 @@ namespace Models.GrazPlan
         /// <summary>
         /// Commences mating of a particular group of animals.  If the animals are not empty females, or if they are too young, has no effect
         /// </summary>
-        /// <param name="mateTo">Genotype of the rams or bulls with which the animals are mated. 
+        /// <param name="mateTo">Genotype of the rams or bulls with which the animals are mated.
         /// Must match the name field of a member of the genotypes property.</param>
         /// <param name="mateDays">Length of the mating period in days.</param>
         /// <param name="group">The animal group to mate. null denotes that all empty females of sufficient age should be mated.</param>
@@ -3966,9 +3966,9 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Converts ram lambs to wether lambs, or bull calves to steers.  If the animal group(s) denoted by group has no suckling young, has no effect. 
-        /// If the number of male lambs or calves in a nominated group is greater than the number to be castrated, the animal group will be split; 
-        /// the sub-group with castrated offspring will remain at the original index and the sub-group with offspring that were not castrated will 
+        /// Converts ram lambs to wether lambs, or bull calves to steers.  If the animal group(s) denoted by group has no suckling young, has no effect.
+        /// If the number of male lambs or calves in a nominated group is greater than the number to be castrated, the animal group will be split;
+        /// the sub-group with castrated offspring will remain at the original index and the sub-group with offspring that were not castrated will
         /// be added at the end of the set of animal groups.
         /// </summary>
         /// <param name="number">Number of male lambs or calves to be castrated.</param>
@@ -4000,7 +4000,7 @@ namespace Models.GrazPlan
         }
 
         /// <summary>
-        /// Weans some or all of the lambs or calves from an animal group. 
+        /// Weans some or all of the lambs or calves from an animal group.
         /// The newly weaned animals are added to the end of the list of animal groups, with males and females in separate groups.
         /// </summary>
         /// <param name="number">The number of lambs or calves to be weaned.</param>
@@ -4029,7 +4029,7 @@ namespace Models.GrazPlan
 
         /// <summary>
         /// Ends lactation in cows that have already had their calves weaned.  The event has no effect on other animals.
-        /// If the number of cows in a nominated group is greater than the number to be dried off, the animal group will be split; 
+        /// If the number of cows in a nominated group is greater than the number to be dried off, the animal group will be split;
         /// the sub-group that is no longer lactating will remain at the original index and the sub-group that continues lactating will be added at the end of the set of animal groups
         /// </summary>
         /// <param name="number">Number of females for which lactation is to end.</param>

--- a/Models/StockManagement/Draft.cs
+++ b/Models/StockManagement/Draft.cs
@@ -9,7 +9,7 @@
     using Models.PMF.Interfaces;
 
     /// <summary>
-    /// An instance of this class creates a genotype cross and adds it to the list of 
+    /// An instance of this class creates a genotype cross and adds it to the list of
     /// available crosses.
     /// </summary>
     [Serializable]
@@ -23,7 +23,7 @@
         private Stock stock = null;
 
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
 
         [Link]
         private List<Zone> zones = null;
@@ -103,7 +103,7 @@
             {
                 if (TypeOfDraft == DraftType.Fixed)
                 {
-                    // Loop through all tag numbers. 
+                    // Loop through all tag numbers.
                     for (int t = 0; t < TagNumbers.Length; t++)
                     {
                         // Find the animal groups that have the tag number and move them to the
@@ -129,7 +129,7 @@
 
         /// <summary>
         /// Perform a draft (move animals) into the specified paddocks. Only move those animals
-        /// that have the specified tag numbers. Tags are assumed to be in priority order - the 
+        /// that have the specified tag numbers. Tags are assumed to be in priority order - the
         /// first tag is the highest priority, the second tag is the 2nd highest etc. The highest
         /// priority tag gets the best paddock (the one with the most forage), the second highest
         /// priority tag gets the second best paddock etc.

--- a/Models/Storage/DataStoreReader.cs
+++ b/Models/Storage/DataStoreReader.cs
@@ -200,8 +200,8 @@
         /// <param name="orderByFieldNames">Optional column name to order by</param>
         /// <param name="distinct">Only return distinct values for field?</param>
         /// <returns></returns>
-        public DataTable GetData(string tableName, string checkpointName = "Current", 
-                                 IEnumerable<string> simulationNames = null, 
+        public DataTable GetData(string tableName, string checkpointName = "Current",
+                                 IEnumerable<string> simulationNames = null,
                                  IEnumerable<string> fieldNames = null,
                                  string filter = null,
                                  int from = 0, int count = 0,
@@ -214,7 +214,7 @@
             // Get the field names in the table
             var table = tables.TryGetValue(tableName, out List<string> fieldNamesInTable);
 
-            // Return null if there are no fields in the table (or the table is missing) 
+            // Return null if there are no fields in the table (or the table is missing)
             // and we have no view.
             if ((fieldNamesInTable == null || fieldNamesInTable.Count == 0)  // no table.
                 && !Connection.ViewExists(tableName))                        // no view

--- a/Models/Sugarcane/Sugarcane.cs
+++ b/Models/Sugarcane/Sugarcane.cs
@@ -21,79 +21,79 @@ namespace Models
     /// <remarks>
     ///## Model Components Overview
     ///
-    /// Crop dry weight accumulation is driven by the conversion of intercepted radiation to biomass, via a radiation-use efficiency (RUE). 
+    /// Crop dry weight accumulation is driven by the conversion of intercepted radiation to biomass, via a radiation-use efficiency (RUE).
     ///
-    /// RUE is reduced whenever extremes of temperature, soil water shortage or excess, or plant nitrogen deficit limit photosynthesis. 
+    /// RUE is reduced whenever extremes of temperature, soil water shortage or excess, or plant nitrogen deficit limit photosynthesis.
     ///
     /// The crop leaf canopy, which intercepts radiation, expands its area as a function of temperature, and can also be limited by extremes of temperature, soil water shortage or excess, or plant nitrogen deficit.
     ///
     /// Biomass is partitioned among the various plant components (leaf, cabbage, structural stem, roots and sucrose) as determined by crop phenological stage.
     ///
-    /// Nitrogen uptake is simulated, as is the return of carbon and nitrogen to the soil in trash and roots. 
+    /// Nitrogen uptake is simulated, as is the return of carbon and nitrogen to the soil in trash and roots.
     ///
-    /// In many sugarcane production systems, commercial yield is measured as the fresh weight of sugarcane stems and their sucrose concentration. Hence, the water content in addition to the dry weight of the stem is simulated. 
+    /// In many sugarcane production systems, commercial yield is measured as the fresh weight of sugarcane stems and their sucrose concentration. Hence, the water content in addition to the dry weight of the stem is simulated.
     ///
     /// Since sugarcane is grown both as a plant and ratoon crop, the model also needs to be able to simulate differences between crop classes based on any known physiological differences between these classes.
     ///
-    /// 
+    ///
     /// ## Crop growth in the absence of nitrogen or water limitation
     ///
     /// ### Thermal time
     ///
-    /// Thermal time is used in the model to drive phenological development and canopy expansion. 
+    /// Thermal time is used in the model to drive phenological development and canopy expansion.
     ///
     /// In APSIM-Sugarcane, thermal time is calculated using a base temperature of 9 oC, optimum temperature of 32 oC, and maximum temperature of 45 oC.
     ///
-    /// The optimum and maximum temperatures were taken from those used for maize [jones_ceres-maize:_1986]. 
+    /// The optimum and maximum temperatures were taken from those used for maize [jones_ceres-maize:_1986].
     ///
-    /// Base temperatures for sugarcane have been variously reported between 8 oC and 15 oC [inman-bamber_temperature_1994][robertson_simulating_1998]. 
-    /// The base of 9 oC used in APSIM sugarcane was chosen to be consistent with those studies which sampled the greatest temperature range, namely [inman-bamber_temperature_1994][robertson_simulating_1998] who identified base temperatures of 10 oC and 8 oC respectively. 
+    /// Base temperatures for sugarcane have been variously reported between 8 oC and 15 oC [inman-bamber_temperature_1994][robertson_simulating_1998].
+    /// The base of 9 oC used in APSIM sugarcane was chosen to be consistent with those studies which sampled the greatest temperature range, namely [inman-bamber_temperature_1994][robertson_simulating_1998] who identified base temperatures of 10 oC and 8 oC respectively.
     ///
-    /// For thermal time calculations in the model, temperature is estimated every three hours from a sine function fitted to daily maximum and minimum temperatures, using the method described by [jones_ceres-maize:_1986]. 
+    /// For thermal time calculations in the model, temperature is estimated every three hours from a sine function fitted to daily maximum and minimum temperatures, using the method described by [jones_ceres-maize:_1986].
     ///
     /// ### Phenology
     ///
-    /// The sugar model uses six different stages to define crop growth and status. 
+    /// The sugar model uses six different stages to define crop growth and status.
     ///
-    /// 
-    /// |Stage     |Description                                   
+    ///
+    /// |Stage     |Description
     /// |----------|:---------------------------------------------
-    /// |sowing    |From sowing to sprouting                      
-    /// |sprouting |From sprouting to emergence                   
+    /// |sowing    |From sowing to sprouting
+    /// |sprouting |From sprouting to emergence
     /// |emergence |From emergence to the beginning of cane growth
     /// |begin_cane|From the beginning of cane growth to flowering
-    /// |flowering |From flowering to the end of the crop         
+    /// |flowering |From flowering to the end of the crop
     /// |end_crop  |Crop is not currently in the simulated system.
-    /// 
-    /// Sprouting occurs after a lag period, set to 350 oCdays for plant crops and 100 oCdays for ratoon crops. 
     ///
-    /// Provided the soil water content of the layer is adequate, shoots will elongate towards the soil surface at a rate of 0.8 mm per oCday. 
+    /// Sprouting occurs after a lag period, set to 350 oCdays for plant crops and 100 oCdays for ratoon crops.
     ///
-    /// The thermal duration between emergence and beginning of stalk growth is a genotype coefficient in the range 1200 to 1800 oCdays. 
+    /// Provided the soil water content of the layer is adequate, shoots will elongate towards the soil surface at a rate of 0.8 mm per oCday.
+    ///
+    /// The thermal duration between emergence and beginning of stalk growth is a genotype coefficient in the range 1200 to 1800 oCdays.
     ///
     /// Although, sugarcane does produce flowers, the number of stalks producing flowers in a field is highly variable, and its physiological basis is not fully understood.
     ///
-    /// While the model structure has been developed to include flowering as a phenological stage, it has been deactivated until a better physiological basis for prediction is available. 
+    /// While the model structure has been developed to include flowering as a phenological stage, it has been deactivated until a better physiological basis for prediction is available.
     ///
     ///
     /// ### Canopy expansion
     ///
     /// The experimental basis for the canopy expansion model is described by [robertson_simulation_2016].
     ///
-    /// Briefly, green leaf area index is the product of ***green leaf area per stalk*** and the ***number of stalks per unit ground area***. 
+    /// Briefly, green leaf area index is the product of ***green leaf area per stalk*** and the ***number of stalks per unit ground area***.
     ///
     /// ***Green leaf area per stalk*** is simulated by summing the fully-expanded area of successive leaves that appear on each stalk, and adding a correction factor for the area of expanding leaves (set to 1.6 leaves per stalk).
-    /// Profiles of leaf area per leaf are input as genotype coefficients. 
+    /// Profiles of leaf area per leaf are input as genotype coefficients.
     /// [robertson_simulation_2016] found leaf appearance rates declined as a continuous function of cumulative thermal time, so that at emergence leaves took 80 oCd to appear while leaf 40 required 150 oCd.
     /// These responses are reproduced in the model (via a series of linear interpolations) in both plant and ratoon crops.
     ///
-    /// ***Stalk number*** rises rapidly to a peak during the first 1400 oCdays from emergence, thereafter declining to reach a stable stalk number (e.g. [inman-bamber_temperature_1994]). 
+    /// ***Stalk number*** rises rapidly to a peak during the first 1400 oCdays from emergence, thereafter declining to reach a stable stalk number (e.g. [inman-bamber_temperature_1994]).
     /// Ratoon crops commonly reach an earlier peak stalk number than plant crops, with consequently faster early canopy expansion in ratoons [robertson_growth_1996].
-    /// In the model, the complexity of simulating the dynamics of tillering in order to predict LAI during early growth is avoided. 
-    /// Instead, the crop is conceived to have a notional constant stalk number throughout growth, usually set at 10 stalks m-2 , although this value can be varied as an input. 
+    /// In the model, the complexity of simulating the dynamics of tillering in order to predict LAI during early growth is avoided.
+    /// Instead, the crop is conceived to have a notional constant stalk number throughout growth, usually set at 10 stalks m-2 , although this value can be varied as an input.
     /// The additional leaf area associated with tillers that appear and subsequently die, is captured via a calibrated tillering factor, that effectively increases the area of the leaves that are produced over the early tillering period.
     ///
-    /// The known faster early expansion of LAI in ratoon crops is simulated via two effects. 
+    /// The known faster early expansion of LAI in ratoon crops is simulated via two effects.
     /// * Firstly, the lag time for regrowth of shoots after harvest is shorter in a ratoon crop than is the equivalent thermal time for a plant crop to initiate stalk elongation.
     /// * Secondly, tillering is recognised in the model coefficients as making a larger contribution to leaf area development in a ratoon crop than a plant crop.
     ///
@@ -105,131 +105,131 @@ namespace Models
     ///
     /// Water stress induces senescence once the soil water deficit factor for photosynthesis declines below 1.0.
     ///
-    /// Frosting removes 10% of the LAI per day if the minimum temperature reaches 0 oC, and 100% if it reaches -5 oC. 
+    /// Frosting removes 10% of the LAI per day if the minimum temperature reaches 0 oC, and 100% if it reaches -5 oC.
     ///
     ///
     /// ### Root growth and development
     ///
-    /// Root biomass is produced independently from the shoot, so that a proportion of daily above-ground biomass production is added to the root system. 
-    /// The proportion decreases from a maximum of 0.30 at emergence and asymptotes to 0.20 at flowering. 
+    /// Root biomass is produced independently from the shoot, so that a proportion of daily above-ground biomass production is added to the root system.
+    /// The proportion decreases from a maximum of 0.30 at emergence and asymptotes to 0.20 at flowering.
     ///
-    /// Root biomass is converted to root length via a specific root length of 18000 mm g-1 . 
+    /// Root biomass is converted to root length via a specific root length of 18000 mm g-1 .
     /// The depth of the root front in plant crops increases by 1.5 cm day-1 [_glover_proceedings_nodate] from emergence, with the maximum depth of rooting set by the user.
     ///
-    /// At harvest, 17% of roots in all the occupied soil layer die [ball-coelho_root_1992]. 
+    /// At harvest, 17% of roots in all the occupied soil layer die [ball-coelho_root_1992].
     ///
     ///
     ///
     /// ### Biomass accumulation and partitioning
     ///
-    /// The sugar model partitions dry matter to **five different plant pools**. These are as follows: 
+    /// The sugar model partitions dry matter to **five different plant pools**. These are as follows:
     ///
-    /// |Plant Part |Description                              
+    /// |Plant Part |Description
     /// |-----------|:----------------------------------------
-    /// |Root       |Below-ground biomass                     
-    /// |Leaf       |Leaf                                     
-    /// |Sstem      |Structural component of millable stalk   
+    /// |Root       |Below-ground biomass
+    /// |Leaf       |Leaf
+    /// |Sstem      |Structural component of millable stalk
     /// |Cabbage    |Leaf sheath and tip of growing stalks etc
-    /// |Sucrose    |Sucrose content of millable stalk        
+    /// |Sucrose    |Sucrose content of millable stalk
     ///
-    /// In addition to the five live biomass pools outlined above, senescent leaf and cabbage is maintained as trash on the plant or progressively detached to become residues on the soil surface. 
-    /// In APSIM, the RESIDUE module [probert_apsim_1996] takes on the role of decomposition of crop residues. 
+    /// In addition to the five live biomass pools outlined above, senescent leaf and cabbage is maintained as trash on the plant or progressively detached to become residues on the soil surface.
+    /// In APSIM, the RESIDUE module [probert_apsim_1996] takes on the role of decomposition of crop residues.
     ///
     /// LAI is used in the model to intercept incident solar radiation following Beer's Law, using a radiation extinction coefficient of 0.38, determined by [muchow_radiation_1994][robertson_growth_1996].
-    /// Intercepted radiation is used to produce daily biomass production using a radiation-use efficiency (RUE) of 1.80 g MJ-1 for plant crops and 1.65 g MJ-1 for ratoon crops. 
-    /// The values of RUE used in the model are those adjusted upwards from field-measured values [muchow_radiation_1994][robertson_growth_1996] due to the underestimate of biomass production caused by incomplete recovery of senesced leaf material [robertson_growth_1996]. 
-    /// In the model, RUE is reduced if the mean daily temperature falls below 15 oC or exceeds 35 oC, and becomes zero if the mean temperature reaches 5 or 50 oC, respectively. 
-    /// These effects are similar to those used in other models of C4 crop species [hammer_assessing_1994]. 
+    /// Intercepted radiation is used to produce daily biomass production using a radiation-use efficiency (RUE) of 1.80 g MJ-1 for plant crops and 1.65 g MJ-1 for ratoon crops.
+    /// The values of RUE used in the model are those adjusted upwards from field-measured values [muchow_radiation_1994][robertson_growth_1996] due to the underestimate of biomass production caused by incomplete recovery of senesced leaf material [robertson_growth_1996].
+    /// In the model, RUE is reduced if the mean daily temperature falls below 15 oC or exceeds 35 oC, and becomes zero if the mean temperature reaches 5 or 50 oC, respectively.
+    /// These effects are similar to those used in other models of C4 crop species [hammer_assessing_1994].
     ///
-    /// Four above-ground biomass pools are modelled: **leaf**, **cabbage**, **structural stem**, **stem sucrose**, 
-    /// (and an additional pool for **roots** that is simulated separately from above-ground production). 
+    /// Four above-ground biomass pools are modelled: **leaf**, **cabbage**, **structural stem**, **stem sucrose**,
+    /// (and an additional pool for **roots** that is simulated separately from above-ground production).
     ///
     /// Between emergence and the beginning of stalk growth, above-ground biomass is partitioned between leaf and cabbage in the ratio 1.7:1 [robertson_growth_1996].
     ///
-    /// After the beginning of stem growth 0.7 of above-ground biomass is partitioned to the stem robertson_growth_1996, with the remainder partitioned between leaf and cabbage in the ratio 1.7:1. 
+    /// After the beginning of stem growth 0.7 of above-ground biomass is partitioned to the stem robertson_growth_1996, with the remainder partitioned between leaf and cabbage in the ratio 1.7:1.
     /// After a minimum amount of stem biomass has accumulated, the daily biomass partitioned to stem is divided between structural and sucrose pools, following the framework developed by [muchow_effect_1996] and [robertson_growth_1996]. Thereafter, the stem biomass is equal to the sum of structural and sucrose pools.
     ///
-    /// If biomass partitioned to leaf is insufficient for growth of the leaf area, as determined by a maximum specific leaf area, then daily leaf area expansion is reduced. 
-    /// If biomass partitioned to leaf is in excess of that required to grow the leaf area on that day, then specific leaf area is permitted to decrease to a lower limit, beyond which the “excess” biomass is partitioned to sucrose and structural stem. 
+    /// If biomass partitioned to leaf is insufficient for growth of the leaf area, as determined by a maximum specific leaf area, then daily leaf area expansion is reduced.
+    /// If biomass partitioned to leaf is in excess of that required to grow the leaf area on that day, then specific leaf area is permitted to decrease to a lower limit, beyond which the “excess” biomass is partitioned to sucrose and structural stem.
     ///
-    /// A stalk growth stress factor is calculated as the most limiting of the water, nitrogen and temperature limitations on photosynthesis. 
-    /// This stress factor influences both the onset and rate of assimilate partitioning to sucrose at the expense of structural stem. 
+    /// A stalk growth stress factor is calculated as the most limiting of the water, nitrogen and temperature limitations on photosynthesis.
+    /// This stress factor influences both the onset and rate of assimilate partitioning to sucrose at the expense of structural stem.
     ///
     /// ### Stem water content
     ///
-    /// A stem water pool is simulated for the purposes of calculating cane fresh weight and CCS%. 
+    /// A stem water pool is simulated for the purposes of calculating cane fresh weight and CCS%.
     ///
-    /// For every gram of structural stem grown, a weight of water is considered to have been accumulated by the cane stems. 
+    /// For every gram of structural stem grown, a weight of water is considered to have been accumulated by the cane stems.
     ///
-    /// This relationship varies with thermal time, ranging from 9 g g-1 initially, to 5 g g-1 late in the crop life cycle. 
+    /// This relationship varies with thermal time, ranging from 9 g g-1 initially, to 5 g g-1 late in the crop life cycle.
     ///
-    /// The former represents the water content of young stem (eg. cabbage) while the latter represents a combination of young stem growth and thickening of older stem. 
+    /// The former represents the water content of young stem (eg. cabbage) while the latter represents a combination of young stem growth and thickening of older stem.
     ///
-    /// Sucrose deposition in the stem removes water content at the rate of 1 g water g-1 sucrose. 
+    /// Sucrose deposition in the stem removes water content at the rate of 1 g water g-1 sucrose.
     ///
     /// ### Varietal effects
     ///
-    /// Currently varieties differ in only two respects in the model. 
+    /// Currently varieties differ in only two respects in the model.
     ///
-    /// * Firstly, Inman-Bamber (1991) found that varieties in South Africa differed in the fully-expanded area of individual leaves. 
-    /// The distributions for NCo376 and N14 were taken from Inman-Bamber and Thompson (1989), while that for Q117 and Q96 was those assigned values that gave best fit to the time-course of LAI during the model calibration stage. 
-    /// * Secondly, [robertson_growth_1996] found that varieties from South Africa and Australia differed in terms of partitioning of biomass to sucrose in the stem. 
+    /// * Firstly, Inman-Bamber (1991) found that varieties in South Africa differed in the fully-expanded area of individual leaves.
+    /// The distributions for NCo376 and N14 were taken from Inman-Bamber and Thompson (1989), while that for Q117 and Q96 was those assigned values that gave best fit to the time-course of LAI during the model calibration stage.
+    /// * Secondly, [robertson_growth_1996] found that varieties from South Africa and Australia differed in terms of partitioning of biomass to sucrose in the stem.
     /// There is scope for incorporating other varietal differences as new knowledge becomes available.
     ///
     /// ## Water deficit limitation
     ///
-    /// Soil water infiltration and redistribution, evaporation and drainage is simulated by other modules in the APSIM framework [probert_apsim_1996] and (Verburg et al, 1997). 
+    /// Soil water infiltration and redistribution, evaporation and drainage is simulated by other modules in the APSIM framework [probert_apsim_1996] and (Verburg et al, 1997).
     ///
-    /// Water stress in the model reduces the rate of leaf area expansion and radiation-use efficiency, via two soil water deficit factors, which vary from zero to 1.0, following the concepts embodied in the CERES models (Ritchie, 1986). 
-    /// Soil water deficit factor 1 (SWDEF1), which is less sensitive to soil drying, reduces the radiation-use efficiency (i.e. net photosynthesis) and hence transpiration, below its maximum. 
-    /// Soil water deficit factor 2 (SWDEF2), which is more sensitive to soil drying, reduces the rate of processes governed primarily by cell expansion, i.e. daily leaf expansion rate. 
+    /// Water stress in the model reduces the rate of leaf area expansion and radiation-use efficiency, via two soil water deficit factors, which vary from zero to 1.0, following the concepts embodied in the CERES models (Ritchie, 1986).
+    /// Soil water deficit factor 1 (SWDEF1), which is less sensitive to soil drying, reduces the radiation-use efficiency (i.e. net photosynthesis) and hence transpiration, below its maximum.
+    /// Soil water deficit factor 2 (SWDEF2), which is more sensitive to soil drying, reduces the rate of processes governed primarily by cell expansion, i.e. daily leaf expansion rate.
     ///
-    /// SWDEF1 and 2 are calculated as a function of the ratio of (potential soil water supply from the root system) and the (transpiration demand). 
+    /// SWDEF1 and 2 are calculated as a function of the ratio of (potential soil water supply from the root system) and the (transpiration demand).
     /// Following [sinclair_water_1986 and Monteith (1986), transpiration demand is modelled as a function of the (current day's crop growth rate), divided by the transpiration-use efficiency.
-    /// When soil water supply exceeds transpiration demand, assimilate fixation is a function of radiation interception and radiation use efficiency. 
-    /// When soil water supply is less than transpiration demand, assimilate fixation is a function of water supply and transpiration efficiency and the vapour pressure deficit (VPD). 
+    /// When soil water supply exceeds transpiration demand, assimilate fixation is a function of radiation interception and radiation use efficiency.
+    /// When soil water supply is less than transpiration demand, assimilate fixation is a function of water supply and transpiration efficiency and the vapour pressure deficit (VPD).
     ///
     /// Transpiration-use efficiency has not been directly measured for sugarcane, but calibration of the current model on datasets exhibiting water deficits (Robertson et al, unpubl. data) resulted in the use of a transpiration-use efficiency of 8 g kg-1 at a VPD of 1 kPa.
-    /// This efficiency declines linearly as a function of VPD (Tanner and Sinclair, 1983). 
-    /// This compares with reported values of 9 g kg-1 kPa-1 for other C 4 species (Tanner and Sinclair 1983), a value that has been used in the models of sorghum (Hammer and Muchow, 1994) and maize [muchow_tailoring_1991]. 
+    /// This efficiency declines linearly as a function of VPD (Tanner and Sinclair, 1983).
+    /// This compares with reported values of 9 g kg-1 kPa-1 for other C 4 species (Tanner and Sinclair 1983), a value that has been used in the models of sorghum (Hammer and Muchow, 1994) and maize [muchow_tailoring_1991].
     ///
-    /// Potential soil water uptake is calculated using the approach first advocated by Monteith (1986) and subsequently tested for sunflower [meinke_sunflower_1993] and grain sorghum (Robertson et al., 1994). 
-    /// It is the sum of root water uptake from each profile layer occupied by roots. 
-    /// The potential rate of extraction in a layer is calculated using a rate constant, which defines the fraction of available water able to be extracted per day. 
-    /// The actual rate of water extraction is the lesser of the potential extraction rate and the transpiration demand. 
+    /// Potential soil water uptake is calculated using the approach first advocated by Monteith (1986) and subsequently tested for sunflower [meinke_sunflower_1993] and grain sorghum (Robertson et al., 1994).
+    /// It is the sum of root water uptake from each profile layer occupied by roots.
+    /// The potential rate of extraction in a layer is calculated using a rate constant, which defines the fraction of available water able to be extracted per day.
+    /// The actual rate of water extraction is the lesser of the potential extraction rate and the transpiration demand.
     /// If the computed potential extraction rate from the profile exceeds demand, then the extracted water is removed from the occupied layers in proportion to the values of potential root water uptake in each layer.
-    /// If the computed potential extraction from the profile is less than the demand then SWDEF2 declines in proportion, and the actual root water uptake from a layer is equal to the computed potential uptake. 
+    /// If the computed potential extraction from the profile is less than the demand then SWDEF2 declines in proportion, and the actual root water uptake from a layer is equal to the computed potential uptake.
     ///
     /// In addition to the effects on canopy expansion and biomass accumulation, water stress influence biomass partitioning in the stem in two ways.
     /// Firstly, the minimum amount of stem biomass required to initiate sucrose accumulation declines with accumulated stress.
-    /// Secondly, the daily dry weight increment between structural stem and sucrose shifts in favour of sucrose as water deficits develop. 
+    /// Secondly, the daily dry weight increment between structural stem and sucrose shifts in favour of sucrose as water deficits develop.
     ///
     /// ## Water excess limitation
-    /// The proportion of the root system exposed to saturated or near saturated soil water conditions is calculated and used to calculate a water logging stress factor. 
+    /// The proportion of the root system exposed to saturated or near saturated soil water conditions is calculated and used to calculate a water logging stress factor.
     /// This factor reduces photosynthetic activity via an effect on RUE.
     ///
     /// ## Nitrogen limitation
-    /// N supply from the soil is simulated in other modules in the APSIM framework [probert_apsim_1996]. 
+    /// N supply from the soil is simulated in other modules in the APSIM framework [probert_apsim_1996].
     ///
-    /// Crop nitrogen demand is simulated using an approach similar to that used in the CERES models [godwin_simulation_1985]. 
-    /// Crop N demand is calculated as the product of maximum tissue N concentration and the increment in tissue weight. 
+    /// Crop nitrogen demand is simulated using an approach similar to that used in the CERES models [godwin_simulation_1985].
+    /// Crop N demand is calculated as the product of maximum tissue N concentration and the increment in tissue weight.
     ///
-    /// Separate N pools are described for green leaf, cabbage, millable stalk and dead leaf. The sucrose pool is assumed to have no nitrogen associated with it. 
-    /// Only the leaf N concentrations influence crop growth processes. Growth is unaffected until leaf N concentrations fall below a critical concentration. 
-    /// Sugarcane has been shown to exhibit luxury N uptake [muchow_radiation_1994](Catchpoole and Keating 1995) and the difference between the maximum and critical N concentrations is intended to simulate this phenomenon. 
-    /// Nitrogen stress is proportional to the extent to which leaf N falls between the critical and the minimum N concentration. 
+    /// Separate N pools are described for green leaf, cabbage, millable stalk and dead leaf. The sucrose pool is assumed to have no nitrogen associated with it.
+    /// Only the leaf N concentrations influence crop growth processes. Growth is unaffected until leaf N concentrations fall below a critical concentration.
+    /// Sugarcane has been shown to exhibit luxury N uptake [muchow_radiation_1994](Catchpoole and Keating 1995) and the difference between the maximum and critical N concentrations is intended to simulate this phenomenon.
+    /// Nitrogen stress is proportional to the extent to which leaf N falls between the critical and the minimum N concentration.
     ///
-    /// Senescing leaves (and the associated leaf sheaths contained in the cabbage pool) are assumed to die at their minimum N concentrations and the balance of the N in these tissues is retranslocated to the green leaf and cabbage pools. 
+    /// Senescing leaves (and the associated leaf sheaths contained in the cabbage pool) are assumed to die at their minimum N concentrations and the balance of the N in these tissues is retranslocated to the green leaf and cabbage pools.
     ///
     /// Maximum, critical and minimum N concentrations are all functions of thermal time, and were chosen on the basis of the findings of Catchpoole and Keating (1995) and [muchow_radiation_1994] and subsequently refined during the model calibration.
-    /// Critical green leaf concentrations used in the model differ between photosynthetic, leaf expansion and stem growth processes. 
-    /// For photosynthesis they begin at 1.2% N at emergence or ratooning and asymptote towards 0.5%N at flowering. 
-    /// For leaf area expansion they are 1.3 and 0.5% N 
-    /// and stem growth, 1.5 and 0.5%N. 
+    /// Critical green leaf concentrations used in the model differ between photosynthetic, leaf expansion and stem growth processes.
+    /// For photosynthesis they begin at 1.2% N at emergence or ratooning and asymptote towards 0.5%N at flowering.
+    /// For leaf area expansion they are 1.3 and 0.5% N
+    /// and stem growth, 1.5 and 0.5%N.
     ///
-    /// N uptake cannot exceed N demand by the crop and is simulated to take place by mass flow in the water that is used for transpiration. 
-    /// Should mass flow not meet crop demand and nitrate be available in soil layers, the approach of [van_keulen_simulation_1987] is used to simulate the uptake of nitrate over and above that which can be accounted for by mass flow. 
-    /// While van Keulen and Seligman (1987) referred to this approach as “diffusion”, the routine more realistically serves as a surrogate for a number of sources of uncertainty in nitrate uptake. 
+    /// N uptake cannot exceed N demand by the crop and is simulated to take place by mass flow in the water that is used for transpiration.
+    /// Should mass flow not meet crop demand and nitrate be available in soil layers, the approach of [van_keulen_simulation_1987] is used to simulate the uptake of nitrate over and above that which can be accounted for by mass flow.
+    /// While van Keulen and Seligman (1987) referred to this approach as “diffusion”, the routine more realistically serves as a surrogate for a number of sources of uncertainty in nitrate uptake.
     ///
     /// Nitrogen stress also influences biomass partitioning in the stem, in a similar fashion to that described above for water stress.
     ///
@@ -237,19 +237,19 @@ namespace Models
     /// ## Other features of the sugar module
     /// APSIM-Sugarcane includes a number of features relevant to sugarcane production systems.
     ///
-    /// Either plant or ratoon crops can be simulated at the outset or a plant crop will regenerate as a ratoon crop if a crop cycle is being simulated. 
-    /// Production systems of plant - multiple ratoon - fallow can be simulated or alternatively other APSIM crop or pasture modules can be included in rotation with sugarcane. 
+    /// Either plant or ratoon crops can be simulated at the outset or a plant crop will regenerate as a ratoon crop if a crop cycle is being simulated.
+    /// Production systems of plant - multiple ratoon - fallow can be simulated or alternatively other APSIM crop or pasture modules can be included in rotation with sugarcane.
     ///
-    /// Trash can be burnt or retained at harvest time. 
+    /// Trash can be burnt or retained at harvest time.
     ///
-    /// Insect or other biological or mechanical damage to the canopy can be simulated via “graze” actions. 
+    /// Insect or other biological or mechanical damage to the canopy can be simulated via “graze” actions.
     ///
-    /// Many sugarcane crops are “hilled-up” early in canopy development, an operation that involves the movement of soil from the interrow to the crop row. 
-    /// This operation facilitates irrigation operations and improves the crop's ability to stand upright. 
-    /// APSIM-Sugarcane responds to a management event of hilling-up by removal of lower leaf area and stem from the biomass pools. 
+    /// Many sugarcane crops are “hilled-up” early in canopy development, an operation that involves the movement of soil from the interrow to the crop row.
+    /// This operation facilitates irrigation operations and improves the crop's ability to stand upright.
+    /// APSIM-Sugarcane responds to a management event of hilling-up by removal of lower leaf area and stem from the biomass pools.
     ///
-    /// Lodging is a widespread phenomenon in high-yielding sugarcane crops. 
-    /// The APSIM-MANAGER [mccown_apsim:_1996] can initiate a lodging event in response to any aspect of the system state (eg crop size, time of year and weather). 
+    /// Lodging is a widespread phenomenon in high-yielding sugarcane crops.
+    /// The APSIM-MANAGER [mccown_apsim:_1996] can initiate a lodging event in response to any aspect of the system state (eg crop size, time of year and weather).
     /// APSIM SUGARCANE responds to lodging via four effects:
     ///
     /// A low rate of stalk death which has been widely observed in heavily lodged crops (Muchow et al., 1995; Robertson et al., 1996)[singh_lodging_2002];
@@ -260,15 +260,15 @@ namespace Models
     ///
     /// A reduction in the maximum number of green leaves, to capture the reported reduction in leaf appearance rate and increase in leaf senescence [singh_lodging_2002]
     ///
-    /// 
+    ///
     /// ##Parameterisation
     ///
     /// **(Structure of the xml in the .apsimx file)**
     ///
-    /// There are **4** separate categories of variables in the Sugarcane modules xml. 
+    /// There are **4** separate categories of variables in the Sugarcane modules xml.
     ///
     /// They are listed below with some examples of the type of parameters included in each.
-    ///    
+    ///
     /// 1. **Constants**
     ///     * Upper and lower bounds for met and soil variables
     /// 2. **Plant_crop**
@@ -285,59 +285,59 @@ namespace Models
     ///         * Sucrose and Cane Stalk  (Partitioning Parameters)
     ///      * **Ratoon Crop Cultivar**
     ///         * Same as for the Plant Crop Cultivar
-    ///         * ***By creating a completely new cultivar with the same name as the plant crop cultivar but appending "_ratoon" to the end of the name, 
-    ///      the Sugarcane module will then automatically use this ratoon crop cultivar rather then the plant crop cultivar 
+    ///         * ***By creating a completely new cultivar with the same name as the plant crop cultivar but appending "_ratoon" to the end of the name,
+    ///      the Sugarcane module will then automatically use this ratoon crop cultivar rather then the plant crop cultivar
     ///      when the crop changes from a Plant Crop to a Ratoon Crop.***
-    /// 
-    /// 
-    /// 
+    ///
+    ///
+    ///
     /// **Sugar Module Outputs**
     ///
     ///
-    /// |Variable Name  | Units      | Description                                                               
-    /// |---------------|:-----------|:-------------------------------------------------------------------------- 
-    /// |Stage_name     |            | Name of the current crop growth stage                                     
-    /// |Stage          |            | Current growth stage number                                               
-    /// |Crop_status    |            | Status of the current crop (alive,dead,out)                               
+    /// |Variable Name  | Units      | Description
+    /// |---------------|:-----------|:--------------------------------------------------------------------------
+    /// |Stage_name     |            | Name of the current crop growth stage
+    /// |Stage          |            | Current growth stage number
+    /// |Crop_status    |            | Status of the current crop (alive,dead,out)
     /// |ratoon_no      |            | Ratoon number (0 for plant crop, 1 for 1st ratoon, 2 for 2nd ratoon, …etc)
-    /// |das            | Days       | Days after sowing (ie. crop duration)                                     
-    /// |Ep             | mm         | Crop evapotranspiration (extraction) for each soil layer                  
-    /// |cep            | mm         | Cumulative plant evapotranspiration                                       
-    /// |rlv            | mm/mm^3    | root length per volume of soil in each soil layer                         
-    /// |esw            | mm         | Extractable Soil water in each soil layer                                 
-    /// |root_depth     | mm         | Root depth                                                                
-    /// |sw_demand      | mm         | Daily demand for soil water                                               
-    /// |biomass        | g/m^2      | Total crop above-ground biomass (Green + Trash)                           
-    /// |green_biomass  | g/m^2      | Total green crop above-ground biomass                                     
-    /// |biomass_n      | g/m^2      | Total Nitrogen in above-ground biomass (Green + Trash)                    
-    /// |green_biomass_n| g/m^2      | Amount of Nitrogen in green above-ground biomass                          
-    /// |dlt_dm         | g/m^2      | Daily increase in plant dry matter (photosynthesis)                       
-    /// |dm_senesced    | g/m^2      | Senesced dry matter in each plant pool                                    
-    /// |n_senesced     | g/m^2      | Amount of Nitrogen in senesced material for each plant pool               
-    /// |Canefw         | t/ha       | Fresh Cane weight                                                         
-    /// |ccs            | %          | Commercial Cane Sugar                                                     
-    /// |Cane_wt        | g/m^2      | Weight of cane dry matter                                                 
-    /// |leaf_wt        | g/m^2      | Weight of plant green leaf                                                
-    /// |root_wt        | g/m^2      | Weight of plant roots                                                     
-    /// |sstem_wt       | g/m^2      | Weight of plant structural stem                                           
-    /// |sucrose_wt     | g/m^2      | Weight of plant sucrose                                                   
-    /// |cabbage_wt     | g/m^2      | Weight of plant cabbage                                                   
-    /// |n_conc_cane    | g/g        | Nitrogen concentration in cane                                            
-    /// |n_conc_leaf    | g/g        | Nitrogen concentration in green leaf                                      
-    /// |n_conc_cabbage | g/g        | Nitrogen concentration in green cabbage                                   
-    /// |n_demand       | g/m^2      | Daily demand for Nitrogen                                                 
-    /// |cover_green    | 0-1        | Fractional cover by green plant material                                  
-    /// |cover_tot      | 0-1        | Fractional cover by total plant material (Green + Trash)                  
-    /// |lai            | mm^2/mm^2  | Leaf area index of green leaves                                           
-    /// |tlai           | mm^2/mm^2  | Total plant leaf area index (green + senesced)                            
-    /// |slai           | mm^2/mm^2  | Senesced leaf area index                                                  
-    /// |n_leaf_crit    | g/m^2      | Critical Nitrogen level for the current crop                              
-    /// |n_leaf_min     | g/m^2      | Minimum Nitrogen level for the current crop                               
-    /// |nfact_photo    | 0-1        | Nitrogen stress factor for photosynthesis                                 
-    /// |nfact_expan    | 0-1        | Nitrogen stress factor for cell expansion                                 
-    /// |swdef_photo    | 0-1        | Soil water stress factor for photosynthesis                               
-    /// |swdef_expan    | 0-1        | Soil water stress factor for cell expansion                               
-    /// |swdef_phen     | 0-1        | Soil water stress factor for phenology                                    
+    /// |das            | Days       | Days after sowing (ie. crop duration)
+    /// |Ep             | mm         | Crop evapotranspiration (extraction) for each soil layer
+    /// |cep            | mm         | Cumulative plant evapotranspiration
+    /// |rlv            | mm/mm^3    | root length per volume of soil in each soil layer
+    /// |esw            | mm         | Extractable Soil water in each soil layer
+    /// |root_depth     | mm         | Root depth
+    /// |sw_demand      | mm         | Daily demand for soil water
+    /// |biomass        | g/m^2      | Total crop above-ground biomass (Green + Trash)
+    /// |green_biomass  | g/m^2      | Total green crop above-ground biomass
+    /// |biomass_n      | g/m^2      | Total Nitrogen in above-ground biomass (Green + Trash)
+    /// |green_biomass_n| g/m^2      | Amount of Nitrogen in green above-ground biomass
+    /// |dlt_dm         | g/m^2      | Daily increase in plant dry matter (photosynthesis)
+    /// |dm_senesced    | g/m^2      | Senesced dry matter in each plant pool
+    /// |n_senesced     | g/m^2      | Amount of Nitrogen in senesced material for each plant pool
+    /// |Canefw         | t/ha       | Fresh Cane weight
+    /// |ccs            | %          | Commercial Cane Sugar
+    /// |Cane_wt        | g/m^2      | Weight of cane dry matter
+    /// |leaf_wt        | g/m^2      | Weight of plant green leaf
+    /// |root_wt        | g/m^2      | Weight of plant roots
+    /// |sstem_wt       | g/m^2      | Weight of plant structural stem
+    /// |sucrose_wt     | g/m^2      | Weight of plant sucrose
+    /// |cabbage_wt     | g/m^2      | Weight of plant cabbage
+    /// |n_conc_cane    | g/g        | Nitrogen concentration in cane
+    /// |n_conc_leaf    | g/g        | Nitrogen concentration in green leaf
+    /// |n_conc_cabbage | g/g        | Nitrogen concentration in green cabbage
+    /// |n_demand       | g/m^2      | Daily demand for Nitrogen
+    /// |cover_green    | 0-1        | Fractional cover by green plant material
+    /// |cover_tot      | 0-1        | Fractional cover by total plant material (Green + Trash)
+    /// |lai            | mm^2/mm^2  | Leaf area index of green leaves
+    /// |tlai           | mm^2/mm^2  | Total plant leaf area index (green + senesced)
+    /// |slai           | mm^2/mm^2  | Senesced leaf area index
+    /// |n_leaf_crit    | g/m^2      | Critical Nitrogen level for the current crop
+    /// |n_leaf_min     | g/m^2      | Minimum Nitrogen level for the current crop
+    /// |nfact_photo    | 0-1        | Nitrogen stress factor for photosynthesis
+    /// |nfact_expan    | 0-1        | Nitrogen stress factor for cell expansion
+    /// |swdef_photo    | 0-1        | Soil water stress factor for photosynthesis
+    /// |swdef_expan    | 0-1        | Soil water stress factor for cell expansion
+    /// |swdef_phen     | 0-1        | Soil water stress factor for phenology
     ///
     /// </remarks>
     [Serializable]
@@ -366,18 +366,18 @@ namespace Models
         /// <summary>
         /// Gets the LAI (m^2/m^2)
         /// </summary>
-        public double LAI 
-        { 
-            get 
-            { 
-                return lai; 
-            } 
-            set 
+        public double LAI
+        {
+            get
+            {
+                return lai;
+            }
+            set
             {
                 var delta = g_lai - value;
                 g_lai -= delta;
-                g_slai += delta; 
-            } 
+                g_slai += delta;
+            }
         }
 
         /// <summary>
@@ -442,7 +442,7 @@ namespace Models
         /// The clock
         /// </summary>
         [Link]
-        private Clock Clock = null;
+        private IClock Clock = null;
 
 
         /// <summary>
@@ -451,7 +451,7 @@ namespace Models
         [Link]
         private IWeather Weather = null;
 
-        
+
         //[Link]
         //private MicroClimate MicroClim; //added for fr_intc_radn_ , but don't know what the corresponding variable is in MicroClimate.
 
@@ -467,7 +467,7 @@ namespace Models
         ISoilWater waterBalance = null;
 
         /// <summary>Access the soil physical properties.</summary>
-        [Link] 
+        [Link]
         private IPhysical soilPhysical = null;
 
         /// <summary>
@@ -479,7 +479,7 @@ namespace Models
         /// <summary>Link to NO3 solute.</summary>
         [Link(ByName = true)]
         private ISolute NO3 = null;
-        
+
         /// <summary>Link to NH4 solute.</summary>
         [Link(ByName = true)]
         private ISolute NH4 = null;
@@ -679,7 +679,7 @@ namespace Models
         //*     ===========================================================
 
 
-      
+
         //[Output]
         /// <summary>
         /// Gets or sets the crop_type.
@@ -736,7 +736,7 @@ namespace Models
 
         //if (n_uptake_option == 1) then
 
-        //! time constant for uptake by  diffusion (days). H van Keulen && NG Seligman. Purdoe 1987. 
+        //! time constant for uptake by  diffusion (days). H van Keulen && NG Seligman. Purdoe 1987.
         //! This is the time it would take to take up by diffusion the current amount of N if it wasn't depleted between time steps
         //[Param(IsOptional = true, MinVal = 0.0, MaxVal = 100.0, Name = "no3_diffn_const")]
         /// <summary>
@@ -1126,7 +1126,7 @@ namespace Models
 
         #region Crop Constants (for Plant/Ratoon)
 
-    
+
         //[XmlElement("plant")]   //this let you override what xml element to look for in the xml. Instead of looking for the variable name.
         /// <summary>
         /// Gets or sets the plant.
@@ -1223,7 +1223,7 @@ namespace Models
             //    {
             //    ISoilCrop ISugarcane = Soil.Crop("Sugarcane");
             //    SoilCrop Sugarcane = (SoilCrop)ISugarcane; //don't need to use As keyword because Soil.Crop() will throw the exception if not found
-            //    return Sugarcane.XF; 
+            //    return Sugarcane.XF;
             //    }
             //}
 
@@ -1331,7 +1331,7 @@ namespace Models
         //! -------------
 
         //TODO: this is supposed to be mapped to fr_intc_radn without the last underscore, but [INPUT] does not allow renaming like [Param] does. So I have rename all fr_intc_radn to fr_intc_radn_
-        //need to remove the local variable fr_intc_radn as well. 
+        //need to remove the local variable fr_intc_radn as well.
         //[ MinVal=0.0, MaxVal=1.0]
         //[Input(IsOptional = true)]
         /// <summary>
@@ -2192,7 +2192,7 @@ namespace Models
         //double      frost_kill;             //! temperature threshold for leaf death (oC)
         //int         num_dead_lfno;
         //int         num_factors;            //! size_of of table
-        //int         num_x_swdef_cellxp;        
+        //int         num_x_swdef_cellxp;
         //double      leaf_no_min;            //! lower limit of leaf number ()
         //double      leaf_no_max;            //! upper limit of leaf number ()
 
@@ -2390,7 +2390,7 @@ namespace Models
         //    //*+  Purpose
         //    //*       Zero parameter variables and arrays
 
-        //    //sv- variables read in from the ini/sim file or calculated from what was read in. 
+        //    //sv- variables read in from the ini/sim file or calculated from what was read in.
         //    //sv- Parameter as in [Param]
 
 
@@ -2821,7 +2821,7 @@ namespace Models
 
         //            new_index = (int)(i_index_ob + Math.Min(1.0, i_dlt_index));
 
-        //            if ((i_index_ob % 1.0) == 0.0) 
+        //            if ((i_index_ob % 1.0) == 0.0)
         //                {
         //                fract_in_old = 1.0 - ((index_devel - 1.0) / i_dlt_index);
         //                portion_in_old = fract_in_old * (i_value + i_array_zb[zb(current_index)] - i_array_zb[zb(current_index)]);
@@ -2919,7 +2919,7 @@ namespace Models
                 //if the (index's decimal remainder + delta) is large enough to make the value go into a new index then when need to split the value proportionally.
                 if (l_index_devel >= 1.0)
                     {
-                    //! now we need to divvy 
+                    //! now we need to divvy
 
                     l_new_index = (int)(i_index_zb + Math.Min(1.0, i_dlt_index));
 
@@ -2971,8 +2971,8 @@ namespace Models
             {
             /*
             double margin_val;
-            //error margin = size of the variable mutiplied by error in the number 0. 
-            margin_val = Math.Abs(Variable) * double.Epsilon; 
+            //error margin = size of the variable mutiplied by error in the number 0.
+            margin_val = Math.Abs(Variable) * double.Epsilon;
             //if Variable was zero hence error margin is now zero
             if (margin_val == 0.0)
             {
@@ -3071,7 +3071,7 @@ namespace Models
                     break;
                     }
                 }
-            return count; //one based 
+            return count; //one based
             }
 
 
@@ -3085,7 +3085,7 @@ namespace Models
         private void AddArray(double[] AddThis_zb, ref double[] ToThis_zb, int NumElemToAdd_ob)
             {
 
-            // subroutine Add_real_array (amount, store, dimen) 
+            // subroutine Add_real_array (amount, store, dimen)
             //!+ Purpose
             //!     add contents of each element of an array to each element of another
             //!     array.
@@ -3745,9 +3745,9 @@ namespace Models
         /// <returns></returns>
         double cproc_transp_eff1(double c_svp_fract, double[] c_transp_eff_cf, double i_current_stage, double i_maxt, double i_mint)
             {
-            //sv- This function was taken from the "CropTemplate" module which as far as I can tell seems to be a precursor to the "Plant" module. 
-            //    It looks like it is a library of plant/crop functions that different crop modules have in common and so use. 
-            //    Specifically this function comes from the crp_wtr.f90 file (Line 864). 
+            //sv- This function was taken from the "CropTemplate" module which as far as I can tell seems to be a precursor to the "Plant" module.
+            //    It looks like it is a library of plant/crop functions that different crop modules have in common and so use.
+            //    Specifically this function comes from the crp_wtr.f90 file (Line 864).
 
             //sv- Also replaces the following function.
             //*     ===========================================================
@@ -3793,8 +3793,8 @@ namespace Models
             //!       representative of the positive net radiation (rn).  Daily SVP
             //!       should be integrated from about 0900 hours to evening when Radn
             //!       becomes negative.
-         
-            //!+  Local Variables       
+
+            //!+  Local Variables
             double l_vpd;           //! vapour pressure deficit (kpa)
             int l_current_phase;
 
@@ -3809,7 +3809,7 @@ namespace Models
 
 
             //sv- taken from FortranInfrastructure module, ConvertModule.f90
-            const double g2mm = 1.0e3 / 1.0e6;          //! convert g water per m^2 to mm water   
+            const double g2mm = 1.0e3 / 1.0e6;          //! convert g water per m^2 to mm water
             //! 1 g water = 1 cm^3 water = 1,000 cubic mm, and
             //! 1 sq m = 1,000,000 sq mm
 
@@ -3817,15 +3817,15 @@ namespace Models
             // "transp_eff" units are (g/m^2/mm) or (g carbo per m^2 / mm water)
             //  because all other dm weights are in (g/m^2)
 
-            //! "transp_eff_cf" ("cf" stands for coefficient) is used to convert vpd to transpiration efficiency. 
-            //! Although the units are sometimes soley expressed as a pressure (kPa) it is really in the form:  
-            //      kPa * kg carbo per m^2 / kg water per m^2   and this can be converted to 
-            //      = kPa * g carbo per m^2 / g water per m^2     
+            //! "transp_eff_cf" ("cf" stands for coefficient) is used to convert vpd to transpiration efficiency.
+            //! Although the units are sometimes soley expressed as a pressure (kPa) it is really in the form:
+            //      kPa * kg carbo per m^2 / kg water per m^2   and this can be converted to
+            //      = kPa * g carbo per m^2 / g water per m^2
             //      = kPa * g carbo per m^2 * g2mm / g water per m^2 * g2mm
-            //      = (kPa * g carbo per m^2 / mm water) * g2mm 
-            //      = kPa * transp_eff * g2mm  
+            //      = (kPa * g carbo per m^2 / mm water) * g2mm
+            //      = kPa * transp_eff * g2mm
 
-            //hence, 
+            //hence,
             //     transp_eff = transp_eff_cf / kPa /g2mm
             //                = transp_eff_cf / vpd /g2mm
 
@@ -3882,7 +3882,7 @@ namespace Models
             //!       the temperatures are > -237.3 oC for the svp function.
 
             //! convert pressure mbar to kpa  //sv- taken from FortranInfrastructure module, ConvertModule.f90
-            double mb2kpa = 100.0 / 1000.0;    //! 1000 mbar = 100 kpa   
+            double mb2kpa = 100.0 / 1000.0;    //! 1000 mbar = 100 kpa
 
             return 6.1078 * Math.Exp(17.269 * temp_arg / (237.3 + temp_arg)) * mb2kpa;
             }
@@ -3908,12 +3908,12 @@ namespace Models
 
             double l_cover_green;
 
-            //cproc_sw_demand1() 
-            //! Return crop water demand from soil by the crop (mm) calculated by dividing (biomass production limited by radiation) by transpiration efficiency.       
+            //cproc_sw_demand1()
+            //! Return crop water demand from soil by the crop (mm) calculated by dividing (biomass production limited by radiation) by transpiration efficiency.
             //! get potential transpiration from potential carbohydrate production and transpiration efficiency
-            //Start - cproc_sw_demand1() 
+            //Start - cproc_sw_demand1()
             g_sw_demand_te = MathUtilities.Divide(i_dlt_dm_pot_rue, i_transp_eff, 0.0);
-            //End - cproc_sw_demand1()  
+            //End - cproc_sw_demand1()
 
             l_cover_green = 1.0 - Math.Exp(-crop.extinction_coef * i_lai);
 
@@ -3935,9 +3935,9 @@ namespace Models
         /// <returns></returns>
         double cproc_sw_demand_bound(double i_sw_demand_unbounded, double i_eo_crop_factor, double i_eo, double i_cover_green)
             {
-            //sv- This function was taken from the "CropTemplate" module which as far as I can tell seems to be a precursor to the "Plant" module. 
-            //    It looks like it is a library of plant/crop functions that different crop modules have in common and so use. 
-            //    Specifically this function comes from the crp_wtr.f90 file (Line 813). 
+            //sv- This function was taken from the "CropTemplate" module which as far as I can tell seems to be a precursor to the "Plant" module.
+            //    It looks like it is a library of plant/crop functions that different crop modules have in common and so use.
+            //    Specifically this function comes from the crp_wtr.f90 file (Line 813).
 
             //!     ===========================================================
             //      subroutine cproc_sw_demand_bound ()
@@ -5199,14 +5199,14 @@ namespace Models
 
 
 
-        //void cproc_phenology1(double g_previous_stage, double g_current_stage, int sowing_stage, int germ_stage, int end_development_stage, int start_stress_stage, int end_stress_stage , int max_stage,        
+        //void cproc_phenology1(double g_previous_stage, double g_current_stage, int sowing_stage, int germ_stage, int end_development_stage, int start_stress_stage, int end_stress_stage , int max_stage,
         //                        double[] c_x_temp, double[] c_y_tt, double g_maxt, double g_mint, double g_nfact_pheno, double g_swdef_pheno, double c_pesw_germ, double[] c_fasw_emerg, double[] c_rel_emerg_rate, int c_num_fasw_emerg,
-        //                        double[] g_dlayer, int max_layer, double g_sowing_depth, 
-        //                        double[] g_sw_dep , double[] g_dul_dep , double[] p_ll_dep, 
+        //                        double[] g_dlayer, int max_layer, double g_sowing_depth,
+        //                        double[] g_sw_dep , double[] g_dul_dep , double[] p_ll_dep,
         //                        double g_dlt_tt, double[] g_phase_tt, double g_phase_devel, double g_dlt_stage, double[] g_tt_tot, double[] g_days_tot)
         //    {
 
-        //sv- MERGED INTO THE ONPROCESS EVENT HANDLER. 
+        //sv- MERGED INTO THE ONPROCESS EVENT HANDLER.
 
         //    //*     ===========================================================
         //    //      subroutine sugar_phenology ()
@@ -5240,7 +5240,7 @@ namespace Models
 
         //    g_dlt_tt = crop_thermal_time(c_x_temp, c_y_tt, g_current_stage, g_maxt, g_mint, start_stress_stage, end_stress_stage, g_nfact_pheno, g_swdef_pheno);
 
-        //    g_phase_devel = crop_phase_devel(sowing_stage, germ_stage, end_development_stage, 
+        //    g_phase_devel = crop_phase_devel(sowing_stage, germ_stage, end_development_stage,
         //                                        c_pesw_germ, c_fasw_emerg, c_rel_emerg_rate, c_num_fasw_emerg, g_current_stage, g_days_tot,
         //                                        g_dlayer, max_layer, g_sowing_depth, g_sw_dep, g_dul_dep, p_ll_dep, g_dlt_tt, g_phase_tt, g_tt_tot);
 
@@ -5922,7 +5922,7 @@ namespace Models
         //    //*     Calculate the initial leaf area
 
 
-        //    if (on_day_of(emerg, i_current_stage)) 
+        //    if (on_day_of(emerg, i_current_stage))
         //        {
         //        o_lai = c_initial_tpla * smm2sm * i_plants;
         //        o_leaf_area[0] = c_initial_tpla;
@@ -6006,7 +6006,7 @@ namespace Models
 
             l_area = sugar_leaf_size(c_leaf_size, c_leaf_size_no, c_tillerf_leaf_size, c_tillerf_leaf_size_no, l_leaf_no_effective_ob);
 
-            //Console.WriteLine("dlt_leaf_no, area, plants: " + i_dlt_leaf_no + " , " + l_area + " , " + i_plants);  
+            //Console.WriteLine("dlt_leaf_no, area, plants: " + i_dlt_leaf_no + " , " + l_area + " , " + i_plants);
 
             return i_dlt_leaf_no * l_area * smm2sm * i_plants;
 
@@ -6055,14 +6055,14 @@ namespace Models
 
             //l_leaf_size = au.linear_interp_real(i_leaf_no_ob, c_leaf_size_no, c_leaf_size, cult.num_leaf_size);
 
-            //Console.WriteLine("c_leaf_size: " + c_leaf_size[0] + " , " + c_leaf_size[1] +" , " + c_leaf_size[2]);  
+            //Console.WriteLine("c_leaf_size: " + c_leaf_size[0] + " , " + c_leaf_size[1] +" , " + c_leaf_size[2]);
             //Console.WriteLine(" c_leaf_size: " + c_leaf_size.Length);
 
-            //Console.WriteLine("leaf no, num leaf size: " + i_leaf_no_ob + " , " + cult.num_tillerf_leaf_size);  
+            //Console.WriteLine("leaf no, num leaf size: " + i_leaf_no_ob + " , " + cult.num_tillerf_leaf_size);
 
             //l_tiller_factor = au.linear_interp_real(i_leaf_no_ob, c_tillerf_leaf_size_no, c_tillerf_leaf_size, cult.num_tillerf_leaf_size);
 
-            //Console.WriteLine("leaf size, tiller_factor: " + l_leaf_size + " , " + l_tiller_factor);  
+            //Console.WriteLine("leaf size, tiller_factor: " + l_leaf_size + " , " + l_tiller_factor);
 
             return l_leaf_size * l_tiller_factor;
 
@@ -6122,8 +6122,8 @@ namespace Models
 
             //when water stress occurs the plant is not able to get all the water it needs.
             //it can only get what is available (ie. sw_supply)
-            //So based on the water that the plant was able to get, 
-            //we need to work out how much biomass it could grow. 
+            //So based on the water that the plant was able to get,
+            //we need to work out how much biomass it could grow.
             //biomass able to be grown(g) = transp_eff(g/mm) * supply(mm)
 
 
@@ -6682,7 +6682,7 @@ namespace Models
             bool l_didInterpolate;
 
 
-            l_stress_factor_min = Math.Min(i_swdef_stalk, Math.Min(i_nfact_stalk, i_temp_stress_stalk));   //get the minimum of any of the 3 values. 
+            l_stress_factor_min = Math.Min(i_swdef_stalk, Math.Min(i_nfact_stalk, i_temp_stress_stalk));   //get the minimum of any of the 3 values.
 
             //! this should give same results as old version for now
 
@@ -7692,10 +7692,10 @@ namespace Models
             //TODO: THIS LOOKS LIKE A BUG IN THE SUGAR CODE. They just zero it, they don't set dlt_N_retrans to N_avail.
 
             //TODO: nb. The way this code is written at the moment there is NO RETRANSLOCATION.
-            //          This function is pointless. 
+            //          This function is pointless.
             //          The way it should work is to look at which plant parts in N_avail are negative (ie. need to be given N from other parts)
             //          and look at which plant parts are positive (ie. have N to give to other parts)
-            //          Then this code needs to move N from the postive to the negative. 
+            //          Then this code needs to move N from the postive to the negative.
             //          If there is more positive than negative, then this is fine
             //          BUT if there is more negative than positive, then a decision needs to be made on which parts with negative values get given
             //          the limited amount of N from the parts that have postive values. Which organs have priority for retranslocation when N_avail is limited.
@@ -8274,7 +8274,7 @@ namespace Models
             //*     Get the nitrogen uptake information
 
             //TODO: Uncomment Below to let SWIM do Nitrogen Uptake. Also need to uncomment crop_get_ext_uptakes() subroutine below.
-            //if (uptake_source == "apsim") 
+            //if (uptake_source == "apsim")
             //    {
             //        //! NIH - note that I use a -ve conversion factor FOR NOW to make it a delta.
             //        crop_get_ext_uptakes(
@@ -8288,7 +8288,7 @@ namespace Models
             //                  ,max_layer         //! array dim
             //                  );
             //    }
-            //else if (i_option == 1) 
+            //else if (i_option == 1)
             if (i_option == 1)
                 {
                 cproc_N_uptake1(NO3_diffn_const,
@@ -8320,7 +8320,7 @@ namespace Models
 
 
 
-        //void crop_get_ext_uptakes (string i_uptake_source, string i_crop_type , string i_uptake_type, double i_unit_conversion_factor, 
+        //void crop_get_ext_uptakes (string i_uptake_source, string i_crop_type , string i_uptake_type, double i_unit_conversion_factor,
         //                            double i_uptake_lbound, double i_uptake_ubound, ref double[] o_uptake_array, int i_max_layer)
         //    {
 
@@ -8354,7 +8354,7 @@ namespace Models
 
 
 
-        //    if ((i_uptake_source == "apsim")  && (i_crop_type != "")) 
+        //    if ((i_uptake_source == "apsim")  && (i_crop_type != ""))
         //        {
         //         //! NB - if crop type is blank then swim will know nothing
         //         //! about this crop (eg if not initialised yet)
@@ -8640,7 +8640,7 @@ namespace Models
 
 
             int l_deepest_layer_ob;         //! deepest layer in which the roots are growing
-            double l_plant_part_fract;      //! fraction of nitrogen to use (0-1) for plant part                
+            double l_plant_part_fract;      //! fraction of nitrogen to use (0-1) for plant part
             double l_N_demand;              //! total nitrogen demand (g/m^2)
             double l_N_uptake_sum;          //! total plant N uptake (g/m^2)
 
@@ -9109,16 +9109,16 @@ namespace Models
         //        }
 
 
-        //    cproc_dm_detachment1(max_part, 
-        //                        crop.sen_detach_frac, g_dm_senesced, ref g_dlt_dm_detached, 
+        //    cproc_dm_detachment1(max_part,
+        //                        crop.sen_detach_frac, g_dm_senesced, ref g_dlt_dm_detached,
         //                        crop.dead_detach_frac, g_dm_dead, ref g_dlt_dm_dead_detached);
 
-        //    cproc_n_detachment1(max_part, 
-        //                        crop.sen_detach_frac, g_n_senesced, ref g_dlt_n_detached, 
+        //    cproc_n_detachment1(max_part,
+        //                        crop.sen_detach_frac, g_n_senesced, ref g_dlt_n_detached,
         //                        crop.dead_detach_frac, g_n_dead, ref g_dlt_n_dead_detached);
 
-        //    cproc_lai_detachment1(leaf, 
-        //                        crop.sen_detach_frac, g_slai, ref g_dlt_slai_detached, 
+        //    cproc_lai_detachment1(leaf,
+        //                        crop.sen_detach_frac, g_slai, ref g_dlt_slai_detached,
         //                        crop.dead_detach_frac, g_tlai_dead, ref g_dlt_tlai_dead_detached);
 
 
@@ -9656,7 +9656,7 @@ namespace Models
 
             //! detached leaf area needs to be accounted for
 
-            //sv-work out delta in "leaf area" and "leaf dm" caused by senescence. (per plant)  
+            //sv-work out delta in "leaf area" and "leaf dm" caused by senescence. (per plant)
             l_dlt_leaf_area_sen = MathUtilities.Divide(i_dlt_slai_detached, io_plants, 0.0) * sm2smm;
             l_dlt_leaf_dm_sen = MathUtilities.Divide(i_dlt_dm_detached[leaf], io_plants, 0.0);
 
@@ -9665,18 +9665,18 @@ namespace Models
             l_num_leaves = max_leaf;
 
             bool l_found_first_nonsenesced = false;
-            int l_empty_leaves_ob = 0;       //! number of empty leaf records    
+            int l_empty_leaves_ob = 0;       //! number of empty leaf records
             //int l_leaf_rec;                   //! leaf record number
 
             //sv- keep looping through all the leaves starting from the bottom, until delta is all used up.
             for (int leaf_rec = 0; leaf_rec < l_num_leaves; leaf_rec++)
                 {
                 //DO LEAF AREA DELTA
-                //sv- if the area of this leaf is less than or equal to the delta  
+                //sv- if the area of this leaf is less than or equal to the delta
                 if (io_leaf_area[leaf_rec] <= l_dlt_leaf_area_sen)
                     {
-                    //sv- if leaf area is zero, this will execute but have no effect.                                 
-                    l_dlt_leaf_area_sen = l_dlt_leaf_area_sen - io_leaf_area[leaf_rec];     //sv- then reduce the delta by the area of this leaf. 
+                    //sv- if leaf area is zero, this will execute but have no effect.
+                    l_dlt_leaf_area_sen = l_dlt_leaf_area_sen - io_leaf_area[leaf_rec];     //sv- then reduce the delta by the area of this leaf.
                     io_leaf_area[leaf_rec] = 0.0;                                   //sv- set the leaf area of this leaf to zero because it has fully senesced.
                     }
                 else
@@ -9700,7 +9700,7 @@ namespace Models
 
                 //SET THE LAST SENESCED LEAF
                 //sv- if this leaf has not fully senesced, and it is the first one we have come across that has not. (starting from the bottom leaf)
-                //    (due to the loop not terminating, We will come across all the other leaves above this leaf, that are not senesced as well.)                                                              
+                //    (due to the loop not terminating, We will come across all the other leaves above this leaf, that are not senesced as well.)
                 if ((io_leaf_dm[leaf_rec] > 0.0) && (l_found_first_nonsenesced == false))
                     {
                     l_found_first_nonsenesced = true;
@@ -9709,7 +9709,7 @@ namespace Models
                     }
                 }
 
-            //sv- Remove the leaf, by removing it's information from leaf_area and leaf_dm, 
+            //sv- Remove the leaf, by removing it's information from leaf_area and leaf_dm,
             //    by moving all the elements in the array down by one index, and then throwing away the first element.
             if (l_found_first_nonsenesced && (l_empty_leaves_ob > 0))
                 {
@@ -9726,12 +9726,12 @@ namespace Models
                     io_leaf_dm[leaf_rec_to_drop_to] = io_leaf_dm[leaf_rec];
                     io_leaf_area[leaf_rec_to_drop_to] = io_leaf_area[leaf_rec];
 
-                    //sv- zero the old indexes 
+                    //sv- zero the old indexes
                     io_leaf_dm[leaf_rec] = 0.0;
                     io_leaf_area[leaf_rec] = 0.0;
 
                     }
-              
+
                 }
 
 
@@ -9745,7 +9745,7 @@ namespace Models
             //    io_leaf_dm[leaf_rec] = io_leaf_dm[leaf_rec + 1];
             //    io_leaf_area[leaf_rec] = io_leaf_area[leaf_rec + 1];
 
-            //    //sv- zero the old indexes 
+            //    //sv- zero the old indexes
             //    io_leaf_dm[leaf_rec + 1] = 0.0;
             //    io_leaf_area[leaf_rec + 1] = 0.0;
             //    }
@@ -10001,7 +10001,7 @@ namespace Models
             //!      stage number of %1
 
 
-            //sv- IMPORTANT - Once again to avoid any confusion I changed the error code from 0 to -1 
+            //sv- IMPORTANT - Once again to avoid any confusion I changed the error code from 0 to -1
             //sv-             even though stage no's are 1 based and 0 does not cause an issue as an error return value
 
             string l_warn_message;     //! err message
@@ -10051,7 +10051,7 @@ namespace Models
             //!+  Definition
             //!     Returns the index of the first element of of the
             //!     "array_size" elements of "array" that compares equal to
-            //!     "number".  Returns 0 if there are none. 
+            //!     "number".  Returns 0 if there are none.
 
             //!+  Mission Statement
             //!      position of %1 in array %2
@@ -10613,7 +10613,7 @@ namespace Models
         /// The node_no_detached.
         /// </value>
         [Units("()")]
-        public double node_no_detached //scalar not an array. Which is why it is one based. 
+        public double node_no_detached //scalar not an array. Which is why it is one based.
         { get { return g_node_no_detached_ob; } }
 
 
@@ -11033,7 +11033,7 @@ namespace Models
         /// <summary>
         /// Gets the cane_dmf.
         /// Cane Dry Matter Fraction.
-        /// The Millable Stalk divided by the Millable Stalk (FRESH). 
+        /// The Millable Stalk divided by the Millable Stalk (FRESH).
         /// nb. Millable Stalk is only the green "structual stem" and "sucrose".
         /// nb. Fresh refers to when the Cane has just been cut and still has high water content
         ///     hence we add some extra water to the weight.
@@ -11099,7 +11099,7 @@ namespace Models
                 double l_scmstf = MathUtilities.Divide(g_dm_green[sucrose], l_canefw, 0.0);
                 double l_ccs = 1.23 * l_scmstf - 0.029;
                 l_ccs = l_bound(l_ccs, 0.0);
-                l_ccs = l_ccs * 100.0;          //! convert to %             
+                l_ccs = l_ccs * 100.0;          //! convert to %
                 return l_ccs;
                 }
             }
@@ -11296,7 +11296,7 @@ namespace Models
 
         /// <summary>
         /// Gets the partition_xs.
-        /// Todays excess biomass. 
+        /// Todays excess biomass.
         /// Not needed after partitioning todays biomass to plant organs.
         /// </summary>
         /// <value>
@@ -11343,7 +11343,7 @@ namespace Models
         public double[] dlt_dm_detached
         { get { return mu.RoundArray(g_dlt_dm_detached,2); } }
 
-        
+
 
 
         // Reporting of N concentrations
@@ -11839,13 +11839,13 @@ namespace Models
         //! plant nitrogen
         //****************
 
-        //TODO: This is always 0 because g_N_uptake_tot is always 0 because no accumulation is actually ever done. 
+        //TODO: This is always 0 because g_N_uptake_tot is always 0 because no accumulation is actually ever done.
         //Obviously no one uses this output variable because no one has compalined about this bug. Probably should be n_uptake = no3_uptake + nh4_uptake
         //if you remove it, also remove g_N_uptake_tot
 
         //[Units("(kg/ha)")] double n_uptake
-        //   { 
-        //    get 
+        //   {
+        //    get
         //        {
         //        double act_N_up = g_N_uptake_tot * gm2kg /sm2ha;
         //        return act_N_up;
@@ -12044,7 +12044,7 @@ namespace Models
         /// Is the plant alive?
         /// </summary>
         [JsonIgnore]
-        public bool IsAlive 
+        public bool IsAlive
             {
             get
                 {
@@ -12053,7 +12053,7 @@ namespace Models
                 else
                     return false;
                 }
-            
+
             }
 
         /// <summary>Returns true if the crop is ready for harvesting</summary>
@@ -12066,7 +12066,7 @@ namespace Models
         /// Gets a list of cultivar names
         /// </summary>
         [JsonIgnore]
-        public string[] CultivarNames 
+        public string[] CultivarNames
             {
             get
                 {
@@ -12086,7 +12086,7 @@ namespace Models
         /// <param name="soilstate"></param>
         /// <returns></returns>
         /// <exception cref="System.NotImplementedException"></exception>
-        public List<ZoneWaterAndN> GetWaterUptakeEstimates(SoilState soilstate)  
+        public List<ZoneWaterAndN> GetWaterUptakeEstimates(SoilState soilstate)
             {
                 throw new NotImplementedException();
             }
@@ -12133,7 +12133,7 @@ namespace Models
             {
             SowNewPlant(population, depth, cultivar);
             }
-       
+
 
 
 
@@ -12163,14 +12163,14 @@ namespace Models
         /// </exception>
         void CheckAllNUptakeOptionalsReadIn()
             {
-            //sugar_read_constants () has an "if" statment in it. 
-            //I have replicated this by trying to read in both lots of variables in (for either case of the if statement) from the ini file. 
-            //This function is then used to make sure that given the specific "n_uptake_option" that all the variables this specific option needs has non zero values. 
+            //sugar_read_constants () has an "if" statment in it.
+            //I have replicated this by trying to read in both lots of variables in (for either case of the if statement) from the ini file.
+            //This function is then used to make sure that given the specific "n_uptake_option" that all the variables this specific option needs has non zero values.
             if (n_uptake_option == 1)
                 {
-                
+
                 //(HOW TO TEST FOR NaN properly, WARNING: (NO3_diffn_const == Double.NaN) does not work)
-                //http://msdn.microsoft.com/en-us/library/bb264491.aspx  
+                //http://msdn.microsoft.com/en-us/library/bb264491.aspx
 
                 if (Double.IsNaN(NO3_diffn_const) || (n_supply_preference == ""))
                     throw new ApsimXException(this, "Using n_uptake_option == 1 and missing either 'NO3_diffn_const' or 'n_supply_preference' from ini file");
@@ -12202,11 +12202,11 @@ namespace Models
 
             //TODO: implement the erosion stuff using a .net event handler rather than just doing another get and seeing if the number of layers has changed.
 
-            //sv- See Erosion Event Handler for where this has been moved to and commented out. 
+            //sv- See Erosion Event Handler for where this has been moved to and commented out.
 
             //Figure out a .NET event way to implement this.
 
-            
+
             //      if (g%num_layers.eq.0) then
             //            ! we assume dlayer hasn't been initialised yet.
             //         call add_real_array (dlayer, g%dlayer, numvals)
@@ -12482,14 +12482,14 @@ namespace Models
 
                 //WATER LOGGING     //sv- also called in Process Event.
 
-                //sugar_water_log(1);       
+                //sugar_water_log(1);
                 g_oxdef_photo = crop_oxdef_photo1(crop.oxdef_photo, crop.oxdef_photo_rtfr, ll15_dep, sat_dep, sw_dep, dlayer, g_root_length, g_root_depth);
 
 
 
                 //BIOMASS(DRY MATTER) PRODUCTION     //sv- also called in Process Event.
 
-                //sugar_bio_RUE(1);         
+                //sugar_bio_RUE(1);
                 g_dlt_dm_pot_rue = sugar_dm_pot_rue(crop.rue, g_current_stage, g_radn_int, g_nfact_photo, g_temp_stress_photo, g_oxdef_photo, g_lodge_redn_photo);
                 g_dlt_dm_pot_rue_pot = sugar_dm_pot_rue_pot(crop.rue, g_current_stage, g_radn_int);
 
@@ -12506,7 +12506,7 @@ namespace Models
 
                 //sugar_water_demand(1);
                 g_sw_demand = sugar_water_demand(g_dlt_dm_pot_rue, g_transp_eff, g_lai, waterBalance.Eo);
- 
+
 
 
 
@@ -12686,7 +12686,7 @@ namespace Models
 
                     //sugar_leaf_no_init(1)
                     cproc_leaf_no_init1(crop.leaf_no_at_emerg, g_current_stage, emerg, ref g_leaf_no_zb, ref g_node_no_zb);     //! initialise total leaf number
-    
+
 
                     //sugar_leaf_no_pot(1)
                     cproc_leaf_no_pot1(crop.x_node_no_app, crop.y_node_app_rate, crop.x_node_no_leaf, crop.y_leaves_per_node,
@@ -12741,7 +12741,7 @@ namespace Models
                                 ref g_dm_green, ref g_leaf_dm_zb);
 
 
-                    //BIOMASS(DRY MATTER) PRODUCTION (choose between "water stressed" and "non water stressed")  
+                    //BIOMASS(DRY MATTER) PRODUCTION (choose between "water stressed" and "non water stressed")
 
 
 
@@ -12786,7 +12786,7 @@ namespace Models
 
 
 
-                    //BIOMASS(DRY MATTER) RETRANSLOCATION         
+                    //BIOMASS(DRY MATTER) RETRANSLOCATION
 
                     //sugar_bio_retrans(1)     //sugar_dm_retranslocate()
 
@@ -12852,7 +12852,7 @@ namespace Models
 
 
 
-                    //BIOMASS SENESCENCE (dm lost) (eg. leaf, cabbage, root) (nb. Leaf is the weight senesced not the area [as above]) 
+                    //BIOMASS SENESCENCE (dm lost) (eg. leaf, cabbage, root) (nb. Leaf is the weight senesced not the area [as above])
 
                     //sugar_sen_bio(1)
                     sugar_dm_senescence(crop.dm_root_sen_frac, crop.leaf_cabbage_ratio, crop.cabbage_sheath_fr,
@@ -13901,14 +13901,14 @@ namespace Models
         /// </summary>
         public void KillCrop()
             {
-            //      Kill crop and End Crop is used in other crop modules as part of the Crop Rotations. 
+            //      Kill crop and End Crop is used in other crop modules as part of the Crop Rotations.
             //      You want to kill the crop and set its status to dead but you want to leave it there until someone does a tillage event to plow it in just before they
             //      plant another crop.
             //      Killing also prevents another crop from being planted by the Crop Rotations manager. If you want the next crop in the rotation to be planted you then
             //      have to use the EndCrop command. EndCrop specifies the crop_status as "crop_out" which means that there is nothing in the ground and you can plant another crop.
             //      It will also get rid of the biomass.
             //      Perhaps we need to create a new Event for Sugarcane called "KillButRegrowCrop" which will kill the crop but let is start growing again.
-            //      I guess it will have to detach the dead biomass over time rather than tilling it back into the soil.  
+            //      I guess it will have to detach the dead biomass over time rather than tilling it back into the soil.
 
             sugar_kill_crop(ref g_crop_status, g_dm_dead, g_dm_green, g_dm_senesced);
             }
@@ -13927,7 +13927,7 @@ namespace Models
 
 
         //sv- Perhaps add a method to Harvest the crop but move the biomass to a supplement pool to feed to cattle and sheep, prawns etc.
-        //    Because animals don't actually graze sugarcane. Letting animals hard hooves onto a cane paddock would destroy the furrows used for flood irrigation. 
+        //    Because animals don't actually graze sugarcane. Letting animals hard hooves onto a cane paddock would destroy the furrows used for flood irrigation.
         //    You cut the cane and then feed it to the animal as a supplement.
 
         //[EventHandler]
@@ -14210,7 +14210,7 @@ namespace Models
 
                 num_layers = count_of_real_vals(dlayer, max_layer);
 
-                //sv- I added this resize, from max_layer to num_layer. 
+                //sv- I added this resize, from max_layer to num_layer.
                 //    Done so the NitrogenChanges.DeltaNO3 etc. gets an array of a sensible size.
                 Array.Resize(ref l_dlt_NO3, num_layers);
                 Array.Resize(ref l_dlt_NH4, num_layers);
@@ -14432,7 +14432,7 @@ namespace Models
 
                     //sv- FOMLayerType and FOMLayerLayerType are confusing but what I think they mean is,
                     //    FOMLayer means FOM "IN" the soil as opposed to "ON" the surface of the SOIL
-                    //    I think they already used the term FOMType for the Surface Residue so they needed a name 
+                    //    I think they already used the term FOMType for the Surface Residue so they needed a name
                     //    for the class when they were refering to FOM "in" the soil. So they used the term FOMLayer.
                     //    This then meant when they needed a name for the class for an actual specific Layer they
                     //    then used the silly name of FOMLayerLayer. Meaning a Layer of the FOMLayer type.
@@ -14619,7 +14619,7 @@ namespace Models
 
     }
 
-    
+
     }
 
 

--- a/Models/Summary.cs
+++ b/Models/Summary.cs
@@ -43,7 +43,7 @@
 
         /// <summary>A link to the clock in the simulation</summary>
         [Link]
-        private Clock clock = null;
+        private IClock clock = null;
 
         /// <summary>A link to the parent simulation</summary>
         [Link]
@@ -207,14 +207,14 @@
             // run, so we don't need to delete existing data in this call to WriteTable().
             storage.Writer.WriteTable(initConditions, false);
         }
-        
+
         #region Static summary report generation
 
         /// <summary>
         /// Write a single sumary file for all simulations.
         /// </summary>
         /// <param name="storage">The storage where the summary data is stored</param>
-        /// <param name="fileName">The file name to write</param>           
+        /// <param name="fileName">The file name to write</param>
         /// <param name="darkTheme">Whether or not the dark theme should be used.</param>
         public static void WriteSummaryToTextFiles(IDataStore storage, string fileName, bool darkTheme)
         {
@@ -231,7 +231,7 @@
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="simulationName"></param>
         public IEnumerable<Message> GetMessages(string simulationName)
@@ -257,7 +257,7 @@
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="simulationName"></param>
         public IEnumerable<InitialConditionsTable> GetInitialConditions(string simulationName)
@@ -346,7 +346,7 @@
 
             }
 
-            // Get the initial conditions table.            
+            // Get the initial conditions table.
             if (showInitialConditions)
             {
                 DataTable initialConditionsTable = storage.Reader.GetData(simulationNames: simulationName.ToEnumerable(), tableName:"_InitialConditions");
@@ -582,7 +582,7 @@
                             st = "Total";
                         else
                             st = row[i].ToString();
-                        
+
                         writer.Write("<td");
                         if (i == 0)
                             writer.Write(" class='col1'");

--- a/Models/Utilities/DebugLogger.cs
+++ b/Models/Utilities/DebugLogger.cs
@@ -27,7 +27,7 @@ namespace Models.Utilities
         Simulation simulation = null;
 
         [Link]
-        Clock clock = null;
+        IClock clock = null;
 
         /// <summary>At the start of the simulation set up LifeCyclePhases</summary>
         /// <param name="sender"></param>
@@ -55,7 +55,7 @@ namespace Models.Utilities
         /// <param name="includePrivates">Include privates when writing an object?</param>
         public void WriteObject(string name, object o, bool includePrivates = false)
         {
-            // Open and close the file every time we write because when debugging simulations 
+            // Open and close the file every time we write because when debugging simulations
             // they can crash with an exception which then means the writer isn't closed.
             using (StreamWriter writer = new StreamWriter(fileName, append: true))
             {

--- a/Tests/UnitTests/MockClock.cs
+++ b/Tests/UnitTests/MockClock.cs
@@ -12,5 +12,7 @@ namespace UnitTests
         public DateTime Today { get; set; }
         public int NumberOfTicks { get; set; }
         public double FractionComplete { get { return 1.0; } }
+        public DateTime StartDate { get; set; }
+        public DateTime EndDate { get; set; }
     }
 }


### PR DESCRIPTION
This pull request replaces the use of Clock with IClock in all of the models where Clock was used. This enables implementation of custom clocks, which I assume (hopefully correctly) is the reason that IClock exists.

The motivation for using a custom Clock for me is to be able to run simulation with daily time step trough Python.

I'm happy to make revisions based on feedback. After making the changes  874 tests pass and 13 fail.