### PR TITLE
7350 Exception is now thrown up the stack

### DIFF
--- a/Models/Functions/HoldFunction.cs
+++ b/Models/Functions/HoldFunction.cs
@@ -81,9 +81,9 @@ namespace Models.Functions
             {
                 _Value = ValueToHold.Value();
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-
+                throw new Exception(ex.Message);
             }
         }
     }

--- a/Models/Functions/HoldFunction.cs
+++ b/Models/Functions/HoldFunction.cs
@@ -77,14 +77,7 @@ namespace Models.Functions
         /// <summary>Get value</summary>
         private void GetValue()
         {
-            try
-            {
-                _Value = ValueToHold.Value();
-            }
-            catch (Exception ex)
-            {
-                throw new Exception(ex.Message);
-            }
+            _Value = ValueToHold.Value();
         }
     }
 }

--- a/Prototypes/LeafApex/LeafApex.apsimx
+++ b/Prototypes/LeafApex/LeafApex.apsimx
@@ -1,73 +1,255 @@
 {
   "$type": "Models.Core.Simulations, Models",
-  "ExplorerWidth": 257,
-  "Version": 80,
-  "ApsimVersion": "Version 0.0.0.0, built 2020-03-05",
+  "ExplorerWidth": 285,
+  "Version": 160,
   "Name": "Simulations",
+  "ResourceName": null,
   "Children": [
     {
-      "$type": "Models.Core.Replacements, Models",
+      "$type": "Models.Core.Folder, Models",
+      "ShowInDocs": false,
+      "GraphsPerPage": 6,
       "Name": "Replacements",
+      "ResourceName": null,
       "Children": [
         {
           "$type": "Models.PMF.Plant, Models",
-          "CropType": "Wheat",
-          "IsAlive": false,
+          "PlantType": "Wheat",
           "IsEnding": false,
           "DaysAfterEnding": 0,
-          "ResourceName": null,
           "Name": "Wheat",
+          "ResourceName": null,
           "Children": [
             {
               "$type": "Models.Memo, Models",
               "Text": "\r\n# The APSIM Wheat Model\r\n\r\n_Brown, H.E., Huth, N.I. and Holzworth, D.P._\r\n\r\nThe APSIM wheat model has been developed using the Plant Modelling Framework (PMF) of [brown_plant_2014]. This new framework provides a library of plant organ and process submodels that can be coupled, at runtime, to construct a model in much the same way that models can be coupled to construct a simulation. This means that dynamic composition of lower level process and organ classes (e.g. photosynthesis, leaf) into larger constructions (e.g. maize, wheat, sorghum) can be achieved by the model developer without additional coding.\r\n\r\nThe model consists of:\r\n\r\n* a phenology model to simulate development between growth phases  \r\n* a structure model to simulate plant morphology  \r\n* a collection of organs to simulate the various plant parts  \r\n* an arbitrator to allocate resources (N, biomass) to the various plant organs  \r\n",
               "Name": "TitlePage",
+              "ResourceName": null,
               "Children": [],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.PMF.OrganArbitrator, Models",
               "Name": "Arbitrator",
+              "ResourceName": null,
               "Children": [
                 {
-                  "$type": "Models.PMF.RelativeAllocation, Models",
-                  "Name": "NArbitrator",
-                  "Children": [],
-                  "IncludeInDocumentation": true,
+                  "$type": "Models.PMF.BiomassTypeArbitrator, Models",
+                  "Name": "DMArbitration",
+                  "ResourceName": null,
+                  "Children": [
+                    {
+                      "$type": "Models.Core.Folder, Models",
+                      "ShowInDocs": false,
+                      "GraphsPerPage": 6,
+                      "Name": "PotentialPartitioningMethods",
+                      "ResourceName": null,
+                      "Children": [
+                        {
+                          "$type": "Models.PMF.Arbitrator.ReallocationMethod, Models",
+                          "Name": "ReallocationMethod",
+                          "ResourceName": null,
+                          "Children": [],
+                          "Enabled": true,
+                          "ReadOnly": false
+                        },
+                        {
+                          "$type": "Models.PMF.Arbitrator.AllocateFixationMethod, Models",
+                          "Name": "AllocateFixationMethod",
+                          "ResourceName": null,
+                          "Children": [],
+                          "Enabled": true,
+                          "ReadOnly": false
+                        },
+                        {
+                          "$type": "Models.PMF.Arbitrator.RetranslocationMethod, Models",
+                          "Name": "RetranslocationMethod",
+                          "ResourceName": null,
+                          "Children": [],
+                          "Enabled": true,
+                          "ReadOnly": false
+                        },
+                        {
+                          "$type": "Models.PMF.Arbitrator.SendPotentialDMAllocationsMethod, Models",
+                          "Name": "SendPotentialDMAllocationsMethod",
+                          "ResourceName": null,
+                          "Children": [],
+                          "Enabled": true,
+                          "ReadOnly": false
+                        }
+                      ],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Core.Folder, Models",
+                      "ShowInDocs": false,
+                      "GraphsPerPage": 6,
+                      "Name": "AllocationMethods",
+                      "ResourceName": null,
+                      "Children": [
+                        {
+                          "$type": "Models.PMF.Arbitrator.NutrientConstrainedAllocationMethod, Models",
+                          "Name": "NutrientConstrainedAllocationMethod",
+                          "ResourceName": null,
+                          "Children": [],
+                          "Enabled": true,
+                          "ReadOnly": false
+                        },
+                        {
+                          "$type": "Models.PMF.Arbitrator.DryMatterAllocationsMethod, Models",
+                          "Name": "DryMatterAllocationsMethod",
+                          "ResourceName": null,
+                          "Children": [],
+                          "Enabled": true,
+                          "ReadOnly": false
+                        }
+                      ],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.PMF.RelativeAllocation, Models",
+                      "Name": "ArbitrationMethod",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    }
+                  ],
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.PMF.RelativeAllocation, Models",
-                  "Name": "DMArbitrator",
+                  "$type": "Models.PMF.BiomassTypeArbitrator, Models",
+                  "Name": "NArbitration",
+                  "ResourceName": null,
+                  "Children": [
+                    {
+                      "$type": "Models.Core.Folder, Models",
+                      "ShowInDocs": false,
+                      "GraphsPerPage": 6,
+                      "Name": "PotentialPartitioningMethods",
+                      "ResourceName": null,
+                      "Children": [
+                        {
+                          "$type": "Models.PMF.Arbitrator.ReallocationMethod, Models",
+                          "Name": "ReallocationMethod",
+                          "ResourceName": null,
+                          "Children": [],
+                          "Enabled": true,
+                          "ReadOnly": false
+                        }
+                      ],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Core.Folder, Models",
+                      "ShowInDocs": false,
+                      "GraphsPerPage": 6,
+                      "Name": "ActualPartitioningMethods",
+                      "ResourceName": null,
+                      "Children": [
+                        {
+                          "$type": "Models.PMF.Arbitrator.AllocateFixationMethod, Models",
+                          "Name": "AllocateFixationMethod",
+                          "ResourceName": null,
+                          "Children": [],
+                          "Enabled": true,
+                          "ReadOnly": false
+                        },
+                        {
+                          "$type": "Models.PMF.Arbitrator.RetranslocationMethod, Models",
+                          "Name": "RetranslocationMethod",
+                          "ResourceName": null,
+                          "Children": [],
+                          "Enabled": true,
+                          "ReadOnly": false
+                        }
+                      ],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Core.Folder, Models",
+                      "ShowInDocs": false,
+                      "GraphsPerPage": 6,
+                      "Name": "AllocationMethods",
+                      "ResourceName": null,
+                      "Children": [
+                        {
+                          "$type": "Models.PMF.Arbitrator.NitrogenAllocationsMethod, Models",
+                          "Name": "NitrogenAllocationsMethod",
+                          "ResourceName": null,
+                          "Children": [],
+                          "Enabled": true,
+                          "ReadOnly": false
+                        }
+                      ],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.PMF.RelativeAllocation, Models",
+                      "Name": "ArbitrationMethod",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.PMF.Arbitrator.AllocateUptakesMethod, Models",
+                      "Name": "AllocateUptakesMethod",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    }
+                  ],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.PMF.Arbitrator.WaterUptakeMethod, Models",
+                  "Name": "WaterUptakeMethod",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.PMF.Arbitrator.NitrogenUptakeMethod, Models",
+                  "Name": "NitrogenUptakeMethod",
+                  "ResourceName": null,
+                  "Children": [],
                   "Enabled": true,
                   "ReadOnly": false
                 }
               ],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.PMF.Phen.Phenology, Models",
               "Name": "Phenology",
+              "ResourceName": null,
               "Children": [
                 {
                   "$type": "Models.Memo, Models",
                   "Text": "Wheat exhibits a range of developmental responses to environment and these are strongly influences by genotype characteristics.\r\nTemperature effects development and it effects are captured by thermal time, incrasing development rates and decreasing phase durations as temperatures as temperatures increase.  However, wheat also exhibits vernalisation and photoperiod sensitivities in its Vegetative phase and further photoperiod sensitivity in the EarlyReproducivePhase.  Photoperiod responses are seen as a reduction in the length of a phase for a photoperiod sensitive genotype in response to a longer photoperiod.  Vernalisation responses are more complicated as they are driven by temperature but interact with photoperiod.  For vernalisation sensitive varieties (Winter types) exposure to cool temperatures or short photoperiods during the Vegetative phase will reduce the thermal time duration of the vegetative phase.  \r\n\r\nThis model draws on the Kirby Framework to capture these vernalisation and photoperiod responses.  This framework assumes that the timing of anthesis is a result of the timing of flag leaf and an additional thermal time passage from there to anthesis.  It also assumes the timing of flag leaf is a rusult of the Final Leaf Number which sets a target, and leaf appearance rate, which sets the rate of progress to this target.  Leaf appearance rate is a function of Thermal time and a genotype specific Phyllochron which changes with Haun stage as described by [Jamieson_LeafAppearance_1995].    \r\n\r\nFinal Leaf Number (FLN) is modeled as the sum of three numbers:\r\n\r\nFLN = MinLeafNumber + VernalLeaves + PhotoLeaves\r\n\r\nWhere MinLeafNumber is the number of leaves that a wheat crop will produce when vernalisation is satisified early in the crops duration (before 2nd true leaf) and it is grown in a long photoperiod..  VernalLeaves are the number of leaves that are added due to vernalisation effects.  For insensitive varieties this will always be zero but this is potentially a larger number for sensitivie varieties and the number progresively decreases as the crop encounters more vernalisation.  PhotoLeaves are the number of leaves that are added to the minimum leaf number as a result of short day exposure.  For insensitive varieties this will be zero but is potential larger for more sensitivie varieties and decreases as day length increases.  More detailed explinations of the components of phenology are provided below.",
                   "Name": "Memo",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.Functions.AirTemperatureFunction, Models",
+                  "$type": "Models.Functions.SubDailyInterpolation, Models",
+                  "agregationMethod": 0,
                   "Name": "ThermalTime",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.XYPairs, Models",
@@ -81,9 +263,10 @@
                         26.0,
                         0.0
                       ],
-                      "Name": "XYPairs",
+                      "XVariableName": null,
+                      "Name": "Response",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -91,26 +274,35 @@
                       "$type": "Models.Memo, Models",
                       "Text": "Thermal time determines the rate of developmental progress through many of the crops phases and is used by organs to determing potential growth rates.",
                       "Name": "Memo",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.ThreeHourAirTemperature, Models",
+                      "TempRangeFactors": null,
+                      "Name": "InterpolationMethod",
+                      "ResourceName": null,
+                      "Children": [],
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Functions.MultiplyFunction, Models",
                   "Name": "DailyVernalisation",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Memo, Models",
-                      "Text": "Vernalisation responses are based on those described by [Brown_Anthesis_2013].   Vernalisation is assumed to be related to the expression of the Vrn1 Gene.  Its experssion is accumulated daily and daily upregulation as a function of development (DeltaHaunStage) and a TempResponseProfile that declines exponentially from a maximum at 1<sup>o</sup>C to zero at 0<sup>o</sup>C and at 18<sup>o</sup>C.",
+                      "Text": "Vernalisation responses are based on those described by [Brown_Anthesis_2013].   Vernalisation is assumed to be related to the expression of the Vrn1 Gene.  Its experssion is accumulated daily and daily upregulation as a function of development (DeltaHaunStage) and a TempResponseProfile that declines exponentially from a maximum at 1^o^C to zero at 0^o^C and at 18^o^C.",
                       "Name": "Memo",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -118,14 +310,16 @@
                       "$type": "Models.Functions.VariableReference, Models",
                       "VariableName": "[Structure].DeltaHaunStage",
                       "Name": "DeltaHaunStage",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
-                      "$type": "Models.Functions.AirTemperatureFunction, Models",
+                      "$type": "Models.Functions.SubDailyInterpolation, Models",
+                      "agregationMethod": 0,
                       "Name": "TempResponseProfile",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.XYPairs, Models",
@@ -179,19 +373,27 @@
                             0.0,
                             -0.5
                           ],
-                          "Name": "XYPairs",
+                          "XVariableName": null,
+                          "Name": "Response",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
+                          "Enabled": true,
+                          "ReadOnly": false
+                        },
+                        {
+                          "$type": "Models.Functions.ThreeHourAirTemperature, Models",
+                          "TempRangeFactors": null,
+                          "Name": "InterpolationMethod",
+                          "ResourceName": null,
+                          "Children": [],
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -200,33 +402,34 @@
                   "Twilight": -6.0,
                   "DayLength": 0.0,
                   "Name": "Photoperiod",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Functions.PhaseLookup, Models",
                   "Name": "PercievedPhotoPeriod",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.PhaseLookupValue, Models",
                       "Start": "Germination",
                       "End": "Emergence",
                       "Name": "ApexBelowGround",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.Constant, Models",
                           "FixedValue": 0.0,
                           "Units": "h",
                           "Name": "Photoperiod",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -235,36 +438,36 @@
                       "Start": "Emergence",
                       "End": "HarvestRipe",
                       "Name": "ApexAboveGround",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Phenology].Photoperiod",
                           "Name": "Photoperiod",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Functions.MinimumFunction, Models",
                   "Name": "Vrn1",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Memo, Models",
                       "Text": "Vrn1 accumulation begins when Vrn4 experssion is down regulated to zero and stops, assuming vernalisation saturation, at a value of 1",
                       "Name": "Memo",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -273,8 +476,8 @@
                       "FixedValue": 1.0,
                       "Units": "Relative Experssion",
                       "Name": "Saturation",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -288,17 +491,19 @@
                       "FractionRemovedOnGraze": 0.0,
                       "FractionRemovedOnPrune": 0.0,
                       "Name": "CurrentExpression",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.LessThanFunction, Models",
                           "Name": "Vernalisation",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Phenology].Vrn4",
                               "Name": "If_Vrn4",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -306,8 +511,8 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Phenology].VernLag",
                               "Name": "IsLessThanLag",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -316,8 +521,8 @@
                               "FixedValue": 0.0,
                               "Units": null,
                               "Name": "Return_Zero",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -325,36 +530,34 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Phenology].DailyVernalisation",
                               "Name": "elseReturn_Vernalisation",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Functions.MinimumFunction, Models",
                   "Name": "Vrn4",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.VariableReference, Models",
                       "VariableName": "[Phenology].VernLag",
                       "Name": "MaxExpression",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -368,23 +571,22 @@
                       "FractionRemovedOnGraze": 0.0,
                       "FractionRemovedOnPrune": 0.0,
                       "Name": "CurrentExpression",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Phenology].DailyVernalisation",
                           "Name": "VernalisationConditioning",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -393,18 +595,18 @@
                   "FixedValue": 7.0,
                   "Units": "Leaves",
                   "Name": "MinimumLeafNumber",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Memo, Models",
                       "Text": "Number of leaves the plant will produce when fully vernalised early and grown in long photoperiod\r\n",
                       "Name": "Memo",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -413,18 +615,18 @@
                   "FixedValue": 0.0,
                   "Units": "Leaves",
                   "Name": "VrnSensitivity",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Memo, Models",
                       "Text": "The difference between Inherent earlyness leaf number and the number of leaves produced when the plant is unvernalised and grown in long photoperiod",
                       "Name": "Memo",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -433,18 +635,18 @@
                   "FixedValue": 1.0,
                   "Units": "Unitless",
                   "Name": "VernLag",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Memo, Models",
                       "Text": "The amount of vernalising temperature required before vernalisation response will be evident.  Value of relative to the amount offl vernalisation temperature required from the end of the lag until vernalisation saturation.  A value of 0 means there is no lag, a value of 1 means the lag is the same (in vernal time) as the vernalisation requirement and a value of 2 means the lag is twice as long as the vernalisation response phase",
                       "Name": "Memo",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -453,18 +655,18 @@
                   "FixedValue": 3.0,
                   "Units": "Leaves",
                   "Name": "PpSensitivity",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Memo, Models",
                       "Text": "The reduction in leaf number going from 8 to 16 h Pp",
                       "Name": "Memo",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -473,18 +675,18 @@
                   "FixedValue": 0.0,
                   "Units": null,
                   "Name": "EarlyReproductivePpSensitivity",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Memo, Models",
                       "Text": "The phyllochrons duration for the plant to go from flag leaf ligual appearance at 16 h Pp compared to the phyllochron duration for the same phase at 8 h Pp.  ",
                       "Name": "Memo",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -493,18 +695,18 @@
                   "FixedValue": 2.5,
                   "Units": null,
                   "Name": "EarlyReproductiveLongDayBase",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Memo, Models",
                       "Text": "The phyllochrons duration for the plant to go from flag leaf ligual appearance at 16 h Pp.",
                       "Name": "Memo",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -513,31 +715,76 @@
                   "Start": "Sowing",
                   "End": "Germination",
                   "Name": "Germinating",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.PMF.Phen.EmergingPhase, Models",
-                  "ShootLag": 40.0,
-                  "ShootRate": 1.5,
                   "Start": "Germination",
                   "End": "Emergence",
                   "TTForTimeStep": 0.0,
                   "Name": "Emerging",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.VariableReference, Models",
                       "VariableName": "[Phenology].ThermalTime",
                       "Name": "ThermalTime",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.AddFunction, Models",
+                      "Name": "Target",
+                      "ResourceName": null,
+                      "Children": [
+                        {
+                          "$type": "Models.Functions.Constant, Models",
+                          "FixedValue": 40.0,
+                          "Units": null,
+                          "Name": "ShootLag",
+                          "ResourceName": null,
+                          "Children": [],
+                          "Enabled": true,
+                          "ReadOnly": false
+                        },
+                        {
+                          "$type": "Models.Functions.MultiplyFunction, Models",
+                          "Name": "DepthxRate",
+                          "ResourceName": null,
+                          "Children": [
+                            {
+                              "$type": "Models.Functions.VariableReference, Models",
+                              "VariableName": "[Plant].SowingData.Depth",
+                              "Name": "SowingDepth",
+                              "ResourceName": null,
+                              "Children": [],
+                              "Enabled": true,
+                              "ReadOnly": false
+                            },
+                            {
+                              "$type": "Models.Functions.Constant, Models",
+                              "FixedValue": 1.5,
+                              "Units": null,
+                              "Name": "ShootRate",
+                              "ResourceName": null,
+                              "Children": [],
+                              "Enabled": true,
+                              "ReadOnly": false
+                            }
+                          ],
+                          "Enabled": true,
+                          "ReadOnly": false
+                        }
+                      ],
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -546,13 +793,14 @@
                   "Start": "Emergence",
                   "End": "TerminalSpikelet",
                   "Name": "Vegetative",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Memo, Models",
                       "Text": "The duration of the vegetative phase is set by a target Haun Stage for the occurance of Terminal Spikelet and the rate of leaf appearance.  ",
                       "Name": "Memo",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -560,21 +808,22 @@
                       "$type": "Models.Functions.VariableReference, Models",
                       "VariableName": "[Phenology].ThermalTime",
                       "Name": "Progression",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.MultiplyFunction, Models",
                       "Name": "Target",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Structure].MeanPhyllochron",
                           "Name": "Phyllochron",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -582,13 +831,12 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Structure].HaunStageTerminalSpikelet",
                           "Name": "HSTS",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -596,13 +844,12 @@
                       "$type": "Models.Memo, Models",
                       "Text": "HSTS decreases as vernalisation is accumulated and as photoperiod extends, capturing the effect of these responses on the duration of the Vegetative phase",
                       "Name": "Memo1",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -611,13 +858,14 @@
                   "Start": "TerminalSpikelet",
                   "End": "FlagLeaf",
                   "Name": "StemElongation",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Memo, Models",
                       "Text": "The Final leaf number is fixed at Terminal Spikelet and leaves contune to appear at a rate set by thermal time and phyllochron until flag leaf liguale appears and this phase is completed.",
                       "Name": "Memo",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -625,13 +873,48 @@
                       "$type": "Models.Functions.VariableReference, Models",
                       "VariableName": "[Phenology].ThermalTime",
                       "Name": "ThermalTime",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.VariableReference, Models",
