### PR TITLE
Added XML wrapper for SLGA soils for conversion

### DIFF
--- a/ApsimNG/Presenters/SoilDownloadPresenter.cs
+++ b/ApsimNG/Presenters/SoilDownloadPresenter.cs
@@ -406,9 +406,11 @@ namespace UserInterface.Presenters
                 // We will have either 0 or 1 soil nodes
                 if (soilNodes.Count > 0)
                 {
-                    var soil = FileFormat.ReadFromString<Soil>(soilNodes[0].OuterXml, e => throw e, false);
-                    soil.Children.Add(new CERESSoilTemperature());
-                    soil.OnCreated();
+                    var soilXML = $"<folder>{soilNodes[0].OuterXml}</folder>";
+                    var soilFolder = FileFormat.ReadFromString<Folder>(soilXML, e => throw e, false);
+
+                    var soil = soilFolder.Children[0] as Soil;
+                    InitialiseSoil(soil);
 
                     soils.Add(new SoilFromDataSource()
                     {


### PR DESCRIPTION
Resolves #7861

- A missing "level" in the XML caused a crucial function to skip when it was looking for a child with the name 'Soil'.
    - Because soil was not a child, but it was present, it simply needed to be nested within a folder element for it to become a child.
- the folder lines where copied from ~ASRIS soils