### PR TITLE
Fixes to cell editing in SheetView

### DIFF
--- a/ApsimNG/Views/Sheet/CellEditor.cs
+++ b/ApsimNG/Views/Sheet/CellEditor.cs
@@ -131,10 +131,23 @@ namespace UserInterface.Views
                 // It's important to call ToSheetEventKey() here, as that function
                 // contains logic for detecting unusual/non-standard return keys.
                 SheetEventKey key = args.Event.ToSheetEventKey();
-                if (key.Key == Keys.Return)
+                if (key.Key == Keys.Return || key.Key == Keys.Tab)
                 {
                     EndEdit();
-                    sheet.CellSelector.MoveDown();
+                    if (key.Key == Keys.Return)
+                        sheet.CellSelector.MoveDown(key.Shift);
+                    else if (key.Key == Keys.Tab)
+                    {
+                        // User has clicked tab to finish editing the cell. If this
+                        // row contains more cells to the right of the current cell
+                        // then move the selection right. Otherwise, move the
+                        // selection down.
+                        sheet.CellSelector.GetSelection(out int col, out _);
+                        if ( (col + 1) < sheet.DataProvider.ColumnCount)
+                            sheet.CellSelector.MoveRight(key.Shift);
+                        else
+                            sheet.CellSelector.MoveDown(key.Shift);
+                    }
                 }
             }
         }

--- a/ApsimNG/Views/Sheet/CellEditor.cs
+++ b/ApsimNG/Views/Sheet/CellEditor.cs
@@ -126,10 +126,16 @@ namespace UserInterface.Views
             {
                 EndEdit(saveEdit: false);
             }
-            else if (args.Event.Key == Gdk.Key.Return)
+            else
             {
-                EndEdit();
-                sheet.CellSelector.MoveDown();
+                // It's important to call ToSheetEventKey() here, as that function
+                // contains logic for detecting unusual/non-standard return keys.
+                SheetEventKey key = args.Event.ToSheetEventKey();
+                if (key.Key == Keys.Return)
+                {
+                    EndEdit();
+                    sheet.CellSelector.MoveDown();
+                }
             }
         }
     }

--- a/ApsimNG/Views/Sheet/GtkExtensions.cs
+++ b/ApsimNG/Views/Sheet/GtkExtensions.cs
@@ -20,7 +20,12 @@ namespace UserInterface.Views
                 keyParams.Key = Keys.PageUp;
             else if (evnt.Key == Gdk.Key.Page_Down)
                 keyParams.Key = Keys.PageDown;
-            else if (evnt.Key == Gdk.Key.Return)
+            else if (evnt.Key == Gdk.Key.Return || evnt.Key == Gdk.Key.KP_Enter
+                || evnt.Key == Gdk.Key.ISO_Enter || evnt.Key == Key.Key_3270_Enter)
+                // Note: ISO enter is the double-height enter key on ISO and JIS
+                // keyboards. 3270_Enter is the enter key on the old IBM 3270
+                // boards, which sits to the right of the spacebar. I'm going
+                // to include this for completeness' sake.
                 keyParams.Key = Keys.Return;
             else if (evnt.Key == Gdk.Key.Home)
                 keyParams.Key = Keys.Home;

--- a/ApsimNG/Views/Sheet/GtkExtensions.cs
+++ b/ApsimNG/Views/Sheet/GtkExtensions.cs
@@ -33,6 +33,9 @@ namespace UserInterface.Views
                 keyParams.Key = Keys.End;
             else if (evnt.Key == Gdk.Key.Delete)
                 keyParams.Key = Keys.Delete;
+            else if (evnt.Key == Gdk.Key.Tab || evnt.Key == Gdk.Key.KP_Tab
+                || evnt.Key == Gdk.Key.ISO_Left_Tab)
+                keyParams.Key = Keys.Tab;
             else
             {
                 string keyName = char.ConvertFromUtf32((int)Gdk.Keyval.ToUnicode((uint)evnt.KeyValue));

--- a/ApsimNG/Views/Sheet/GtkExtensions.cs
+++ b/ApsimNG/Views/Sheet/GtkExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Gdk;
+﻿using System;
+using Gdk;
 
 namespace UserInterface.Views
 {
@@ -28,7 +29,15 @@ namespace UserInterface.Views
             else if (evnt.Key == Gdk.Key.Delete)
                 keyParams.Key = Keys.Delete;
             else
-                keyParams.KeyValue = (char)evnt.KeyValue;
+            {
+                string keyName = char.ConvertFromUtf32((int)Gdk.Keyval.ToUnicode((uint)evnt.KeyValue));
+                if (!char.TryParse(keyName, out keyParams.KeyValue))
+                    // Fallback to previous behaviour. This shouldn't usually happen, but it's probably
+                    // possible, and this fallback is unlikely to work successfully. E.g. on my keyboard,
+                    // the KeyValue from numpad 1, when cast to char, yields 'ﾱ'.
+                    keyParams.KeyValue = (char)evnt.KeyValue;
+            }
+
             keyParams.Control = evnt.State == ModifierType.ControlMask;
             keyParams.Shift = evnt.State == ModifierType.ShiftMask;
             return keyParams;

--- a/ApsimNG/Views/Sheet/SheetEventKey.cs
+++ b/ApsimNG/Views/Sheet/SheetEventKey.cs
@@ -13,7 +13,8 @@
         Home,
         End,
         Return,
-        Delete
+        Delete,
+        Tab
     }
 
     public class SheetEventKey


### PR DESCRIPTION
Mainly related to the use of the numpad, although I've also added support for some other, more obscure keyboards. To be honest there is probably more to be done here: e.g. using tab/enter for grid cell navigation when *not* in edit mode (currently this does nothing).

Resolves #7738.