+                      "VariableName": "[Structure].FinalLeafNumber",
+                      "Name": "FinalLeafNumber",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.ExpressionFunction, Models",
+                      "Expression": "[Leaf].ExpandedCohortNo + [Leaf].NextExpandingLeafProportion",
+                      "Name": "LeafNumber",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.VariableReference, Models",
+                      "VariableName": "[Leaf].ExpandedCohortNo",
+                      "Name": "FullyExpandedLeafNo",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.VariableReference, Models",
+                      "VariableName": "[Leaf].InitialisedCohortNo",
+                      "Name": "InitialisedLeafNumber",
+                      "ResourceName": null,
+                      "Children": [],
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -640,49 +923,54 @@
                   "Start": "FlagLeaf",
                   "End": "Flowering",
                   "Name": "EarlyReproductive",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.VariableReference, Models",
                       "VariableName": "[Phenology].ThermalTime",
                       "Name": "Progression",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.MultiplyFunction, Models",
                       "Name": "Target",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Structure].Phyllochron.BasePhyllochron",
                           "Name": "Phyllochron",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Functions.AddFunction, Models",
                           "Name": "Phyllochrons",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Phenology].EarlyReproductiveLongDayBase",
                               "Name": "LongDayBase",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
                             {
                               "$type": "Models.Functions.MultiplyFunction, Models",
                               "Name": "IncreaseDueToShortPhotoPeriod",
+                              "ResourceName": null,
                               "Children": [
                                 {
                                   "$type": "Models.Functions.LinearInterpolationFunction, Models",
                                   "Name": "PhotoPeriodResponse",
+                                  "ResourceName": null,
                                   "Children": [
                                     {
                                       "$type": "Models.Functions.XYPairs, Models",
@@ -694,9 +982,10 @@
                                         1.0,
                                         0.0
                                       ],
+                                      "XVariableName": null,
                                       "Name": "XYPairs",
+                                      "ResourceName": null,
                                       "Children": [],
-                                      "IncludeInDocumentation": true,
                                       "Enabled": true,
                                       "ReadOnly": false
                                     },
@@ -704,13 +993,12 @@
                                       "$type": "Models.Functions.VariableReference, Models",
                                       "VariableName": "[Phenology].Photoperiod",
                                       "Name": "XValue",
+                                      "ResourceName": null,
                                       "Children": [],
-                                      "IncludeInDocumentation": true,
                                       "Enabled": true,
                                       "ReadOnly": false
                                     }
                                   ],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 },
@@ -718,28 +1006,24 @@
                                   "$type": "Models.Functions.VariableReference, Models",
                                   "VariableName": "[Phenology].EarlyReproductivePpSensitivity",
                                   "Name": "PpSensitivity",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 }
                               ],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -748,14 +1032,15 @@
                   "Start": "Flowering",
                   "End": "StartGrainFill",
                   "Name": "GrainDevelopment",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.Constant, Models",
                       "FixedValue": 120.0,
                       "Units": null,
                       "Name": "Target",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -763,13 +1048,12 @@
                       "$type": "Models.Functions.VariableReference, Models",
                       "VariableName": "[Phenology].ThermalTime",
                       "Name": "Progression",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -778,14 +1062,15 @@
                   "Start": "StartGrainFill",
                   "End": "EndGrainFill",
                   "Name": "GrainFilling",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.Constant, Models",
                       "FixedValue": 545.0,
                       "Units": null,
                       "Name": "Target",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -793,13 +1078,12 @@
                       "$type": "Models.Functions.VariableReference, Models",
                       "VariableName": "[Phenology].ThermalTime",
                       "Name": "Progression",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -808,14 +1092,15 @@
                   "Start": "EndGrainFill",
                   "End": "Maturity",
                   "Name": "Maturing",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.Constant, Models",
                       "FixedValue": 35.0,
                       "Units": null,
                       "Name": "Target",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -823,13 +1108,12 @@
                       "$type": "Models.Functions.VariableReference, Models",
                       "VariableName": "[Phenology].ThermalTime",
                       "Name": "Progression",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -838,14 +1122,15 @@
                   "Start": "Maturity",
                   "End": "HarvestRipe",
                   "Name": "Ripening",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.Constant, Models",
                       "FixedValue": 300.0,
                       "Units": null,
                       "Name": "Target",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -853,13 +1138,12 @@
                       "$type": "Models.Functions.VariableReference, Models",
                       "VariableName": "[Phenology].ThermalTime",
                       "Name": "Progression",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -868,26 +1152,26 @@
                   "Start": "HarvestRipe",
                   "End": "Unused",
                   "Name": "ReadyForHarvesting",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.VariableReference, Models",
                       "VariableName": "[Phenology].ThermalTime",
                       "Name": "ThermalTime",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.PMF.Phen.ZadokPMF, Models",
                   "Name": "Zadok",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -896,13 +1180,14 @@
                   "SetEvent": "FlagLeaf",
                   "ReSetEvent": "never",
                   "Name": "FlagLeafDAS",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Memo, Models",
                       "Text": "\r\nA function is used to provide flowering date as days after sowing(DAS).\r\n",
                       "Name": "memo",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -911,22 +1196,21 @@
                       "FixedValue": 0.0,
                       "Units": null,
                       "Name": "PreEventValue",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.VariableReference, Models",
-                      "VariableName": "[Phenology].DaysAfterSowing",
+                      "VariableName": "[Plant].DaysAfterSowing",
                       "Name": "PostEventValue",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -935,13 +1219,14 @@
                   "SetEvent": "Flowering",
                   "ReSetEvent": "never",
                   "Name": "FloweringDAS",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Memo, Models",
                       "Text": "\r\nA function is used to provide flowering date as days after sowing(DAS).\r\n",
                       "Name": "memo",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -950,22 +1235,21 @@
                       "FixedValue": 0.0,
                       "Units": null,
                       "Name": "PreEventValue",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.VariableReference, Models",
-                      "VariableName": "[Phenology].DaysAfterSowing",
+                      "VariableName": "[Plant].DaysAfterSowing",
                       "Name": "PostEventValue",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -974,13 +1258,14 @@
                   "SetEvent": "Maturity",
                   "ReSetEvent": "never",
                   "Name": "MaturityDAS",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Memo, Models",
                       "Text": "\r\nA function is used to provide maturity date as days after sowing(DAS).",
                       "Name": "memo",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -989,27 +1274,25 @@
                       "FixedValue": 0.0,
                       "Units": null,
                       "Name": "PreEventValue",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.VariableReference, Models",
-                      "VariableName": "[Phenology].DaysAfterSowing",
+                      "VariableName": "[Plant].DaysAfterSowing",
                       "Name": "PostEventValue",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 }
               ],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
@@ -1018,14 +1301,15 @@
               "CohortInitialisationStage": "Germination",
               "LeafInitialisationStage": "Emergence",
               "Name": "Structure",
+              "ResourceName": null,
               "Children": [
                 {
                   "$type": "Models.Functions.Constant, Models",
                   "FixedValue": 0.0,
                   "Units": null,
                   "Name": "StemSenescenceAge",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -1033,27 +1317,29 @@
                   "$type": "Models.Functions.VariableReference, Models",
                   "VariableName": "[Phenology].ThermalTime",
                   "Name": "ThermalTime",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Functions.MultiplyFunction, Models",
                   "Name": "Phyllochron",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Memo, Models",
                       "Text": "Based on [Jamieson_SIRIUS_1998] where leaf appearace could be described by a base phyllochron determined between leaves 2 and 7 and a phyllochron that was 70% of base phyllochron for leaves < 2 and 130% of base phyllochron for leaves > 7",
                       "Name": "Rational",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.LinearInterpolationFunction, Models",
                       "Name": "LeafStageFactor",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.XYPairs, Models",
@@ -1075,9 +1361,10 @@
                             1.4,
                             1.4
                           ],
+                          "XVariableName": null,
                           "Name": "XYPairs",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -1085,13 +1372,12 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Leaf].AppearedCohortNo",
                           "Name": "XValue",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -1100,14 +1386,15 @@
                       "FixedValue": 120.0,
                       "Units": "oC.d",
                       "Name": "BasePhyllochron",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.LinearInterpolationFunction, Models",
                       "Name": "PhotoPeriodEffect",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.XYPairs, Models",
@@ -1121,9 +1408,10 @@
                             1.0,
                             1.0
                           ],
+                          "XVariableName": null,
                           "Name": "XYPairs",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -1131,47 +1419,49 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Phenology].Photoperiod",
                           "Name": "XValue",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Functions.MultiplyFunction, Models",
                   "Name": "BranchingRate",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Memo, Models",
                       "Text": "Potential branching rate is determined by the commonly observed pattern of tillering in wheat, in which each tiller emerges with the third leaf on its parent axis (e.g. first tiller emerges at the same time as the third leaf on the main stem, the first secondary tiller appears with the third leaf on tiller 1).  This is described as a simple function of main stem leaf number.",
                       "Name": "Memo",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.PhaseLookup, Models",
                       "Name": "PotentialBranchingRate",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.PhaseLookupValue, Models",
                           "Start": "Emergence",
                           "End": "TerminalSpikelet",
                           "Name": "Vegetative",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.LinearInterpolationFunction, Models",
                               "Name": "PotentialBranchingRate",
+                              "ResourceName": null,
                               "Children": [
                                 {
                                   "$type": "Models.Functions.XYPairs, Models",
@@ -1195,9 +1485,10 @@
                                     12.0,
                                     20.0
                                   ],
+                                  "XVariableName": null,
                                   "Name": "XYPairs",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 },
@@ -1205,18 +1496,16 @@
                                   "$type": "Models.Functions.VariableReference, Models",
                                   "VariableName": "[Structure].LeafTipsAppeared",
                                   "Name": "XValue",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 }
                               ],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -1225,41 +1514,42 @@
                           "Start": "TerminalSpikelet",
                           "End": "HarvestRipe",
                           "Name": "Reproductive",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.Constant, Models",
                               "FixedValue": 0.0,
                               "Units": null,
                               "Name": "Zero",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.MinimumFunction, Models",
                       "Name": "StressFactors",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.LinearInterpolationFunction, Models",
                           "Name": "NitrogenEffect",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Memo, Models",
                               "Text": "Inadequate Nitrogen supply is assumed to affect tillering prior to any effect on photosynthesis or leaf size.",
                               "Name": "Memo",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -1275,9 +1565,10 @@
                                 1.0,
                                 1.0
                               ],
+                              "XVariableName": null,
                               "Name": "XYPairs",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -1285,26 +1576,26 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Arbitrator].FN",
                               "Name": "XValue",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Functions.LinearInterpolationFunction, Models",
                           "Name": "CoverEffect",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Memo, Models",
                               "Text": "Tillering is said to cease once a threshold fraction of incoming radiation has been achieved.  This captures shading effects on tillering described by [evers2006cessation].",
                               "Name": "Memo",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -1320,9 +1611,10 @@
                                 1.0,
                                 0.0
                               ],
+                              "XVariableName": null,
                               "Name": "XYPairs",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -1330,19 +1622,19 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Leaf].CoverTotal",
                               "Name": "XValue",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Functions.LinearInterpolationFunction, Models",
                           "Name": "WaterStressEffect",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.XYPairs, Models",
@@ -1354,9 +1646,10 @@
                                 0.0,
                                 1.0
                               ],
+                              "XVariableName": null,
                               "Name": "XYPairs",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -1364,43 +1657,44 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Root].WaterTensionFactor",
                               "Name": "XValue",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Functions.PhaseLookup, Models",
                   "Name": "BranchMortality",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.PhaseLookupValue, Models",
                       "Start": "FlagLeaf",
                       "End": "Flowering",
                       "Name": "MortalityPhase",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.MultiplyFunction, Models",
                           "Name": "Mortality",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.LinearInterpolationFunction, Models",
                               "Name": "MortalityPerDegDay",
+                              "ResourceName": null,
                               "Children": [
                                 {
                                   "$type": "Models.Functions.XYPairs, Models",
@@ -1412,9 +1706,10 @@
                                     0.002,
                                     0.0
                                   ],
+                                  "XVariableName": null,
                                   "Name": "XYPairs",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 },
@@ -1422,13 +1717,12 @@
                                   "$type": "Models.Functions.VariableReference, Models",
                                   "VariableName": "[Structure].MeanTillerGrowthRate",
                                   "Name": "XValue",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 }
                               ],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -1436,33 +1730,32 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Phenology].ThermalTime",
                               "Name": "ThermalTime",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.PMF.Struct.HeightFunction, Models",
                   "Name": "HeightModel",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.LinearInterpolationFunction, Models",
                       "Name": "PotentialHeight",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.XYPairs, Models",
@@ -1480,9 +1773,10 @@
                             1100.0,
                             1200.0
                           ],
+                          "XVariableName": null,
                           "Name": "XYPairs",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -1490,19 +1784,19 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Phenology].Stage",
                           "Name": "XValue",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.LinearInterpolationFunction, Models",
                       "Name": "WaterStress",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.XYPairs, Models",
@@ -1514,9 +1808,10 @@
                             0.0,
                             1.0
                           ],
+                          "XVariableName": null,
                           "Name": "XYPairs",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -1524,18 +1819,16 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Wheat].Leaf.Fw",
                           "Name": "XValue",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -1544,17 +1837,19 @@
                   "NumberOfDays": 5,
                   "StageToStartMovingAverage": "Emergence",
                   "Name": "MeanTillerGrowthRate",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.DivideFunction, Models",
                       "Name": "TillerGrowthRate",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Arbitrator].DM.TotalFixationSupply",
                           "Name": "DailyGrowth",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -1562,8 +1857,8 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Phenology].ThermalTime",
                           "Name": "ThermalTime",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -1571,18 +1866,16 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Structure].TotalStemPopn",
                           "Name": "StemPopulation",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -1591,18 +1884,18 @@
                   "NumberOfDays": 300,
                   "StageToStartMovingAverage": "Emergence",
                   "Name": "MeanPhyllochron",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.VariableReference, Models",
                       "VariableName": "[Structure].Phyllochron",
                       "Name": "Phyllochron",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -1610,44 +1903,48 @@
                   "$type": "Models.Functions.HoldFunction, Models",
                   "WhenToHold": "TerminalSpikelet",
                   "Name": "FinalLeafNumber",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.AddFunction, Models",
                       "Name": "FinalNodeNumber",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Phenology].MinimumLeafNumber",
                           "Name": "MinLeafNumber",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Functions.MultiplyFunction, Models",
                           "Name": "VernalLeaves",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Phenology].VrnSensitivity",
                               "Name": "UnVernalisedLeaves",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
                             {
                               "$type": "Models.Functions.SubtractFunction, Models",
                               "Name": "VernalisationReductionFactor",
+                              "ResourceName": null,
                               "Children": [
                                 {
                                   "$type": "Models.Functions.Constant, Models",
                                   "FixedValue": 1.0,
                                   "Units": null,
                                   "Name": "One",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 },
@@ -1655,37 +1952,37 @@
                                   "$type": "Models.Functions.VariableReference, Models",
                                   "VariableName": "[Phenology].Vrn1",
                                   "Name": "RelativeVrn1Expression",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 }
                               ],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Functions.MultiplyFunction, Models",
                           "Name": "PhotoPLeaves",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Phenology].PpSensitivity",
                               "Name": "ShortPpLeaves",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
                             {
                               "$type": "Models.Functions.LinearInterpolationFunction, Models",
                               "Name": "PhotoPeriodReductionFactor",
+                              "ResourceName": null,
                               "Children": [
                                 {
                                   "$type": "Models.Functions.XYPairs, Models",
@@ -1697,9 +1994,10 @@
                                     1.0,
                                     0.0
                                   ],
+                                  "XVariableName": null,
                                   "Name": "XYPairs",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 },
@@ -1707,60 +2005,57 @@
                                   "$type": "Models.Functions.VariableReference, Models",
                                   "VariableName": "[Phenology].Photoperiod",
                                   "Name": "XValue",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 }
                               ],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Functions.ExpressionFunction, Models",
