### PR TITLE
add UAN_N  fertiliser

### DIFF
--- a/Models/Core/Apsim710File/Importer.cs
+++ b/Models/Core/Apsim710File/Importer.cs
@@ -112,6 +112,7 @@
             this.fertilisers.Add("NH4NO3", "NH4NO3N");
             this.fertilisers.Add("DAP", "DAP");
             this.fertilisers.Add("MAP", "MAP");
+            this.fertilisers.Add("UAN_N", "UAN_N");
             this.fertilisers.Add("urea_N", "UreaN");
             this.fertilisers.Add("urea_no3", "UreaNO3");
             this.fertilisers.Add("urea", "Urea");

--- a/Models/Management/Fertiliser.cs
+++ b/Models/Management/Fertiliser.cs
@@ -57,6 +57,8 @@ namespace Models
             DAP,
             /// <summary>The map</summary>
             MAP,
+            /// <summary>The UAN n</summary>
+            UAN_N,
             /// <summary>The urea n</summary>
             UreaN,
             /// <summary>The urea n o3</summary>

--- a/Models/Resources/Fertiliser.json
+++ b/Models/Resources/Fertiliser.json
@@ -105,6 +105,18 @@
         },
         {
           "$type": "Models.FertiliserType, Models",
+          "Name": "UAN_N",
+          "Description": "N as Urea-AmmoniumNitrate",
+          "FractionNO3": 0.25,
+          "FractionNH4": 0.25,
+          "FractionUrea": 0.5,
+          "FractionRockP": 0.0,
+          "FractionBandedP": 0.0,
+          "FractionLabileP": 0.0,
+          "FractionCa": 0.0
+        },
+        {
+          "$type": "Models.FertiliserType, Models",
           "Name": "UreaN",
           "Description": "N as urea",
           "FractionNO3": 0.0,


### PR DESCRIPTION
This adds the UAN_N fertiliser previously available in APSIM classic. The nutrient fractions are pulled from the old XML definition [here](https://github.com/APSIMInitiative/APSIMClassic/blob/27396788a2c0fcc2750b72700d7fccf35fc7c7ea/Model/Fertiliser.xml#L95).

Resolves #7868 