### PR TITLE
8085 Getting Future Weather

### DIFF
--- a/APSIM.Shared/Utilities/ApsimTextFile.cs
+++ b/APSIM.Shared/Utilities/ApsimTextFile.cs
@@ -798,7 +798,7 @@ namespace APSIM.Shared.Utilities
         /// <exception cref="System.Exception">Date  + Date.ToString() +  doesn't exist in file:  + _FileName</exception>
         public void SeekToDate(DateTime date)
         {
-            if (date < _FirstDate || date > _LastDate)
+            if (date < _FirstDate)
                 throw new Exception("Date " + date.ToString() + " doesn't exist in file: " + _FileName);
 
             //check if we've looked at this date before

--- a/Models/Climate/Weather.cs
+++ b/Models/Climate/Weather.cs
@@ -691,10 +691,8 @@ namespace Models.Climate
         /// <param name="date">the date to read met data</param>
         public DailyMetDataFromFile GetMetData(DateTime date)
         {
-            
             //check if we've looked at this date before
             WeatherRecordEntry previousEntry = null;
-            bool first = true;
             foreach (WeatherRecordEntry entry in this.weatherCache)
             {
                 if (entry.Date.Equals(date))
@@ -706,7 +704,6 @@ namespace Models.Climate
                     previousEntry = entry;
                     break;
                 }
-                first = false;
             }
             
             if (this.reader == null)
@@ -733,7 +730,7 @@ namespace Models.Climate
             WeatherRecordEntry record = new WeatherRecordEntry();
             record.Date = date;
             record.MetData = readMetData;
-            if (!first && previousEntry != null)
+            if (previousEntry != null)
                 this.weatherCache.AddBefore(this.weatherCache.Find(previousEntry), record);
             else
                 this.weatherCache.AddFirst(record);

--- a/Models/Climate/Weather.cs
+++ b/Models/Climate/Weather.cs
@@ -691,6 +691,7 @@ namespace Models.Climate
         /// <param name="date">the date to read met data</param>
         public DailyMetDataFromFile GetMetData(DateTime date)
         {
+            
             //check if we've looked at this date before
             WeatherRecordEntry previousEntry = null;
             bool first = true;
@@ -707,18 +708,16 @@ namespace Models.Climate
                 }
                 first = false;
             }
-
+            
             if (this.reader == null)
                 if (!this.OpenDataFile())
                     throw new ApsimXException(this, "Cannot find weather file '" + this.FileName + "'");
-
-            //seek to the date required
-            this.reader.SeekToDate(date);
 
             //get weather for that date
             DailyMetDataFromFile readMetData = new DailyMetDataFromFile();
             try
             {
+                this.reader.SeekToDate(date);
                 readMetData.Raw = reader.GetNextLineOfData();
             }
             catch (IndexOutOfRangeException err)
@@ -730,6 +729,7 @@ namespace Models.Climate
                 throw new Exception("Non consecutive dates found in file: " + this.FileName + ".");
 
             //since this data was valid, store in our cache for next time
+            
             WeatherRecordEntry record = new WeatherRecordEntry();
             record.Date = date;
             record.MetData = readMetData;
@@ -737,6 +737,7 @@ namespace Models.Climate
                 this.weatherCache.AddBefore(this.weatherCache.Find(previousEntry), record);
             else
                 this.weatherCache.AddFirst(record);
+            
 
             return CheckDailyMetData(readMetData);
         }

--- a/Models/Interfaces/IWeather.cs
+++ b/Models/Interfaces/IWeather.cs
@@ -127,4 +127,18 @@ namespace Models.Interfaces
         /// </summary>
         public object[] Raw { get; set; }
     }
+
+    ///<summary>
+    /// Stores a weather data file with a datetime it was read from
+    ///</summary>
+    [Serializable]
+    public class WeatherRecordEntry
+    {
+        /// <summary>Date this weather was recorded on</summary>
+        public DateTime Date { get; set; }
+
+        /// <summary>The weather data</summary>
+        public DailyMetDataFromFile MetData { get; set; }
+        
+    }
 }

