### PR TITLE
Prevent numbers from being parsed as dates.

### DIFF
--- a/ApsimNG/Views/AxisView.cs
+++ b/ApsimNG/Views/AxisView.cs
@@ -1,12 +1,13 @@
-﻿namespace UserInterface.Views
-{
-    using System;
-    using Gtk;
-    using Interfaces;
-    using OxyPlot.Axes;
+﻿using System;
+using System.Globalization;
+using Gtk;
+using UserInterface.Interfaces;
+using OxyPlot.Axes;
 
+namespace UserInterface.Views
+{
     /// <summary>
-    /// A Windows forms implementation of an AxisView
+    /// An implementation of an AxisView
     /// </summary>
     public class AxisView : ViewBase, IAxisView
     {
@@ -159,15 +160,16 @@
         { 
             get
             {
-                DateTime date;
                 if (string.IsNullOrEmpty(entryMin.Text))
                     return double.NaN;
-                else if (DateTime.TryParse(entryMin.Text, out date))
+                else if (DateTime.TryParseExact(entryMin.Text,
+                                                CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern,
+                                                CultureInfo.CurrentCulture,
+                                                DateTimeStyles.None,
+                                                out var date))
                     return DateTimeAxis.ToDouble(date);
                 else
-                    return Convert.ToDouble(
-                                            entryMin.Text,
-                                            System.Globalization.CultureInfo.InvariantCulture);
+                    return Convert.ToDouble(entryMin.Text, CultureInfo.InvariantCulture);
             }
         }
 
@@ -178,15 +180,16 @@
         {
             get
             {
-                DateTime date;
                 if (string.IsNullOrEmpty(entryMax.Text))
                     return double.NaN;
-                else if (DateTime.TryParse(entryMax.Text, out date))
+                else if (DateTime.TryParseExact(entryMax.Text,
+                                                CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern,
+                                                CultureInfo.CurrentCulture,
+                                                DateTimeStyles.None,
+                                                out var date))
                     return DateTimeAxis.ToDouble(date);
                 else
-                    return Convert.ToDouble(
-                                            entryMax.Text,
-                                            System.Globalization.CultureInfo.InvariantCulture);
+                    return Convert.ToDouble(entryMax.Text, CultureInfo.InvariantCulture);
             }
             
             set


### PR DESCRIPTION
working on #8001 

Not sure if this does exactly what is wanted. DateTime.TryParse seemed to be too aggressive about interpreting things as dates. 