-                  "Expression": "([Structure].FinalLeafNumber.Value() - 2.85)/1.1",
+                  "Expression": "([Structure].FinalLeafNumber - 2.85)/1.1",
                   "Name": "HaunStageTerminalSpikelet",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Memo, Models",
                       "Text": "The Haun stage at which Terminal Spikelet occurs is determined from final leaf number using the approach described in [Brown_Anthesis_2013].",
                       "Name": "Memo",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Functions.AddFunction, Models",
                   "Name": "HaunStage",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.VariableReference, Models",
                       "VariableName": "[Leaf].ExpandedCohortNo",
                       "Name": "AppearedLeaves",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -1768,18 +2063,16 @@
                       "$type": "Models.Functions.VariableReference, Models",
                       "VariableName": "[Leaf].NextExpandingLeafProportion",
                       "Name": "ProportionOfExpandingLeaf",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 }
               ],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
@@ -1795,31 +2088,30 @@
               "potentialDMAllocation": null,
               "Live": {
                 "$type": "Models.PMF.Biomass, Models",
-                "DMDOfStructural": 0.6,
                 "Name": "Biomass",
+                "ResourceName": null,
                 "Children": [],
-                "IncludeInDocumentation": true,
                 "Enabled": true,
                 "ReadOnly": false
               },
               "Dead": {
                 "$type": "Models.PMF.Biomass, Models",
-                "DMDOfStructural": 0.6,
                 "Name": "Biomass",
+                "ResourceName": null,
                 "Children": [],
-                "IncludeInDocumentation": true,
                 "Enabled": true,
                 "ReadOnly": false
               },
               "Name": "Grain",
+              "ResourceName": null,
               "Children": [
                 {
                   "$type": "Models.Functions.Constant, Models",
                   "FixedValue": 0.03,
                   "Units": null,
                   "Name": "MaxNConcDailyGrowth",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -1828,8 +2120,8 @@
                   "FixedValue": 0.12,
                   "Units": null,
                   "Name": "WaterContent",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -1838,8 +2130,8 @@
                   "FixedValue": 0.0123,
                   "Units": null,
                   "Name": "MinimumNConc",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -1848,8 +2140,8 @@
                   "FixedValue": 0.03,
                   "Units": null,
                   "Name": "MaximumNConc",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -1858,8 +2150,8 @@
                   "FixedValue": 0.043,
                   "Units": "g",
                   "Name": "MaximumPotentialGrainSize",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -1873,41 +2165,44 @@
                   "FractionRemovedOnGraze": 0.0,
                   "FractionRemovedOnPrune": 0.0,
                   "Name": "AccumThermalTime",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.VariableReference, Models",
                       "VariableName": "[Phenology].ThermalTime",
                       "Name": "DailyThermalTimeValue",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Functions.PhaseLookup, Models",
                   "Name": "DMDemandFunction",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.PhaseLookupValue, Models",
                       "Start": "Flowering",
                       "End": "StartGrainFill",
                       "Name": "InitialPhase",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.DemandFunctions.FillingRateFunction, Models",
                           "Name": "FillingRateFunction",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Grain].NumberFunction",
                               "Name": "NumberFunction",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -1915,8 +2210,8 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Phenology].GrainDevelopment.Target",
                               "Name": "FillingDuration",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -1924,21 +2219,22 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Phenology].ThermalTime",
                               "Name": "ThermalTime",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
                             {
                               "$type": "Models.Functions.MultiplyFunction, Models",
                               "Name": "PotentialSizeIncrement",
+                              "ResourceName": null,
                               "Children": [
                                 {
                                   "$type": "Models.Functions.VariableReference, Models",
                                   "VariableName": "[Grain].InitialGrainProportion",
                                   "Name": "InitialProportion",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 },
@@ -1946,23 +2242,20 @@
                                   "$type": "Models.Functions.VariableReference, Models",
                                   "VariableName": "[Grain].MaximumPotentialGrainSize",
                                   "Name": "MaximumSize",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 }
                               ],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -1971,17 +2264,19 @@
                       "Start": "StartGrainFill",
                       "End": "EndGrainFill",
                       "Name": "LinearPhase",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.DemandFunctions.FillingRateFunction, Models",
                           "Name": "FillingRateFunction",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Grain].NumberFunction",
                               "Name": "NumberFunction",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -1989,8 +2284,8 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Phenology].GrainFilling.Target",
                               "Name": "FillingDuration",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -1998,26 +2293,28 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Phenology].ThermalTime",
                               "Name": "ThermalTime",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
                             {
                               "$type": "Models.Functions.MultiplyFunction, Models",
                               "Name": "PotentialSizeIncrement",
+                              "ResourceName": null,
                               "Children": [
                                 {
                                   "$type": "Models.Functions.SubtractFunction, Models",
                                   "Name": "ProportionLinearPhase",
+                                  "ResourceName": null,
                                   "Children": [
                                     {
                                       "$type": "Models.Functions.Constant, Models",
                                       "FixedValue": 1.0,
                                       "Units": null,
                                       "Name": "One",
+                                      "ResourceName": null,
                                       "Children": [],
-                                      "IncludeInDocumentation": true,
                                       "Enabled": true,
                                       "ReadOnly": false
                                     },
@@ -2025,13 +2322,12 @@
                                       "$type": "Models.Functions.VariableReference, Models",
                                       "VariableName": "[Grain].InitialGrainProportion",
                                       "Name": "InitialProportion",
+                                      "ResourceName": null,
                                       "Children": [],
-                                      "IncludeInDocumentation": true,
                                       "Enabled": true,
                                       "ReadOnly": false
                                     }
                                   ],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 },
@@ -2039,28 +2335,24 @@
                                   "$type": "Models.Functions.VariableReference, Models",
                                   "VariableName": "[Grain].MaximumPotentialGrainSize",
                                   "Name": "MaximumSize",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 }
                               ],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -2068,8 +2360,8 @@
                   "$type": "Models.Functions.ExpressionFunction, Models",
                   "Expression": "([Grain].Live.N + [Grain].Dead.N)/([Grain].Live.Wt + [Grain].Dead.Wt) * 100 * 5.71",
                   "Name": "Protein",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -2078,44 +2370,48 @@
                   "FixedValue": 0.05,
                   "Units": null,
                   "Name": "InitialGrainProportion",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Functions.PhaseLookup, Models",
                   "Name": "NFillingRate",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.PhaseLookupValue, Models",
                       "Start": "Flowering",
                       "End": "EndGrainFill",
                       "Name": "GrainFilling",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.DemandFunctions.FillingRateFunction, Models",
                           "Name": "FillingRateFunction",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Grain].NumberFunction",
                               "Name": "NumberFunction",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
                             {
                               "$type": "Models.Functions.AddFunction, Models",
                               "Name": "FillingDuration",
+                              "ResourceName": null,
                               "Children": [
                                 {
                                   "$type": "Models.Functions.VariableReference, Models",
                                   "VariableName": "[Phenology].GrainDevelopment.Target",
                                   "Name": "FloweringToGrainFilling",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 },
@@ -2123,13 +2419,12 @@
                                   "$type": "Models.Functions.VariableReference, Models",
                                   "VariableName": "[Phenology].GrainFilling.Target",
                                   "Name": "GrainFilling",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 }
                               ],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -2137,21 +2432,22 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Phenology].ThermalTime",
                               "Name": "ThermalTime",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
                             {
                               "$type": "Models.Functions.MultiplyFunction, Models",
                               "Name": "PotentialSizeIncrement",
+                              "ResourceName": null,
                               "Children": [
                                 {
                                   "$type": "Models.Functions.VariableReference, Models",
                                   "VariableName": "[Grain].MaximumPotentialGrainSize",
                                   "Name": "MaximumSize",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 },
@@ -2159,34 +2455,31 @@
                                   "$type": "Models.Functions.VariableReference, Models",
                                   "VariableName": "[Grain].MaximumNConc",
                                   "Name": "MaximumNConc",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 }
                               ],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.PMF.Library.BiomassRemoval, Models",
                   "Name": "BiomassRemovalDefaults",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.PMF.OrganBiomassRemovalType, Models",
@@ -2195,8 +2488,8 @@
                       "FractionLiveToResidue": 0.0,
                       "FractionDeadToResidue": 0.0,
                       "Name": "Harvest",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -2207,8 +2500,8 @@
                       "FractionLiveToResidue": 0.0,
                       "FractionDeadToResidue": 0.0,
                       "Name": "Cut",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -2219,8 +2512,8 @@
                       "FractionLiveToResidue": 0.8,
                       "FractionDeadToResidue": 0.0,
                       "Name": "Prune",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -2231,8 +2524,8 @@
                       "FractionLiveToResidue": 0.2,
                       "FractionDeadToResidue": 0.0,
                       "Name": "Graze",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -2243,13 +2536,12 @@
                       "FractionLiveToResidue": 0.05,
                       "FractionDeadToResidue": 0.0,
                       "Name": "Thin",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -2257,37 +2549,37 @@
                   "$type": "Models.Functions.HoldFunction, Models",
                   "WhenToHold": "Flowering",
                   "Name": "NumberFunction",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.MultiplyFunction, Models",
                       "Name": "GrainNumber",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.Constant, Models",
                           "FixedValue": 22.0,
                           "Units": "grains",
                           "Name": "GrainsPerGramOfStem",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Functions.VariableReference, Models",
-                          "VariableName": "[StemPlusSpike].Wt",
+                          "VariableName": "[Stem].Wt",
                           "Name": "StemMass",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -2296,8 +2588,8 @@
                   "FixedValue": 1.0,
                   "Units": null,
                   "Name": "DMConversionEfficiency",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -2306,8 +2598,8 @@
                   "FixedValue": 0.0,
                   "Units": null,
                   "Name": "RemobilisationCost",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -2316,13 +2608,90 @@
                   "FixedValue": 0.4,
                   "Units": null,
                   "Name": "CarbonConcentration",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.PMF.NutrientPoolFunctions, Models",
+                  "Name": "DMDemandPriorityFactors",
+                  "ResourceName": null,
+                  "Children": [
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "Structural",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "Metabolic",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "Storage",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    }
+                  ],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.PMF.NutrientPoolFunctions, Models",
+                  "Name": "NDemandPriorityFactors",
+                  "ResourceName": null,
+                  "Children": [
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "Structural",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "Metabolic",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "Storage",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    }
+                  ],
                   "Enabled": true,
                   "ReadOnly": false
                 }
               ],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
@@ -2335,16 +2704,24 @@
               "potentialDMAllocation": null,
               "GrowthRespiration": 0.0,
               "MaintenanceRespiration": 0.0,
-              "RootAngle": 45.0,
               "Name": "Root",
+              "ResourceName": null,
               "Children": [
+                {
+                  "$type": "Models.Functions.RootShape.RootShapeCylinder, Models",
+                  "Name": "RootShape",
+                  "ResourceName": null,
+                  "Children": [],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
                 {
                   "$type": "Models.Functions.Constant, Models",
                   "FixedValue": 1.0,
                   "Units": null,
                   "Name": "KLModifier",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -2353,8 +2730,8 @@
                   "FixedValue": 1.0,
                   "Units": null,
                   "Name": "SoilWaterEffect",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -2363,8 +2740,8 @@
                   "FixedValue": 20.0,
                   "Units": null,
                   "Name": "MaxDailyNUptake",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -2373,8 +2750,8 @@
                   "FixedValue": 0.005,
                   "Units": null,
                   "Name": "SenescenceRate",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -2383,8 +2760,8 @@
                   "FixedValue": 1000000.0,
                   "Units": null,
                   "Name": "MaximumRootDepth",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -2393,8 +2770,8 @@
                   "FixedValue": 0.01,
                   "Units": null,
                   "Name": "MaximumNConc",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -2403,24 +2780,36 @@
                   "FixedValue": 0.01,
                   "Units": null,
                   "Name": "MinimumNConc",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.Functions.PhaseBasedSwitch, Models",
+                  "$type": "Models.Functions.PhaseLookupValue, Models",
                   "Start": "Germination",
                   "End": "Maturity",
                   "Name": "NitrogenDemandSwitch",
-                  "Children": [],
-                  "IncludeInDocumentation": true,
+                  "ResourceName": null,
+                  "Children": [
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "Constant",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    }
+                  ],
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.PMF.Library.BiomassRemoval, Models",
                   "Name": "BiomassRemovalDefaults",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.PMF.OrganBiomassRemovalType, Models",
@@ -2429,8 +2818,8 @@
                       "FractionLiveToResidue": 0.2,
                       "FractionDeadToResidue": 0.0,
                       "Name": "Harvest",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -2441,8 +2830,8 @@
                       "FractionLiveToResidue": 0.3,
                       "FractionDeadToResidue": 0.0,
                       "Name": "Cut",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -2453,8 +2842,8 @@
                       "FractionLiveToResidue": 0.1,
                       "FractionDeadToResidue": 0.0,
                       "Name": "Prune",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -2465,8 +2854,8 @@
                       "FractionLiveToResidue": 0.15,
                       "FractionDeadToResidue": 0.0,
                       "Name": "Graze",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -2477,19 +2866,19 @@
                       "FractionLiveToResidue": 0.05,
                       "FractionDeadToResidue": 0.0,
                       "Name": "Thin",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Functions.LinearInterpolationFunction, Models",
                   "Name": "KNO3",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.XYPairs, Models",
@@ -2501,9 +2890,10 @@
                         0.02,
                         0.02
                       ],
+                      "XVariableName": null,
                       "Name": "XYPairs",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -2511,19 +2901,19 @@
                       "$type": "Models.Functions.VariableReference, Models",
                       "VariableName": "[Root].LengthDensity",
                       "Name": "XValue",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Functions.LinearInterpolationFunction, Models",
                   "Name": "KNH4",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.XYPairs, Models",
@@ -2535,9 +2925,10 @@
                         0.01,
                         0.01
                       ],
+                      "XVariableName": null,
                       "Name": "XYPairs",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -2545,23 +2936,12 @@
                       "$type": "Models.Functions.VariableReference, Models",
                       "VariableName": "[Root].LengthDensity",
                       "Name": "XValue",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
-                  "Enabled": true,
-                  "ReadOnly": false
-                },
-                {
-                  "$type": "Models.Functions.Constant, Models",
-                  "FixedValue": 0.005,
-                  "Units": "g/plant",
-                  "Name": "InitialDM",
-                  "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -2570,37 +2950,39 @@
                   "FixedValue": 105.0,
                   "Units": "m/g",
                   "Name": "SpecificRootLength",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Functions.MultiplyFunction, Models",
                   "Name": "RootFrontVelocity",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.PhaseLookup, Models",
                       "Name": "PotentialRootFrontVelocity",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.PhaseLookupValue, Models",
                           "Start": "Germination",
                           "End": "Emergence",
                           "Name": "PreEmergence",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.Constant, Models",
                               "FixedValue": 5.0,
                               "Units": null,
                               "Name": "Value",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -2609,24 +2991,23 @@
                           "Start": "Emergence",
                           "End": "Maturity",
                           "Name": "PostEmergence",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.Constant, Models",
                               "FixedValue": 20.0,
                               "Units": null,
                               "Name": "Value",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -2634,6 +3015,7 @@
                       "$type": "Models.Functions.WeightedTemperatureFunction, Models",
                       "MaximumTemperatureWeighting": 0.5,
                       "Name": "TemperatureFactor",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.XYPairs, Models",
@@ -2649,26 +3031,27 @@
                             1.0,
                             0.0
                           ],
+                          "XVariableName": null,
                           "Name": "XYPairs",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.LinearInterpolationFunction, Models",
                       "Name": "WaterFactor",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.SoilWaterScale, Models",
                           "Name": "SoilWaterScale",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -2684,9 +3067,10 @@
                             1.0,
                             1.0
                           ],
+                          "XVariableName": null,
                           "Name": "XYPairs",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -2694,30 +3078,29 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[SoilWaterScale]",
                           "Name": "XValue",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Functions.LinearInterpolationFunction, Models",
                   "Name": "NUptakeSWFactor",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.SoilWaterScale, Models",
                       "Name": "SoilWaterScale",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -2731,9 +3114,10 @@
                         0.0,
                         1.0
                       ],
+                      "XVariableName": null,
                       "Name": "XYPairs",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -2741,8 +3125,8 @@
                       "$type": "Models.Memo, Models",
                       "Text": "This is modelled in the same way as the old wheat model",
                       "Name": "Memo",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -2750,13 +3134,12 @@
                       "$type": "Models.Functions.VariableReference, Models",
                       "VariableName": "[SoilWaterScale]",
                       "Name": "XValue",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -2765,8 +3148,8 @@
                   "FixedValue": 1.0,
                   "Units": null,
                   "Name": "DMConversionEfficiency",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -2775,8 +3158,8 @@
                   "FixedValue": 1.0,
                   "Units": null,
                   "Name": "MaintenanceRespirationFunction",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -2785,8 +3168,8 @@
                   "FixedValue": 0.0,
                   "Units": null,
                   "Name": "RemobilisationCost",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -2795,45 +3178,49 @@
                   "FixedValue": 0.4,
                   "Units": null,
                   "Name": "CarbonConcentration",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.PMF.BiomassDemand, Models",
