### PR TITLE
changed XYPair.graphView height to 200

### DIFF
--- a/ApsimNG/Views/XYPairsView.cs
+++ b/ApsimNG/Views/XYPairsView.cs
@@ -29,6 +29,7 @@
             graphView = new GraphView(this);
             vpaned.Pack1(gridView.MainWidget, true, false);
             vpaned.Pack2(graphView.MainWidget, true, false);
+            graphView.Height = 200;
             gridView.NumericFormat = null;
             mainWidget.Destroyed += _mainWidget_Destroyed;
         }


### PR DESCRIPTION
 Resolves #7655

- Makes the graph take up 2/3rds of the right side explorer pane.