### PR TITLE
7908 Fixed Errors In Training Toolbox

### DIFF
--- a/ApsimNG/Resources/Toolboxes/TrainingToolbox.apsimx
+++ b/ApsimNG/Resources/Toolboxes/TrainingToolbox.apsimx
@@ -253,7 +253,8 @@
                 0.46,
                 0.44
               ],
-              "RelativeTo": null,
+              "InitialPAWmm": 400.5,
+              "RelativeTo": "LL15",
               "FilledFromTop": false,
               "Name": "Water",
               "ResourceName": null,
@@ -639,7 +640,8 @@
                 0.169,
                 0.196
               ],
-              "RelativeTo": null,
+              "InitialPAWmm": 61.499999999999986,
+              "RelativeTo": "LL15",
               "FilledFromTop": false,
               "Name": "Water",
               "ResourceName": null,
@@ -900,7 +902,7 @@
                         "[Soil].SoilWater.Runoff",
                         "[Soil].SoilWater.Drainage",
                         "sum([Soil].NO3.kgha)",
-                        "sum([Soil].SoilNitrogen.MineralisedN",
+                        "sum([Soil].Nutrient.MineralisedN",
                         "[SurfaceOrganicMatter].Wt",
                         "[SurfaceOrganicMatter].Cover"
                       ],
@@ -1195,6 +1197,7 @@
                             0.28,
                             0.28
                           ],
+                          "InitialPAWmm": 40.05,
                           "RelativeTo": "LL15",
                           "FilledFromTop": true,
                           "Name": "Water",
@@ -1664,7 +1667,7 @@
                         "[Soil].SoilWater.Runoff",
                         "[Soil].SoilWater.Drainage",
                         "sum([Soil].NO3.kgha)",
-                        "sum([Soil].SoilNitrogen.MineralisedN",
+                        "sum([Soil].Nutrient.MineralisedN",
                         "[SurfaceOrganicMatter].Wt",
                         "[SurfaceOrganicMatter].Cover"
                       ],
@@ -1908,6 +1911,7 @@
                             0.14,
                             0.14
                           ],
+                          "InitialPAWmm": 6.199999999999999,
                           "RelativeTo": "LL15",
                           "FilledFromTop": true,
                           "Name": "Water",
@@ -2352,7 +2356,7 @@
               "LegendPosition": 0,
               "LegendOrientation": 0,
               "AnnotationLocation": 0,
-              "DisabledSeries": null,
+              "DisabledSeries": [],
               "LegendOutsideGraph": false,
               "Name": "Runoff",
               "ResourceName": null,
@@ -2443,7 +2447,7 @@
             {
               "$type": "Models.Core.Simulation, Models",
               "Descriptors": null,
-              "Name": "Clay Fallow",
+              "Name": "Clay Fallow 2",
               "ResourceName": null,
               "Children": [
                 {
@@ -2495,7 +2499,7 @@
                         "[Soil].SoilWater.Runoff",
                         "[Soil].SoilWater.Drainage",
                         "sum([Soil].NO3.kgha)",
-                        "sum([Soil].SoilNitrogen.MineralisedN",
+                        "sum([Soil].Nutrient.MineralisedN",
                         "[SurfaceOrganicMatter].Wt",
                         "[SurfaceOrganicMatter].Cover"
                       ],
@@ -2790,6 +2794,7 @@
                             0.28,
                             0.28
                           ],
+                          "InitialPAWmm": 40.05,
                           "RelativeTo": "LL15",
                           "FilledFromTop": true,
                           "Name": "Water",
@@ -3164,7 +3169,7 @@
                         "[Soil].SoilWater.Runoff",
                         "[Soil].SoilWater.Drainage",
                         "sum([Soil].NO3.kgha)",
-                        "sum([Soil].SoilNitrogen.MineralisedN",
+                        "sum([Soil].Nutrient.MineralisedN",
                         "[SurfaceOrganicMatter].Wt",
                         "[SurfaceOrganicMatter].Cover"
                       ],
@@ -3459,6 +3464,7 @@
                             0.28,
                             0.28
                           ],
