### PR TITLE
8200 Stops carriage returns from being added to Rotation Manager

### DIFF
--- a/ApsimNG/Views/BubbleChartView.cs
+++ b/ApsimNG/Views/BubbleChartView.cs
@@ -335,8 +335,8 @@ namespace UserInterface.Views
             else if (arc != null)
             {
                 ctxFrame.Label = "Transition from " + arc.SourceName + " to " + arc.DestinationName;
-                RuleList.Text = String.Join(Environment.NewLine, rules[arc.Name].ToArray()) ;
-                ActionList.Text = String.Join(Environment.NewLine, actions[arc.Name].ToArray());
+                RuleList.Text = String.Join('\n', rules[arc.Name].ToArray()) ;
+                ActionList.Text = String.Join('\n', actions[arc.Name].ToArray());
                 ctxBox.PackStart(arcSelWdgt, true, true, 0);
             }
             else


### PR DESCRIPTION
Resolves #8200 

On windows carriage returns would be added to the rules and actions making them unparsable. It also caused blank lines to be added into these boxes every time they were opened, as both the newline and carriage characters were treated as new lines.