### PR TITLE
Fix error reporting in the importer.

### DIFF
--- a/Models/Core/Apsim710File/Importer.cs
+++ b/Models/Core/Apsim710File/Importer.cs
@@ -137,8 +137,8 @@
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine(e.Message + " " + e.InnerException.Message);
-                    throw new Exception(e.Message + " " + e.InnerException.Message);
+                    Console.WriteLine(e.ToString());
+                    throw new Exception(e.ToString());
                 }
             }
             else
@@ -439,7 +439,7 @@
             }
             catch (Exception exp)
             {
-                throw new Exception("Cannot import " + compNode.Name + " :Error - " + exp.ToString() + "\n");
+                throw new Exception($"Cannot import {compNode.Name}.", exp);
             }
             return newNode;
         }
@@ -460,7 +460,7 @@
             if (srcNode != null)
             {
                 XmlNode arrayNode;
-                
+
                 // values are ppm
                 // find soil layers and values for NO3
                 arrayNode = XmlUtilities.Find(srcNode, "Thickness");
@@ -706,7 +706,7 @@
             this.CopyNodeAndValue(compNode, newNode, "DataSource", "DataSource", false);
             this.CopyNodeAndValue(compNode, newNode, "Comments", "Comments", false);
             this.AddChildComponents(compNode, newNode);
-            
+
             return newNode;
         }
 


### PR DESCRIPTION
Error reporting in the importer would often itself throw a null reference error, concealing the error that actually occurred. Exceptions thrown during import should now display properly in the UI.

Resolves #7723 