### PR TITLE
7166 Position is saved and restored when undo move

### DIFF
--- a/ApsimNG/Commands/MoveModelCommand.cs
+++ b/ApsimNG/Commands/MoveModelCommand.cs
@@ -13,6 +13,7 @@
         private Func<IModel, TreeViewNode> describeModel;
         private IModel fromParent;
         private string originalName;
+        private int originalPosition;
 
         /// <summary>
         /// The model which was changed by the command. This will be selected
@@ -44,6 +45,7 @@
             // The Move method may rename the FromModel. Go get the original name in case of
             // Undo later.
             originalName = fromModel.Name;
+            originalPosition = tree.GetNodePosition(fromModel.FullPath);
             string originalPath = this.fromModel.FullPath;
 
             // Move model.
@@ -61,7 +63,7 @@
             tree.Delete(fromModel.FullPath);
             Structure.Move(fromModel, fromParent);
             fromModel.Name = originalName;
-            tree.AddChild(fromParent.FullPath, describeModel(fromModel));
+            tree.AddChild(fromParent.FullPath, describeModel(fromModel), originalPosition);
             tree.SelectedNode = fromModel.FullPath;
         }
     }

--- a/ApsimNG/Interfaces/ITreeView.cs
+++ b/ApsimNG/Interfaces/ITreeView.cs
@@ -76,6 +76,10 @@ namespace UserInterface.Interfaces
         /// <param name="position">The position.</param>
         void AddChild(string parentNodePath, TreeViewNode nodeDescription, int position = -1);
 
+        /// <summary>Return the position of the node under its parent</summary>
+        /// <param name="path">The full node path.</param>
+        public int GetNodePosition(string path);
+
         /// <summary>
         /// Returns tree nodes which are expanded.
         /// </summary>

--- a/ApsimNG/Views/TreeView.cs
+++ b/ApsimNG/Views/TreeView.cs
@@ -326,6 +326,18 @@ namespace UserInterface.Views
             }
         }
 
+        /// <summary>Return the position of the node under its parent</summary>
+        /// <param name="path">The full node path.</param>
+        public int GetNodePosition(string path)
+        {
+            int count = 0;
+            if (FindNode(path, out TreeIter node))
+                while (treemodel.IterPrevious(ref node))
+                    count = count + 1;
+
+            return count;
+        }
+
         /// <summary>
         /// Treeview is being destroyed.
         /// </summary>


### PR DESCRIPTION
Resolves #7166

Undo/Redo already mostly worked when shift-dragging a node, however this change will move the node back to its correct position instead of just placing it at the bottom.