### PR TITLE
Document XY will use up to 6 decimal places

### DIFF
--- a/Models/Functions/XYPairs.cs
+++ b/Models/Functions/XYPairs.cs
@@ -66,8 +66,30 @@ namespace Models.Functions
             for (int i = 0; i < Math.Max(X.Length, Y.Length); i++)
             {
                 DataRow row = table.NewRow();
-                row[0] = i <= X.Length - 1 ? X[i].ToString("F1") : "";
-                row[1] = i <= Y.Length - 1 ? Y[i].ToString("F1") : "";
+
+                const double tolerance = 1e-9;
+                const int minDecimalPlaces = 1; //minimum 1 decimal place
+                const int maxDecimalPlaces = 6; //max 5 decimal places
+                string xDigits = "F" + minDecimalPlaces.ToString();
+                string yDigits = "F" + minDecimalPlaces.ToString();
+                double xDeci = Math.Round(X[i], minDecimalPlaces);
+                double yDeci = Math.Round(Y[i], minDecimalPlaces);
+                for (int j = minDecimalPlaces + 1; j <= maxDecimalPlaces; j++)
+                {
+                    if (Math.Abs(Math.Round(X[i], j) - xDeci) > tolerance)
+                    {
+                        xDigits = "F" + j.ToString();
+                        xDeci = Math.Round(X[i], j);
+                    }
+                    if (Math.Abs(Math.Round(Y[i], j) - yDeci) > tolerance)
+                    {
+                        yDigits = "F" + j.ToString();
+                        yDeci = Math.Round(Y[i], j);
+                    }
+                }
+
+                row[0] = i <= X.Length - 1 ? X[i].ToString(xDigits) : "";
+                row[1] = i <= Y.Length - 1 ? Y[i].ToString(yDigits) : "";
                 table.Rows.Add(row);
             }
             yield return new Table(table);


### PR DESCRIPTION
Resolves #7967

Previously all XY pairs in a auto-doc would be rounded to 1 decimal place, which made graphs and tables not agree on the numbers. Now it will use up to 6 decimal places depending on what is needed.