### PR TITLE
5521 Removed DltThermalTime

### DIFF
--- a/Models/PMF/Organs/Root.cs
+++ b/Models/PMF/Organs/Root.cs
@@ -826,10 +826,6 @@
         //------------------------------------------------------------------------------------------------
         // sorghum specific variables
 
-        /// <summary>Used to calc maximim diffusion rate</summary>
-        [Link(Type = LinkType.Child, ByName = true, IsOptional = true)]
-        public IFunction DltThermalTime = null;
-
         /// <summary>The kgha2gsm</summary>
         protected const double kgha2gsm = 0.1;
 


### PR DESCRIPTION
Removed the DltThermalTime property, ran the sorghum example to make sure it didn't do anything. Should pass tests.