### PR TITLE
7492 'Create Documentation' checks if user has saved

### DIFF
--- a/ApsimNG/Menus/ContextMenu.cs
+++ b/ApsimNG/Menus/ContextMenu.cs
@@ -973,8 +973,16 @@ namespace UserInterface.Presenters
                 explorerPresenter.MainPresenter.ShowMessage("Creating documentation...", Simulation.MessageType.Information);
                 explorerPresenter.MainPresenter.ShowWaitCursor(true);
 
-                IModel modelToDocument = explorerPresenter.CurrentNode.Clone();
-                explorerPresenter.ApsimXFile.Links.Resolve(modelToDocument, true, true, false);
+                IModel currentN = explorerPresenter.CurrentNode;
+                IModel modelToDocument;
+
+                if (currentN is Models.Graph || currentN is Simulation)
+                    modelToDocument = currentN;
+                else
+                {
+                    modelToDocument = currentN.Clone();
+                    explorerPresenter.ApsimXFile.Links.Resolve(modelToDocument, true, true, false);
+                }               
 
                 PdfWriter pdf = new PdfWriter();
                 string fileNameWritten = Path.ChangeExtension(explorerPresenter.ApsimXFile.FileName, ".pdf");

--- a/ApsimNG/Menus/ContextMenu.cs
+++ b/ApsimNG/Menus/ContextMenu.cs
@@ -978,6 +978,19 @@ namespace UserInterface.Presenters
 
                 PdfWriter pdf = new PdfWriter();
                 string fileNameWritten = Path.ChangeExtension(explorerPresenter.ApsimXFile.FileName, ".pdf");
+
+                //if filename is null, prompt user to save the file
+                if (fileNameWritten == null)
+                {
+                    explorerPresenter.Save();
+                    fileNameWritten = Path.ChangeExtension(explorerPresenter.ApsimXFile.FileName, ".pdf");
+                }
+                //check if filename is still null (user didn't save) and throw a useful exception
+                if (fileNameWritten == null)
+                {
+                    throw new Exception("You must save this file before documentation can be created");
+                }
+
                 pdf.Write(fileNameWritten, modelToDocument.Document());
 
                 explorerPresenter.MainPresenter.ShowMessage($"Written {fileNameWritten}", Simulation.MessageType.Information);


### PR DESCRIPTION
Resolves #7492 

The first commit directly fixes the problem outlined in the issue, users are now prompted to save if they try and make documentation on something like an example file.

The 2nd commit addresses a problem found during this where if you create documentation on a graph or a simulation node, you get an exception and an empty document. Investigating the code, it seems that cloning the node as part of this process, breaks the connections these nodes need to generate the graph pictures for documentation. _**My solution was to not clone the node if it's one of those, but that may not be the best solution.**_