### PR TITLE
7841 Make sure SimulationName appears in PredictedObserved Dropdown

### DIFF
--- a/Models/PostSimulationTools/PredictedObserved.cs
+++ b/Models/PostSimulationTools/PredictedObserved.cs
@@ -308,7 +308,23 @@ namespace Models.PostSimulationTools
             IEnumerable<string> predictedColumns = storage.Reader.GetColumns(PredictedTableName).Select(c => c.Item1);
             IEnumerable<string> observedColumns = storage.Reader.GetColumns(ObservedTableName).Select(c => c.Item1);
 
-            return predictedColumns.Intersect(observedColumns).ToArray();
+            List<string> intersect = predictedColumns.Intersect(observedColumns).ToList();
+
+            //These columns will always exist, however may have been added when the table was loaded.
+            //We need to add them back in here for PredictObserve
+            if (!intersect.Contains("SimulationName"))
+            {
+                int pos = intersect.IndexOf("SimulationID");
+                intersect.Insert(pos+1, "SimulationName");
+            }
+
+            if (!intersect.Contains("CheckpointName"))
+            {
+                int pos = intersect.IndexOf("CheckpointID");
+                intersect.Insert(pos + 1, "CheckpointName");
+            }
+
+            return intersect.ToArray();
         }
     }
 }

--- a/Models/Storage/DataStoreReader.cs
+++ b/Models/Storage/DataStoreReader.cs
@@ -288,25 +288,34 @@ namespace Models.Storage
             // Run query.
             DataTable result = Connection.ExecuteQuery(sql);
 
-            // Add SimulationName and CheckpointName if necessary.
-            if (result.Rows.Count > 0 && fieldNamesInTable.Contains("SimulationID"))
+            if (result.Rows.Count > 0)
             {
-                result.Columns.Add("CheckpointName", typeof(string));
-                result.Columns.Add("SimulationName", typeof(string));
-                result.Columns["CheckpointName"].SetOrdinal(0);
-                result.Columns["SimulationName"].SetOrdinal(2);
-                foreach (DataRow row in result.Rows)
+                // Add SimulationName and CheckpointName if necessary.
+                if (!fieldNamesInTable.Contains("CheckpointName"))
                 {
-                    string simulationName = null;
-                    if (!Convert.IsDBNull(row["SimulationID"]) && Int32.TryParse(row["SimulationID"].ToString(), out int simulationID))
-                        simulationName = simulationIDs.FirstOrDefault(x => x.Value == simulationID).Key;
-                    else
+                    result.Columns.Add("CheckpointName", typeof(string));
+                    result.Columns["CheckpointName"].SetOrdinal(0);
+                }
+                if (!fieldNamesInTable.Contains("SimulationName"))
+                {
+                    result.Columns.Add("SimulationName", typeof(string));
+                    result.Columns["SimulationName"].SetOrdinal(2);
+                }
+                if (fieldNamesInTable.Contains("SimulationID"))
+                {
+                    foreach (DataRow row in result.Rows)
                     {
-                        throw new Exception($"In table {tableName}, SimulationID has a value of {row["SimulationID"].ToString()} which is not valid");
-                    }
+                        string simulationName = null;
+                        if (!Convert.IsDBNull(row["SimulationID"]) && Int32.TryParse(row["SimulationID"].ToString(), out int simulationID))
+                            simulationName = simulationIDs.FirstOrDefault(x => x.Value == simulationID).Key;
+                        else
+                        {
+                            throw new Exception($"In table {tableName}, SimulationID has a value of {row["SimulationID"].ToString()} which is not valid");
+                        }
 
-                    row["CheckpointName"] = checkpointName;
-                    row["SimulationName"] = simulationName;
+                        row["CheckpointName"] = checkpointName;
+                        row["SimulationName"] = simulationName;
+                    }
                 }
             }
 

--- a/Tests/UnitTests/PostSimulationTools/SimulationComparisonTests.cs
+++ b/Tests/UnitTests/PostSimulationTools/SimulationComparisonTests.cs
@@ -1,21 +1,15 @@
-﻿namespace UnitTests
-{
-    using APSIM.Shared.Utilities;
-    using Models;
-    using Models.Core;
-    using Models.Core.ApsimFile;
-    using Models.PostSimulationTools;
-    using Models.Soils;
-    using Models.Soils.Nutrients;
-    using Models.Storage;
-    using Models.Surface;
-    using NUnit.Framework;
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Reflection;
-    using UnitTests.Soils;
+﻿using APSIM.Shared.Utilities;
+using Models.PostSimulationTools;
+using Models.Storage;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using System.Reflection;
 
+namespace UnitTests
+{
     public class SimulationComparisonTests
     {
         private IDatabaseConnection database;
@@ -73,12 +67,12 @@
             dataStore.Reader.Refresh();
             var data = dataStore.Reader.GetData("SimulationComparison");
 
-            Assert.IsTrue(
-                Utilities.CreateTable(new string[] {  "CheckpointID", "Year", "Sim1.Col1", "Sim2.Col1", "Sim1.Col2", "Sim2.Col2" },
-                   new List<object[]> { new object[] {             1,   1970,          10,          14,          11,          15 },
-                                        new object[] {             1,   1971,          12,          16,          13,          17 }
-                   })
-               .IsSame(data));
+            DataTable table = Utilities.CreateTable(new string[] { "CheckpointName", "CheckpointID", "SimulationName", "Year", "Sim1.Col1", "Sim2.Col1", "Sim1.Col2", "Sim2.Col2" },
+                   new List<object[]> { new object[] {                         null,             1,              null,   1970,          10,          14,          11,          15 },
+                                        new object[] {                         null,             1,              null,   1971,          12,          16,          13,          17 }
+                   });
+
+            Assert.IsTrue(table.IsSame(data));
         }
 
         /// <summary>Create a table that we can test</summary>


### PR DESCRIPTION
Resolves #7841

It was possible for SimulationName to not show up in the PredictedObserved view as an option in the dropdowns. When loading directly from the database, some tables do not have SimulationName, but in that case it was supposed to be added dynamically.

This change manually adds it back in if it's missing. 

Also fixed another bug where under certain circumstances, the Datastore would try and add SimulationName and CheckpointName columns to a table that already had them. I simply added an extra check for those.