+                  "$type": "Models.PMF.NutrientDemandFunctions, Models",
                   "Name": "DMDemands",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.MultiplyFunction, Models",
                       "Name": "Structural",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.DemandFunctions.PartitionFractionDemandFunction, Models",
                           "Name": "DMDemandFunction",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.PhaseLookup, Models",
                               "Name": "PartitionFraction",
+                              "ResourceName": null,
                               "Children": [
                                 {
                                   "$type": "Models.Functions.PhaseLookupValue, Models",
                                   "Start": "Germination",
                                   "End": "Emergence",
                                   "Name": "PreEmergence",
+                                  "ResourceName": null,
                                   "Children": [
                                     {
                                       "$type": "Models.Functions.Constant, Models",
                                       "FixedValue": 0.0,
                                       "Units": null,
                                       "Name": "Value",
+                                      "ResourceName": null,
                                       "Children": [],
-                                      "IncludeInDocumentation": true,
                                       "Enabled": true,
                                       "ReadOnly": false
                                     }
                                   ],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 },
@@ -2842,10 +3229,12 @@
                                   "Start": "Emergence",
                                   "End": "Flowering",
                                   "Name": "PreFlowering",
+                                  "ResourceName": null,
                                   "Children": [
                                     {
                                       "$type": "Models.Functions.LinearInterpolationFunction, Models",
                                       "Name": "AgeFactor",
+                                      "ResourceName": null,
                                       "Children": [
                                         {
                                           "$type": "Models.Functions.XYPairs, Models",
@@ -2857,9 +3246,10 @@
                                             0.5,
                                             0.2
                                           ],
+                                          "XVariableName": null,
                                           "Name": "XYPairs",
+                                          "ResourceName": null,
                                           "Children": [],
-                                          "IncludeInDocumentation": true,
                                           "Enabled": true,
                                           "ReadOnly": false
                                         },
@@ -2867,18 +3257,16 @@
                                           "$type": "Models.Functions.VariableReference, Models",
                                           "VariableName": "[Phenology].Stage",
                                           "Name": "XValue",
+                                          "ResourceName": null,
                                           "Children": [],
-                                          "IncludeInDocumentation": true,
                                           "Enabled": true,
                                           "ReadOnly": false
                                         }
                                       ],
-                                      "IncludeInDocumentation": true,
                                       "Enabled": true,
                                       "ReadOnly": false
                                     }
                                   ],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 },
@@ -2887,29 +3275,27 @@
                                   "Start": "Flowering",
                                   "End": "EndGrainFill",
                                   "Name": "PostFlowering",
+                                  "ResourceName": null,
                                   "Children": [
                                     {
                                       "$type": "Models.Functions.Constant, Models",
                                       "FixedValue": 0.2,
                                       "Units": null,
                                       "Name": "Value",
+                                      "ResourceName": null,
                                       "Children": [],
-                                      "IncludeInDocumentation": true,
                                       "Enabled": true,
                                       "ReadOnly": false
                                     }
                                   ],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 }
                               ],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -2918,13 +3304,12 @@
                           "FixedValue": 1.0,
                           "Units": null,
                           "Name": "StructuralFraction",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -2933,26 +3318,28 @@
                       "FixedValue": 0.0,
                       "Units": null,
                       "Name": "Metabolic",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.DemandFunctions.StorageDMDemandFunction, Models",
                       "Name": "Storage",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.SubtractFunction, Models",
                           "Name": "StorageFraction",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.Constant, Models",
                               "FixedValue": 1.0,
                               "Units": null,
                               "Name": "One",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -2960,40 +3347,69 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Root].DMDemands.Structural.StructuralFraction",
                               "Name": "StructuralFraction",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "QStructuralPriority",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "QMetabolicPriority",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "QStoragePriority",
+                      "ResourceName": null,
+                      "Children": [],
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.PMF.BiomassDemand, Models",
+                  "$type": "Models.PMF.NutrientDemandFunctions, Models",
                   "Name": "NDemands",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.MultiplyFunction, Models",
                       "Name": "Structural",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Root].minimumNconc",
                           "Name": "MinNconc",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -3001,30 +3417,31 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Root].potentialDMAllocation.Structural",
                           "Name": "PotentialDMAllocation",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.MultiplyFunction, Models",
                       "Name": "Metabolic",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.SubtractFunction, Models",
                           "Name": "MetabolicNconc",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Root].criticalNConc",
                               "Name": "CritNconc",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -3032,13 +3449,12 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Root].minimumNconc",
                               "Name": "MinNconc",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -3046,26 +3462,26 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Root].potentialDMAllocation.Structural",
                           "Name": "PotentialDMAllocation",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.DemandFunctions.StorageNDemandFunction, Models",
                       "Name": "Storage",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Root].nitrogenDemandSwitch",
                           "Name": "NitrogenDemandSwitch",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -3073,23 +3489,108 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Root].maximumNconc",
                           "Name": "MaxNconc",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "QStructuralPriority",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "QMetabolicPriority",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "QStoragePriority",
+                      "ResourceName": null,
+                      "Children": [],
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Functions.VariableReference, Models",
+                  "VariableName": "[Root].MinimumNConc",
+                  "Name": "CriticalNConc",
+                  "ResourceName": null,
+                  "Children": [],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.PMF.NutrientPoolFunctions, Models",
+                  "Name": "InitialWt",
+                  "ResourceName": null,
+                  "Children": [
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 0.005,
+                      "Units": "g/plant",
+                      "Name": "Structural",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 0.0,
+                      "Units": null,
+                      "Name": "Metabolic",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 0.0,
+                      "Units": null,
+                      "Name": "Storage",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    }
+                  ],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Functions.Constant, Models",
+                  "FixedValue": 1.0,
+                  "Units": null,
+                  "Name": "RootDepthStressFactor",
+                  "ResourceName": null,
+                  "Children": [],
                   "Enabled": true,
                   "ReadOnly": false
                 }
               ],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
@@ -3111,6 +3612,8 @@
               "Gsmax350": 0.011,
               "R50": 150.0,
               "LAI": 0.0,
+              "Depth": 0.0,
+              "Width": 0.0,
               "FRGR": 0.0,
               "PotentialEP": 0.0,
               "WaterDemand": 0.0,
@@ -3121,6 +3624,7 @@
               "CohortsAtInitialisation": 0,
               "FractionDied": 0.0,
               "Name": "Leaf",
+              "ResourceName": null,
               "Children": [
                 {
                   "$type": "Models.PMF.Organs.LeafCohort, Models",
@@ -3149,10 +3653,9 @@
                   "MetabolicDMAllocation": 0.0,
                   "Rank": 1,
                   "Area": 200.0,
-                  "MaintenanceRespiration": 0.0,
                   "Name": "InitialLeaves[1]",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -3183,25 +3686,30 @@
                   "MetabolicDMAllocation": 0.0,
                   "Rank": 2,
                   "Area": 0.0,
-                  "MaintenanceRespiration": 0.0,
                   "Name": "InitialLeaves[2]",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.PMF.Organs.Leaf+LeafCohortParameters, Models",
                   "ExpansionStressValue": 0.0,
+                  "CellDivisionStressValue": 0.0,
+                  "LagAccelerationValue": 0.0,
+                  "SenescenceAccelerationValue": 0.0,
+                  "ShadeInducedSenescenceRateValue": 0.0,
+                  "SenessingLeafRelativeSizeValue": 0.0,
                   "Name": "CohortParameters",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.Constant, Models",
                       "FixedValue": 1.0,
                       "Units": null,
                       "Name": "NReallocationFactor",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -3210,8 +3718,8 @@
                       "FixedValue": 0.0,
                       "Units": null,
                       "Name": "MaintenanceRespirationFunction",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -3220,8 +3728,8 @@
                       "FixedValue": 0.03,
                       "Units": null,
                       "Name": "NRetranslocationFactor",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -3230,8 +3738,8 @@
                       "FixedValue": 0.0,
                       "Units": null,
                       "Name": "DMReallocationFactor",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -3240,18 +3748,20 @@
                       "FixedValue": 0.0,
                       "Units": null,
                       "Name": "DMRetranslocationFactor",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.MinimumFunction, Models",
                       "Name": "CellDivisionStress",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.LinearInterpolationFunction, Models",
                           "Name": "WaterStressFactor",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.XYPairs, Models",
@@ -3263,9 +3773,10 @@
                                 0.1,
                                 1.0
                               ],
+                              "XVariableName": null,
                               "Name": "XYPairs",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -3273,19 +3784,19 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Wheat].Leaf.Fw",
                               "Name": "XValue",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Functions.LinearInterpolationFunction, Models",
                           "Name": "NitrogenStressFactor",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.XYPairs, Models",
@@ -3299,9 +3810,10 @@
                                 0.1,
                                 1.0
                               ],
+                              "XVariableName": null,
                               "Name": "XYPairs",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -3309,28 +3821,28 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Wheat].Leaf.Fn",
                               "Name": "XValue",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.MinimumFunction, Models",
                       "Name": "ExpansionStress",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.LinearInterpolationFunction, Models",
                           "Name": "WaterStress",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.XYPairs, Models",
@@ -3344,9 +3856,10 @@
                                 1.0,
                                 1.0
                               ],
+                              "XVariableName": null,
                               "Name": "XYPairs",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -3354,19 +3867,19 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Root].WaterTensionFactor",
                               "Name": "XValue",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Functions.LinearInterpolationFunction, Models",
                           "Name": "TemperatureEffect",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.XYPairs, Models",
@@ -3380,9 +3893,10 @@
                                 1.0,
                                 1.0
                               ],
+                              "XVariableName": null,
                               "Name": "XYPairs",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -3390,19 +3904,19 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[IWeather].MeanT",
                               "Name": "XValue",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Functions.LinearInterpolationFunction, Models",
                           "Name": "NitrogenStressFactor",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.XYPairs, Models",
@@ -3416,9 +3930,10 @@
                                 0.1,
                                 1.0
                               ],
+                              "XVariableName": null,
                               "Name": "XYPairs",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -3426,38 +3941,38 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Wheat].Leaf.Fn",
                               "Name": "XValue",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.MultiplyFunction, Models",
                       "Name": "MaxArea",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.Constant, Models",
                           "FixedValue": 2600.0,
                           "Units": "mm^2",
                           "Name": "AreaLargestLeaves",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Functions.LinearInterpolationFunction, Models",
                           "Name": "AgeFactor",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.XYPairs, Models",
@@ -3471,9 +3986,10 @@
                                 0.5,
                                 1.0
                               ],
+                              "XVariableName": null,
                               "Name": "XYPairs",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -3481,32 +3997,31 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Phenology].Stage",
                               "Name": "XValue",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.MultiplyFunction, Models",
                       "Name": "GrowthDuration",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.Constant, Models",
                           "FixedValue": 1.3,
                           "Units": null,
                           "Name": "Multiplier",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -3514,23 +4029,24 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Structure].Phyllochron",
                           "Name": "Phyllochron",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.MultiplyFunction, Models",
                       "Name": "LagDuration",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.LinearInterpolationFunction, Models",
                           "Name": "AgeFactor",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.XYPairs, Models",
@@ -3542,9 +4058,10 @@
                                 0.4,
                                 1.0
                               ],
+                              "XVariableName": null,
                               "Name": "XYPairs",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -3552,30 +4069,31 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Phenology].Stage",
                               "Name": "XValue",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Functions.SubtractFunction, Models",
                           "Name": "LastLeafDuration",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.AddFunction, Models",
                               "Name": "ThermalTimeToRipe",
+                              "ResourceName": null,
                               "Children": [
                                 {
                                   "$type": "Models.Functions.VariableReference, Models",
                                   "VariableName": "[Phenology].EarlyReproductive.Target",
                                   "Name": "EarlyReproductive",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 },
@@ -3583,8 +4101,8 @@
                                   "$type": "Models.Functions.VariableReference, Models",
                                   "VariableName": "[Phenology].GrainDevelopment.Target",
                                   "Name": "GrainDevelopment",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 },
@@ -3592,8 +4110,8 @@
                                   "$type": "Models.Functions.VariableReference, Models",
                                   "VariableName": "[Phenology].GrainFilling.Target",
                                   "Name": "GrainFilling",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 },
@@ -3601,8 +4119,8 @@
                                   "$type": "Models.Functions.VariableReference, Models",
                                   "VariableName": "[Phenology].Maturing.Target",
                                   "Name": "Maturing",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 },
@@ -3610,13 +4128,12 @@
                                   "$type": "Models.Functions.VariableReference, Models",
                                   "VariableName": "[Phenology].Ripening.Target",
                                   "Name": "Ripening",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 }
                               ],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -3624,32 +4141,31 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Leaf].CohortParameters.SenescenceDuration",
                               "Name": "SenescenceDuration",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.MultiplyFunction, Models",
                       "Name": "SenescenceDuration",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.Constant, Models",
                           "FixedValue": 3.0,
                           "Units": null,
                           "Name": "Multiplier",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -3657,13 +4173,12 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Structure].Phyllochron",
                           "Name": "Phyllochron",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -3672,8 +4187,8 @@
                       "FixedValue": 1000000.0,
                       "Units": null,
                       "Name": "DetachmentLagDuration",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -3682,8 +4197,8 @@
                       "FixedValue": 1000000.0,
                       "Units": null,
                       "Name": "DetachmentDuration",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -3692,14 +4207,15 @@
                       "FixedValue": 1.0,
                       "Units": null,
                       "Name": "RelativeBranchLeafSize",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.LinearInterpolationFunction, Models",
                       "Name": "MaximumNConc",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.XYPairs, Models",
@@ -3713,9 +4229,10 @@
                             0.05,
                             0.02
                           ],
+                          "XVariableName": null,
                           "Name": "XYPairs",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -3723,23 +4240,24 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Phenology].Stage",
                           "Name": "XValue",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.MultiplyFunction, Models",
                       "Name": "CriticalNConc",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.LinearInterpolationFunction, Models",
                           "Name": "CriticalNConcAt350ppm",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.XYPairs, Models",
@@ -3753,9 +4271,10 @@
                                 0.04,
                                 0.015
                               ],
+                              "XVariableName": null,
                               "Name": "XYPairs",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -3763,19 +4282,19 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Phenology].Stage",
                               "Name": "XValue",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Functions.LinearInterpolationFunction, Models",
                           "Name": "CO2Factor",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.XYPairs, Models",
@@ -3787,9 +4306,10 @@
                                 1.0,
                                 0.93
                               ],
+                              "XVariableName": null,
                               "Name": "XYPairs",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -3797,24 +4317,23 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Weather].CO2",
                               "Name": "XValue",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.LinearInterpolationFunction, Models",
                       "Name": "MinimumNConc",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.XYPairs, Models",
@@ -3828,9 +4347,10 @@
                             0.005,
                             0.005
                           ],
+                          "XVariableName": null,
                           "Name": "XYPairs",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -3838,47 +4358,49 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Phenology].Stage",
                           "Name": "XValue",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.AddFunction, Models",
-                      "Name": "DroughtInducedLagAcceleration",
+                      "Name": "LagAcceleration",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.Constant, Models",
                           "FixedValue": 1.0,
                           "Units": null,
                           "Name": "One",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Functions.MultiplyFunction, Models",
                           "Name": "Stress",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.Constant, Models",
                               "FixedValue": 1.0,
                               "Units": null,
                               "Name": "StressResponseCoefficient",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
                             {
                               "$type": "Models.Functions.LinearInterpolationFunction, Models",
                               "Name": "StressFactor",
+                              "ResourceName": null,
                               "Children": [
                                 {
                                   "$type": "Models.Functions.XYPairs, Models",
@@ -3890,9 +4412,10 @@
                                     0.5,
                                     0.0
                                   ],
+                                  "XVariableName": null,
                                   "Name": "XYPairs",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 },
@@ -3900,57 +4423,57 @@
                                   "$type": "Models.Functions.VariableReference, Models",
                                   "VariableName": "[Wheat].Leaf.Fw",
                                   "Name": "XValue",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 }
                               ],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.AddFunction, Models",
-                      "Name": "DroughtInducedSenAcceleration",
+                      "Name": "SenescenceAcceleration",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.Constant, Models",
                           "FixedValue": 1.0,
                           "Units": null,
                           "Name": "One",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Functions.MultiplyFunction, Models",
                           "Name": "Stress",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.Constant, Models",
                               "FixedValue": 1.0,
                               "Units": null,
                               "Name": "StressResponseCoefficient",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
                             {
                               "$type": "Models.Functions.LinearInterpolationFunction, Models",
                               "Name": "StressFactor",
+                              "ResourceName": null,
                               "Children": [
                                 {
                                   "$type": "Models.Functions.XYPairs, Models",
@@ -3962,9 +4485,10 @@
                                     0.5,
                                     0.0
                                   ],
+                                  "XVariableName": null,
                                   "Name": "XYPairs",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 },
@@ -3972,29 +4496,27 @@
                                   "$type": "Models.Functions.VariableReference, Models",
                                   "VariableName": "[Wheat].Leaf.Fw",
                                   "Name": "XValue",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 }
                               ],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.LinearInterpolationFunction, Models",
                       "Name": "SpecificLeafAreaMax",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.XYPairs, Models",
@@ -4006,9 +4528,10 @@
                             18000.0,
                             30000.0
                           ],
+                          "XVariableName": null,
                           "Name": "XYPairs",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -4016,19 +4539,19 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Phenology].Stage",
                           "Name": "XValue",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.LinearInterpolationFunction, Models",
                       "Name": "SpecificLeafAreaMin",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.XYPairs, Models",
@@ -4040,9 +4563,10 @@
                             10000.0,
                             18000.0
                           ],
