### PR TITLE
Replaced , with . when reading in weather constant

### DIFF
--- a/APSIM.Shared/Utilities/ApsimTextFile.cs
+++ b/APSIM.Shared/Utilities/ApsimTextFile.cs
@@ -921,6 +921,10 @@ namespace APSIM.Shared.Utilities
                             value = coltext1.Substring(posEquals + 1).Trim();
                             if (name != "Title")
                                 unit = StringUtilities.SplitOffBracketedValue(ref value, '(', ')');
+
+                            //Replace , notation with . in case they are inputting data from another region
+                            value = value.Replace(",", ".");
+
                             _Constants.Add(new ApsimConstant(name, value, unit, comment));
                         }
                         resultDt.Rows[rowCount].Delete();
@@ -946,6 +950,10 @@ namespace APSIM.Shared.Utilities
                             comment = StringUtilities.SplitOffAfterDelimiter(ref coltext3, "!");
                             comment.Trim();
                         }
+
+                        //Replace , notation with . in case they are inputting data from another region
+                        value = value.Replace(",", ".");
+
                         _Constants.Add(new ApsimConstant(name, value, unit, comment));
                         resultDt.Rows[rowCount].Delete();
                     }


### PR DESCRIPTION
Resolves #7947

Weather constants would be read in with commas instead of periods when reading an excel file formatted for another region. 

This should have been handled by a localization function that is attached to the constant getter function, but it was instead just removing the , and combining the entire number. It's much safer to format it correctly when reading in the first place.