### PR TITLE
7180 2nd check for events with space in name

### DIFF
--- a/Models/Report/EventReportFrequency.cs
+++ b/Models/Report/EventReportFrequency.cs
@@ -24,7 +24,6 @@ namespace Models
             if (tokens.Length == 1)
             {
                 new EventReportFrequency(report, events, tokens[0]);
-                return true;
             } 
             else if (tokens.Length > 1) 
             {
@@ -34,12 +33,22 @@ namespace Models
                 }
                 catch
                 {   //if trying with only first token failed, try again with entire line
-                    new EventReportFrequency(report, events, line);
+                    try
+                    {
+                        new EventReportFrequency(report, events, line);
+                    }
+                    catch
+                    {
+                        return false;
+                    }
                 }
-                return true;
+            } 
+            else
+            {
+                return false;
             }
 
-            return false;
+            return true;
         }
 
         /// <summary>

--- a/Models/Report/EventReportFrequency.cs
+++ b/Models/Report/EventReportFrequency.cs
@@ -1,6 +1,7 @@
 ﻿using APSIM.Shared.Utilities;
 using Models.Core;
 using System;
+using System.Linq.Expressions;
 
 namespace Models
 {
@@ -24,7 +25,20 @@ namespace Models
             {
                 new EventReportFrequency(report, events, tokens[0]);
                 return true;
+            } 
+            else if (tokens.Length > 1) 
+            {
+                try
+                {
+                    new EventReportFrequency(report, events, tokens[0]);
+                }
+                catch
+                {   //if trying with only first token failed, try again with entire line
+                    new EventReportFrequency(report, events, line);
+                }
+                return true;
             }
+
             return false;
         }
 


### PR DESCRIPTION
Resolves #7180 

This should fix the follow up problems that Adam reported. When it tries to make an event, if fails with the single token, it will then also try with the full line. If that also fails, then it throws an exception same as before.