### PR TITLE
Allow Max and Min to take two doubles as well

### DIFF
--- a/APSIM.Shared/Utilities/ExpressionEvaluator.cs
+++ b/APSIM.Shared/Utilities/ExpressionEvaluator.cs
@@ -1031,9 +1031,39 @@ namespace APSIM.Shared.Utilities
                     }
                     else if (args.Length == 2)
                     {
-                        result.m_value = Math.Min(((Symbol)args[0]).m_value, ((Symbol)args[1]).m_value);
-                        result.m_name = name;
-                        result.m_values = null;
+                        if (args[0].m_values != null && args[1].m_values != null)
+                        {
+                            result.m_name = "Invalid parameters in: " + name + ". Cannot pass two arrays.";
+                            result.m_type = ExpressionType.Error;
+                        }
+                        else if (args[0].m_values != null || args[1].m_values != null)
+                        {
+                            double[] array;
+                            double value;
+                            if (args[0].m_values != null)
+                            {
+                                array = args[0].m_values;
+                                value = args[1].m_value;
+                            }
+                            else
+                            {
+                                array = args[1].m_values;
+                                value = args[0].m_value;
+                            }
+                            for (int i = 0; i < array.Length; i++)
+                            {
+                                array[i] = Math.Min(array[i], value);
+                            }
+                            result.m_value = 0;
+                            result.m_name = name;
+                            result.m_values = array;
+                        }
+                        else
+                        {
+                            result.m_value = Math.Min(args[0].m_value, args[1].m_value);
+                            result.m_name = name;
+                            result.m_values = null;
+                        }
                     }
                     else
                     {
@@ -1052,9 +1082,39 @@ namespace APSIM.Shared.Utilities
                     }
                     else if (args.Length == 2)
                     {
-                        result.m_value = Math.Max(((Symbol)args[0]).m_value, ((Symbol)args[1]).m_value);
-                        result.m_name = name;
-                        result.m_values = null;
+                        if (args[0].m_values != null && args[1].m_values != null)
+                        {
+                            result.m_name = "Invalid parameters in: " + name + ". Cannot pass two arrays.";
+                            result.m_type = ExpressionType.Error;
+                        }
+                        else if (args[0].m_values != null || args[1].m_values != null)
+                        {
+                            double[] array;
+                            double value;
+                            if (args[0].m_values != null)
+                            {
+                                array = args[0].m_values;
+                                value = args[1].m_value;
+                            }
+                            else
+                            {
+                                array = args[1].m_values;
+                                value = args[0].m_value;
+                            }
+                            for(int i = 0; i < array.Length; i++)
+                            {
+                                array[i] = Math.Max(array[i], value);
+                            }
+                            result.m_value = 0;
+                            result.m_name = name;
+                            result.m_values = array;
+                        }
+                        else
+                        {
+                            result.m_value = Math.Max(args[0].m_value, args[1].m_value);
+                            result.m_name = name;
+                            result.m_values = null;
+                        }
                     }
                     else
                     {

--- a/APSIM.Shared/Utilities/ExpressionEvaluator.cs
+++ b/APSIM.Shared/Utilities/ExpressionEvaluator.cs
@@ -1029,6 +1029,12 @@ namespace APSIM.Shared.Utilities
                         result.m_name = name;
                         result.m_values = null;
                     }
+                    else if (args.Length == 2)
+                    {
+                        result.m_value = Math.Min(((Symbol)args[0]).m_value, ((Symbol)args[1]).m_value);
+                        result.m_name = name;
+                        result.m_values = null;
+                    }
                     else
                     {
                         result.m_name = "Invalid number of parameters in: " + name + ".";
@@ -1041,6 +1047,12 @@ namespace APSIM.Shared.Utilities
                         result.m_value = ((Symbol)args[0]).m_value;
                         double[] Values = ((Symbol)args[0]).m_values;
                         result.m_value = MathUtilities.Max(Values);
+                        result.m_name = name;
+                        result.m_values = null;
+                    }
+                    else if (args.Length == 2)
+                    {
+                        result.m_value = Math.Max(((Symbol)args[0]).m_value, ((Symbol)args[1]).m_value);
                         result.m_name = name;
                         result.m_values = null;
                     }

--- a/Models/Functions/ExpressionFunction.cs
+++ b/Models/Functions/ExpressionFunction.cs
@@ -124,7 +124,7 @@ namespace Models.Functions
             fn.EvaluatePostfix();
             if (fn.Error)
             {
-               // throw new Exception(fn.ErrorDescription);
+                throw new Exception(fn.ErrorDescription);
             }
         }
 

--- a/Models/Functions/ExpressionFunction.cs
+++ b/Models/Functions/ExpressionFunction.cs
@@ -124,7 +124,7 @@ namespace Models.Functions
             fn.EvaluatePostfix();
             if (fn.Error)
             {
-                throw new Exception(fn.ErrorDescription);
+               // throw new Exception(fn.ErrorDescription);
             }
         }
 


### PR DESCRIPTION
Resolves #7963

Max and Min functions in an expression now work similar to C and will take either an array of number, or two single numbers.