### PR TITLE
 8149 Panel sliders now stored in xml and use percentage

### DIFF
--- a/ApsimNG/Interfaces/IExplorerView.cs
+++ b/ApsimNG/Interfaces/IExplorerView.cs
@@ -13,6 +13,9 @@
         /// <summary>The toolstrip at the top of the explorer view</summary>
         IToolStripView ToolStrip { get; }
 
+        /// <summary>Position of the divider between the tree and content</summary>
+        int DividerPosition { get; set; }
+
         /// <summary>
         /// Add a view to the right hand panel.
         /// </summary>

--- a/ApsimNG/Presenters/ExplorerPresenter.cs
+++ b/ApsimNG/Presenters/ExplorerPresenter.cs
@@ -79,8 +79,8 @@ namespace UserInterface.Presenters
         /// <value>The width of the tree.</value>
         public int TreeWidth
         {
-            get { return view.Tree.TreeWidth; }
-            set { this.view.Tree.TreeWidth = value; }
+            get { return view.DividerPosition; }
+            set { this.view.DividerPosition = value; }
         }
 
         /// <summary>Gets the presenter for the main window</summary>
@@ -364,7 +364,6 @@ namespace UserInterface.Presenters
         /// <param name="fileName">Path to which the file will be saved.</param>
         public void WriteSimulation(string fileName)
         {
-            ApsimXFile.ExplorerWidth = TreeWidth;
             ApsimXFile.Write(fileName);
             CommandHistory.Save();
         }

--- a/ApsimNG/Presenters/MainPresenter.cs
+++ b/ApsimNG/Presenters/MainPresenter.cs
@@ -83,11 +83,25 @@ namespace UserInterface.Presenters
             this.view.TabClosing += this.OnTabClosing;
             this.view.ShowDetailedError += this.ShowDetailedErrorMessage;
             this.view.Show();
-            if (Utility.Configuration.Settings.StatusPanelHeight > 0.5 * this.view.WindowSize.Height)
-                this.view.StatusPanelHeight = 20;
+
+            int height = this.view.WindowSize.Height;
+            int savedHeight = Utility.Configuration.Settings.StatusPanelHeight;
+            if (savedHeight > 90)
+                this.view.StatusPanelHeight = (int)Math.Round(height * 0.9);
+            else if (savedHeight < 10)
+                this.view.StatusPanelHeight = (int)Math.Round(height * 0.1);
             else
-                this.view.StatusPanelHeight = Utility.Configuration.Settings.StatusPanelHeight;
-            this.view.SplitScreenPosition = Configuration.Settings.SplitScreenPosition;
+                this.view.StatusPanelHeight = (int)Math.Round(height * (savedHeight/100.0f));
+
+            int width = this.view.WindowSize.Width;
+            int savedWidth = Utility.Configuration.Settings.SplitScreenPosition;
+            if (savedWidth > 90)
+                this.view.SplitScreenPosition = (int)Math.Round(width * 0.9);
+            else if (savedWidth < 10)
+                this.view.SplitScreenPosition = (int)Math.Round(width * 0.1);
+            else
+                this.view.SplitScreenPosition = (int)Math.Round(width * (savedWidth / 100.0f));
+
             // Process command line.
             this.ProcessCommandLineArguments(commandLineArguments);
         }
@@ -964,14 +978,14 @@ namespace UserInterface.Presenters
             // restore the simulation tree width on the form
             if (newPresenter.GetType() == typeof(ExplorerPresenter))
             {
-                if (simulations.ExplorerWidth == 0)
-                {
-                    ((ExplorerPresenter)newPresenter).TreeWidth = 250;
-                }
+                int width = this.view.WindowSize.Width;
+                int savedWidth = Utility.Configuration.Settings.TreeSplitScreenPosition;
+                if (savedWidth > 90)
+                    ((ExplorerPresenter)newPresenter).TreeWidth = (int)Math.Round(width * 0.9);
+                else if (savedWidth < 10)
+                    ((ExplorerPresenter)newPresenter).TreeWidth = (int)Math.Round(width * 0.1);
                 else
-                {
-                    ((ExplorerPresenter)newPresenter).TreeWidth = simulations.ExplorerWidth;
-                }
+                    ((ExplorerPresenter)newPresenter).TreeWidth = (int)Math.Round(width * (savedWidth / 100.0f));
             }
             return newPresenter;
         }
@@ -1308,14 +1322,20 @@ namespace UserInterface.Presenters
         /// <param name="e">Close arguments</param>
         private void OnClosing(object sender, AllowCloseArgs e)
         {
+            int treeWidth = 0;
+            if (this.GetCurrentExplorerPresenter() != null)
+                treeWidth = this.GetCurrentExplorerPresenter().TreeWidth;
+
             e.AllowClose = this.AllowClose();
             if (e.AllowClose)
             {
-                Configuration.Settings.SplitScreenPosition = view.SplitScreenPosition;
+                Utility.Configuration.Settings.SplitScreenPosition = (int)MathF.Round(((float)this.view.SplitScreenPosition / (float)this.view.WindowSize.Width) * 100);
                 Utility.Configuration.Settings.MainFormLocation = this.view.WindowLocation;
                 Utility.Configuration.Settings.MainFormSize = this.view.WindowSize;
                 Utility.Configuration.Settings.MainFormMaximized = this.view.WindowMaximised;
-                Utility.Configuration.Settings.StatusPanelHeight = this.view.StatusPanelHeight;
+                Utility.Configuration.Settings.StatusPanelHeight = (int)MathF.Round(((float)this.view.StatusPanelHeight / (float)this.view.WindowSize.Height)*100);
+                if (treeWidth > 0)
+                    Utility.Configuration.Settings.TreeSplitScreenPosition = (int)MathF.Round(((float)treeWidth / (float)this.view.WindowSize.Width) * 100);
                 Utility.Configuration.Settings.Save();
             }
         }