+                          "InitialPAWmm": 40.05,
                           "RelativeTo": "LL15",
                           "FilledFromTop": true,
                           "Name": "Water",
@@ -4043,7 +4049,7 @@
                         "sum([Soil].SoilWater.ESW)",
                         "sum([Soil].NO3.kgha) as NO3Total",
                         "sum([Soil].NH4.kgha) as NH4Total",
-                        "sum([Soil].SoilNitrogen.Denitrification) as Denitrification"
+                        "sum([Soil].Nutrient.DenitrifiedN) as Denitrification"
                       ],
                       "EventNames": [
                         "[Clock].EndOfDay"
@@ -4226,7 +4232,7 @@
                               "LLMetadata": null,
                               "KLMetadata": null,
                               "XFMetadata": null,
-                              "Name": "SoilCropSoil",
+                              "Name": "WheatSoil",
                               "ResourceName": null,
                               "Children": [],
                               "Enabled": true,
@@ -4264,7 +4270,7 @@
                               "LLMetadata": null,
                               "KLMetadata": null,
                               "XFMetadata": null,
-                              "Name": "SoilCropSoil",
+                              "Name": "BarleySoil",
                               "ResourceName": null,
                               "Children": [],
                               "Enabled": true,
@@ -4336,6 +4342,7 @@
                             0.37,
                             0.36
                           ],
+                          "InitialPAWmm": 200.24999999999994,
                           "RelativeTo": "LL15",
                           "FilledFromTop": false,
                           "Name": "Water",
@@ -4889,7 +4896,7 @@
                         "[Wheat].Grain.Wt",
                         "[Wheat].Grain.N",
                         "[Wheat].Total.Wt",
-                        "sum([Soil].SoilNitrogen.TotalC)/1000 as SoilCtpha"
+                        "sum([Soil].Nutrient.TotalC)/1000 as SoilCtpha"
                       ],
                       "EventNames": [
                         "[Wheat].Harvesting"
@@ -5219,7 +5226,8 @@
                             0.457070570557793,
                             0.452331759845006
                           ],
-                          "RelativeTo": null,
+                          "InitialPAWmm": 361.2454283127387,
+                          "RelativeTo": "LL15",
                           "FilledFromTop": false,
                           "Name": "Water",
                           "ResourceName": null,
@@ -5574,7 +5582,7 @@
                         "[Wheat].Grain.Wt",
                         "[Wheat].Grain.N",
                         "[Wheat].Total.Wt",
-                        "sum([Soil].SoilNitrogen.TotalC)/1000 as SoilCtpha"
+                        "sum([Soil].Nutrient.TotalC)/1000 as SoilCtpha"
                       ],
                       "EventNames": [
                         "[Wheat].Harvesting"
@@ -5904,7 +5912,8 @@
                             0.457070570557793,
                             0.452331759845006
                           ],
-                          "RelativeTo": null,
+                          "InitialPAWmm": 361.2454283127387,
+                          "RelativeTo": "LL15",
                           "FilledFromTop": false,
                           "Name": "Water",
                           "ResourceName": null,
@@ -6249,7 +6258,7 @@
                         "[Wheat].Grain.Wt",
                         "[Wheat].Grain.N",
                         "[Wheat].Total.Wt",
-                        "sum([Soil].SoilNitrogen.TotalC)/1000 as SoilCtpha"
+                        "sum([Soil].Nutrient.TotalC)/1000 as SoilCtpha"
                       ],
                       "EventNames": [
                         "[Wheat].Harvesting"
@@ -6579,7 +6588,8 @@
                             0.457070570557793,
                             0.452331759845006
                           ],
-                          "RelativeTo": null,
+                          "InitialPAWmm": 361.2454283127387,
+                          "RelativeTo": "LL15",
                           "FilledFromTop": false,
                           "Name": "Water",
                           "ResourceName": null,


### PR DESCRIPTION
Resolves #7908

Renamed the Soils in Exercise 3 to Wheat and Barley to match exercises 1 & 2. Updated references from SoilNitrogen.