### PR TITLE
7929 Catch for expection and better error message

### DIFF
--- a/Models/Graph/SeriesDefinition.cs
+++ b/Models/Graph/SeriesDefinition.cs
@@ -318,8 +318,17 @@
 
                 filter = filter?.Replace('\"', '\'');
                 View = new DataView(data);
-                View.RowFilter = filter;
-
+                try
+                {
+                    View.RowFilter = filter;
+                }
+                catch (Exception ex)
+                {
+                    //this will still cause a pause when running in debug mode, that is due to how visual studio
+                    //works when an exception thrown by external code but is not handled by that external code.
+                    throw new Exception("Filter cannot be parsed: " + ex.Message);
+                }
+                
                 // Get the units for our x and y variables.
                 XFieldUnits = reader.Units(Series.TableName, XFieldName);
                 YFieldUnits = reader.Units(Series.TableName, YFieldName);


### PR DESCRIPTION
Resolves #7929 

This adds a try-catch around the function call before it goes into system code to update the data grid. When in visual studio debug mode it will still pause here (though this can be changed in your settings) as it is an exception that is thrown and not handled by the external code.

I've added an error message to inform the user which field is the problem so that the mistake is easier to fix.