### PR TITLE
1197 Removed Length from Zone State Classes

### DIFF
--- a/Models/PMF/Organs/IRootGeometryData.cs
+++ b/Models/PMF/Organs/IRootGeometryData.cs
@@ -21,9 +21,6 @@ namespace Models.PMF.Organs
        /// <summary>The parent plant</summary>
         Plant plant { get; set; }
 
-        /// <summary>Gets or sets the length.</summary>
-        double Length { get; set; }
-
         /// <summary>Gets or sets the depth.</summary>
         [Units("mm")]
         double Depth { get; set; }

--- a/Models/PMF/Organs/NetworkZoneState.cs
+++ b/Models/PMF/Organs/NetworkZoneState.cs
@@ -69,9 +69,6 @@ namespace Models.PMF.Organs
         /// <summary>Gets or sets the layer dead.</summary>
         public OrganNutrientsState[] LayerDeadProportion { get; set; }
 
-        /// <summary>Gets or sets the length.</summary>
-        public double Length { get; set; }
-
         /// <summary>Gets or sets the depth.</summary>
         [Units("mm")]
         public double Depth { get; set; }

--- a/Models/PMF/Organs/RootZoneState.cs
+++ b/Models/PMF/Organs/RootZoneState.cs
@@ -91,9 +91,6 @@ namespace Models.PMF.Organs
         /// <summary>Gets or sets the layer dead.</summary>
         public Biomass[] LayerDead { get; set; }
 
-        /// <summary>Gets or sets the length.</summary>
-        public double Length { get; set; }
-
         /// <summary>Gets or sets the depth.</summary>
         [Units("mm")]
         public double Depth { get; set; }


### PR DESCRIPTION
Resolves #1197 

Fixing a very old issue. Length property was replaced by RootLength (as highlighted in the issue) at some point, and all references to the Length property have since been cut. Ran some the related unit tests afterwards which all seemed to work, so this should be a simple change.