### PR TITLE
7935 Column Captions set to Column Name after read

### DIFF
--- a/APSIM.Shared/Utilities/ApsimTextFile.cs
+++ b/APSIM.Shared/Utilities/ApsimTextFile.cs
@@ -389,7 +389,19 @@ namespace APSIM.Shared.Utilities
             }
             //will I ever hit this without having any data???
 
-            return data;
+            if (data != null)
+            {
+                //the excel to table function will not set the column caption
+                //so we do it here manually, otherwise it's just called 'column1' etc
+                for (int i = 0; i < data.Columns.Count; i++)
+                {
+                    data.Columns[i].Caption = data.Columns[i].ColumnName;
+                }
+                return data;
+            } else
+            {
+                throw new Exception("Error converting excel data to table");
+            }
         }
 
 


### PR DESCRIPTION
Resolves #7935

A weird little bug where the excel to table converter used by the weather class would only set the column name and not the column caption when reading from an Excel file. Ended up adding a loop right after it calls the system code to copy the name into the caption for each column.