--- a/Tests/UnitTests/Weather/WeatherTests.cs
+++ b/Tests/UnitTests/Weather/WeatherTests.cs
@@ -11,6 +11,7 @@ using System.Data;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Globalization;
 
 namespace UnitTests.Weather
 {
@@ -162,8 +163,8 @@ namespace UnitTests.Weather
             baseSim.Prepare();
             baseSim.Run();
 
-            DailyMetDataFromFile weather1900 = weather.GetMetData(DateTime.Parse("03/01/1900"));
-            DailyMetDataFromFile weather2000 = weather.GetMetData(DateTime.Parse("01/01/2000"));
+            DailyMetDataFromFile weather1900 = weather.GetMetData(DateTime.ParseExact("1900-01-03", "yyyy-MM-dd", CultureInfo.InvariantCulture));
+            DailyMetDataFromFile weather2000 = weather.GetMetData(DateTime.ParseExact("2000-01-01", "yyyy-MM-dd", CultureInfo.InvariantCulture));
 
             Assert.AreEqual(31.9, weather1900.MaxT, 0.01);
             Assert.AreEqual(16.6, weather1900.MinT, 0.01);

--- a/Tests/UnitTests/Weather/WeatherTests.cs
+++ b/Tests/UnitTests/Weather/WeatherTests.cs
@@ -157,8 +157,8 @@ namespace UnitTests.Weather
 
             Models.Climate.Weather weather = baseSim.Children[0] as Models.Climate.Weather;
             Clock clock = baseSim.Children[1] as Clock;
-            clock.StartDate = DateTime.Parse("01/01/1900");
-            clock.EndDate = DateTime.Parse("02/01/1900");
+            clock.StartDate = DateTime.ParseExact("1900-01-01", "yyyy-MM-dd", CultureInfo.InvariantCulture);
+            clock.EndDate = DateTime.ParseExact("1900-01-02", "yyyy-MM-dd", CultureInfo.InvariantCulture);
 
             baseSim.Prepare();
             baseSim.Run();

--- a/Tests/UnitTests/Weather/WeatherTests.cs
+++ b/Tests/UnitTests/Weather/WeatherTests.cs
@@ -165,17 +165,17 @@ namespace UnitTests.Weather
             DailyMetDataFromFile weather1900 = weather.GetMetData(DateTime.Parse("03/01/1900"));
             DailyMetDataFromFile weather2000 = weather.GetMetData(DateTime.Parse("01/01/2000"));
 
-            Assert.AreEqual(weather1900.MaxT, 31.9, 0.00001);
-            Assert.AreEqual(weather1900.MinT, 16.6, 0.00001);
-            Assert.AreEqual(weather1900.Wind, 3.0, 0.00001);
-            Assert.AreEqual(weather1900.Radn, 25, 0.00001);
-            Assert.AreEqual(weather1900.Rain, 0, 0.00001);
+            Assert.AreEqual(31.9, weather1900.MaxT, 0.01);
+            Assert.AreEqual(16.6, weather1900.MinT, 0.01);
+            Assert.AreEqual(3.0, weather1900.Wind, 0.01);
+            Assert.AreEqual(25.0, weather1900.Radn, 0.01);
+            Assert.AreEqual(0.0, weather1900.Rain, 0.01);
 
-            Assert.AreEqual(weather2000.MaxT, 30.0, 0.00001);
-            Assert.AreEqual(weather2000.MinT, 17.5, 0.00001);
-            Assert.AreEqual(weather2000.Wind, 3.0, 0.00001);
-            Assert.AreEqual(weather2000.Radn, 29, 0.00001);
-            Assert.AreEqual(weather2000.Rain, 0, 0.00001);
+            Assert.AreEqual(30.5, weather2000.MaxT, 0.01);
+            Assert.AreEqual(13.5, weather2000.MinT, 0.01);
+            Assert.AreEqual(3.0, weather2000.Wind, 0.01);
+            Assert.AreEqual(28.0, weather2000.Radn, 0.01);
+            Assert.AreEqual(0.0, weather2000.Rain, 0.01);
 
             //should get the 3/1/1900 weather data
             Assert.AreEqual(weather1900, weather.TomorrowsMetData);

--- a/Tests/UnitTests/Weather/WeatherTests.cs
+++ b/Tests/UnitTests/Weather/WeatherTests.cs
@@ -179,9 +179,12 @@ namespace UnitTests.Weather
             Assert.AreEqual(0.0, weather2000.Rain, 0.01);
 
             //should get the 3/1/1900 weather data
-            Assert.AreEqual(weather1900, weather.TomorrowsMetData);
+            Assert.AreEqual(weather1900.MaxT, weather.TomorrowsMetData.MaxT, 0.01);
+            Assert.AreEqual(weather1900.MinT, weather.TomorrowsMetData.MinT, 0.01);
+            Assert.AreEqual(weather1900.Wind, weather.TomorrowsMetData.Wind, 0.01);
+            Assert.AreEqual(weather1900.Radn, weather.TomorrowsMetData.Radn, 0.01);
+            Assert.AreEqual(weather1900.Rain, weather.TomorrowsMetData.Rain, 0.01);
         }
