### PR TITLE
7859 Check m to avoid dividing by 0

### DIFF
--- a/Models/Soils/SWIM/HyProps.cs
+++ b/Models/Soils/SWIM/HyProps.cs
@@ -229,7 +229,7 @@ namespace Models.Soils
 
                     double m = (est2 - est) / dpF;
 
-                    if ((Math.Abs(est - theta) < tolerance) || (m == 0))
+                    if ((Math.Abs(est - theta) < tolerance) || Math.Abs(m) < tolerance)
                         break;
 
                     double pFnew = pF - (est - theta) / m;

--- a/Models/Soils/SWIM/HyProps.cs
+++ b/Models/Soils/SWIM/HyProps.cs
@@ -229,8 +229,9 @@ namespace Models.Soils
 
                     double m = (est2 - est) / dpF;
 
-                    if (Math.Abs(est - theta) < tolerance)
+                    if ((Math.Abs(est - theta) < tolerance) || (m == 0))
                         break;
+
                     double pFnew = pF - (est - theta) / m;
                     if (pFnew > (Math.Log10(-psi0)))
                         pF += dpF;  // This is not really adequate - just saying...


### PR DESCRIPTION
Resolves #7859 

When doing suction calculations for water potential, it was possible to divide by 0 and end up generating very strange numbers. I've added a check to not do the calculation if m is 0, though this might fail unit tests if any had accidentally been triggering this issue.

**Is stopping the calculation is the correct action? or if it should it just use a minimum m instead.**