### PR TITLE
7495 Cultivars under a resource can now be edited

### DIFF
--- a/ApsimNG/Menus/ContextMenu.cs
+++ b/ApsimNG/Menus/ContextMenu.cs
@@ -816,7 +816,7 @@ namespace UserInterface.Presenters
                     foreach (IModel child in model.FindAllDescendants())
                     {
                         child.IsHidden = hidden;
-                        if (isResource && String.Compare(child.ToString(), "Models.PMF.Cultivar") != 0)
+                        if (isResource && !(child is Models.PMF.Cultivar))
                             child.ReadOnly = true;
                     }
                     foreach (IModel child in model.Children)
@@ -898,7 +898,7 @@ namespace UserInterface.Presenters
                     return;
 
                 // Don't allow users to change read-only status resource children, except for Cultivars
-                if ((model.FindAllAncestors().Any(a => !string.IsNullOrEmpty(a.ResourceName))) && String.Compare(model.ToString(), "Models.PMF.Cultivar") != 0)
+                if ((model.FindAllAncestors().Any(a => !string.IsNullOrEmpty(a.ResourceName))) && !(model is Models.PMF.Cultivar))
                     return;
                     
 

--- a/ApsimNG/Menus/ContextMenu.cs
+++ b/ApsimNG/Menus/ContextMenu.cs
@@ -816,7 +816,7 @@ namespace UserInterface.Presenters
                     foreach (IModel child in model.FindAllDescendants())
                     {
                         child.IsHidden = hidden;
-                        if (isResource)
+                        if (isResource && String.Compare(child.ToString(), "Models.PMF.Cultivar") != 0)
                             child.ReadOnly = true;
                     }
                     foreach (IModel child in model.Children)
@@ -892,10 +892,15 @@ namespace UserInterface.Presenters
                 IModel model = explorerPresenter.CurrentNode as IModel;
                 if (model == null)
                     return;
-                
+
                 // Don't allow users to change read-only status of released models.
-                if (!string.IsNullOrEmpty(model.ResourceName) || model.FindAllAncestors().Any(a => !string.IsNullOrEmpty(a.ResourceName)))
+                if (!string.IsNullOrEmpty(model.ResourceName))
                     return;
+
+                // Don't allow users to change read-only status resource children, except for Cultivars
+                if ((model.FindAllAncestors().Any(a => !string.IsNullOrEmpty(a.ResourceName))) && String.Compare(model.ToString(), "Models.PMF.Cultivar") != 0)
+                    return;
+                    
 
                 bool readOnly = !model.ReadOnly;
                 List<ChangeProperty.Property> changes = new List<ChangeProperty.Property>();


### PR DESCRIPTION
Resolves #7495

Adds a simple check into the "Show Model Structure" and "Read Only" context menu options so that Cultivar nodes under a resource can be changed from read only and be edited like they are supposed to.