### PR TITLE
8134 Operation Parsing

### DIFF
--- a/ApsimNG/Presenters/OperationsPresenter.cs
+++ b/ApsimNG/Presenters/OperationsPresenter.cs
@@ -100,14 +100,17 @@ namespace UserInterface.Presenters
                 List<Operation> operations = new List<Operation>();
                 foreach (string line in this.view.Lines)
                 {
-                    Operation operation = Operation.ParseOperationString(line);
-                    if (operation != null)
+                    if (line.Length > 0)
                     {
-                        operations.Add(operation);
-                    } 
-                    else
-                    {
-                        explorerPresenter.MainPresenter.ShowMessage($"Warning: unable to parse operation '{line}'", Models.Core.Simulation.MessageType.Warning);
+                        Operation operation = Operation.ParseOperationString(line);
+                        if (operation != null)
+                        {
+                            operations.Add(operation);
+                        }
+                        else
+                        {
+                            explorerPresenter.MainPresenter.ShowMessage($"Warning: unable to parse operation '{line}'", Models.Core.Simulation.MessageType.Warning);
+                        }
                     }
                 }
 

--- a/ApsimNG/Presenters/OperationsPresenter.cs
+++ b/ApsimNG/Presenters/OperationsPresenter.cs
@@ -1,14 +1,14 @@
-﻿namespace UserInterface.Presenters
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Drawing;
-    using APSIM.Shared.Utilities;
-    using EventArguments;
-    using Interfaces;
-    using Models;
-    using Views;
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using APSIM.Shared.Utilities;
+using Models;
+using UserInterface.EventArguments;
+using UserInterface.Interfaces;
+using UserInterface.Views;
 