-
 
         /*
          * This doesn't make sense to use anymore since weather sensibility tests no longer throw exceptions

--- a/Tools/CompareTestLogs.py
+++ b/Tools/CompareTestLogs.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from os.path import exists
  
 SEARCH_TEXT = " has finished. Elapsed time was "
 
@@ -7,7 +8,10 @@ class sim:
     time = 0
 
 def getSimName(line):
-    return line[:line.find(')')+1]
+    if ')' in line:
+        return line[:line.find(')')+1]
+    else:
+        return line[:line.find(SEARCH_TEXT)]
     
 def getSimTime(line):
     end_cut_off = line[0:line.rfind(' ')]
@@ -21,14 +25,33 @@ def makeSimsList(lines):
             s = sim()
             s.name = getSimName(line)
             s.time = getSimTime(line)
+            if len(s.name) == 0:
+                print(line)
             sims.append(s)
     return sims
 
 def main():
-    with open('log1.txt','r') as file:
+    print("This script will compare two jenkin logs and output the difference")
+    print("in time for each simulation that was run.")
+    print(" ")
+    print("Built for APSIM NextGen Build 7256")
+    print(" ")
+
+    logFile1 = input("Enter filename with extension for first log file (log1.txt):")
+    logFile2 = input("Enter filename with extension for second log file (log1.txt):")
+    
+    if exists(logFile1) == False:
+        print("Invalid Filename " + logFile1)
+        return False;
+        
+    if exists(logFile2) == False:
+        print("Invalid Filename " + logFile2)
+        return False;
+
+    with open(logFile1,'r') as file:
         sims1 = makeSimsList(file.readlines())
         
-    with open('log2.txt','r') as file:
+    with open(logFile2,'r') as file:
         sims2 = makeSimsList(file.readlines())
     #this is not efficent at all, but it works
     output = ""

--- a/Tools/CompareTestLogs.py
+++ b/Tools/CompareTestLogs.py
@@ -1,0 +1,53 @@
+from decimal import Decimal
+ 
+SEARCH_TEXT = " has finished. Elapsed time was "
+
+class sim:
+    name = ""
+    time = 0
+
+def getSimName(line):
+    return line[:line.find(')')+1]
+    
+def getSimTime(line):
+    end_cut_off = line[0:line.rfind(' ')]
+    num_str = end_cut_off[end_cut_off.rfind(' ')+1:]
+    return Decimal(num_str)
+    
+def makeSimsList(lines):
+    sims = []
+    for line in lines:
+        if SEARCH_TEXT in line:
+            s = sim()
+            s.name = getSimName(line)
+            s.time = getSimTime(line)
+            sims.append(s)
+    return sims
+
+def main():
+    with open('log1.txt','r') as file:
+        sims1 = makeSimsList(file.readlines())
+        
+    with open('log2.txt','r') as file:
+        sims2 = makeSimsList(file.readlines())
+    #this is not efficent at all, but it works
+    output = ""
+    for i in range(0, len(sims2)):
+        s2 = sims2[i]
+        found = False
+        for j in range(0, len(sims1)):
+            s1 = sims1[j]
+            if s1.name == s2.name:
+                output += s1.name + ","
+                output += str(s1.time) + ","
+                output += str(s2.time) + ","
+                output += str(s2.time - s1.time) + "\n"
+                found = True
+        if not found:
+            print(s2.name + " was not found in first log file")
+        
+    with open('output.csv','w') as file:
+        file.write(output)
+        
+#program start        
+main()


### PR DESCRIPTION
Resolves #8085

There are now two caches when reading weather data. The first is on the weather file which marks the date and file position of lines it reads. If you need to seek to a new position it now tries to find the closest position it has been before and works from there.

The weather also keeps a cache of every met data record it has already read. This means it doesn't need to re-read the file when looking at previous data, or if it's fetched future data and has then gotten to that future date during the same simulation.

Yesterday and Tomorrow's data is now grabbed when they are needed instead of being properties that are updated every day that is simulated. I may need to change that back for performance.

Based on the tests, it shows some values have changed. This is most likely because previously yesterday's weather was always set to today's weather for the first day of the simulation. With this new way, it will now actually get yesterday's weather if it exists. I think that is what is causing the minor variance, but will need to double check that.

Based on the speed it ran on the previous test, I may need to continue to work on this to improve the speed of this solution.