+                          "XVariableName": null,
                           "Name": "XYPairs",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -4050,13 +4574,12 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Leaf].Fn",
                           "Name": "XValue",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -4065,8 +4588,8 @@
                       "FixedValue": 0.0,
                       "Units": null,
                       "Name": "InitialNConc",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -4075,8 +4598,8 @@
                       "FixedValue": 0.5,
                       "Units": null,
                       "Name": "StructuralFraction",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -4085,8 +4608,8 @@
                       "FixedValue": 0.0,
                       "Units": null,
                       "Name": "StorageFraction",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -4095,8 +4618,8 @@
                       "FixedValue": 0.3,
                       "Units": null,
                       "Name": "LeafSizeShapeParameter",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -4105,32 +4628,33 @@
                       "FixedValue": 1.0,
                       "Units": "0-1",
                       "Name": "SenessingLeafRelativeSize",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.MultiplyFunction, Models",
                       "Name": "ShadeInducedSenescenceRate",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.Constant, Models",
                           "FixedValue": 0.0,
                           "Units": null,
                           "Name": "RatePerDegDay",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Memo, Models",
                               "Text": "1% per degree day means it takes one phyllochron for a shaded leaf to fully sceness\r\n",
                               "Name": "Memo",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -4138,13 +4662,12 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Phenology].ThermalTime",
                           "Name": "ThermalTime",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -4153,8 +4676,8 @@
                       "Values": "1 1 1",
                       "Units": null,
                       "Name": "LagDurationAgeMultiplier",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -4163,8 +4686,8 @@
                       "Values": "1 1 1",
                       "Units": null,
                       "Name": "SenescenceDurationAgeMultiplier",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -4173,8 +4696,8 @@
                       "Values": "1 1 1 1 1 1 1 1 1 1 1 1",
                       "Units": null,
                       "Name": "LeafSizeAgeMultiplier",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -4183,8 +4706,8 @@
                       "FixedValue": 0.0,
                       "Units": null,
                       "Name": "RemobilisationCost",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -4193,27 +4716,27 @@
                       "FixedValue": 0.4,
                       "Units": null,
                       "Name": "CarbonConcentration",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Functions.SupplyFunctions.RUEModel, Models",
                   "Name": "Photosynthesis",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.Constant, Models",
                       "FixedValue": 1.5,
                       "Units": null,
                       "Name": "RUE",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -4221,6 +4744,7 @@
                       "$type": "Models.Functions.WeightedTemperatureFunction, Models",
                       "MaximumTemperatureWeighting": 0.75,
                       "Name": "FT",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.XYPairs, Models",
@@ -4236,20 +4760,21 @@
                             1.0,
                             0.0
                           ],
+                          "XVariableName": null,
                           "Name": "XYPairs",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.LinearInterpolationFunction, Models",
                       "Name": "FN",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.XYPairs, Models",
@@ -4263,9 +4788,10 @@
                             1.0,
                             1.0
                           ],
+                          "XVariableName": null,
                           "Name": "XYPairs",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -4273,19 +4799,19 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Leaf].Fn",
                           "Name": "XValue",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.LinearInterpolationFunction, Models",
                       "Name": "FW",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.XYPairs, Models",
@@ -4299,9 +4825,10 @@
                             1.0,
                             1.0
                           ],
+                          "XVariableName": null,
                           "Name": "XYPairs",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -4309,19 +4836,19 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Leaf].Fw",
                           "Name": "XValue",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.LinearInterpolationFunction, Models",
                       "Name": "FVPD",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.XYPairs, Models",
@@ -4335,9 +4862,10 @@
                             1.0,
                             0.0
                           ],
+                          "XVariableName": null,
                           "Name": "XYPairs",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -4345,13 +4873,12 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Photosynthesis].VPD",
                           "Name": "XValue",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -4359,22 +4886,21 @@
                       "$type": "Models.Functions.SupplyFunctions.RUECO2Function, Models",
                       "PhotosyntheticPathway": "C3",
                       "Name": "FCO2",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.VariableReference, Models",
-                      "VariableName": "[Leaf].RadIntTot",
+                      "VariableName": "[Leaf].RadiationIntercepted",
                       "Name": "RadnInt",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -4383,8 +4909,8 @@
                   "FixedValue": 0.0,
                   "Units": null,
                   "Name": "FrostFraction",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -4392,34 +4918,36 @@
                   "$type": "Models.Functions.VariableReference, Models",
                   "VariableName": "[Phenology].ThermalTime",
                   "Name": "ThermalTime",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Functions.MinimumFunction, Models",
                   "Name": "FRGRFunction",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.VariableReference, Models",
                       "VariableName": "[Leaf].Photosynthesis.FT",
                       "Name": "RUE_FT",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.MinimumFunction, Models",
                       "Name": "Others",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Leaf].Photosynthesis.FN",
                           "Name": "RUE_FN",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -4427,24 +4955,23 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Leaf].Photosynthesis.FVPD",
                           "Name": "RUE_FVPD",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.PMF.Library.BiomassRemoval, Models",
                   "Name": "BiomassRemovalDefaults",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.PMF.OrganBiomassRemovalType, Models",
@@ -4453,8 +4980,8 @@
                       "FractionLiveToResidue": 0.3,
                       "FractionDeadToResidue": 0.3,
                       "Name": "Harvest",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -4465,8 +4992,8 @@
                       "FractionLiveToResidue": 0.0,
                       "FractionDeadToResidue": 0.0,
                       "Name": "Cut",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -4477,8 +5004,8 @@
                       "FractionLiveToResidue": 0.6,
                       "FractionDeadToResidue": 0.6,
                       "Name": "Prune",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -4489,8 +5016,8 @@
                       "FractionLiveToResidue": 0.1,
                       "FractionDeadToResidue": 0.1,
                       "Name": "Graze",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -4501,13 +5028,12 @@
                       "FractionLiveToResidue": 0.05,
                       "FractionDeadToResidue": 0.05,
                       "Name": "Thin",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -4516,8 +5042,8 @@
                   "FixedValue": 0.5,
                   "Units": null,
                   "Name": "ExtinctionCoeff",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -4526,8 +5052,8 @@
                   "FixedValue": 0.5,
                   "Units": null,
                   "Name": "StructuralFraction",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -4536,8 +5062,8 @@
                   "FixedValue": 1.0,
                   "Units": null,
                   "Name": "DMConversionEfficiency",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -4546,8 +5072,8 @@
                   "FixedValue": 0.0,
                   "Units": null,
                   "Name": "RemobilisationCost",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -4556,8 +5082,8 @@
                   "FixedValue": 0.4,
                   "Units": null,
                   "Name": "CarbonConcentration",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -4566,13 +5092,109 @@
                   "FixedValue": 1.0,
                   "Units": null,
                   "Name": "StomatalConductanceCO2Modifier",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Functions.Constant, Models",
+                  "FixedValue": 0.0,
+                  "Units": null,
+                  "Name": "WidthFunction",
+                  "ResourceName": null,
+                  "Children": [],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Functions.VariableReference, Models",
+                  "VariableName": "[Leaf].Height",
+                  "Name": "DepthFunction",
+                  "ResourceName": null,
+                  "Children": [],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.PMF.NutrientPoolFunctions, Models",
+                  "Name": "DMDemandPriorityFactors",
+                  "ResourceName": null,
+                  "Children": [
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "Structural",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "Metabolic",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "Storage",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    }
+                  ],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.PMF.NutrientPoolFunctions, Models",
+                  "Name": "NDemandPriorityFactors",
+                  "ResourceName": null,
+                  "Children": [
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "Structural",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "Metabolic",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "Storage",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    }
+                  ],
                   "Enabled": true,
                   "ReadOnly": false
                 }
               ],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
@@ -4586,14 +5208,15 @@
               "potentialDMAllocation": null,
               "IsAboveGround": true,
               "Name": "Spike",
+              "ResourceName": null,
               "Children": [
                 {
                   "$type": "Models.Functions.Constant, Models",
                   "FixedValue": 0.0,
                   "Units": null,
                   "Name": "NReallocationFactor",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -4602,8 +5225,8 @@
                   "FixedValue": 0.1,
                   "Units": null,
                   "Name": "NRetranslocationFactor",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -4612,8 +5235,8 @@
                   "FixedValue": 0.01,
                   "Units": null,
                   "Name": "MaximumNConc",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -4622,8 +5245,8 @@
                   "FixedValue": 0.0,
                   "Units": "/d",
                   "Name": "SenescenceRate",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -4632,14 +5255,15 @@
                   "FixedValue": 0.003,
                   "Units": null,
                   "Name": "MinimumNConc",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.PMF.Library.BiomassRemoval, Models",
                   "Name": "BiomassRemovalDefaults",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.PMF.OrganBiomassRemovalType, Models",
@@ -4648,8 +5272,8 @@
                       "FractionLiveToResidue": 0.1,
                       "FractionDeadToResidue": 0.0,
                       "Name": "Harvest",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -4660,8 +5284,8 @@
                       "FractionLiveToResidue": 0.0,
                       "FractionDeadToResidue": 0.0,
                       "Name": "Cut",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -4672,8 +5296,8 @@
                       "FractionLiveToResidue": 0.6,
                       "FractionDeadToResidue": 0.0,
                       "Name": "Prune",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -4684,8 +5308,8 @@
                       "FractionLiveToResidue": 0.2,
                       "FractionDeadToResidue": 0.0,
                       "Name": "Graze",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -4696,48 +5320,59 @@
                       "FractionLiveToResidue": 0.05,
                       "FractionDeadToResidue": 0.0,
                       "Name": "Thin",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.Functions.PhaseBasedSwitch, Models",
+                  "$type": "Models.Functions.PhaseLookupValue, Models",
                   "Start": "Emergence",
                   "End": "StartGrainFill",
                   "Name": "NitrogenDemandSwitch",
-                  "Children": [],
-                  "IncludeInDocumentation": true,
+                  "ResourceName": null,
+                  "Children": [
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "Constant",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    }
+                  ],
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Functions.PhaseLookup, Models",
                   "Name": "DMRetranslocationFactor",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.PhaseLookupValue, Models",
                       "Start": "Emergence",
                       "End": "StartGrainFill",
                       "Name": "VegetativeGrowth",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.Constant, Models",
                           "FixedValue": 0.0,
                           "Units": null,
                           "Name": "DMRetranslocationFactor",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -4746,34 +5381,23 @@
                       "Start": "StartGrainFill",
                       "End": "EndGrainFill",
                       "Name": "ReproductiveGrowth",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.Constant, Models",
                           "FixedValue": 0.5,
                           "Units": null,
                           "Name": "DMRetranslocationFactor",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
-                  "Enabled": true,
-                  "ReadOnly": false
-                },
-                {
-                  "$type": "Models.Functions.Constant, Models",
-                  "FixedValue": 0.0,
-                  "Units": "g/m^2",
-                  "Name": "InitialWtFunction",
-                  "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -4782,8 +5406,8 @@
                   "FixedValue": 0.0,
                   "Units": "/d",
                   "Name": "DetachmentRateFunction",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -4792,8 +5416,8 @@
                   "FixedValue": 0.0,
                   "Units": "0-1",
                   "Name": "MaintenanceRespirationFunction",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -4802,8 +5426,8 @@
                   "FixedValue": 1.0,
                   "Units": "0-1",
                   "Name": "DMConversionEfficiency",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -4811,8 +5435,8 @@
                   "$type": "Models.Functions.VariableReference, Models",
                   "VariableName": "[Structure].TotalStemPopn",
                   "Name": "HeadNumber",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -4821,8 +5445,8 @@
                   "FixedValue": 0.0,
                   "Units": null,
                   "Name": "DMReallocationFactor",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -4830,8 +5454,8 @@
                   "$type": "Models.Functions.VariableReference, Models",
                   "VariableName": "[Spike].MinimumNConc",
                   "Name": "CriticalNConc",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -4840,8 +5464,8 @@
                   "FixedValue": 0.0,
                   "Units": null,
                   "Name": "RemobilisationCost",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -4850,29 +5474,32 @@
                   "FixedValue": 0.4,
                   "Units": null,
                   "Name": "CarbonConcentration",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.PMF.BiomassDemand, Models",
+                  "$type": "Models.PMF.NutrientDemandFunctions, Models",
                   "Name": "DMDemands",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.MultiplyFunction, Models",
                       "Name": "Structural",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.DemandFunctions.PopulationBasedDemandFunction, Models",
                           "Name": "DMDemandFunction",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Phenology].ThermalTime",
                               "Name": "ThermalTime",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -4881,8 +5508,8 @@
                               "FixedValue": 1.0,
                               "Units": null,
                               "Name": "ExpansionStress",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -4890,8 +5517,8 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Spike].HeadNumber",
                               "Name": "OrganPopulation",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -4900,8 +5527,8 @@
                               "FixedValue": 5.0,
                               "Units": null,
                               "Name": "StartStage",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -4910,21 +5537,22 @@
                               "FixedValue": 0.5,
                               "Units": null,
                               "Name": "MaximumOrganWt",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
                             {
                               "$type": "Models.Functions.AddFunction, Models",
                               "Name": "GrowthDuration",
+                              "ResourceName": null,
                               "Children": [
                                 {
                                   "$type": "Models.Functions.VariableReference, Models",
                                   "VariableName": "[Phenology].EarlyReproductive.Target",
                                   "Name": "EarlyReproductive",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 },
@@ -4932,18 +5560,16 @@
                                   "$type": "Models.Functions.VariableReference, Models",
                                   "VariableName": "[Phenology].GrainDevelopment.Target",
                                   "Name": "GrainDevelopment",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 }
                               ],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -4952,13 +5578,12 @@
                           "FixedValue": 0.9,
                           "Units": null,
                           "Name": "StructuralFraction",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -4967,26 +5592,28 @@
                       "FixedValue": 0.0,
                       "Units": null,
                       "Name": "Metabolic",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.DemandFunctions.StorageDMDemandFunction, Models",
                       "Name": "Storage",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.SubtractFunction, Models",
                           "Name": "StorageFraction",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.Constant, Models",
                               "FixedValue": 1.0,
                               "Units": null,
                               "Name": "One",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -4994,40 +5621,69 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Spike].DMDemands.Structural.StructuralFraction",
                               "Name": "StructuralFraction",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "QStructuralPriority",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "QMetabolicPriority",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "QStoragePriority",
+                      "ResourceName": null,
+                      "Children": [],
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.PMF.BiomassDemand, Models",
+                  "$type": "Models.PMF.NutrientDemandFunctions, Models",
                   "Name": "NDemands",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.MultiplyFunction, Models",
                       "Name": "Structural",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Spike].minimumNconc",
                           "Name": "MinNconc",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -5035,30 +5691,31 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Spike].potentialDMAllocation.Structural",
                           "Name": "PotentialDMAllocation",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.MultiplyFunction, Models",
                       "Name": "Metabolic",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.SubtractFunction, Models",
                           "Name": "MetabolicNconc",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Spike].criticalNConc",
                               "Name": "CritNconc",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -5066,13 +5723,12 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Spike].minimumNconc",
                               "Name": "MinNconc",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -5080,26 +5736,26 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Spike].potentialDMAllocation.Structural",
                           "Name": "PotentialDMAllocation",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.DemandFunctions.StorageNDemandFunction, Models",
                       "Name": "Storage",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Spike].nitrogenDemandSwitch",
                           "Name": "NitrogenDemandSwitch",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -5107,31 +5763,116 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Spike].maximumNconc",
                           "Name": "MaxNconc",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "QStructuralPriority",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "QMetabolicPriority",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "QStoragePriority",
+                      "ResourceName": null,
+                      "Children": [],
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.PMF.RetranslocateNonStructural, Models",
                   "Name": "RetranslocateNitrogen",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.PMF.NutrientPoolFunctions, Models",
+                  "Name": "InitialWt",
+                  "ResourceName": null,
+                  "Children": [
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 0.0,
+                      "Units": "g/m^2",
+                      "Name": "Structural",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 0.0,
+                      "Units": null,
+                      "Name": "Metabolic",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 0.0,
+                      "Units": null,
+                      "Name": "Storage",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    }
+                  ],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Functions.Constant, Models",
+                  "FixedValue": 0.0,
+                  "Units": null,
+                  "Name": "Photosynthesis",
+                  "ResourceName": null,
+                  "Children": [],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Functions.VariableReference, Models",
+                  "VariableName": "[Spike].MinimumNConc",
+                  "Name": "initialNConcFunction",
+                  "ResourceName": null,
+                  "Children": [],
                   "Enabled": true,
                   "ReadOnly": false
                 }
               ],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
@@ -5145,20 +5886,22 @@
               "potentialDMAllocation": null,
               "IsAboveGround": true,
               "Name": "Stem",
+              "ResourceName": null,
               "Children": [
                 {
                   "$type": "Models.Functions.Constant, Models",
                   "FixedValue": 0.0,
                   "Units": "/d",
                   "Name": "SenescenceRate",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Functions.LinearInterpolationFunction, Models",
                   "Name": "MaximumNConc",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.XYPairs, Models",
@@ -5174,9 +5917,10 @@
                         0.015,
                         0.012
                       ],
+                      "XVariableName": null,
                       "Name": "XYPairs",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -5184,13 +5928,12 @@
                       "$type": "Models.Functions.VariableReference, Models",
                       "VariableName": "[Phenology].Stage",
                       "Name": "XValue",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -5199,18 +5942,29 @@
                   "FixedValue": 0.0025,
                   "Units": null,
                   "Name": "MinimumNConc",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.Functions.PhaseBasedSwitch, Models",
+                  "$type": "Models.Functions.PhaseLookupValue, Models",
                   "Start": "Emergence",
                   "End": "StartGrainFill",
                   "Name": "NitrogenDemandSwitch",
-                  "Children": [],
-                  "IncludeInDocumentation": true,
+                  "ResourceName": null,
+                  "Children": [
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "Constant",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    }
+                  ],
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -5219,33 +5973,34 @@
                   "FixedValue": 0.0,
                   "Units": null,
                   "Name": "NReallocationFactor",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Functions.PhaseLookup, Models",
                   "Name": "NRetranslocationFactor",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.PhaseLookupValue, Models",
                       "Start": "Sowing",
                       "End": "Flowering",
                       "Name": "VegetativeGrowth",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.Constant, Models",
                           "FixedValue": 0.0,
                           "Units": null,
                           "Name": "Fraction",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -5254,49 +6009,49 @@
                       "Start": "Flowering",
                       "End": "HarvestRipe",
                       "Name": "ReproductiveGrowth",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.Constant, Models",
                           "FixedValue": 0.5,
                           "Units": null,
                           "Name": "Fraction",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Functions.PhaseLookup, Models",
                   "Name": "DMRetranslocationFactor",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.PhaseLookupValue, Models",
                       "Start": "Emergence",
                       "End": "StartGrainFill",
                       "Name": "VegetativeGrowth",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.Constant, Models",
                           "FixedValue": 0.0,
                           "Units": null,
                           "Name": "DMRetranslocationFactor",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -5305,30 +6060,30 @@
                       "Start": "StartGrainFill",
                       "End": "EndGrainFill",
                       "Name": "ReproductiveGrowth",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.Constant, Models",
                           "FixedValue": 0.5,
                           "Units": null,
                           "Name": "DMRetranslocationFactor",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.PMF.Library.BiomassRemoval, Models",
                   "Name": "BiomassRemovalDefaults",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.PMF.OrganBiomassRemovalType, Models",