+namespace UserInterface.Presenters
+{
     /// <summary>
     /// A presenter class for showing an operations model in an operations view.
     /// </summary>
@@ -95,31 +95,19 @@
         {
             try
             {
+                explorerPresenter.MainPresenter.ClearStatusPanel();
                 this.explorerPresenter.CommandHistory.ModelChanged -= this.OnModelChanged;
                 List<Operation> operations = new List<Operation>();
                 foreach (string line in this.view.Lines)
                 {
-                    string currentLine = line;
-                    bool isComment = line.Trim().StartsWith("//");
-                    if (isComment)
+                    Operation operation = Operation.ParseOperationString(line);
+                    if (operation != null)
                     {
-                        int index = line.IndexOf("//");
-                        if (index >= 0)
-                            currentLine = currentLine.Remove(index, 2).Trim();
-                    }
-
-                    int pos = currentLine.IndexOfAny(" \t".ToCharArray());
-                    if (pos != -1)
-                    {
-                        Operation operation = new Operation();
-                        string dateString = currentLine.Substring(0, pos);
-                        operation.Date = DateUtilities.ValidateDateString(dateString);
-                        if (operation.Date == null)
-                            explorerPresenter.MainPresenter.ShowMessage($"Warning: unable to parse date string {dateString}", Models.Core.Simulation.MessageType.Warning);
-
-                        operation.Action = currentLine.Substring(pos + 1);
-                        operation.Enabled = !isComment;
                         operations.Add(operation);
+                    } 
+                    else
+                    {
+                        explorerPresenter.MainPresenter.ShowMessage($"Warning: unable to parse operation '{line}'", Models.Core.Simulation.MessageType.Warning);
                     }
                 }
 

--- a/Models/Management/Operations.cs
+++ b/Models/Management/Operations.cs
@@ -23,6 +23,21 @@ namespace Models
             Enabled = true;
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        public Operation(bool enabled, string date, string action)
+        {
+            Enabled = enabled;
+            Date = date;
+            Action = action;
+        }
+
+        /// <summary>
+        /// Used to determine whether the operation is enabled or not.
+        /// </summary>
+        public bool Enabled { get; set; }
+
         /// <summary>Gets or sets the date.</summary>
         public string Date { get; set; }
 
@@ -42,42 +57,52 @@ namespace Models
         }
 
         /// <summary>
-        /// Used to determine whether the operation is enabled or not.
-        /// </summary>
-        public bool Enabled { get; set; }
-
-        /// <summary>
         /// Parses a string into an Operation
-        /// Format: // 2000-01-01 [Element].Function(1000)
+        /// Format: // 2000-01-01 [NodeName].Function(1000)
         /// </summary>
         /// <param name="line">The string to parse</param>
         /// <returns>An Operation or null if there was an error parsing the string</returns>
         public static Operation ParseOperationString(string line)
         {
-            string lineTrimmed = line.Trim();
-
-            Regex parser = new Regex(@"^(\/?\/?)\s*?(\S*)\s*(\S*)$");
-            Match match = parser.Match(lineTrimmed);
-
-            if (match.Success)
+            try
             {
-                Operation operation = new Operation();
-                if (match.Groups[1].Value.CompareTo("//") == 0)
-                    operation.Enabled = false;
-                else
-                    operation.Enabled = true;
+                if (line == null)
+                    return null;
 
-                string dateString = match.Groups[2].Value;
-                operation.Date = DateUtilities.ValidateDateString(dateString);
-                if (operation.Date == null)
+                if (line.Length == 0)
+                    return null;
+
+                string lineTrimmed = line.Trim();
+
+                Regex parser = new Regex(@"^(\/?\/?)\s*?(\S*)\s*(\S*)$");
+                Match match = parser.Match(lineTrimmed);
+
+                if (match.Success)
+                {
+                    Operation operation = new Operation();
+                    if (match.Groups[1].Value.CompareTo("//") == 0)
+                        operation.Enabled = false;
+                    else
+                        operation.Enabled = true;
+
+                    string dateString = match.Groups[2].Value;
+                    operation.Date = DateUtilities.ValidateDateString(dateString);
+                    if (operation.Date == null)
+                        return null;
+
+                    if (match.Groups[3].Value.Length > 0)
+                        operation.Action = match.Groups[3].Value;
+                    else
+                        return null;
+
+                    return operation;
+                }
+                else
                 {
                     return null;
                 }
-                operation.Action = match.Groups[3].Value;
-
-                return operation;
             }
-            else
+            catch
             {
                 return null;
             }

--- a/Models/Management/Operations.cs
+++ b/Models/Management/Operations.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using APSIM.Shared.Utilities;
 using Models.Core;
 
@@ -44,6 +45,43 @@ namespace Models
         /// Used to determine whether the operation is enabled or not.
         /// </summary>
         public bool Enabled { get; set; }
+
+        /// <summary>
+        /// Parses a string into an Operation
+        /// Format: // 2000-01-01 [Element].Function(1000)
+        /// </summary>
+        /// <param name="line">The string to parse</param>
+        /// <returns>An Operation or null if there was an error parsing the string</returns>
+        public static Operation ParseOperationString(string line)
+        {
+            string lineTrimmed = line.Trim();
+
+            Regex parser = new Regex(@"^(\/?\/?)\s*?(\S*)\s*(\S*)$");
+            Match match = parser.Match(lineTrimmed);
+
+            if (match.Success)
+            {
+                Operation operation = new Operation();
+                if (match.Groups[1].Value.CompareTo("//") == 0)
+                    operation.Enabled = false;
+                else
+                    operation.Enabled = true;
+
+                string dateString = match.Groups[2].Value;
+                operation.Date = DateUtilities.ValidateDateString(dateString);
+                if (operation.Date == null)
+                {
+                    return null;
+                }
+                operation.Action = match.Groups[3].Value;
+
+                return operation;
+            }
+            else
+            {
+                return null;
+            }
+        }
     }
 
     /// <summary>This class encapsulates an operations schedule.</summary>

--- a/Tests/UnitTests/Operations/Operations.cs
+++ b/Tests/UnitTests/Operations/Operations.cs
@@ -1,0 +1,68 @@
+﻿using APSIM.Shared.Utilities;
+using NUnit.Framework;
+using System;
+using Models;
+
+namespace UnitTests
+{
+    [TestFixture]
+    public class OperationsTests
+    {
+        [Test]
+        public void TestOperationParsing()
+        {
+            string[] passingStrings =
+            {
+                "2000-01-01 [NodeName].Function(1000)",
+                " 2000-01-01 [NodeName].Function(1000) ",
+                "2000-01-01\t[NodeName].Function(1000)",
+                "\t2000-01-01\t[NodeName].Function(1000)\t",
+                "2000/01/01 [NodeName].Function(1000)",
+                "//2000-01-01 [NodeName].Function(1000)",
+                " // 2000-01-01 [NodeName].Function(1000) ",
+                "//\t2000-01-01\t[NodeName].Function(1000)",
+                "\t//\t2000-01-01\t[NodeName].Function(1000)\t",
+                "//2000/01/01 [NodeName].Function(1000)"
+            };
+
+            Operation[] expectedOperations =
+            {
+                new Operation(true, "2000-01-01", "[NodeName].Function(1000)"),
+                new Operation(true, "2000-01-01", "[NodeName].Function(1000)"),
+                new Operation(true, "2000-01-01", "[NodeName].Function(1000)"),
+                new Operation(true, "2000-01-01", "[NodeName].Function(1000)"),
+                new Operation(true, "2000-01-01", "[NodeName].Function(1000)"),
+                new Operation(false, "2000-01-01", "[NodeName].Function(1000)"),
+                new Operation(false, "2000-01-01", "[NodeName].Function(1000)"),
+                new Operation(false, "2000-01-01", "[NodeName].Function(1000)"),
+                new Operation(false, "2000-01-01", "[NodeName].Function(1000)"),
+                new Operation(false, "2000-01-01", "[NodeName].Function(1000)")
+            };
+
+            for (int i = 0; i < passingStrings.Length; i++)
+            {
+                Operation actualOperation = Operation.ParseOperationString(passingStrings[i]);
+                Assert.AreEqual(expectedOperations[i].Enabled, actualOperation.Enabled);
+                Assert.AreEqual(expectedOperations[i].Date, actualOperation.Date);
+                Assert.AreEqual(expectedOperations[i].Action, actualOperation.Action);
+            }
+
+            string[] failingStrings =
+            {
+                "2000-13-01 [NodeName].Function(1000)", //bad date
+                "2000-01-01[NodeName].Function(1000)",  //missing whitespace
+                "[NodeName].Function(1000) 2000-01-01", //wrong order
+                "2000-01-01 ",                          //missing action
+                " [NodeName].Function(1000)",           //missing date
+                "",                                     //empty string
+                null,                                   //null
+                "///2000-01-01 [NodeName].Function(1000)", //too many comments
+            };
+
+            for (int i = 0; i < failingStrings.Length; i++)
+            {
+                Assert.Null(Operation.ParseOperationString(failingStrings[i]));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves #8134

Parsing an Operation from a string has been moved to a static method in the Operation class instead of in the presenter. A set of unit tests has also been added to make sure it's working correctly.