### PR TITLE
MacOS installer: always build in self-contained mode

### DIFF
--- a/Setup/netcoreapp3.1/macos/buildMacInstaller
+++ b/Setup/netcoreapp3.1/macos/buildMacInstaller
@@ -35,7 +35,7 @@ cp "$apsimx/Models/Properties/AssemblyVersion.cs" "$apsimx/ApsimNG/Properties/"
 projects=(ApsimNG APSIM.Server Models)
 for project in ${projects[@]}
 do
-    dotnet publish --nologo -f netcoreapp3.1 -c Release -r osx-x64 $project
+    dotnet publish --nologo -f netcoreapp3.1 -c Release -r osx-x64 $project --self-contained
 done
 
 # Now generate the installer.


### PR DESCRIPTION
Resolves #7765

This might fix #7765 but I don't have a mac to test on so don't really know for sure. I had thought `--self-contained` was true by default when publishing, but maybe that has changed in recent sdk versions.