@@ -5337,8 +6092,8 @@
                       "FractionLiveToResidue": 0.1,
                       "FractionDeadToResidue": 0.0,
                       "Name": "Harvest",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -5349,8 +6104,8 @@
                       "FractionLiveToResidue": 0.0,
                       "FractionDeadToResidue": 0.0,
                       "Name": "Cut",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -5361,8 +6116,8 @@
                       "FractionLiveToResidue": 0.6,
                       "FractionDeadToResidue": 0.0,
                       "Name": "Prune",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -5373,8 +6128,8 @@
                       "FractionLiveToResidue": 0.2,
                       "FractionDeadToResidue": 0.0,
                       "Name": "Graze",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -5385,26 +6140,26 @@
                       "FractionLiveToResidue": 0.05,
                       "FractionDeadToResidue": 0.0,
                       "Name": "Thin",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Functions.DivideFunction, Models",
                   "Name": "PercentWSC",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.VariableReference, Models",
                       "VariableName": "[Stem].Live.StorageWt",
                       "Name": "WSC",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -5412,23 +6167,12 @@
                       "$type": "Models.Functions.VariableReference, Models",
                       "VariableName": "[Stem].Live.Wt",
                       "Name": "StemWt",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
-                  "Enabled": true,
-                  "ReadOnly": false
-                },
-                {
-                  "$type": "Models.Functions.Constant, Models",
-                  "FixedValue": 0.0,
-                  "Units": "g/m^2",
-                  "Name": "InitialWtFunction",
-                  "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -5437,8 +6181,8 @@
                   "FixedValue": 0.0,
                   "Units": "/d",
                   "Name": "DetachmentRateFunction",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -5447,8 +6191,8 @@
                   "FixedValue": 0.0,
                   "Units": "0-1",
                   "Name": "MaintenanceRespirationFunction",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -5457,8 +6201,8 @@
                   "FixedValue": 1.0,
                   "Units": "0-1",
                   "Name": "DMConversionEfficiency",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -5467,8 +6211,8 @@
                   "FixedValue": 0.0,
                   "Units": null,
                   "Name": "DMReallocationFactor",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -5476,8 +6220,8 @@
                   "$type": "Models.Functions.VariableReference, Models",
                   "VariableName": "[Stem].MinimumNConc",
                   "Name": "CriticalNConc",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -5486,8 +6230,8 @@
                   "FixedValue": 0.0,
                   "Units": null,
                   "Name": "RemobilisationCost",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -5496,33 +6240,37 @@
                   "FixedValue": 0.4,
                   "Units": null,
                   "Name": "CarbonConcentration",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.PMF.BiomassDemand, Models",
+                  "$type": "Models.PMF.NutrientDemandFunctions, Models",
                   "Name": "DMDemands",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.MultiplyFunction, Models",
                       "Name": "Structural",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.DemandFunctions.PartitionFractionDemandFunction, Models",
                           "Name": "DMDemandFunction",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.PhaseLookup, Models",
                               "Name": "PartitionFraction",
+                              "ResourceName": null,
                               "Children": [
                                 {
                                   "$type": "Models.Memo, Models",
                                   "Text": "",
                                   "Name": "memo",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 },
@@ -5531,19 +6279,19 @@
                                   "Start": "Emergence",
                                   "End": "TerminalSpikelet",
                                   "Name": "PreStemElongation",
+                                  "ResourceName": null,
                                   "Children": [
                                     {
                                       "$type": "Models.Functions.Constant, Models",
                                       "FixedValue": 0.4,
                                       "Units": null,
                                       "Name": "StemFraction",
+                                      "ResourceName": null,
                                       "Children": [],
-                                      "IncludeInDocumentation": true,
                                       "Enabled": true,
                                       "ReadOnly": false
                                     }
                                   ],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 },
@@ -5552,19 +6300,19 @@
                                   "Start": "TerminalSpikelet",
                                   "End": "FlagLeaf",
                                   "Name": "StemElongation",
+                                  "ResourceName": null,
                                   "Children": [
                                     {
                                       "$type": "Models.Functions.Constant, Models",
                                       "FixedValue": 0.6,
                                       "Units": null,
                                       "Name": "StemFraction",
+                                      "ResourceName": null,
                                       "Children": [],
-                                      "IncludeInDocumentation": true,
                                       "Enabled": true,
                                       "ReadOnly": false
                                     }
                                   ],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 },
@@ -5573,54 +6321,53 @@
                                   "Start": "FlagLeaf",
                                   "End": "Flowering",
                                   "Name": "EarEmergence",
+                                  "ResourceName": null,
                                   "Children": [
                                     {
                                       "$type": "Models.Functions.Constant, Models",
                                       "FixedValue": 0.6,
                                       "Units": null,
                                       "Name": "StemFraction",
+                                      "ResourceName": null,
                                       "Children": [],
-                                      "IncludeInDocumentation": true,
                                       "Enabled": true,
                                       "ReadOnly": false
                                     }
                                   ],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 }
                               ],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Functions.PhaseLookup, Models",
                           "Name": "StructuralFraction",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.PhaseLookupValue, Models",
                               "Start": "Sowing",
                               "End": "FlagLeaf",
                               "Name": "VegetativeGrowth",
+                              "ResourceName": null,
                               "Children": [
                                 {
                                   "$type": "Models.Functions.Constant, Models",
                                   "FixedValue": 0.7,
                                   "Units": null,
                                   "Name": "Fraction",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 }
                               ],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -5629,29 +6376,27 @@
                               "Start": "FlagLeaf",
                               "End": "HarvestRipe",
                               "Name": "ReproductiveGrowth",
+                              "ResourceName": null,
                               "Children": [
                                 {
                                   "$type": "Models.Functions.Constant, Models",
                                   "FixedValue": 0.05,
                                   "Units": null,
                                   "Name": "Fraction",
+                                  "ResourceName": null,
                                   "Children": [],
-                                  "IncludeInDocumentation": true,
                                   "Enabled": true,
                                   "ReadOnly": false
                                 }
                               ],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -5660,26 +6405,28 @@
                       "FixedValue": 0.0,
                       "Units": null,
                       "Name": "Metabolic",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.DemandFunctions.StorageDMDemandFunction, Models",
                       "Name": "Storage",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.SubtractFunction, Models",
                           "Name": "StorageFraction",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.Constant, Models",
                               "FixedValue": 1.0,
                               "Units": null,
                               "Name": "One",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -5687,40 +6434,69 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Stem].DMDemands.Structural.StructuralFraction",
                               "Name": "StructuralFraction",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "QStructuralPriority",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "QMetabolicPriority",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "QStoragePriority",
+                      "ResourceName": null,
+                      "Children": [],
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.PMF.BiomassDemand, Models",
+                  "$type": "Models.PMF.NutrientDemandFunctions, Models",
                   "Name": "NDemands",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Functions.MultiplyFunction, Models",
                       "Name": "Structural",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Stem].minimumNconc",
                           "Name": "MinNconc",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -5728,30 +6504,31 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Stem].potentialDMAllocation.Structural",
                           "Name": "PotentialDMAllocation",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.MultiplyFunction, Models",
                       "Name": "Metabolic",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.SubtractFunction, Models",
                           "Name": "MetabolicNconc",
+                          "ResourceName": null,
                           "Children": [
                             {
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Stem].criticalNConc",
                               "Name": "CritNconc",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             },
@@ -5759,13 +6536,12 @@
                               "$type": "Models.Functions.VariableReference, Models",
                               "VariableName": "[Stem].minimumNconc",
                               "Name": "MinNconc",
+                              "ResourceName": null,
                               "Children": [],
-                              "IncludeInDocumentation": true,
                               "Enabled": true,
                               "ReadOnly": false
                             }
                           ],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -5773,26 +6549,26 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Stem].potentialDMAllocation.Structural",
                           "Name": "PotentialDMAllocation",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
                     {
                       "$type": "Models.Functions.DemandFunctions.StorageNDemandFunction, Models",
                       "Name": "Storage",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Stem].nitrogenDemandSwitch",
                           "Name": "NitrogenDemandSwitch",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
@@ -5800,41 +6576,132 @@
                           "$type": "Models.Functions.VariableReference, Models",
                           "VariableName": "[Stem].maximumNconc",
                           "Name": "MaxNconc",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "QStructuralPriority",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "QMetabolicPriority",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 1.0,
+                      "Units": null,
+                      "Name": "QStoragePriority",
+                      "ResourceName": null,
+                      "Children": [],
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.PMF.RetranslocateNonStructural, Models",
                   "Name": "RetranslocateNitrogen",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.PMF.NutrientPoolFunctions, Models",
+                  "Name": "InitialWt",
+                  "ResourceName": null,
+                  "Children": [
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 0.0,
+                      "Units": "g/m^2",
+                      "Name": "Structural",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 0.0,
+                      "Units": null,
+                      "Name": "Metabolic",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    },
+                    {
+                      "$type": "Models.Functions.Constant, Models",
+                      "FixedValue": 0.0,
+                      "Units": null,
+                      "Name": "Storage",
+                      "ResourceName": null,
+                      "Children": [],
+                      "Enabled": true,
+                      "ReadOnly": false
+                    }
+                  ],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Functions.Constant, Models",
+                  "FixedValue": 0.0,
+                  "Units": null,
+                  "Name": "Photosynthesis",
+                  "ResourceName": null,
+                  "Children": [],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Functions.VariableReference, Models",
+                  "VariableName": "[Stem].MinimumNConc",
+                  "Name": "initialNConcFunction",
+                  "ResourceName": null,
+                  "Children": [],
                   "Enabled": true,
                   "ReadOnly": false
                 }
               ],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
-              "$type": "Models.PMF.CultivarFolder, Models",
+              "$type": "Models.Core.Folder, Models",
+              "ShowInDocs": false,
+              "GraphsPerPage": 6,
               "Name": "Cultivars",
+              "ResourceName": null,
               "Children": [
                 {
-                  "$type": "Models.PMF.CultivarFolder, Models",
+                  "$type": "Models.Core.Folder, Models",
+                  "ShowInDocs": false,
+                  "GraphsPerPage": 6,
                   "Name": "New Zealand",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.PMF.Cultivar, Models",
@@ -5844,8 +6711,8 @@
                         "[Phenology].PpSensitivity.FixedValue = 3"
                       ],
                       "Name": "Alberic",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -5859,8 +6726,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 80"
                       ],
                       "Name": "Amarok",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -5872,8 +6739,8 @@
                         "[Phenology].PpSensitivity.FixedValue = 3"
                       ],
                       "Name": "Aspiring",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -5888,8 +6755,8 @@
                         "[Leaf].ExtinctionCoeff.FixedValue = 0.7"
                       ],
                       "Name": "BattenWinter",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -5904,8 +6771,8 @@
                         "[Leaf].ExtinctionCoeff.FixedValue = 0.7"
                       ],
                       "Name": "BattenSpring",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -5917,8 +6784,8 @@
                         "[Phenology].PpSensitivity.FixedValue = 3"
                       ],
                       "Name": "Centaur",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -5932,8 +6799,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Claire",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -5946,8 +6813,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Conquest",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -5965,18 +6832,18 @@
                         "[Structure].BranchingRate.PotentialBranchingRate.Vegetative.PotentialBranchingRate.XYPairs.Y = 0,0,0,0,4,7,12,20"
                       ],
                       "Name": "Discovery",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Memo, Models",
                           "Text": "This is a spring wheat with a high grain number and later tillering\r\n",
                           "Name": "Memo",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -5988,8 +6855,8 @@
                         "[Phenology].PpSensitivity.FixedValue = 3"
                       ],
                       "Name": "Einstein",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6001,8 +6868,8 @@
                         "[Phenology].PpSensitivity.FixedValue = 3"
                       ],
                       "Name": "Exceed",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6014,8 +6881,8 @@
                         "[Phenology].PpSensitivity.FixedValue = 3"
                       ],
                       "Name": "Majestic",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6027,8 +6894,8 @@
                         "[Phenology].PpSensitivity.FixedValue = 3"
                       ],
                       "Name": "Option",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6042,8 +6909,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Otane",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6055,8 +6922,8 @@
                         "[Phenology].PpSensitivity.FixedValue = 3"
                       ],
                       "Name": "Pennant",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6068,8 +6935,8 @@
                         "[Phenology].PpSensitivity.FixedValue = 3"
                       ],
                       "Name": "Regency",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6081,8 +6948,8 @@
                         "[Phenology].PpSensitivity.FixedValue = 3"
                       ],
                       "Name": "Richmond",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6094,8 +6961,8 @@
                         "[Phenology].PpSensitivity.FixedValue = 3"
                       ],
                       "Name": "Robigus",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6109,8 +6976,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Rongotea",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6122,8 +6989,8 @@
                         "[Phenology].PpSensitivity.FixedValue = 3"
                       ],
                       "Name": "Rubric",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6135,8 +7002,8 @@
                         "[Phenology].PpSensitivity.FixedValue = 3"
                       ],
                       "Name": "Sage",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6148,8 +7015,8 @@
                         "[Phenology].PpSensitivity.FixedValue = 3"
                       ],
                       "Name": "Saracen",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6161,8 +7028,8 @@
                         "[Phenology].PpSensitivity.FixedValue = 3"
                       ],
                       "Name": "Savannah",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6174,8 +7041,8 @@
                         "[Phenology].PpSensitivity.FixedValue = 3"
                       ],
                       "Name": "Solstice",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6187,8 +7054,8 @@
                         "[Phenology].PpSensitivity.FixedValue = 3"
                       ],
                       "Name": "Tanker",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6200,8 +7067,8 @@
                         "[Phenology].PpSensitivity.FixedValue = 3"
                       ],
                       "Name": "Tribute",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6220,8 +7087,8 @@
                         "[Leaf].CohortParameters.MaxArea.AreaLargestLeaves.FixedValue = 3000"
                       ],
                       "Name": "Wakanui",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6233,19 +7100,21 @@
                         "[Phenology].PpSensitivity.FixedValue = 3"
                       ],
                       "Name": "Weston",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.PMF.CultivarFolder, Models",
+                  "$type": "Models.Core.Folder, Models",
+                  "ShowInDocs": false,
+                  "GraphsPerPage": 6,
                   "Name": "Australia",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.PMF.Cultivar, Models",
@@ -6257,8 +7126,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Axe",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6271,8 +7140,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Bolac",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6285,225 +7154,225 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Cunningham",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Anlace",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Arrivato",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Babbler",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Barham",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Baxter",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Bowie",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Buckley",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Buckly",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Burunga",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Camm",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Carinya",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "ChiefCLPlus",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "CLF_Janz",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Dagger",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "DBAAurora",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "ElmoreCLPlus",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Espada",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Frame",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Gazelle",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Halberd",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Hybrid_Meteor",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "JusticaCLPlus",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Preston",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Saphire",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Scout",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Stiletto",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Wallup",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6516,8 +7385,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Derrimut",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6530,25 +7399,25 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "EGAGregory",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Gregory",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Lancer",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6560,8 +7429,8 @@
                         "[Phenology].PpSensitivity.FixedValue = 4"
                       ],
                       "Name": "GattonHartog",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6576,8 +7445,8 @@
                         "[Phenology].EarlyReproductiveLongDayBase.FixedValue"
                       ],
                       "Name": "Gamenya",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6590,169 +7459,169 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Gauntlet",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Braewood",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Chara",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Clearfield_stl",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Drysdale",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Envoy",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Estoc",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Giles",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Harper",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Krichauff",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Magenta",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Mitch",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Phantom",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Pugsley",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Sentinel",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Silverstar",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Suneca",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Sunlin",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Sunvale",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Trojan",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Strzelecki",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6765,8 +7634,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Gladius",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6781,8 +7650,8 @@
                         "[Grain].NumberFunction.GrainNumber.GrainsPerGramOfStem.FixedValue = 17"
                       ],
                       "Name": "Gutha",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6795,49 +7664,49 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "H45",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Saintly",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Tamarinrock",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Waagin",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Wollaroi",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Zippy",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6850,8 +7719,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "H46",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -6865,201 +7734,201 @@
                         "[Grain].MaximumPotentialGrainSize.FixedValue = 0.041"
                       ],
                       "Name": "Hartog",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Annuello",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Carnamah",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Catalina",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "CLF_Stiletto",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Cobra",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Corack",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Correll",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Diamondbird",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Goroke",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "GrenadeCLPlus",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Guardian",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Halbred",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Impala",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Justica",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Kord",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Merlin",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Mitre",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Peake",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Shield",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Spitfire",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Sunguard",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Sunstate",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Yallaroi",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Yawa",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7072,153 +7941,153 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Hibred_Mercury",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Scythe",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Arrino",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Bonnie_rock",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Bowerbird",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Condo",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Dart",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Dollarbird",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Emurock",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Hyperno",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "ImposeCLPlus",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Kalka",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Kirchauff",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Kukri",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Hunter",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "LRPBArrow",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Ouyen",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Tamaroi",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Katana",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7231,8 +8100,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Janz",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7245,57 +8114,57 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Kelallac",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Beaufort",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Calingiri",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Endure",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Forrest",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Scenario",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Zen",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7308,8 +8177,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Kennedy",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7322,8 +8191,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Lang",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7336,8 +8205,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Livingston",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7350,17 +8219,17 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Lincoln",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Crusader",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7373,8 +8242,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Mace",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7388,41 +8257,41 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "MacKellar",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Adagio",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Brennan",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Declic",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Revenue",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7435,8 +8304,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Matong",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7449,8 +8318,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 90"
                       ],
                       "Name": "McCubbin",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7464,8 +8333,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 80"
                       ],
                       "Name": "Mercury",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7478,8 +8347,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Ruby",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7493,8 +8362,8 @@
                         "[Grain].MaximumPotentialGrainSize.FixedValue = 0.045"
                       ],
                       "Name": "Spear",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7507,8 +8376,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Sunbri",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7522,49 +8391,49 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Sunco",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Advantage",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Bellaroi",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Caparoi",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Ellison",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Suntop",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7577,8 +8446,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Ventura",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7591,49 +8460,49 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Wedgetail",
