### PR TITLE
8013 Handle copying of Soil nodes

### DIFF
--- a/ApsimNG/Presenters/NewGridPresenter.cs
+++ b/ApsimNG/Presenters/NewGridPresenter.cs
@@ -1,5 +1,6 @@
 ﻿namespace UserInterface.Presenters
 {
+    using DocumentFormat.OpenXml.Drawing.Charts;
     using EventArguments;
     using global::UserInterface.Interfaces;
     using Models.Core;
@@ -54,7 +55,23 @@
         /// <param name="explorerPresenter">Parent explorer presenter.</param>
         public void Attach(object model, object v, ExplorerPresenter explorerPresenter)
         {
-            tabularData = (model as ITabularData).GetTabularData();
+            try
+            {
+                tabularData = (model as ITabularData).GetTabularData();
+            }
+            catch (Exception ex)
+            {
+                if (ex.Data["tableData"] != null)
+                {
+                    tabularData = ex.Data["tableData"] as TabularData;
+                    explorerPresenter.MainPresenter.ShowMsgDialog(ex.Message, "Warning", Gtk.MessageType.Warning, Gtk.ButtonsType.Ok);
+                }
+                else
+                {
+                    throw new Exception(ex.Message, ex);
+                }
+            }
+           
             view = v as ViewBase;
             this.explorerPresenter = explorerPresenter;
 

--- a/ApsimNG/Presenters/ProfilePresenter.cs
+++ b/ApsimNG/Presenters/ProfilePresenter.cs
@@ -99,8 +99,11 @@
         public void Detach()
         {
             DisconnectEvents();
-            gridPresenter.Detach();
-            propertyPresenter.Detach();
+            if (this.propertyPresenter != null)
+            {
+                gridPresenter.Detach();
+                propertyPresenter.Detach();
+            }
             view.Dispose();
         }
 

--- a/ApsimNG/Views/Sheet/MultiCellSelect.cs
+++ b/ApsimNG/Views/Sheet/MultiCellSelect.cs
@@ -41,6 +41,20 @@ namespace UserInterface.Views
             {
                 selectedColumnIndexRight = colIndex;
                 selectedRowIndexBottom = rowIndex;
+
+                //flip indexs around if cells were selected in a backwards order
+                if (selectedColumnIndexRight < selectedColumnIndex)
+                {
+                    int temp = selectedColumnIndex;
+                    selectedColumnIndex = selectedColumnIndexRight;
+                    selectedColumnIndexRight = temp;
+                }
+                if (selectedRowIndexBottom < selectedRowIndex)
+                {
+                    int temp = selectedRowIndex;
+                    selectedRowIndex = selectedRowIndexBottom;
+                    selectedRowIndexBottom = temp;
+                }
                 sheet.Refresh();
             }
             else

--- a/Models/Soils/SoilCrop.cs
+++ b/Models/Soils/SoilCrop.cs
@@ -4,6 +4,7 @@
     using Models.Core;
     using Models.Interfaces;
     using System;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>A soil crop parameterization class.</summary>
@@ -118,7 +119,43 @@
         /// <summary>Tabular data. Called by GUI.</summary>
         public TabularData GetTabularData()
         {
-            return new TabularData(Name, new TabularData.Column[]
+            //Do validation on the soilCrop to make that sure has the same amount of layers as the physical node
+            //If not, we remove layers to make it match, or add new layers with 0 values
+            //Then throw an exception back to the GUI to warn the user what has been changed.
+            //This is used to allow users to copy soil from another simulation without it crashing.
+            //It cannot detect if the layer count was the same, but the structure was different, as depth values
+            //are not stored here.
+            bool throwException = false;
+            if (Depth.Length != LL.Length)
+            {
+                throwException = true;
+
+                List<double> listLL = LL.ToList();
+                List<double> listKL = KL.ToList();
+                List<double> listXF = XF.ToList();
+
+                if (Depth.Length < LL.Length)
+                {
+                    listLL = listLL.GetRange(0, Depth.Length);
+                    listKL = listKL.GetRange(0, Depth.Length);
+                    listXF = listXF.GetRange(0, Depth.Length);
+                }
+                else //Depth.Length > LL.Length
+                {
+                    for (int i = LL.Length; i < Depth.Length; i++)
+                    {
+                        listLL.Add(0.0);
+                        listKL.Add(0.0);
+                        listXF.Add(0.0);
+                    }
+                }
+
+                LL = listLL.ToArray();
+                KL = listKL.ToArray();
+                XF = listXF.ToArray();
+            }
+
+            TabularData tb = new TabularData(Name, new TabularData.Column[]
             {
                 new TabularData.Column("Depth", new VariableProperty(Parent, Parent.GetType().GetProperty("Depth")), readOnly:true),
                 new TabularData.Column("LL", new VariableProperty(this, GetType().GetProperty("LL"))),
@@ -126,6 +163,17 @@
                 new TabularData.Column("XF", new VariableProperty(this, GetType().GetProperty("XF"))),
                 new TabularData.Column("PAWC", new VariableProperty(this, GetType().GetProperty("PAWCmm")), units: $"{PAWCmm.Sum():F1} mm")
             });
+
+            if (throwException)
+            {
+                Exception e = new Exception("Soil Layers do not match on "+ Name + ".\n"+ Name +" has been modified to match Physical node.");
+                e.Data.Add("tableData", tb);
+                throw e;
+            } 
+            else
+            {
+                return tb;
+            }
         }
     }
 }


### PR DESCRIPTION
Resolves #8013

When someone tries to copy a soil from one apsimx project to another, if the layer count doesn't match, it will throw them a bunch of errors and give a blank screen. This will now handle it a bit more gracefully, modifying the soil to match the current Physical node structure, and alerting the user to what has happened with a pop-up message.

While I was there, I also added a fix to allow grid cells to be shift-selected in any order. So you can select cells from bottom to top or right to left instead of being forced to go left to right, top to bottom for it to work.