### PR TITLE
7924 Added check to see if ManagerView is set

### DIFF
--- a/ApsimNG/Presenters/ManagerPresenter.cs
+++ b/ApsimNG/Presenters/ManagerPresenter.cs
@@ -150,7 +150,7 @@
         /// <param name="changedModel">The changed manager model</param>
         public void CommandHistory_ModelChanged(object changedModel)
         {
-            if (changedModel == manager)
+            if (changedModel == manager && managerView.Editor != null)
             {
                 managerView.Editor.Text = manager.Code;
             }


### PR DESCRIPTION
Resolves #7924

The event to click another node is handled before the event to finish renaming the Manager node. So when the rename event tries to update the right view, its already potentially been changed.

I added a check in to make sure the ManagerView has an Editor attached when it tries to update the code view, which seems to have fixed the problem without causing other issues. I can still rename nodes and undo/redo the renaming events.