+                      "ResourceName": null,
                       "Children": [
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Lorikeet",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Rosella",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Whistler",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Wylah",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         },
                         {
                           "$type": "Models.Core.Alias, Models",
                           "Name": "Eaglehawk",
+                          "ResourceName": null,
                           "Children": [],
-                          "IncludeInDocumentation": true,
                           "Enabled": true,
                           "ReadOnly": false
                         }
                       ],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7646,8 +8515,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Westonia",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7662,8 +8531,8 @@
                         "[Grain].MaximumPotentialGrainSize.FixedValue = 0.045"
                       ],
                       "Name": "Wilgoyne",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7676,8 +8545,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Wyalkatchem",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7692,8 +8561,8 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 80"
                       ],
                       "Name": "Yitpi",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7706,19 +8575,21 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Young",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.PMF.CultivarFolder, Models",
+                  "$type": "Models.Core.Folder, Models",
+                  "ShowInDocs": false,
+                  "GraphsPerPage": 6,
                   "Name": "Turkey",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.PMF.Cultivar, Models",
@@ -7733,19 +8604,21 @@
                         "[Phenology].GrainFilling.Target.FixedValue = 800"
                       ],
                       "Name": "Konya",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.PMF.CultivarFolder, Models",
+                  "$type": "Models.Core.Folder, Models",
+                  "ShowInDocs": false,
+                  "GraphsPerPage": 6,
                   "Name": "China",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.PMF.Cultivar, Models",
@@ -7756,19 +8629,21 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Keyu13",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.PMF.CultivarFolder, Models",
+                  "$type": "Models.Core.Folder, Models",
+                  "ShowInDocs": false,
+                  "GraphsPerPage": 6,
                   "Name": "USA",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.PMF.Cultivar, Models",
@@ -7780,8 +8655,8 @@
                         "[Leaf].CohortParameters.MaxArea.AreaLargestLeaves.FixedValue = 4000"
                       ],
                       "Name": "Yecora",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7795,8 +8670,8 @@
                         "[Grain].MaximumNConc.FixedValue = 0.02"
                       ],
                       "Name": "Rex",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7810,8 +8685,8 @@
                         "[Grain].MaximumNConc.FixedValue = 0.02"
                       ],
                       "Name": "Nugaines",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7825,8 +8700,8 @@
                         "[Grain].MaximumNConc.FixedValue = 0.02"
                       ],
                       "Name": "Hyslop",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7840,19 +8715,21 @@
                         "[Grain].MaximumNConc.FixedValue = 0.02"
                       ],
                       "Name": "Stephens",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.PMF.CultivarFolder, Models",
+                  "$type": "Models.Core.Folder, Models",
+                  "ShowInDocs": false,
+                  "GraphsPerPage": 6,
                   "Name": "Europe",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.PMF.Cultivar, Models",
@@ -7865,8 +8742,8 @@
                         "[Leaf].ExtinctionCoeff.FixedValue = 0.8"
                       ],
                       "Name": "Dekan",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7881,8 +8758,8 @@
                         "[Leaf].ExtinctionCoeff.FixedValue = 0.8"
                       ],
                       "Name": "Rosario",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     },
@@ -7897,19 +8774,21 @@
                         "[Leaf].ExtinctionCoeff.FixedValue = 0.8"
                       ],
                       "Name": "Ararat",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.PMF.CultivarFolder, Models",
+                  "$type": "Models.Core.Folder, Models",
+                  "ShowInDocs": false,
+                  "GraphsPerPage": 6,
                   "Name": "Africa",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.PMF.Cultivar, Models",
@@ -7922,19 +8801,21 @@
                         "[Phenology].GrainFilling.Target.FixedValue = 350"
                       ],
                       "Name": "HAR1685",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.PMF.CultivarFolder, Models",
+                  "$type": "Models.Core.Folder, Models",
+                  "ShowInDocs": false,
+                  "GraphsPerPage": 6,
                   "Name": "Iran",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.PMF.Cultivar, Models",
@@ -7945,28 +8826,45 @@
                         "[Structure].Phyllochron.BasePhyllochron.FixedValue = 100"
                       ],
                       "Name": "Gorgan",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 }
               ],
