### PR TITLE
7524 X2Y2 field now controlled in DisableUnusedControls

### DIFF
--- a/ApsimNG/Presenters/SeriesPresenter.cs
+++ b/ApsimNG/Presenters/SeriesPresenter.cs
@@ -218,6 +218,7 @@
 
             // This doesn't quite work yet. If the previous series was a scatter plot, there is no x2, y2 to work with
             // and things go a bit awry.
+            // this function is now called in disableUnusedControls if this needs to be added back later
             // this.seriesView.ShowX2Y2(series.Type == SeriesType.Area);
 
             // If the series is a box plot, then we want to disable certain unused controls
@@ -541,15 +542,16 @@
             this.seriesView.DataSource.Values = dataSources.ToArray();
             this.seriesView.DataSource.SelectedValue = series.TableName;
 
+            //Show/Hide controls that are not relevant for the current graph type
+            //Needs to run before we populate the fields, so we don't try to populate
+            //fields with no values
+            DisableUnusedControls();
+
             // Populate field name drop downs.
             warnings.AddRange(PopulateFieldNames());
 
             // Populate filter textbox.
             this.seriesView.Filter.Text = series.Filter;
-
-            this.seriesView.ShowX2Y2(series.Type == SeriesType.Region);
-
-            DisableUnusedControls();
 
             explorerPresenter.MainPresenter.ClearStatusPanel();
             if (warnings != null && warnings.Count > 0)
@@ -565,6 +567,18 @@
             seriesView.MarkerType.IsSensitive = !isBoxPlot;
             seriesView.XCumulative.IsSensitive = !isBoxPlot;
             seriesView.XOnTop.IsSensitive = !isBoxPlot;
+
+            //show X2 and Y2 if this is a region graph, hide if not
+            if (series.Type == SeriesType.Region)
+            {
+                this.seriesView.ShowX2Y2(true);
+            } else
+            {
+                this.seriesView.ShowX2Y2(false);
+                //null the x2 and y2 field names so they don't cause errors if a model changes
+                series.X2FieldName = null;
+                series.Y2FieldName = null;
+            }
         }
 
         /// <summary>Populate the line drop down.</summary>

--- a/ApsimNG/Views/SeriesView.cs
+++ b/ApsimNG/Views/SeriesView.cs
@@ -97,8 +97,8 @@
             table1.Attach(new Label("Data Source:") { Xalign = 0 }, 0, 0, 1, 1);
             table1.Attach(new Label("X:") { Xalign = 0 }, 0, 1, 1, 1);
             table1.Attach(new Label("Y:") { Xalign = 0 }, 0, 2, 1, 1);
-            label4 = new Label("Y2:") { Xalign = 0 };
-            label5 = new Label("X2:") { Xalign = 0 };
+            label4 = new Label("X2:") { Xalign = 0 };
+            label5 = new Label("Y2:") { Xalign = 0 };
             table1.Attach(label4, 0, 3, 1, 1);
             table1.Attach(label5, 0, 4, 1, 1);
             table1.Attach(new Label("Type:") { Xalign = 0 }, 0, 5, 1, 1);
@@ -111,8 +111,8 @@
             table1.Attach(dataSourceDropDown.MainWidget, 1, 0, 1, 1/*, 10, 2*/);
             table1.Attach(xDropDown.MainWidget, 1, 1, 1, 1/*10, 2*/);
             table1.Attach(yDropDown.MainWidget, 1, 2, 1, 1/*10, 2*/);
-            table1.Attach(y2DropDown.MainWidget, 1, 3, 1, 1/*10, 2*/);
-            table1.Attach(x2DropDown.MainWidget, 1, 4, 1, 1/*10, 2*/);
+            table1.Attach(x2DropDown.MainWidget, 1, 3, 1, 1/*10, 2*/);
+            table1.Attach(y2DropDown.MainWidget, 1, 4, 1, 1/*10, 2*/);
             table1.Attach(seriesDropDown.MainWidget, 1, 5, 1, 1/*10, 2*/);
             table1.Attach(lineTypeDropDown.MainWidget, 1, 6, 1, 1/*10, 2*/);
             table1.Attach(markerTypeDropDown.MainWidget, 1, 7, 1, 1/*10, 2*/);


### PR DESCRIPTION
Resolves #7524

There were a few bugs happening here.

First, the X2 and Y2 field would only display if the Region was selected before the node was clicked in the tree, changing the graph type would not refresh the field's visibility. That was fixed by moving the ShowX2Y2 function call into DisableUnusedControls which is called both when the page is first made, and when the graphtype field is changed

To solve the actual reported bug, the X2 and Y2 field names are now null'ed if the fields are disabled, such as if the graph type is changed from region.

Lastly the X2 and Y2 field were appearing in the wrong order in menu (x, y, y2, x2), so I switched their positions around.