### PR TITLE
4865 Change CriticalNConc to reference correct MinNConc

### DIFF
--- a/Models/Resources/Eucalyptus.json
+++ b/Models/Resources/Eucalyptus.json
@@ -3879,7 +3879,7 @@
             },
             {
               "$type": "Models.Functions.VariableReference, Models",
-              "VariableName": "[Stem].MinimumNConc",
+              "VariableName": "[CoarseRoot].MinimumNConc",
               "Name": "CriticalNConc",
               "Children": [],
               "IncludeInDocumentation": true,


### PR DESCRIPTION
Resolves #4865

Followed the instructions from the issue to update the Eucalyptus resource so CourseRoot.CriticalNConc points to the correct MinimumNConc