### PR TITLE
Throw an error for unrecognized types in VariableExpression.

### DIFF
--- a/Models/Core/VariableExpression.cs
+++ b/Models/Core/VariableExpression.cs
@@ -160,14 +160,18 @@
                     sym.m_values = (double[])singleArrayOfValues.ToArray();
                 }
                 else if (sometypeofobject is IFunction fun)
-                {
-                    // TODO: Functions can take array indices for their values. How to use that in an expression?
-                    // Currently this does what VariableGroup does when encountering a function, but this warrants
-                    // more thought.
                     sym.m_value = fun.Value();
-                }
                 else
-                    throw new Exception($"Don't know how to use type {sometypeofobject.GetType()} of variable {sym.m_name} in an expression!");
+                {
+                    try
+                    {
+                        sym.m_value = Convert.ToDouble(sometypeofobject, System.Globalization.CultureInfo.InvariantCulture);
+                    }
+                    catch (InvalidCastException)
+                    {
+                         throw new Exception($"Don't know how to use type {sometypeofobject.GetType()} of variable {sym.m_name} in an expression!");
+                    }
+                }
                 variablesToFill[i] = sym;
             }
             fn.Variables = variablesToFill;

--- a/Models/Core/VariableExpression.cs
+++ b/Models/Core/VariableExpression.cs
@@ -161,17 +161,6 @@
                 }
                 else if (sometypeofobject is IFunction fun)
                     sym.m_value = fun.Value();
-                else
-                {
-                    try
-                    {
-                        sym.m_value = Convert.ToDouble(sometypeofobject, System.Globalization.CultureInfo.InvariantCulture);
-                    }
-                    catch (InvalidCastException)
-                    {
-                         throw new Exception($"Don't know how to use type {sometypeofobject.GetType()} of variable {sym.m_name} in an expression!");
-                    }
-                }
                 variablesToFill[i] = sym;
             }
             fn.Variables = variablesToFill;

--- a/Models/Core/VariableExpression.cs
+++ b/Models/Core/VariableExpression.cs
@@ -161,6 +161,17 @@
                 }
                 else if (sometypeofobject is IFunction fun)
                     sym.m_value = fun.Value();
+                else
+                {
+                    try
+                    {
+                        sym.m_value = Convert.ToDouble(sometypeofobject, System.Globalization.CultureInfo.InvariantCulture);
+                    }
+                    catch (InvalidCastException)
+                    {
+                        throw new Exception($"Don't know how to use type {sometypeofobject.GetType()} of variable {sym.m_name} in an expression!");
+                    }
+                }
                 variablesToFill[i] = sym;
             }
             fn.Variables = variablesToFill;

--- a/Models/Core/VariableExpression.cs
+++ b/Models/Core/VariableExpression.cs
@@ -3,6 +3,7 @@
     using APSIM.Shared.Utilities;
     using System;
     using System.Collections.Generic;
+    using Models.Functions;
 
     /// <summary>
     /// TODO: Update summary.
@@ -158,6 +159,15 @@
                             singleArrayOfValues.Add(value);
                     sym.m_values = (double[])singleArrayOfValues.ToArray();
                 }
+                else if (sometypeofobject is IFunction fun)
+                {
+                    // TODO: Functions can take array indices for their values. How to use that in an expression?
+                    // Currently this does what VariableGroup does when encountering a function, but this warrants
+                    // more thought.
+                    sym.m_value = fun.Value();
+                }
+                else
+                    throw new Exception($"Don't know how to use type {sometypeofobject.GetType()} of variable {sym.m_name} in an expression!");
                 variablesToFill[i] = sym;
             }
             fn.Variables = variablesToFill;


### PR DESCRIPTION
Also, allows for IFunctions to have their .Values() used in expressions. Previously, unknown types would silently substitute in scalar 0 when used in expressions. Doesn't address @peter-devoil's concerns about multiple 'as' variables with the same name being silently ignored. 

Working on #7835 