### PR TITLE
6706 Models using IFunction can have valid parent restrictions

### DIFF
--- a/ApsimNG/Presenters/AddModelPresenter.cs
+++ b/ApsimNG/Presenters/AddModelPresenter.cs
@@ -73,8 +73,21 @@
                 AddTreeNodeIfDoesntExist(modelThatCanBeAdded, rootNode);
 
             tree.Populate(rootNode);
-            if (models.Count() < 10)
+
+            //count how many non-function results are returned
+            int count = 0;
+            foreach (Apsim.ModelDescription description in models)
+            {
+                if (!description.ModelType.AssemblyQualifiedName.Contains("Models.Functions"))
+                    count += 1;
+            }
+
+            if (count < 10)
+            {
                 tree.ExpandChildren(".Models");
+                tree.CollapseChildren(".Models.Functions");
+            }
+                
         }
 
         private static void AddTreeNodeIfDoesntExist(Apsim.ModelDescription modelThatCanBeAdded, TreeViewNode parent)

--- a/Models/PMF/Structure/HeightFunction.cs
+++ b/Models/PMF/Structure/HeightFunction.cs
@@ -12,6 +12,7 @@ namespace Models.PMF.Struct
     /// Calculates the potential height increment and then multiplies it by the smallest of any childern functions (Child functions represent stress).
     /// </summary>
     [Serializable]
+    [ValidParent(ParentType = typeof(Structure))]
     public class HeightFunction : Model, IFunction
     {
         /// <summary>The potential height</summary>

--- a/Models/Soils/WaterModel/CNReductionForCover.cs
+++ b/Models/Soils/WaterModel/CNReductionForCover.cs
@@ -10,6 +10,7 @@ namespace Models.WaterModel
 
     /// <summary>Implements the curve number reduction caused by cover.</summary>
     [Serializable]
+    [ValidParent(typeof(WaterBalance))]
     public class CNReductionForCover : Model, IFunction
     {
         // --- Links -------------------------------------------------------------------------

--- a/Models/Soils/WaterModel/CNReductionForTillage.cs
+++ b/Models/Soils/WaterModel/CNReductionForTillage.cs
@@ -15,6 +15,7 @@ namespace Models.WaterModel
     /// and erosion.Aust.J.Soil Res. 34: 91-102.
     /// </summary>
     [Serializable]
+    [ValidParent(typeof(WaterBalance))]
     public class CNReductionForTillage : Model, IFunction
     {
         // --- Links -------------------------------------------------------------------------


### PR DESCRIPTION
Working on #6706

Looking through an old issue and I noticed that models using the IFunction interface would always appear in the Add Model menu, even if they had been given a ValidParent tag to restrict them. Rewrote the function that handles valid parent checking so that it respects that and it cleans up most of the random classes that always show up in the add model menu.

After that only 3 models still appeared that shouldn't: Soils.WaterModel.CNReductionForTillage, Soils.WaterModel.CNReductionForCover and PMF.Structure.HeightFunction.

CNReductionForTillage and CNReductionForCover were only used under a WaterBalance node, so I gave them that parent.

Not sure what to do with HeightFunction however, as it does not seem to be used in any of our examples or validation simulations. The last big edit to it seems to be in 2017, so is this an old leftover class?