### PR TITLE
8104 StorageWriter Busy Waiting Fix

### DIFF
--- a/Models/Storage/DataStoreWriter.cs
+++ b/Models/Storage/DataStoreWriter.cs
@@ -24,7 +24,7 @@ namespace Models.Storage
         private List<IRunnable> commands = new List<IRunnable>();
 
         /// <summary>A sleep job to stop the job runner from exiting.</summary>
-        private IRunnable sleepJob = new EmptyJob();
+        private IRunnable sleepJob = new JobRunnerSleepJob(10);
 
         /// <summary>The runner used to run commands on a worker thread.</summary>
         private JobRunner commandRunner;


### PR DESCRIPTION
Resolves #8104 

StorageWriter previously used an EmptyJob to busy wait when it didn't have anything to write. An existing SleepJob class already existed, so that was added instead with a 10ms sleep delay.

No hit to performance that I could see, however as noted by Drew in #6772 this could be refactored in the future to actually solve the problem.