### PR TITLE
8146 Exporting DataStore sorts by SimulationName

### DIFF
--- a/APSIM.Shared/Utilities/DataTableUtilities.cs
+++ b/APSIM.Shared/Utilities/DataTableUtilities.cs
@@ -659,6 +659,16 @@ namespace APSIM.Shared.Utilities
                 stringTable.Rows.Add(newRow);
             }
 
+            //Sort Rows by SimulationName in alphabetical order
+            if (stringTable.Columns.Contains("SimulationName"))
+            {
+                DataView dv = stringTable.DefaultView;
+                dv.Sort = "SimulationName ASC";
+                if (stringTable.Columns.Contains("Clock.Today"))
+                    dv.Sort += ", Clock.Today ASC";
+                stringTable = dv.ToTable();
+            }
+
             // Need to work out column widths
             List<int> columnWidths = new List<int>();
             foreach (DataColumn column in stringTable.Columns)

--- a/ApsimNG/Utility/Excel.cs
+++ b/ApsimNG/Utility/Excel.cs
@@ -1,7 +1,8 @@
-﻿namespace Utility
-{
-    using ClosedXML.Excel;
+﻿using ClosedXML.Excel;
+using System.Data;
 
+namespace Utility
+{
     /// <summary>
     /// TODO: Update summary.
     /// </summary>
@@ -17,7 +18,17 @@
             XLWorkbook workbook = new XLWorkbook();
             foreach (System.Data.DataTable table in tables)
             {
-                workbook.Worksheets.Add(table);
+                DataTable sortedTable = table;
+                //Sort Rows by SimulationNatableme in alphabetical order
+                if (table.Columns.Contains("SimulationName"))
+                {
+                    DataView dv = table.DefaultView;
+                    dv.Sort = "SimulationName ASC";
+                    if (table.Columns.Contains("Clock.Today"))
+                        dv.Sort += ", Clock.Today ASC";
+                    sortedTable = dv.ToTable();
+                }
+                workbook.Worksheets.Add(sortedTable);
             }
 
             workbook.SaveAs(fileName);

--- a/Models/Summary.cs
+++ b/Models/Summary.cs
@@ -201,7 +201,7 @@ namespace Models
         #region Static summary report generation
 
         /// <summary>
-        /// Write a single sumary file for all simulations.
+        /// Write a single summary file for all simulations.
         /// </summary>
         /// <param name="storage">The storage where the summary data is stored</param>
         /// <param name="fileName">The file name to write</param>
@@ -210,7 +210,11 @@ namespace Models
         {
             using (StreamWriter report = new StreamWriter(fileName))
             {
-                foreach (string simulationName in storage.Reader.SimulationNames)
+                //get list of simulations in alphabetical order
+                List<string> names = storage.Reader.SimulationNames;
+                names.Sort();
+
+                foreach (string simulationName in names)
                 {
                     Summary.WriteReport(storage, simulationName, report, null, outtype: Summary.OutputType.html, darkTheme: darkTheme, true, true, true, true);
                     report.WriteLine();


### PR DESCRIPTION
Resolves #8146

Added sorting for the excel and csv exporting of the data tables, and for the summary export option. In the case of the excel and csv, if two sims have the same name (multiple entries) then they are sorted by Clock.Today if that is a column that exists.