-              "IncludeInDocumentation": true,
+              "Enabled": true,
+              "ReadOnly": false
+            },
+            {
+              "$type": "Models.Functions.Constant, Models",
+              "FixedValue": 0.0,
+              "Units": null,
+              "Name": "MortalityRate",
+              "ResourceName": null,
+              "Children": [],
+              "Enabled": true,
+              "ReadOnly": false
+            },
+            {
+              "$type": "Models.Functions.Constant, Models",
+              "FixedValue": 0.0,
+              "Units": null,
+              "Name": "SeedMortalityRate",
+              "ResourceName": null,
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             }
           ],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
         {
-          "$type": "Models.Report.Report, Models",
+          "$type": "Models.Report, Models",
           "VariableNames": [
             "[Clock].Today",
             "[Clock].StartDate"
@@ -7974,42 +8872,45 @@
           "EventNames": [
             "[Wheat].Harvesting"
           ],
+          "GroupByVariableName": null,
           "Name": "HarvestReport",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
         {
-          "$type": "Models.Report.Report, Models",
+          "$type": "Models.Report, Models",
           "VariableNames": [
             "[Clock].Today",
-            "[Soil].SoilWater.SW",
-            "sum([Soil].SoilWater.SWmm) as ProfileWater",
+            "[Soil].Water.Volumetric",
+            "sum([Soil].Water.MM) as ProfileWater",
             "[SurfaceOrganicMatter].Wt",
             "([Wheat].Leaf.Transpiration + [Soil].SoilWater.Es + [MicroClimate].PrecipitationInterception) as ET",
-            "sum([Soil].SoilNitrogen.NO3.kgha) as TotalSoilNitrogen"
+            "sum([Soil].NO3.kgha) as TotalSoilNitrogen"
           ],
           "EventNames": [
             "[Clock].DoReport"
           ],
+          "GroupByVariableName": null,
           "Name": "DailyReport",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
         {
           "$type": "Models.Manager, Models",
-          "Code": "using System;\r\nusing System.Collections.Generic;\r\nusing System.Xml.Serialization;\r\nusing Models.Core;\r\nusing Models.Interfaces;\r\nusing Models.PMF;\r\nusing Models.PMF.Organs;\r\nusing Models.Soils.Arbitrator;\r\nusing APSIM.Shared.Utilities;\r\n\r\n\r\n\r\nnamespace Models\r\n{\r\n    [Serializable] \r\n    public class Script : Model\r\n    {\r\n        [Link] Clock Clock;\r\n        [Link] Plant Wheat;\r\n        \r\n        public event EventHandler LeafReport;\r\n        \r\n        [XmlIgnore] public int LeafPosition { get; set; }\r\n        [XmlIgnore] public double MaxLeafSize { get; set; }\r\n        \r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n        \tvar leaf = Wheat.Leaf as Leaf;\r\n            if ((leaf.ExpandedCohortNo > LeafPosition) & (Wheat.Structure.NextLeafProportion == 1))\r\n            {\r\n                LeafPosition = (int)\r\n                leaf.ExpandedCohortNo;\r\n                MaxLeafSize = leaf.CohortSize[LeafPosition - 1];\r\n                LeafReport.Invoke(this, new EventArgs());\r\n            }\r\n        }\r\n    }\r\n}\r\n",
+          "Code": "using Models.Soils;\r\nusing APSIM.Shared.Utilities;\r\nusing Models.Soils.Arbitrator;\r\nusing Models.PMF.Organs;\r\nusing Models.PMF;\r\nusing Models.Interfaces;\r\nusing Models.Core;\r\nusing System.Xml.Serialization;\r\nusing System.Collections.Generic;\r\nusing System;\r\nusing Newtonsoft.Json;\r\n\r\n\r\n\r\nnamespace Models\r\n{\r\n    [Serializable] \r\n    public class Script : Model\r\n    {\r\n        [Link] Clock Clock;\r\n        [Link] Plant Wheat;\r\n        \r\n        public event EventHandler LeafReport;\r\n        \r\n        [JsonIgnore] public int LeafPosition { get; set; }\r\n        [JsonIgnore] public double MaxLeafSize { get; set; }\r\n        \r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n            var leaf = Wheat.Leaf as Leaf;\r\n            if ((leaf.ExpandedCohortNo > LeafPosition) & (Wheat.Structure.NextLeafProportion == 1))\r\n            {\r\n                LeafPosition = (int)\r\n                leaf.ExpandedCohortNo;\r\n                MaxLeafSize = leaf.CohortSize[LeafPosition - 1];\r\n                LeafReport.Invoke(this, new EventArgs());\r\n            }\r\n        }\r\n    }\r\n}\r\n",
           "Parameters": [],
           "Name": "MaxLeafSize",
-          "IncludeInDocumentation": true,
-          "Enabled": true,
+          "ResourceName": null,
+          "Children": [],
+          "Enabled": false,
           "ReadOnly": false
         },
         {
-          "$type": "Models.Report.Report, Models",
+          "$type": "Models.Report, Models",
           "VariableNames": [
             "[MaxLeafSize].Script.MaxLeafSize",
             "[MaxLeafSize].Script.LeafPosition"
@@ -8017,23 +8918,24 @@
           "EventNames": [
             "[MaxLeafSize].Script.LeafReport"
           ],
+          "GroupByVariableName": null,
           "Name": "MaxLeafSizeReport",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
         {
           "$type": "Models.Manager, Models",
-          "Code": "using System;\r\nusing Models.Core;\r\nusing System.Collections.Generic;\r\nusing System.Text;\r\nusing Models.Soils;\r\nusing Models.PMF;\r\nusing Models;\r\nusing System.Xml.Serialization;\r\nusing APSIM.Shared.Utilities;\r\n\r\nnamespace Models\r\n{\r\n    [Serializable] \r\n    public class Script : Model\r\n    {\r\n        [Link] Plant Wheat;\r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n            if (Wheat.Phenology.CurrentPhaseName == \"Maturing\")\r\n            {\r\n                Wheat.Harvest();\r\n                Wheat.EndCrop();\r\n            }\r\n        }\r\n    }\r\n}\r\n       \r\n",
+          "Code": "using Models.PMF.Phen;\r\nusing System;\r\nusing Models.Core;\r\nusing System.Collections.Generic;\r\nusing System.Text;\r\nusing Models.Soils;\r\nusing Models.PMF;\r\nusing Models;\r\nusing System.Xml.Serialization;\r\nusing APSIM.Shared.Utilities;\r\n\r\nnamespace Models\r\n{\r\n    [Serializable] \r\n    public class Script : Model\r\n    {\r\n        [Link] private Plant Wheat;\r\n        [Link(Type = LinkType.Path, Path = \"[Wheat].Phenology\")]\r\n        private Phenology phenology;\r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n            if (phenology.CurrentPhase.Name == \"Maturing\")\r\n            {\r\n                Wheat.Harvest();\r\n                Wheat.EndCrop();\r\n            }\r\n        }\r\n    }\r\n}\r\n       \r\n",
           "Parameters": null,
           "Name": "Harvesting",
-          "IncludeInDocumentation": true,
+          "ResourceName": null,
+          "Children": [],
           "Enabled": true,
           "ReadOnly": false
         }
       ],
-      "IncludeInDocumentation": true,
       "Enabled": true,
       "ReadOnly": false
     },
@@ -8042,51 +8944,52 @@
       "useFirebird": false,
       "CustomFileName": null,
       "Name": "DataStore",
+      "ResourceName": null,
       "Children": [],
-      "IncludeInDocumentation": true,
       "Enabled": true,
       "ReadOnly": false
     },
     {
       "$type": "Models.Core.Simulation, Models",
+      "Descriptors": null,
       "Name": "test",
+      "ResourceName": null,
       "Children": [
         {
           "$type": "Models.Clock, Models",
           "Start": "1995-06-13T00:00:00",
           "End": "1995-10-30T00:00:00",
           "Name": "Clock",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
         {
           "$type": "Models.Summary, Models",
-          "CaptureErrors": true,
-          "CaptureWarnings": true,
-          "CaptureSummaryText": true,
+          "Verbosity": 100,
           "Name": "summaryfile",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
         {
-          "$type": "Models.Weather, Models",
+          "$type": "Models.Climate.Weather, Models",
+          "ConstantsFile": null,
           "FileName": "%root%\\Tests\\Validation\\Wheat\\APS26.met",
           "ExcelWorkSheetName": null,
           "Name": "Weather",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
         {
           "$type": "Models.Soils.Arbitrator.SoilArbitrator, Models",
           "Name": "Soil Arbitrator",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
@@ -8097,26 +9000,27 @@
           "AspectAngle": 0.0,
           "Altitude": 50.0,
           "Name": "paddock",
+          "ResourceName": null,
           "Children": [
             {
               "$type": "Models.Irrigation, Models",
               "Name": "Irrigation",
+              "ResourceName": null,
               "Children": [],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Fertiliser, Models",
               "Name": "Fertiliser",
+              "ResourceName": "Fertiliser",
               "Children": [],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Manager, Models",
-              "Code": "using System;\r\nusing Models.Core;\r\nusing Models.PMF;\r\nusing APSIM.Shared.Utilities;\r\n\r\nnamespace Models\r\n{\r\n    [Serializable]\r\n    public class Script : Model\r\n    {\r\n        [Link] Clock Clock;\r\n        [Link] Fertiliser Fertiliser;\r\n        [Link] Summary Summary;\r\n        \r\n        [Description(\"Day of year fertiliser is to be applied\")]\r\n        public int FertDayOfYear { get; set; }\r\n\r\n        [Description(\"Amount of fertiliser to be applied\")]\r\n        public double Amount { get; set; }\r\n\r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n            if (Clock.Today.DayOfYear == FertDayOfYear)\r\n            {\r\n                Fertiliser.Apply(Amount: Amount, Type: Fertiliser.Types.NO3N);\r\n            }\r\n        \r\n        }\r\n        \r\n    }\r\n}\r\n",
+              "Code": "using Models.Soils;\r\nusing System;\r\nusing Models.Core;\r\nusing Models.PMF;\r\nusing APSIM.Shared.Utilities;\r\n\r\nnamespace Models\r\n{\r\n    [Serializable]\r\n    public class Script : Model\r\n    {\r\n        [Link] Clock Clock;\r\n        [Link] Fertiliser Fertiliser;\r\n        [Link] Summary Summary;\r\n        \r\n        [Description(\"Day of year fertiliser is to be applied\")]\r\n        public int FertDayOfYear { get; set; }\r\n\r\n        [Description(\"Amount of fertiliser to be applied\")]\r\n        public double Amount { get; set; }\r\n\r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n            if (Clock.Today.DayOfYear == FertDayOfYear)\r\n            {\r\n                Fertiliser.Apply(Amount: Amount, Type: Fertiliser.Types.NO3N);\r\n            }\r\n        \r\n        }\r\n        \r\n    }\r\n}\r\n",
               "Parameters": [
                 {
                   "Key": "FertDayOfYear",
@@ -8128,7 +9032,8 @@
                 }
               ],
               "Name": "ApplyFertiliser",
-              "IncludeInDocumentation": true,
+              "ResourceName": null,
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             },
@@ -8149,23 +9054,14 @@
               "Latitude": 0.0,
               "Longitude": 0.0,
               "LocationAccuracy": null,
+              "YearOfSampling": null,
               "DataSource": null,
               "Comments": null,
               "Name": "APS26Field",
+              "ResourceName": null,
               "Children": [
                 {
                   "$type": "Models.Soils.Physical, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180",
-                    "180-210",
-                    "210-240"
-                  ],
                   "Thickness": [
                     150.0,
                     150.0,
@@ -8180,6 +9076,8 @@
                   "ParticleSizeClay": null,
                   "ParticleSizeSand": null,
                   "ParticleSizeSilt": null,
+                  "Rocks": null,
+                  "Texture": null,
                   "BD": [
                     1.38,
                     1.38,
@@ -8242,7 +9140,13 @@
                   "DULMetadata": null,
                   "SATMetadata": null,
                   "KSMetadata": null,
+                  "RocksMetadata": null,
+                  "TextureMetadata": null,
+                  "ParticleSizeSandMetadata": null,
+                  "ParticleSizeSiltMetadata": null,
+                  "ParticleSizeClayMetadata": null,
                   "Name": "Physical",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Soils.SoilCrop, Models",
@@ -8283,18 +9187,17 @@
                       "KLMetadata": null,
                       "XFMetadata": null,
                       "Name": "WheatSoil",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.Soils.SoilWater, Models",
+                  "$type": "Models.WaterModel.WaterBalance, Models",
                   "SummerDate": "1-Nov",
                   "SummerU": 6.0,
                   "SummerCona": 3.5,
@@ -8307,10 +9210,9 @@
                   "CN2Bare": 78.0,
                   "CNRed": 20.0,
                   "CNCov": 0.8,
-                  "slope": 0.0,
-                  "discharge_width": 0.0,
-                  "catchment_area": 0.0,
-                  "max_pond": 0.0,
+                  "DischargeWidth": 0.0,
+                  "CatchmentArea": 0.0,
+                  "PSIDul": -100.0,
                   "Thickness": [
                     150.0,
                     150.0,
@@ -8322,18 +9224,6 @@
                     300.0,
                     300.0,
                     300.0
-                  ],
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-45",
-                    "45-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180",
-                    "180-210",
-                    "210-240"
                   ],
                   "SWCON": [
                     0.3,
@@ -8359,10 +9249,9 @@
                     0.0,
                     0.0
                   ],
-                  "PrecipitationInterception": 0.0,
                   "Name": "SoilWater",
+                  "ResourceName": "WaterBalance",
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -8400,67 +9289,15 @@
                     0.08,
                     0.9
                   ],
+                  "NPartitionApproach": 0,
                   "Name": "SoilNitrogen",
-                  "Children": [
-                    {
-                      "$type": "Models.Soils.SoilNitrogenNO3, Models",
-                      "Name": "NO3",
-                      "Children": [],
-                      "IncludeInDocumentation": true,
-                      "Enabled": true,
-                      "ReadOnly": false
-                    },
-                    {
-                      "$type": "Models.Soils.SoilNitrogenNH4, Models",
-                      "Name": "NH4",
-                      "Children": [],
-                      "IncludeInDocumentation": true,
-                      "Enabled": true,
-                      "ReadOnly": false
-                    },
-                    {
-                      "$type": "Models.Soils.SoilNitrogenUrea, Models",
-                      "Name": "Urea",
-                      "Children": [],
-                      "IncludeInDocumentation": true,
-                      "Enabled": true,
-                      "ReadOnly": false
-                    },
-                    {
-                      "$type": "Models.Soils.SoilNitrogenPlantAvailableNO3, Models",
-                      "Name": "PlantAvailableNO3",
-                      "Children": [],
-                      "IncludeInDocumentation": true,
-                      "Enabled": true,
-                      "ReadOnly": false
-                    },
-                    {
-                      "$type": "Models.Soils.SoilNitrogenPlantAvailableNH4, Models",
-                      "Name": "PlantAvailableNH4",
-                      "Children": [],
-                      "IncludeInDocumentation": true,
-                      "Enabled": true,
-                      "ReadOnly": false
-                    }
-                  ],
-                  "IncludeInDocumentation": true,
+                  "ResourceName": null,
+                  "Children": [],
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Soils.Organic, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-45",
-                    "45-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180",
-                    "180-210",
-                    "210-240"
-                  ],
                   "FOMCNRatio": 40.0,
                   "Thickness": [
                     150.0,
@@ -8486,6 +9323,7 @@
                     0.45,
                     0.45
                   ],
+                  "CarbonUnits": 0,
                   "SoilCNRatio": [
                     14.5,
                     14.5,
@@ -8524,36 +9362,26 @@
                   ],
                   "FOM": [
                     118.86637544625975,
-                    98.543686417513115,
-                    81.695585452956777,
+                    98.54368641751311,
+                    81.69558545295678,
                     67.7280191672963,
-                    46.548741447432221,
+                    46.54874144743222,
                     31.992450938033123,
-                    21.988068531956351,
+                    21.98806853195635,
                     15.112163763334749,
                     10.386428133873403,
-                    7.1384807013441156
+                    7.138480701344116
                   ],
+                  "CarbonMetadata": null,
+                  "FOMMetadata": null,
                   "Name": "Organic",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Soils.Chemical, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-45",
-                    "45-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180",
-                    "180-210",
-                    "210-240"
-                  ],
                   "Thickness": [
                     150.0,
                     150.0,
@@ -8565,30 +9393,6 @@
                     300.0,
                     300.0,
                     300.0
-                  ],
-                  "NO3N": [
-                    1.5,
-                    1.8,
-                    1.5,
-                    1.5,
-                    0.4,
-                    0.2,
-                    0.4,
-                    0.3,
-                    0.3,
-                    0.3
-                  ],
-                  "NH4N": [
-                    0.5,
-                    0.8,
-                    0.5,
-                    0.5,
-                    0.42,
-                    0.42,
-                    0.37,
-                    0.25,
-                    0.3,
-                    0.3
                   ],
                   "PH": [
                     7.5,
@@ -8602,29 +9406,21 @@
                     8.0,
                     8.0
                   ],
-                  "CL": null,
+                  "PHUnits": 0,
                   "EC": null,
                   "ESP": null,
+                  "ECMetadata": null,
+                  "CLMetadata": null,
+                  "ESPMetadata": null,
+                  "PHMetadata": null,
                   "Name": "Chemical",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.Soils.Sample, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-45",
-                    "45-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180",
-                    "180-210",
-                    "210-240"
-                  ],
+                  "$type": "Models.Soils.Water, Models",
                   "Thickness": [
                     150.0,
                     150.0,
@@ -8637,9 +9433,7 @@
                     300.0,
                     300.0
                   ],
-                  "NO3N": null,
-                  "NH4N": null,
-                  "SW": [
+                  "InitialValues": [
                     0.327449243,
                     0.342949562,
                     0.334037891,
@@ -8651,34 +9445,25 @@
                     0.269,
                     0.269
                   ],
-                  "OC": null,
-                  "EC": null,
-                  "CL": null,
-                  "ESP": null,
-                  "PH": null,
-                  "SWUnits": 0,
-                  "OCUnits": 0,
-                  "PHUnits": 0,
-                  "Name": "Initial Water",
+                  "InitialPAWmm": 209.61014444999995,
+                  "RelativeTo": "LL15",
+                  "FilledFromTop": false,
+                  "Name": "Water",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.Soils.Sample, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-45",
-                    "45-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180",
-                    "180-210",
-                    "210-240"
-                  ],
+                  "$type": "Models.Soils.CERESSoilTemperature, Models",
+                  "Name": "Temperature",
+                  "ResourceName": null,
+                  "Children": [],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Soils.SoilNitrogenNO3, Models",
                   "Thickness": [
                     150.0,
                     150.0,
@@ -8691,38 +9476,122 @@
                     300.0,
                     300.0
                   ],
-                  "NO3N": null,
-                  "NH4N": null,
-                  "SW": null,
-                  "OC": null,
-                  "EC": null,
-                  "CL": null,
-                  "ESP": null,
-                  "PH": null,
-                  "SWUnits": 0,
-                  "OCUnits": 0,
-                  "PHUnits": 0,
-                  "Name": "Initial Nitrogen",
+                  "InitialValues": [
+                    1.5,
+                    1.8,
+                    1.5,
+                    1.5,
+                    0.4,
+                    0.2,
+                    0.4,
+                    0.3,
+                    0.3,
+                    0.3
+                  ],
+                  "InitialValuesUnits": 0,
+                  "WaterTableConcentration": 0.0,
+                  "D0": 0.0,
+                  "Exco": null,
+                  "FIP": null,
+                  "DepthConstant": 0.0,
+                  "MaxDepthSoluteAccessible": 0.0,
+                  "RunoffEffectivenessAtMovingSolute": 0.0,
+                  "MaxEffectiveRunoff": 0.0,
+                  "Name": "NO3",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.Soils.CERESSoilTemperature, Models",
-                  "Name": "CERESSoilTemperature",
+                  "$type": "Models.Soils.SoilNitrogenNH4, Models",
+                  "Thickness": [
+                    150.0,
+                    150.0,
+                    150.0,
+                    150.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0
+                  ],
+                  "InitialValues": [
+                    0.5,
+                    0.8,
+                    0.5,
+                    0.5,
+                    0.42,
+                    0.42,
+                    0.37,
+                    0.25,
+                    0.3,
+                    0.3
+                  ],
+                  "InitialValuesUnits": 0,
+                  "WaterTableConcentration": 0.0,
+                  "D0": 0.0,
+                  "Exco": null,
+                  "FIP": null,
+                  "DepthConstant": 0.0,
+                  "MaxDepthSoluteAccessible": 0.0,
+                  "RunoffEffectivenessAtMovingSolute": 0.0,
+                  "MaxEffectiveRunoff": 0.0,
+                  "Name": "NH4",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Soils.SoilNitrogenUrea, Models",
+                  "Thickness": [
+                    150.0,
+                    150.0,
+                    150.0,
+                    150.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0
+                  ],
+                  "InitialValues": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "InitialValuesUnits": 1,
+                  "WaterTableConcentration": 0.0,
+                  "D0": 0.0,
+                  "Exco": null,
+                  "FIP": null,
+                  "DepthConstant": 0.0,
+                  "MaxDepthSoluteAccessible": 0.0,
+                  "RunoffEffectivenessAtMovingSolute": 0.0,
+                  "MaxEffectiveRunoff": 0.0,
+                  "Name": "Urea",
+                  "ResourceName": null,
+                  "Children": [],
                   "Enabled": true,
                   "ReadOnly": false
                 }
               ],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Surface.SurfaceOrganicMatter, Models",
+              "SurfOM": [],
               "Canopies": [],
               "InitialResidueName": "wheat_stubble",
               "InitialResidueType": "Wheat",
@@ -8730,22 +9599,17 @@
               "InitialStandingFraction": 0.0,
               "InitialCPR": 0.0,
               "InitialCNR": 80.0,
-              "FractionFaecesAdded": 1.0,
-              "ResourceName": "SurfaceOrganicMatter",
               "Name": "SurfaceOrganicMatter",
-              "IncludeInDocumentation": true,
+              "ResourceName": "SurfaceOrganicMatter",
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.PMF.Plant, Models",
-              "CropType": "Wheat",
-              "IsAlive": false,
-              "IsEnding": false,
-              "DaysAfterEnding": 0,
-              "ResourceName": "Wheat",
               "Name": "Wheat",
-              "IncludeInDocumentation": true,
+              "ResourceName": "Wheat",
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             },
@@ -8862,8 +9726,8 @@
                 }
               ],
               "Name": "IrrigationSchedule",
+              "ResourceName": null,
               "Children": [],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
@@ -8873,20 +9737,19 @@
               "b_interception": 1.0,
               "c_interception": 0.0,
               "d_interception": 0.0,
-              "soil_albedo": 0.3,
               "SoilHeatFluxFraction": 0.0,
               "MinimumHeightDiffForNewLayer": 0.0,
               "NightInterceptionFraction": 0.0,
-              "ReferenceHeight": 0.0,
+              "ReferenceHeight": 2.0,
               "Name": "MicroClimate",
+              "ResourceName": null,
               "Children": [],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Manager, Models",
-              "Code": "using Models.Interfaces;\r\nusing APSIM.Shared.Utilities;\r\nusing Models.Surface;\r\nusing Models.Soils;\r\nusing Models.PMF.OilPalm;\r\nusing Models.PMF;\r\nusing Models.Core;\r\nusing System;\r\n\r\nnamespace Models\r\n{\r\n    [Serializable]\r\n    [System.Xml.Serialization.XmlInclude(typeof(Model))]\r\n    public class Script : Model\r\n    {\r\n        [Link] private Clock Clock;\r\n        [Link] private Soil Soil;\r\n        [Link] private SurfaceOrganicMatter SurfaceOM;\r\n        [Link] private Summary Summary;\r\n        [Link(ByName = true)]\r\n        private SoilNitrogen SoilNitrogen;\r\n        \r\n        public double NitTot { get; set; }\r\n        public double CarbonTot { get; set; }\r\n        \r\n        [EventSubscribe(\"Commencing\")]\r\n        private void OnSimulationCommencing(object sender, EventArgs e)\r\n        {    \r\n            NitTot = 0;\r\n            CarbonTot = 0;\r\n        }\r\n        \r\n        \r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n            NitTot = MathUtilities.Sum(SoilNitrogen.TotalN);\r\n            CarbonTot = MathUtilities.Sum(SoilNitrogen.TotalC);\r\n        }\r\n    }\r\n}\r\n",
+              "Code": "using System;\r\nusing Models.Core;\r\nusing Models.PMF;\r\nusing Models.PMF.OilPalm;\r\nusing Models.Soils;\r\nusing Models.Surface;\r\nusing APSIM.Shared.Utilities;\r\nusing Models.Interfaces;\r\n\r\nnamespace Models\r\n{\r\n    [Serializable]\r\n    [System.Xml.Serialization.XmlInclude(typeof(Model))]\r\n    public class Script : Model\r\n    {\r\n        [Link] private Clock Clock;\r\n        [Link] private Soil Soil;\r\n        [Link] private SurfaceOrganicMatter SurfaceOM;\r\n        [Link] private Summary Summary;\r\n        [Link(ByName = true)]\r\n        private SoilNitrogen SoilNitrogen;\r\n        \r\n        public double NitTot { get; set; }\r\n        public double CarbonTot { get; set; }\r\n        \r\n        [EventSubscribe(\"StartOfSimulation\")]\r\n        private void OnSimulationCommencing(object sender, EventArgs e)\r\n        {    \r\n            NitTot = 0;\r\n            CarbonTot = 0;\r\n        }\r\n        \r\n        \r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n            NitTot = MathUtilities.Sum(SoilNitrogen.TotalN);\r\n            CarbonTot = MathUtilities.Sum(SoilNitrogen.TotalC);\r\n        }\r\n    }\r\n}\r\n",
               "Parameters": [
                 {
                   "Key": "NitTot",
@@ -8898,40 +9761,43 @@
                 }
               ],
               "Name": "Calculations",
-              "IncludeInDocumentation": true,
+              "ResourceName": null,
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             },
             {
-              "$type": "Models.Report.Report, Models",
+              "$type": "Models.Report, Models",
               "VariableNames": [
                 "[Leaf].ApexNum"
               ],
               "EventNames": [
                 ""
               ],
+              "GroupByVariableName": null,
               "Name": "DailyReport",
+              "ResourceName": null,
               "Children": [],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
-              "$type": "Models.Report.Report, Models",
+              "$type": "Models.Report, Models",
               "VariableNames": [
                 ""
               ],
               "EventNames": [
                 ""
               ],
+              "GroupByVariableName": null,
               "Name": "HarvestReport",
+              "ResourceName": null,
               "Children": [],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
-              "$type": "Models.Report.Report, Models",
+              "$type": "Models.Report, Models",
               "VariableNames": [
                 "[Clock].Today",
                 "[Leaf].ApexNum",
@@ -8941,33 +9807,32 @@
               "EventNames": [
                 "[Clock].DoReport"
               ],
+              "GroupByVariableName": null,
               "Name": "SupReport",
+              "ResourceName": null,
               "Children": [],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Manager, Models",
-              "Code": "using System;\r\nusing Models.Core;\r\nusing System.Collections.Generic;\r\nusing System.Text;\r\nusing Models.Soils;\r\nusing Models.PMF;\r\nusing Models;\r\nusing System.Xml.Serialization;\r\nusing APSIM.Shared.Utilities;\r\n\r\nnamespace Models\r\n{\r\n    [Serializable] \r\n    public class Script : Model\r\n    {\r\n        [Link] Plant Wheat;\r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n            if (Wheat.Phenology.CurrentPhaseName == \"Ripening\")\r\n            {\r\n                Wheat.Harvest();\r\n                Wheat.EndCrop();\r\n            }\r\n        }\r\n    }\r\n}\r\n       \r\n",
+              "Code": "using Models.PMF.Phen;\r\nusing System;\r\nusing Models.Core;\r\nusing System.Collections.Generic;\r\nusing System.Text;\r\nusing Models.Soils;\r\nusing Models.PMF;\r\nusing Models;\r\nusing System.Xml.Serialization;\r\nusing APSIM.Shared.Utilities;\r\n\r\nnamespace Models\r\n{\r\n    [Serializable] \r\n    public class Script : Model\r\n    {\r\n        [Link] private Plant Wheat;\r\n        [Link(Type = LinkType.Path, Path = \"[Wheat].Phenology\")]\r\n        private Phenology phenology;\r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n            if (phenology.CurrentPhase.Name == \"Ripening\")\r\n            {\r\n                Wheat.Harvest();\r\n                Wheat.EndCrop();\r\n            }\r\n        }\r\n    }\r\n}\r\n       \r\n",
               "Parameters": null,
               "Name": "Harvesting",
-              "IncludeInDocumentation": true,
+              "ResourceName": null,
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             }
           ],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         }
       ],
-      "IncludeInDocumentation": true,
       "Enabled": true,
       "ReadOnly": false
     }
   ],
-  "IncludeInDocumentation": true,
   "Enabled": true,
   "ReadOnly": false
 }

--- a/Tests/UnitTests/Functions/HoldFunctionTests.cs
+++ b/Tests/UnitTests/Functions/HoldFunctionTests.cs
@@ -98,9 +98,17 @@
 
             Utilities.CallEvent(f.Children[1].Children[0], "Commencing", new object[] { this, new EventArgs() });
 
-            (f.Children[0] as MockFunctionThatThrows).DoThrow = true;
-            Utilities.CallEvent(f, "Commencing", new object[] { this, new EventArgs() });
-            Assert.AreEqual(f.Value(), 0);
+            try
+            {
+                (f.Children[0] as MockFunctionThatThrows).DoThrow = true;
+                Utilities.CallEvent(f, "Commencing", new object[] { this, new EventArgs() });
+                Assert.Fail();
+            }
+            catch
+            {
+                Assert.AreEqual(f.Value(), 0);
+            }
+            
 
             (f.Children[0] as MockFunctionThatThrows).DoThrow = false;
             Utilities.CallEvent(f, "DoUpdate", new object[] { this, new EventArgs() });


### PR DESCRIPTION
Working on #7350

The error exception was being discarded in the worker threads with an empty catch, now that will pass the exception up the line and it now gets to the GUI, halts the simulation and displays the error.

This might break a unit test if any had errors that were being hidden by this empty exception handler. Though that's a good thing, since these mistakes slow down the simulation by a huge amount and should be fixed.