### PR TITLE
Fix problem with leading spaces in Simulation names

### DIFF
--- a/Models/Core/Locator.cs
+++ b/Models/Core/Locator.cs
@@ -282,7 +282,7 @@
                 bool includeDisabled = (flags & LocatorFlags.IncludeDisabled) == LocatorFlags.IncludeDisabled;
                 for (i = 0; i < namePathBits.Length; i++)
                 {
-                    IModel localModel = relativeTo.Children.FirstOrDefault(m => m.Name.Equals(namePathBits[i], compareType) && (includeDisabled || m.Enabled));
+                    IModel localModel = relativeTo.Children.FirstOrDefault(m => m.Name.Trim().Equals(namePathBits[i], compareType) && (includeDisabled || m.Enabled));
                     if (localModel == null)
                     {
                         break;


### PR DESCRIPTION
Resolves #7803.

Not sure how those spaces got there in the first place, but the Locator wasn't handling them. 