### PR TITLE
Changed project files to remove Jenkins error: NETSDK1152

### DIFF
--- a/APSIM.Cli/APSIM.Cli.csproj
+++ b/APSIM.Cli/APSIM.Cli.csproj
@@ -7,7 +7,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>apsim</AssemblyName>
     <SelfContained>false</SelfContained>
-</PropertyGroup>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="../APSIM.Shared/APSIM.Shared.csproj" />
@@ -15,5 +15,9 @@
     <ProjectReference Include="../Models/Models.csproj" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
   </ItemGroup>
+
+  <PropertyGroup>
+   <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
 
 </Project>

--- a/APSIM.Documentation/APSIM.Documentation.csproj
+++ b/APSIM.Documentation/APSIM.Documentation.csproj
@@ -15,5 +15,9 @@
 
     <EmbeddedResource Include="index.css" />
   </ItemGroup>
+  
+  <PropertyGroup>
+   <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>  
 
 </Project>

--- a/APSIM.Interop/APSIM.Interop.csproj
+++ b/APSIM.Interop/APSIM.Interop.csproj
@@ -7,6 +7,10 @@
     <SelfContained>false</SelfContained>
   </PropertyGroup>
 
+  <PropertyGroup>
+   <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
+  
   <ItemGroup>
     <ProjectReference Include="../APSIM.Shared/APSIM.Shared.csproj" />
     <ProjectReference Include="../Models/Models.csproj" />

--- a/APSIM.Server/APSIM.Server.csproj
+++ b/APSIM.Server/APSIM.Server.csproj
@@ -8,6 +8,10 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SelfContained>false</SelfContained>
   </PropertyGroup>
+  
+  <PropertyGroup>
+   <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>  
 
   <ItemGroup>
     <ProjectReference Include="../Models/Models.csproj" />

--- a/APSIM.Shared/APSIM.Shared.csproj
+++ b/APSIM.Shared/APSIM.Shared.csproj
@@ -11,6 +11,10 @@
     <SelfContained>false</SelfContained>
   </PropertyGroup>
   
+  <PropertyGroup>
+   <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="DocumentFormat.OpenXml" Version="2.19.0" />
     <PackageReference Include="ExcelDataReader.DataSet" Version="3.6.0" />

--- a/ApsimNG/ApsimNG.csproj
+++ b/ApsimNG/ApsimNG.csproj
@@ -25,6 +25,10 @@
     <SelfContained>false</SelfContained>
   </PropertyGroup>
   
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
+  
   <ItemGroup>
     <!-- Nothing under Resources directory should be included in compilation -->
     <None Remove="Resources\**\*" />

--- a/Models/Importer/Importer.csproj
+++ b/Models/Importer/Importer.csproj
@@ -8,7 +8,11 @@
     <StartupObject />
     <SelfContained>false</SelfContained>
   </PropertyGroup>
-
+  
+  <PropertyGroup>
+   <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
+  
   <ItemGroup>
     <None Remove="StyleCop.Cache" />
   </ItemGroup>

--- a/Models/Models.csproj
+++ b/Models/Models.csproj
@@ -15,6 +15,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <SelfContained>false</SelfContained>
   </PropertyGroup>
+  
+  <PropertyGroup>
+   <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>  
 
   <ItemGroup>
     <ProjectReference Include="..\APSIM.Shared\APSIM.Shared.csproj" />

--- a/Tests/UnitTests/UnitTests.csproj
+++ b/Tests/UnitTests/UnitTests.csproj
@@ -12,6 +12,10 @@
     <SelfContained>false</SelfContained>
   </PropertyGroup>
 
+  <PropertyGroup>
+   <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
+  
   <ItemGroup>
     <EmbeddedResource Include="**\*.xml" />
     <EmbeddedResource Include="**\*.json" />


### PR DESCRIPTION
Resolves #7745. Get rid of these errors:

```
  Models -> /tmp/ApsimX/bin/Release/netcoreapp3.1/Models.dll
  Models -> /tmp/ApsimX/bin/Release/netcoreapp3.1/osx-x64/Models.dll
  APSIM.Interop -> /tmp/ApsimX/bin/Release/netcoreapp3.1/APSIM.Interop.dll
  APSIM.Server -> /tmp/ApsimX/bin/Release/netcoreapp3.1/osx-x64/apsim-server.dll

  ApsimNG -> /tmp/ApsimX/bin/Release/netcoreapp3.1/osx-x64/ApsimNG.dll
/usr/share/dotnet/sdk/7.0.102/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.ConflictResolution.targets(112,5): error NETSDK1152: Found multiple publish output files with the same relative path: /tmp/ApsimX/Models/obj/Release/netcoreapp3.1/apphost, /tmp/ApsimX/Models/obj/Release/netcoreapp3.1/osx-x64/apphost, /tmp/ApsimX/bin/Release/netcoreapp3.1/Models.deps.json, /tmp/ApsimX/bin/Release/netcoreapp3.1/osx-x64/Models.deps.json, /tmp/ApsimX/bin/Release/netcoreapp3.1/Models.runtimeconfig.json, /tmp/ApsimX/bin/Release/netcoreapp3.1/osx-x64/Models.runtimeconfig.json. [/tmp/ApsimX/ApsimNG/ApsimNG.csproj::TargetFramework=netcoreapp3.1]

```