### PR TITLE
8193 Documentation Presenter markdown generation put into async function

### DIFF
--- a/ApsimNG/Presenters/DocumentationPresenter.cs
+++ b/ApsimNG/Presenters/DocumentationPresenter.cs
@@ -3,16 +3,11 @@ using APSIM.Shared.Utilities;
 using Models.Core;
 using Models.Functions;
 using System;
-using System.Collections.Generic;
 using System.Data;
-using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using UserInterface.Views;
-using UserInterface.Interfaces;
-using Utility;
 using Models.PMF.Phen;
 
 namespace UserInterface.Presenters
@@ -37,9 +32,9 @@ namespace UserInterface.Presenters
             PopulateView();
         }
 
-        private void PopulateView()
+        private async void PopulateView()
         {
-            view.Text = DocumentModel(model).Replace("<", @"\<");
+            view.Text = await Task.Run(() => DocumentModel(model).Replace("<", @"\<"));
         }
 
         private string DocumentModel(IModel model)


### PR DESCRIPTION
Resolves #8193

Put an async handle around the markdown generation. This along with the changes from last week means there is very little lag when loading a Documentation Presenter window.