--- a/ApsimNG/Utility/Configuration.cs
+++ b/ApsimNG/Utility/Configuration.cs
@@ -35,13 +35,18 @@ namespace Utility
         public int FilesInHistory { get; set; }
 
         /// <summary>Position of split screen divider.</summary>
-        /// <remarks>Not sure what units this uses...might be pixels.</remarks>
+        /// <remarks>Percentage 0-100</remarks>
         public int SplitScreenPosition { get; set; }
+
+        /// <summary>Position of split screen divider.</summary>
+        /// <remarks>Percentage 0-100</remarks>
+        public int TreeSplitScreenPosition { get; set; }
 
         /// <summary>The previous folder where a file was opened or saved</summary>
         public string PreviousFolder { get; set; }
 
         /// <summary>The previous height of the status panel</summary>
+        /// <remarks>Percentage 0-100</remarks>
         public int StatusPanelHeight { get; set; }
 
         /// <summary>

--- a/ApsimNG/Views/ExplorerView.cs
+++ b/ApsimNG/Views/ExplorerView.cs
@@ -20,6 +20,7 @@ namespace UserInterface.Views
     public class ExplorerView : ViewBase, IExplorerView
     {
         private VBox rightHandView;
+        private HPaned hpaned1;
         private Gtk.TreeView treeviewWidget;
         private MarkdownView descriptionView;
 
@@ -29,6 +30,8 @@ namespace UserInterface.Views
             Builder builder = BuilderFromResource("ApsimNG.Resources.Glade.ExplorerView.glade");
             mainWidget = (VBox)builder.GetObject("vbox1");
             ToolStrip = new ToolStripView((Toolbar)builder.GetObject("toolStrip"));
+
+            hpaned1 = (HPaned)builder.GetObject("hpaned1");
 
             treeviewWidget = (Gtk.TreeView)builder.GetObject("treeview1");
             treeviewWidget.Realized += OnLoaded;
@@ -47,6 +50,13 @@ namespace UserInterface.Views
 
         /// <summary>The toolstrip at the top of the explorer view</summary>
         public IToolStripView ToolStrip { get; private set; }
+
+        /// <summary>The tree on the left side of the explorer view</summary>
+        public int DividerPosition
+        {
+            get { return hpaned1.Position; }
+            set { hpaned1.Position = value; }
+        }
 
         /// <summary>
         /// Add a user control to the right hand panel. If Control is null then right hand panel will be cleared.

--- a/ApsimNG/Views/MainView.cs
+++ b/ApsimNG/Views/MainView.cs
@@ -169,9 +169,6 @@
 
             hbox1.HeightRequest = 20;
 
-            int paneHeight = MainWidget.Screen.RootWindow.Height;
-            vpaned1.Position = (int)Math.Round(paneHeight * 0.8); //set the slider for the pane at about 80% down
-
             // Normally, one would specify the style class in the UI (.glade) file.
             // However, doing so breaks gtk2-compatibility, so for now, we will just
             // set the style class in code.
@@ -329,11 +326,26 @@
         {
             get
             {
-                return hbox1.Allocation.Height;
+                return vpaned1.Position;
             }
             set
             {
-                hbox1.HeightRequest = value;
+                vpaned1.Position = value;
+            }
+        }
+
+        /// <summary>
+        /// Controls the width of the tree panel.
+        /// </summary>
+        public int TreePanelWidth
+        {
+            get
+            {
+                return vpaned1.Position;
+            }
+            set
+            {
+                vpaned1.Position = value;
             }
         }
 

--- a/Models/Core/Simulations.cs
+++ b/Models/Core/Simulations.cs
@@ -25,10 +25,6 @@ namespace Models.Core
         [NonSerialized]
         private Links links;
 
-        /// <summary>Gets or sets the width of the explorer.</summary>
-        /// <value>The width of the explorer.</value>
-        public Int32 ExplorerWidth { get; set; }
-
         /// <summary>Gets or sets the version.</summary>
         [System.Xml.Serialization.XmlAttribute("Version")]
         public int Version { get; set; }


### PR DESCRIPTION
Resolves #8149

The status panel and the treeview panel had variables to store their positions, but neither were working correctly. The treeview width is no longer stored in the apsim file, and is instead in the config xml. Both now work correctly and will stay in the same position between apsim launches.

A pull request last week also caused the status bar to dissappear off the bottom of the screen, so this should also fix that and may  fix #8162

A known bug that is still here is that when launching apsim from a previous smaller resolution to a now larger resolution, the status bar dissappears off the bottom of the screen again. Relaunching apsim a 2nd time after this will make it reset to a default position. This seems to be some sort of GTK weirdness, as I cannot find any other code that changes this bar.