### PR TITLE
Standardise examples

### DIFF
--- a/Examples/Barley.apsimx
+++ b/Examples/Barley.apsimx
@@ -1,51 +1,50 @@
 {
   "$type": "Models.Core.Simulations, Models",
-  "ExplorerWidth": 300,
-  "Version": 100,
-  "ApsimVersion": "0.0.0.0",
+  "Version": 168,
   "Name": "Simulations",
+  "ResourceName": null,
   "Children": [
     {
       "$type": "Models.Core.Simulation, Models",
-      "IsRunning": false,
+      "Descriptors": null,
       "Name": "Simulation",
+      "ResourceName": null,
       "Children": [
         {
           "$type": "Models.Clock, Models",
-          "Start": "1900-01-01T00:00:00",
-          "End": "2000-12-31T00:00:00",
+          "Start": "1900-01-01T00:00",
+          "End": "2000-12-31T00:00",
           "Name": "Clock",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
         {
           "$type": "Models.Summary, Models",
-          "CaptureErrors": true,
-          "CaptureWarnings": true,
-          "CaptureSummaryText": true,
-          "Name": "SummaryFile",
+          "Verbosity": 100,
+          "Name": "Summary",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
         {
-          "$type": "Models.Weather, Models",
+          "$type": "Models.Climate.Weather, Models",
+          "ConstantsFile": null,
           "FileName": "%root%\\Examples\\WeatherFiles\\Dalby.met",
           "ExcelWorkSheetName": null,
           "Name": "Weather",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
         {
           "$type": "Models.Soils.Arbitrator.SoilArbitrator, Models",
           "Name": "SoilArbitrator",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
@@ -56,6 +55,7 @@
           "AspectAngle": 0.0,
           "Altitude": 50.0,
           "Name": "Field",
+          "ResourceName": null,
           "Children": [
             {
               "$type": "Models.Report, Models",
@@ -78,22 +78,22 @@
               ],
               "GroupByVariableName": null,
               "Name": "Report",
+              "ResourceName": null,
               "Children": [],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Fertiliser, Models",
               "Name": "Fertiliser",
+              "ResourceName": "Fertiliser",
               "Children": [],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Soils.Soil, Models",
-              "RecordNumber": 0,
+              "RecordNumber": 104,
               "ASCOrder": "Vertosol",
               "ASCSubOrder": "Black",
               "SoilType": "Clay",
@@ -108,21 +108,14 @@
               "Latitude": -27.581836,
               "Longitude": 151.320206,
               "LocationAccuracy": " +/- 20m",
+              "YearOfSampling": "0",
               "DataSource": "CSIRO Sustainable Ecosystems, Toowoomba; Characteriesd as part of the GRDC funded project\"Doing it better, doing it smarter, managing soil water in Australian agriculture' 2011",
-              "Comments": "OC, CLL for all crops estimated-based on Bongeen Mywybilla Soil No1",
+              "Comments": "Clay - OC, CLL for all crops estimated-based on Bongeen Mywybilla Soil No1",
               "Name": "Soil",
+              "ResourceName": null,
               "Children": [
                 {
                   "$type": "Models.Soils.Physical, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180"
-                  ],
                   "Thickness": [
                     150.0,
                     150.0,
@@ -135,6 +128,8 @@
                   "ParticleSizeClay": null,
                   "ParticleSizeSand": null,
                   "ParticleSizeSilt": null,
+                  "Rocks": null,
+                  "Texture": null,
                   "BD": [
                     1.01056473311131,
                     1.07145631083388,
@@ -195,7 +190,13 @@
                   "DULMetadata": null,
                   "SATMetadata": null,
                   "KSMetadata": null,
+                  "RocksMetadata": null,
+                  "TextureMetadata": null,
+                  "ParticleSizeSandMetadata": null,
+                  "ParticleSizeSiltMetadata": null,
+                  "ParticleSizeClayMetadata": null,
                   "Name": "Physical",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Soils.SoilCrop, Models",
@@ -230,13 +231,12 @@
                       "KLMetadata": null,
                       "XFMetadata": null,
                       "Name": "BarleySoil",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -254,9 +254,9 @@
                   "CN2Bare": 73.0,
                   "CNRed": 20.0,
                   "CNCov": 0.8,
-                  "Slope": "NaN",
                   "DischargeWidth": "NaN",
                   "CatchmentArea": "NaN",
+                  "PSIDul": -100.0,
                   "Thickness": [
                     150.0,
                     150.0,
@@ -276,23 +276,14 @@
                     0.3
                   ],
                   "KLAT": null,
-                  "ResourceName": "WaterBalance",
                   "Name": "SoilWater",
-                  "IncludeInDocumentation": true,
+                  "ResourceName": "WaterBalance",
+                  "Children": [],
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Soils.Organic, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180"
-                  ],
                   "FOMCNRatio": 40.0,
                   "Thickness": [
                     150.0,
@@ -312,6 +303,7 @@
                     0.12,
                     0.12
                   ],
+                  "CarbonUnits": 0,
                   "SoilCNRatio": [
                     12.0,
                     12.0,
@@ -340,31 +332,24 @@
                     1.0
                   ],
                   "FOM": [
-                    347.12903231275641,
+                    347.1290323127564,
                     270.3443621919937,
                     163.97214434990104,
-                    99.454132887040629,
-                    60.321980831124677,
-                    36.587130828674873,
+                    99.45413288704063,
+                    60.32198083112468,
+                    36.58713082867487,
                     22.1912165985086
                   ],
+                  "CarbonMetadata": null,
+                  "FOMMetadata": null,
                   "Name": "Organic",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Soils.Chemical, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180"
-                  ],
                   "Thickness": [
                     150.0,
                     150.0,
@@ -373,24 +358,6 @@
                     300.0,
                     300.0,
                     300.0
-                  ],
-                  "NO3N": [
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0
-                  ],
-                  "NH4N": [
-                    0.1,
-                    0.1,
-                    0.1,
-                    0.1,
-                    0.1,
-                    0.1,
-                    0.1
                   ],
                   "PH": [
                     8.0,
@@ -401,38 +368,22 @@
                     8.0,
                     8.0
                   ],
-                  "CL": null,
+                  "PHUnits": 0,
                   "EC": null,
                   "ESP": null,
+                  "CEC": null,
+                  "ECMetadata": null,
+                  "CLMetadata": null,
+                  "ESPMetadata": null,
+                  "PHMetadata": null,
                   "Name": "Chemical",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.Soils.InitialWater, Models",
-                  "PercentMethod": 1,
-                  "FractionFull": 1.0,
-                  "DepthWetSoil": "NaN",
-                  "RelativeTo": null,
-                  "Name": "InitialWater",
-                  "Children": [],
-                  "IncludeInDocumentation": true,
-                  "Enabled": true,
-                  "ReadOnly": false
-                },
-                {
-                  "$type": "Models.Soils.Sample, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180"
-                  ],
+                  "$type": "Models.Soils.Water, Models",
                   "Thickness": [
                     150.0,
                     150.0,
@@ -442,103 +393,162 @@
                     300.0,
                     300.0
                   ],
-                  "NO3N": null,
-                  "NH4N": null,
-                  "SW": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
+                  "InitialValues": [
+                    0.52100021807301,
+                    0.496723476938497,
+                    0.488437607673005,
+                    0.480296969355493,
+                    0.471583596524955,
+                    0.457070570557793,
+                    0.452331759845006
                   ],
-                  "OC": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "EC": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "CL": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "ESP": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "PH": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "SWUnits": 0,
-                  "OCUnits": 0,
-                  "PHUnits": 0,
-                  "Name": "InitialN",
+                  "InitialPAWmm": 361.2454283127387,
+                  "RelativeTo": "LL15",
+                  "FilledFromTop": false,
+                  "Name": "Water",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Soils.CERESSoilTemperature, Models",
-                  "Name": "CERESSoilTemperature",
+                  "Name": "Temperature",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Soils.Nutrients.Nutrient, Models",
-                  "ResourceName": "Nutrient",
                   "Name": "Nutrient",
-                  "IncludeInDocumentation": true,
+                  "ResourceName": "Nutrient",
+                  "Children": [],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Soils.Solute, Models",
+                  "Thickness": [
+                    150.0,
+                    150.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0
+                  ],
+                  "InitialValues": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "InitialValuesUnits": 0,
+                  "WaterTableConcentration": 0.0,
+                  "D0": 0.0,
+                  "Exco": null,
+                  "FIP": null,
+                  "DepthConstant": 0.0,
+                  "MaxDepthSoluteAccessible": 0.0,
+                  "RunoffEffectivenessAtMovingSolute": 0.0,
+                  "MaxEffectiveRunoff": 0.0,
+                  "Name": "NO3",
+                  "ResourceName": null,
+                  "Children": [],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Soils.Solute, Models",
+                  "Thickness": [
+                    150.0,
+                    150.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0
+                  ],
+                  "InitialValues": [
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1
+                  ],
+                  "InitialValuesUnits": 0,
+                  "WaterTableConcentration": 0.0,
+                  "D0": 0.0,
+                  "Exco": null,
+                  "FIP": null,
+                  "DepthConstant": 0.0,
+                  "MaxDepthSoluteAccessible": 0.0,
+                  "RunoffEffectivenessAtMovingSolute": 0.0,
+                  "MaxEffectiveRunoff": 0.0,
+                  "Name": "NH4",
+                  "ResourceName": null,
+                  "Children": [],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Soils.Solute, Models",
+                  "Thickness": [
+                    150.0,
+                    150.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0
+                  ],
+                  "InitialValues": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "InitialValuesUnits": 1,
+                  "WaterTableConcentration": 0.0,
+                  "D0": 0.0,
+                  "Exco": null,
+                  "FIP": null,
+                  "DepthConstant": 0.0,
+                  "MaxDepthSoluteAccessible": 0.0,
+                  "RunoffEffectivenessAtMovingSolute": 0.0,
+                  "MaxEffectiveRunoff": 0.0,
+                  "Name": "Urea",
+                  "ResourceName": null,
+                  "Children": [],
                   "Enabled": true,
                   "ReadOnly": false
                 }
               ],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Surface.SurfaceOrganicMatter, Models",
+              "SurfOM": [],
+              "Canopies": [],
               "InitialResidueName": "wheat_stubble",
               "InitialResidueType": "wheat",
               "InitialResidueMass": 500.0,
               "InitialStandingFraction": 0.0,
               "InitialCPR": 0.0,
               "InitialCNR": 100.0,
-              "ResourceName": "SurfaceOrganicMatter",
               "Name": "SurfaceOrganicMatter",
-              "IncludeInDocumentation": true,
+              "ResourceName": "SurfaceOrganicMatter",
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             },
@@ -548,59 +558,79 @@
               "b_interception": 1.0,
               "c_interception": 0.0,
               "d_interception": 0.0,
-              "soil_albedo": 0.3,
               "SoilHeatFluxFraction": 0.4,
               "MinimumHeightDiffForNewLayer": 0.0,
               "NightInterceptionFraction": 0.5,
               "ReferenceHeight": 2.0,
               "Name": "MicroClimate",
+              "ResourceName": null,
               "Children": [],
-              "IncludeInDocumentation": true,
-              "Enabled": true,
-              "ReadOnly": false
-            },
-            {
-              "$type": "Models.Manager, Models",
-              "Code": "using Models.PMF;\r\nusing Models.Core;\r\nusing System;\r\nusing System.Linq;\r\nnamespace Models\r\n{\r\n    [Serializable]\r\n    public class Script : Model\r\n    {\r\n        [Link] Clock Clock;\r\n        [Link] Fertiliser Fertiliser;\r\n        [Link] Summary Summary;\r\n        \r\n        \r\n        [Description(\"Amount of fertiliser to be applied (kg/ha)\")]\r\n        public double Amount { get; set;}\r\n        \r\n        [Description(\"Crop to be fertilised\")]\r\n        public string CropName { get; set;}\r\n        \r\n        \r\n        \r\n\r\n        [EventSubscribe(\"Sowing\")]\r\n        private void OnSowing(object sender, EventArgs e)\r\n        {\r\n            Model crop = sender as Model;\r\n            if (crop.Name.ToLower()==CropName.ToLower())\r\n                Fertiliser.Apply(Amount: Amount, Type: Fertiliser.Types.NO3N);\r\n        }\r\n        \r\n    }\r\n}\r\n",
-              "Parameters": [
-                {
-                  "Key": "Amount",
-                  "Value": "160"
-                },
-                {
-                  "Key": "CropName",
-                  "Value": "Barley"
-                }
-              ],
-              "Name": "SowingFertiliser",
-              "IncludeInDocumentation": true,
-              "Enabled": true,
-              "ReadOnly": false
-            },
-            {
-              "$type": "Models.Manager, Models",
-              "Code": "using APSIM.Shared.Utilities;\r\nusing Models.Utilities;\r\nusing Models.Soils.Nutrients;\r\nusing Models.Soils;\r\nusing Models.PMF;\r\nusing Models.Core;\r\nusing System;\r\nusing System.Linq;\r\n\r\nnamespace Models\r\n{\r\n    [Serializable]\r\n    public class Script : Model\r\n    {\r\n        [Link(ByName = true)] Plant Barley;\r\n\r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n            if (Barley.IsReadyForHarvesting)\r\n            {\r\n               Barley.Harvest();\r\n               Barley.EndCrop();    \r\n            }\r\n        \r\n        }\r\n        \r\n    }\r\n}\r\n",
-              "Parameters": [],
-              "Name": "Harvest",
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.PMF.Plant, Models",
-              "ResourceName": "Barley",
               "Name": "Barley",
-              "IncludeInDocumentation": false,
+              "ResourceName": "Barley",
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Manager, Models",
-              "Code": "using APSIM.Shared.Utilities;\r\nusing Models.Utilities;\r\nusing Models.Soils.Nutrients;\r\nusing Models.Soils;\r\nusing Models.PMF;\r\nusing Models.Core;\r\nusing System;\r\nusing System.Linq;\r\n\r\nnamespace Models\r\n{\r\n    [Serializable]\r\n    public class Script : Model\r\n    {\r\n        [Link] Clock Clock;\r\n        [Link] Fertiliser Fertiliser;\r\n        [Link] Summary Summary;\r\n        [Link] Soil Soil;\r\n        Accumulator accumulatedRain;\r\n        \r\n        [Description(\"Crop\")]\r\n        public IPlant Crop { get; set; }\r\n        [Description(\"Sowing date (d-mmm)\")]\r\n        public string SowDate { get; set; }\r\n    [Display(Type = DisplayType.CultivarName, PlantName = \"Barley\")]\r\n        [Description(\"Cultivar to be sown\")]\r\n        public string CultivarName { get; set; }\r\n        [Description(\"Sowing depth (mm)\")]\r\n        public double SowingDepth { get; set; }\r\n        [Description(\"Row spacing (mm)\")]\r\n        public double RowSpacing { get; set; }\r\n        [Description(\"Plant population (/m2)\")]\r\n        public double Population { get; set; }\r\n        \r\n\r\n\r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n            if (DateUtilities.WithinDates(SowDate, Clock.Today, SowDate))\r\n            {\r\n                Crop.Sow(population: Population, cultivar: CultivarName, depth: SowingDepth, rowSpacing: RowSpacing);    \r\n            }\r\n        \r\n        }\r\n        \r\n    }\r\n}\r\n",
+              "CodeArray": [
+                "using APSIM.Shared.Utilities;",
+                "using Models.Utilities;",
+                "using Models.Soils;",
+                "using Models.PMF;",
+                "using Models.Core;",
+                "using System;",
+                "using System.Linq;",
+                "",
+                "namespace Models",
+                "{",
+                "    [Serializable]",
+                "    public class Script : Model",
+                "    {",
+                "        [Link] Clock Clock;",
+                "        [Link] Fertiliser Fertiliser;",
+                "        [Link] Summary Summary;",
+                "        [Link] Soil Soil;",
+                "        ",
+                "        [Description(\"Crop\")]",
+                "        public IPlant Crop { get; set; }",
+                "",
+                "        [Description(\"Sowing date (d-mmm)\")]",
+                "        public string SowDate { get; set; }",
+                "",
+                "        [Display(Type = DisplayType.CultivarName)]",
+                "        [Description(\"Cultivar to be sown\")]",
+                "        public string CultivarName { get; set; }",
+                "",
+                "        [Description(\"Sowing depth (mm)\")]",
+                "        public double SowingDepth { get; set; }",
+                "",
+                "        [Description(\"Row spacing (mm)\")]",
+                "        public double RowSpacing { get; set; }",
+                "",
+                "        [Description(\"Plant population (/m2)\")]",
+                "        public double Population { get; set; }",
+                "",
+                "        [EventSubscribe(\"DoManagement\")]",
+                "        private void OnDoManagement(object sender, EventArgs e)",
+                "        {",
+                "            if (DateUtilities.WithinDates(SowDate, Clock.Today, SowDate))",
+                "            {",
+                "                Crop.Sow(population: Population, cultivar: CultivarName, depth: SowingDepth, rowSpacing: RowSpacing);    ",
+                "            }",
+                "        }",
+                "    }",
+                "}"
+              ],
               "Parameters": [
                 {
                   "Key": "Crop",
-                  "Value": "[Barley]"
+                  "Value": "Barley"
                 },
                 {
                   "Key": "SowDate",
@@ -612,24 +642,123 @@
                 },
                 {
                   "Key": "SowingDepth",
-                  "Value": "50"
+                  "Value": 50.0
                 },
                 {
                   "Key": "RowSpacing",
-                  "Value": "750"
+                  "Value": 750.0
                 },
                 {
                   "Key": "Population",
-                  "Value": "6"
+                  "Value": 6.0
                 }
               ],
               "Name": "Sow on a fixed date",
-              "IncludeInDocumentation": true,
+              "ResourceName": null,
+              "Children": [],
+              "Enabled": true,
+              "ReadOnly": false
+            },
+            {
+              "$type": "Models.Manager, Models",
+              "CodeArray": [
+                "using Models.Soils;",
+                "using System;",
+                "using System.Linq;",
+                "using Models.Core;",
+                "using Models.PMF;",
+                "namespace Models",
+                "{",
+                "    [Serializable]",
+                "    public class Script : Model",
+                "    {",
+                "        [Link] Clock Clock;",
+                "        [Link] Fertiliser Fertiliser;",
+                "        ",
+                "        [Description(\"Crop to be fertilised\")]",
+                "        public IPlant Crop { get; set; }",
+                "",
+                "        [Description(\"Type of fertiliser to apply? \")] ",
+                "        public Fertiliser.Types FertiliserType { get; set; }",
+                "    ",
+                "        [Description(\"Amount of fertiliser to be applied (kg/ha)\")]",
+                "        public double Amount { get; set; }",
+                "        ",
+                "        [EventSubscribe(\"Sowing\")]",
+                "        private void OnSowing(object sender, EventArgs e)",
+                "        {",
+                "            Model crop = sender as Model;",
+                "            if (Crop != null && crop.Name.ToLower() == (Crop as IModel).Name.ToLower())",
+                "                Fertiliser.Apply(Amount: Amount, Type: FertiliserType);",
+                "        }",
+                "    }",
+                "}"
+              ],
+              "Parameters": [
+                {
+                  "Key": "Crop",
+                  "Value": "Barley"
+                },
+                {
+                  "Key": "FertiliserType",
+                  "Value": "NO3N"
+                },
+                {
+                  "Key": "Amount",
+                  "Value": 160.0
+                }
+              ],
+              "Name": "Fertilise at sowing",
+              "ResourceName": null,
+              "Children": [],
+              "Enabled": true,
+              "ReadOnly": false
+            },
+            {
+              "$type": "Models.Manager, Models",
+              "CodeArray": [
+                "using APSIM.Shared.Utilities;",
+                "using Models.Utilities;",
+                "using Models.Soils;",
+                "using Models.PMF;",
+                "using Models.Core;",
+                "using System;",
+                "using System.Linq;",
+                "",
+                "namespace Models",
+                "{",
+                "    [Serializable] ",
+                "    public class Script : Model",
+                "    {",
+                "        [Description(\"Crop\")]",
+                "        public IPlant Crop { get; set; }",
+                "        ",
+                "        [EventSubscribe(\"DoManagement\")]",
+                "        private void OnDoManagement(object sender, EventArgs e)",
+                "        {",
+                "            if (Crop.IsReadyForHarvesting)",
+                "            {",
+                "                Crop.Harvest();",
+                "                Crop.EndCrop();",
+                "            }",
+                "        }",
+                "    }",
+                "}",
+                "       "
+              ],
+              "Parameters": [
+                {
+                  "Key": "Crop",
+                  "Value": "Barley"
+                }
+              ],
+              "Name": "Harvest",
+              "ResourceName": null,
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             }
           ],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
@@ -638,33 +767,33 @@
           "Caption": null,
           "Axis": [
             {
-              "$type": "Models.Axis, Models",
-              "Type": 3,
+              "$type": "APSIM.Shared.Graphing.Axis, APSIM.Shared",
               "Title": "Date",
+              "Position": 3,
               "Inverted": false,
-              "Minimum": "NaN",
-              "Maximum": "NaN",
-              "Interval": "NaN",
-              "DateTimeAxis": false,
-              "CrossesAtZero": false
+              "CrossesAtZero": false,
+              "Minimum": null,
+              "Maximum": null,
+              "Interval": null
             },
             {
-              "$type": "Models.Axis, Models",
-              "Type": 0,
+              "$type": "APSIM.Shared.Graphing.Axis, APSIM.Shared",
               "Title": "Yield (kg/ha)",
+              "Position": 0,
               "Inverted": false,
-              "Minimum": "NaN",
-              "Maximum": "NaN",
-              "Interval": "NaN",
-              "DateTimeAxis": false,
-              "CrossesAtZero": false
+              "CrossesAtZero": false,
+              "Minimum": null,
+              "Maximum": null,
+              "Interval": null
             }
           ],
           "LegendPosition": 0,
           "LegendOrientation": 0,
-          "DisabledSeries": [],
+          "AnnotationLocation": 0,
+          "DisabledSeries": null,
           "LegendOutsideGraph": false,
           "Name": "Barley Yield Time Series",
+          "ResourceName": null,
           "Children": [
             {
               "$type": "Models.Series, Models",
@@ -682,26 +811,24 @@
               "TableName": "Report",
               "XFieldName": "Clock.Today",
               "YFieldName": "Yield",
-              "X2FieldName": "",
-              "Y2FieldName": "",
-              "ShowInLegend": true,
+              "X2FieldName": null,
+              "Y2FieldName": null,
+              "ShowInLegend": false,
               "IncludeSeriesNameInLegend": false,
               "Cumulative": false,
               "CumulativeX": false,
               "Filter": null,
               "Name": "Barley Yield",
+              "ResourceName": null,
               "Children": [],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             }
           ],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         }
       ],
-      "IncludeInDocumentation": true,
       "Enabled": true,
       "ReadOnly": false
     },
@@ -710,13 +837,12 @@
       "useFirebird": false,
       "CustomFileName": null,
       "Name": "DataStore",
+      "ResourceName": null,
       "Children": [],
-      "IncludeInDocumentation": true,
       "Enabled": true,
       "ReadOnly": false
     }
   ],
-  "IncludeInDocumentation": true,
   "Enabled": true,
   "ReadOnly": false
 }

--- a/Examples/Barley.apsimx
+++ b/Examples/Barley.apsimx
@@ -12,8 +12,8 @@
       "Children": [
         {
           "$type": "Models.Clock, Models",
-          "Start": "1900-01-01T00:00",
-          "End": "2000-12-31T00:00",
+          "Start": "1900-01-01T00:00:00",
+          "End": "2000-12-31T00:00:00",
           "Name": "Clock",
           "ResourceName": null,
           "Children": [],
@@ -33,7 +33,7 @@
           "$type": "Models.Climate.Weather, Models",
           "ConstantsFile": null,
           "FileName": "%root%\\Examples\\WeatherFiles\\Dalby.met",
-          "ExcelWorkSheetName": null,
+          "ExcelWorkSheetName": "",
           "Name": "Weather",
           "ResourceName": null,
           "Children": [],
@@ -43,6 +43,22 @@
         {
           "$type": "Models.Soils.Arbitrator.SoilArbitrator, Models",
           "Name": "SoilArbitrator",
+          "ResourceName": null,
+          "Children": [],
+          "Enabled": true,
+          "ReadOnly": false
+        },
+        {
+          "$type": "Models.MicroClimate, Models",
+          "a_interception": 0.0,
+          "b_interception": 1.0,
+          "c_interception": 0.0,
+          "d_interception": 0.0,
+          "SoilHeatFluxFraction": 0.4,
+          "MinimumHeightDiffForNewLayer": 0.0,
+          "NightInterceptionFraction": 0.5,
+          "ReferenceHeight": 2.0,
+          "Name": "MicroClimate",
           "ResourceName": null,
           "Children": [],
           "Enabled": true,
@@ -553,22 +569,6 @@
               "ReadOnly": false
             },
             {
-              "$type": "Models.MicroClimate, Models",
-              "a_interception": 0.0,
-              "b_interception": 1.0,
-              "c_interception": 0.0,
-              "d_interception": 0.0,
-              "SoilHeatFluxFraction": 0.4,
-              "MinimumHeightDiffForNewLayer": 0.0,
-              "NightInterceptionFraction": 0.5,
-              "ReferenceHeight": 2.0,
-              "Name": "MicroClimate",
-              "ResourceName": null,
-              "Children": [],
-              "Enabled": true,
-              "ReadOnly": false
-            },
-            {
               "$type": "Models.PMF.Plant, Models",
               "Name": "Barley",
               "ResourceName": "Barley",
@@ -642,15 +642,15 @@
                 },
                 {
                   "Key": "SowingDepth",
-                  "Value": 50.0
+                  "Value": "50.0"
                 },
                 {
                   "Key": "RowSpacing",
-                  "Value": 750.0
+                  "Value": "750.0"
                 },
                 {
                   "Key": "Population",
-                  "Value": 6.0
+                  "Value": "6.0"
                 }
               ],
               "Name": "Sow on a fixed date",
@@ -705,7 +705,7 @@
                 },
                 {
                   "Key": "Amount",
-                  "Value": 160.0
+                  "Value": "160.0"
                 }
               ],
               "Name": "Fertilise at sowing",
@@ -778,7 +778,7 @@
             },
             {
               "$type": "APSIM.Shared.Graphing.Axis, APSIM.Shared",
-              "Title": "Yield (kg/ha)",
+              "Title": null,
               "Position": 0,
               "Inverted": false,
               "CrossesAtZero": false,
@@ -790,9 +790,9 @@
           "LegendPosition": 0,
           "LegendOrientation": 0,
           "AnnotationLocation": 0,
-          "DisabledSeries": null,
+          "DisabledSeries": [],
           "LegendOutsideGraph": false,
-          "Name": "Barley Yield Time Series",
+          "Name": "Graph",
           "ResourceName": null,
           "Children": [
             {
@@ -810,7 +810,7 @@
               "LineThickness": 0,
               "TableName": "Report",
               "XFieldName": "Clock.Today",
-              "YFieldName": "Yield",
+              "YFieldName": "Barley.Grain.Total.Wt",
               "X2FieldName": null,
               "Y2FieldName": null,
               "ShowInLegend": false,
@@ -818,7 +818,7 @@
               "Cumulative": false,
               "CumulativeX": false,
               "Filter": null,
-              "Name": "Barley Yield",
+              "Name": "Series",
               "ResourceName": null,
               "Children": [],
               "Enabled": true,

--- a/Examples/Maize.apsimx
+++ b/Examples/Maize.apsimx
@@ -12,8 +12,8 @@
       "Children": [
         {
           "$type": "Models.Clock, Models",
-          "Start": "1990-01-01T00:00",
-          "End": "2000-12-31T00:00",
+          "Start": "1990-01-01T00:00:00",
+          "End": "2000-12-31T00:00:00",
           "Name": "Clock",
           "ResourceName": null,
           "Children": [],
@@ -33,7 +33,7 @@
           "$type": "Models.Climate.Weather, Models",
           "ConstantsFile": null,
           "FileName": "%root%\\Examples\\WeatherFiles\\Dalby.met",
-          "ExcelWorkSheetName": null,
+          "ExcelWorkSheetName": "",
           "Name": "Weather",
           "ResourceName": null,
           "Children": [],
@@ -43,6 +43,22 @@
         {
           "$type": "Models.Soils.Arbitrator.SoilArbitrator, Models",
           "Name": "SoilArbitrator",
+          "ResourceName": null,
+          "Children": [],
+          "Enabled": true,
+          "ReadOnly": false
+        },
+        {
+          "$type": "Models.MicroClimate, Models",
+          "a_interception": 0.0,
+          "b_interception": 1.0,
+          "c_interception": 0.0,
+          "d_interception": 0.0,
+          "SoilHeatFluxFraction": 0.4,
+          "MinimumHeightDiffForNewLayer": 0.0,
+          "NightInterceptionFraction": 0.5,
+          "ReferenceHeight": 2.0,
+          "Name": "MicroClimate",
           "ResourceName": null,
           "Children": [],
           "Enabled": true,
@@ -68,6 +84,7 @@
                 "[Maize].Grain.Wt",
                 "[Maize].Grain.Size",
                 "[Maize].Grain.NumberFunction",
+                "[Maize].Grain.Total.Wt",
                 "[Maize].Grain.N",
                 "[Maize].Total.Wt"
               ],
@@ -551,22 +568,6 @@
               "ReadOnly": false
             },
             {
-              "$type": "Models.MicroClimate, Models",
-              "a_interception": 0.0,
-              "b_interception": 1.0,
-              "c_interception": 0.0,
-              "d_interception": 0.0,
-              "SoilHeatFluxFraction": 0.4,
-              "MinimumHeightDiffForNewLayer": 0.0,
-              "NightInterceptionFraction": 0.5,
-              "ReferenceHeight": 2.0,
-              "Name": "MicroClimate",
-              "ResourceName": null,
-              "Children": [],
-              "Enabled": true,
-              "ReadOnly": false
-            },
-            {
               "$type": "Models.PMF.Plant, Models",
               "Name": "Maize",
               "ResourceName": "Maize",
@@ -669,15 +670,15 @@
                 },
                 {
                   "Key": "MinESW",
-                  "Value": 100.0
+                  "Value": "100.0"
                 },
                 {
                   "Key": "MinRain",
-                  "Value": 25.0
+                  "Value": "25.0"
                 },
                 {
                   "Key": "RainDays",
-                  "Value": 7
+                  "Value": "7"
                 },
                 {
                   "Key": "CultivarName",
@@ -685,15 +686,15 @@
                 },
                 {
                   "Key": "SowingDepth",
-                  "Value": 30.0
+                  "Value": "30.0"
                 },
                 {
                   "Key": "RowSpacing",
-                  "Value": 750.0
+                  "Value": "750.0"
                 },
                 {
                   "Key": "Population",
-                  "Value": 6.0
+                  "Value": "6.0"
                 }
               ],
               "Name": "Sow using a variable rule",
@@ -748,7 +749,7 @@
                 },
                 {
                   "Key": "Amount",
-                  "Value": 160.0
+                  "Value": "160.0"
                 }
               ],
               "Name": "Fertilise at sowing",
@@ -821,7 +822,7 @@
             },
             {
               "$type": "APSIM.Shared.Graphing.Axis, APSIM.Shared",
-              "Title": "Yield (kg/ha)",
+              "Title": null,
               "Position": 0,
               "Inverted": false,
               "CrossesAtZero": false,
@@ -833,9 +834,9 @@
           "LegendPosition": 0,
           "LegendOrientation": 0,
           "AnnotationLocation": 0,
-          "DisabledSeries": null,
+          "DisabledSeries": [],
           "LegendOutsideGraph": false,
-          "Name": "Maize Yield Time Series",
+          "Name": "Graph",
           "ResourceName": null,
           "Children": [
             {
@@ -853,7 +854,7 @@
               "LineThickness": 0,
               "TableName": "Report",
               "XFieldName": "Clock.Today",
-              "YFieldName": "Yield",
+              "YFieldName": "Maize.Grain.Total.Wt",
               "X2FieldName": null,
               "Y2FieldName": null,
               "ShowInLegend": false,
@@ -861,7 +862,7 @@
               "Cumulative": false,
               "CumulativeX": false,
               "Filter": null,
-              "Name": "Maize Yield",
+              "Name": "Series",
               "ResourceName": null,
               "Children": [],
               "Enabled": true,

--- a/Examples/Maize.apsimx
+++ b/Examples/Maize.apsimx
@@ -1,51 +1,50 @@
 {
   "$type": "Models.Core.Simulations, Models",
-  "ExplorerWidth": 296,
-  "Version": 100,
-  "ApsimVersion": "0.0.0.0",
+  "Version": 168,
   "Name": "Simulations",
+  "ResourceName": null,
   "Children": [
     {
       "$type": "Models.Core.Simulation, Models",
-      "IsRunning": false,
+      "Descriptors": null,
       "Name": "Simulation",
+      "ResourceName": null,
       "Children": [
         {
           "$type": "Models.Clock, Models",
-          "Start": "1990-01-01T00:00:00",
-          "End": "2000-12-31T00:00:00",
+          "Start": "1990-01-01T00:00",
+          "End": "2000-12-31T00:00",
           "Name": "Clock",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
         {
           "$type": "Models.Summary, Models",
-          "CaptureErrors": true,
-          "CaptureWarnings": true,
-          "CaptureSummaryText": true,
-          "Name": "SummaryFile",
+          "Verbosity": 100,
+          "Name": "Summary",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
         {
-          "$type": "Models.Weather, Models",
+          "$type": "Models.Climate.Weather, Models",
+          "ConstantsFile": null,
           "FileName": "%root%\\Examples\\WeatherFiles\\Dalby.met",
           "ExcelWorkSheetName": null,
           "Name": "Weather",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
         {
           "$type": "Models.Soils.Arbitrator.SoilArbitrator, Models",
-          "Name": "Soil Arbitrator",
+          "Name": "SoilArbitrator",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
@@ -56,6 +55,7 @@
           "AspectAngle": 0.0,
           "Altitude": 50.0,
           "Name": "Field",
+          "ResourceName": null,
           "Children": [
             {
               "$type": "Models.Report, Models",
@@ -64,6 +64,7 @@
                 "[Maize].Phenology.CurrentStageName",
                 "[Maize].AboveGround.Wt",
                 "[Maize].AboveGround.N",
+                "[Maize].Grain.Total.Wt*10 as Yield",
                 "[Maize].Grain.Wt",
                 "[Maize].Grain.Size",
                 "[Maize].Grain.NumberFunction",
@@ -75,22 +76,22 @@
               ],
               "GroupByVariableName": null,
               "Name": "Report",
+              "ResourceName": null,
               "Children": [],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Fertiliser, Models",
               "Name": "Fertiliser",
+              "ResourceName": "Fertiliser",
               "Children": [],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Soils.Soil, Models",
-              "RecordNumber": 0,
+              "RecordNumber": 104,
               "ASCOrder": "Vertosol",
               "ASCSubOrder": "Black",
               "SoilType": "Clay",
@@ -105,21 +106,14 @@
               "Latitude": -27.581836,
               "Longitude": 151.320206,
               "LocationAccuracy": " +/- 20m",
+              "YearOfSampling": "0",
               "DataSource": "CSIRO Sustainable Ecosystems, Toowoomba; Characteriesd as part of the GRDC funded project\"Doing it better, doing it smarter, managing soil water in Australian agriculture' 2011",
-              "Comments": "OC, CLL for all crops estimated-based on Bongeen Mywybilla Soil No1",
+              "Comments": "Clay - OC, CLL for all crops estimated-based on Bongeen Mywybilla Soil No1",
               "Name": "Soil",
+              "ResourceName": null,
               "Children": [
                 {
                   "$type": "Models.Soils.Physical, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180"
-                  ],
                   "Thickness": [
                     150.0,
                     150.0,
@@ -132,6 +126,8 @@
                   "ParticleSizeClay": null,
                   "ParticleSizeSand": null,
                   "ParticleSizeSilt": null,
+                  "Rocks": null,
+                  "Texture": null,
                   "BD": [
                     1.01056473311131,
                     1.07145631083388,
@@ -192,7 +188,13 @@
                   "DULMetadata": null,
                   "SATMetadata": null,
                   "KSMetadata": null,
+                  "RocksMetadata": null,
+                  "TextureMetadata": null,
+                  "ParticleSizeSandMetadata": null,
+                  "ParticleSizeSiltMetadata": null,
+                  "ParticleSizeClayMetadata": null,
                   "Name": "Physical",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Soils.SoilCrop, Models",
@@ -227,13 +229,12 @@
                       "KLMetadata": null,
                       "XFMetadata": null,
                       "Name": "MaizeSoil",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -251,9 +252,9 @@
                   "CN2Bare": 73.0,
                   "CNRed": 20.0,
                   "CNCov": 0.8,
-                  "Slope": "NaN",
                   "DischargeWidth": "NaN",
                   "CatchmentArea": "NaN",
+                  "PSIDul": -100.0,
                   "Thickness": [
                     150.0,
                     150.0,
@@ -273,23 +274,14 @@
                     0.3
                   ],
                   "KLAT": null,
-                  "ResourceName": "WaterBalance",
                   "Name": "SoilWater",
-                  "IncludeInDocumentation": true,
+                  "ResourceName": "WaterBalance",
+                  "Children": [],
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Soils.Organic, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180"
-                  ],
                   "FOMCNRatio": 40.0,
                   "Thickness": [
                     150.0,
@@ -309,6 +301,7 @@
                     0.12,
                     0.12
                   ],
+                  "CarbonUnits": 0,
                   "SoilCNRatio": [
                     12.0,
                     12.0,
@@ -337,31 +330,24 @@
                     1.0
                   ],
                   "FOM": [
-                    347.12903231275641,
+                    347.1290323127564,
                     270.3443621919937,
                     163.97214434990104,
-                    99.454132887040629,
-                    60.321980831124677,
-                    36.587130828674873,
+                    99.45413288704063,
+                    60.32198083112468,
+                    36.58713082867487,
                     22.1912165985086
                   ],
+                  "CarbonMetadata": null,
+                  "FOMMetadata": null,
                   "Name": "Organic",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Soils.Chemical, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180"
-                  ],
                   "Thickness": [
                     150.0,
                     150.0,
@@ -370,24 +356,6 @@
                     300.0,
                     300.0,
                     300.0
-                  ],
-                  "NO3N": [
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0
-                  ],
-                  "NH4N": [
-                    0.1,
-                    0.1,
-                    0.1,
-                    0.1,
-                    0.1,
-                    0.1,
-                    0.1
                   ],
                   "PH": [
                     8.0,
@@ -398,38 +366,22 @@
                     8.0,
                     8.0
                   ],
-                  "CL": null,
+                  "PHUnits": 0,
                   "EC": null,
                   "ESP": null,
+                  "CEC": null,
+                  "ECMetadata": null,
+                  "CLMetadata": null,
+                  "ESPMetadata": null,
+                  "PHMetadata": null,
                   "Name": "Chemical",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.Soils.InitialWater, Models",
-                  "PercentMethod": 1,
-                  "FractionFull": 1.0,
-                  "DepthWetSoil": "NaN",
-                  "RelativeTo": null,
-                  "Name": "InitialWater",
-                  "Children": [],
-                  "IncludeInDocumentation": true,
-                  "Enabled": true,
-                  "ReadOnly": false
-                },
-                {
-                  "$type": "Models.Soils.Sample, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180"
-                  ],
+                  "$type": "Models.Soils.Water, Models",
                   "Thickness": [
                     150.0,
                     150.0,
@@ -439,111 +391,162 @@
                     300.0,
                     300.0
                   ],
-                  "NO3N": null,
-                  "NH4N": null,
-                  "SW": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
+                  "InitialValues": [
+                    0.52100021807301,
+                    0.496723476938497,
+                    0.488437607673005,
+                    0.480296969355493,
+                    0.471583596524955,
+                    0.457070570557793,
+                    0.452331759845006
                   ],
-                  "OC": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "EC": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "CL": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "ESP": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "PH": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "SWUnits": 0,
-                  "OCUnits": 0,
-                  "PHUnits": 0,
-                  "Name": "InitialN",
+                  "InitialPAWmm": 361.2454283127387,
+                  "RelativeTo": "LL15",
+                  "FilledFromTop": false,
+                  "Name": "Water",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Soils.CERESSoilTemperature, Models",
-                  "Name": "CERESSoilTemperature",
+                  "Name": "Temperature",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Soils.Nutrients.Nutrient, Models",
-                  "ResourceName": "Nutrient",
                   "Name": "Nutrient",
-                  "IncludeInDocumentation": true,
+                  "ResourceName": "Nutrient",
+                  "Children": [],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Soils.Solute, Models",
+                  "Thickness": [
+                    150.0,
+                    150.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0
+                  ],
+                  "InitialValues": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "InitialValuesUnits": 0,
+                  "WaterTableConcentration": 0.0,
+                  "D0": 0.0,
+                  "Exco": null,
+                  "FIP": null,
+                  "DepthConstant": 0.0,
+                  "MaxDepthSoluteAccessible": 0.0,
+                  "RunoffEffectivenessAtMovingSolute": 0.0,
+                  "MaxEffectiveRunoff": 0.0,
+                  "Name": "NO3",
+                  "ResourceName": null,
+                  "Children": [],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Soils.Solute, Models",
+                  "Thickness": [
+                    150.0,
+                    150.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0
+                  ],
+                  "InitialValues": [
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1
+                  ],
+                  "InitialValuesUnits": 0,
+                  "WaterTableConcentration": 0.0,
+                  "D0": 0.0,
+                  "Exco": null,
+                  "FIP": null,
+                  "DepthConstant": 0.0,
+                  "MaxDepthSoluteAccessible": 0.0,
+                  "RunoffEffectivenessAtMovingSolute": 0.0,
+                  "MaxEffectiveRunoff": 0.0,
+                  "Name": "NH4",
+                  "ResourceName": null,
+                  "Children": [],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Soils.Solute, Models",
+                  "Thickness": [
+                    150.0,
+                    150.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0
+                  ],
+                  "InitialValues": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "InitialValuesUnits": 1,
+                  "WaterTableConcentration": 0.0,
+                  "D0": 0.0,
+                  "Exco": null,
+                  "FIP": null,
+                  "DepthConstant": 0.0,
+                  "MaxDepthSoluteAccessible": 0.0,
+                  "RunoffEffectivenessAtMovingSolute": 0.0,
+                  "MaxEffectiveRunoff": 0.0,
+                  "Name": "Urea",
+                  "ResourceName": null,
+                  "Children": [],
                   "Enabled": true,
                   "ReadOnly": false
                 }
               ],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Surface.SurfaceOrganicMatter, Models",
+              "SurfOM": [],
+              "Canopies": [],
               "InitialResidueName": "wheat_stubble",
               "InitialResidueType": "wheat",
               "InitialResidueMass": 500.0,
               "InitialStandingFraction": 0.0,
               "InitialCPR": 0.0,
               "InitialCNR": 100.0,
-              "ResourceName": "SurfaceOrganicMatter",
               "Name": "SurfaceOrganicMatter",
-              "IncludeInDocumentation": true,
-              "Enabled": true,
-              "ReadOnly": false
-            },
-            {
-              "$type": "Models.PMF.Plant, Models",
-              "ResourceName": "Maize",
-              "Name": "Maize",
-              "IncludeInDocumentation": true,
+              "ResourceName": "SurfaceOrganicMatter",
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             },
@@ -553,39 +556,109 @@
               "b_interception": 1.0,
               "c_interception": 0.0,
               "d_interception": 0.0,
-              "soil_albedo": 0.3,
               "SoilHeatFluxFraction": 0.4,
               "MinimumHeightDiffForNewLayer": 0.0,
               "NightInterceptionFraction": 0.5,
               "ReferenceHeight": 2.0,
               "Name": "MicroClimate",
+              "ResourceName": null,
               "Children": [],
-              "IncludeInDocumentation": true,
+              "Enabled": true,
+              "ReadOnly": false
+            },
+            {
+              "$type": "Models.PMF.Plant, Models",
+              "Name": "Maize",
+              "ResourceName": "Maize",
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Manager, Models",
-              "Code": "using Models.PMF;\r\nusing Models.Core;\r\nusing System;\r\nusing System.Linq;\r\nnamespace Models\r\n{\r\n    [Serializable]\r\n    public class Script : Model\r\n    {\r\n        [Link] Clock Clock;\r\n        [Link] Fertiliser Fertiliser;\r\n        [Link] Summary Summary;\r\n        \r\n        \r\n        [Description(\"Amount of fertiliser to be applied (kg/ha)\")]\r\n        public double Amount { get; set; }\r\n        \r\n        [Description(\"Crop to be fertilised\")]\r\n        public string CropName { get; set; }\r\n        \r\n        \r\n        \r\n\r\n        [EventSubscribe(\"Sowing\")]\r\n        private void OnSowing(object sender, EventArgs e)\r\n        {\r\n            Model crop = sender as Model;\r\n            if (crop.Name.ToLower() == CropName.ToLower())\r\n                Fertiliser.Apply(Amount: Amount, Type: Fertiliser.Types.NO3N);\r\n        }\r\n        \r\n    }\r\n}\r\n",
-              "Parameters": [
-                {
-                  "Key": "Amount",
-                  "Value": "160"
-                },
-                {
-                  "Key": "CropName",
-                  "Value": "maize"
-                }
+              "CodeArray": [
+                "using Models.Interfaces;",
+                "using APSIM.Shared.Utilities;",
+                "using Models.Utilities;",
+                "using Models.Soils;",
+                "using Models.PMF;",
+                "using Models.Core;",
+                "using System;",
+                "using System.Linq;",
+                "using Models.Climate;",
+                "",
+                "namespace Models",
+                "{",
+                "    [Serializable]",
+                "    public class Script : Model",
+                "    {",
+                "        [Link] private Clock Clock;",
+                "        [Link] private Fertiliser Fertiliser;",
+                "        [Link] private Summary Summary;",
+                "        [Link] private Soil Soil;",
+                "        private Accumulator accumulatedRain;",
+                "        [Link]",
+                "        private ISoilWater waterBalance;",
+                "        ",
+                "        [Description(\"Crop\")]",
+                "        public IPlant Crop { get; set; }",
+                "",
+                "        [Description(\"Start of sowing window (d-mmm)\")]",
+                "        public string StartDate { get; set; }",
+                "",
+                "        [Description(\"End of sowing window (d-mmm)\")]",
+                "        public string EndDate { get; set; }",
+                "",
+                "        [Description(\"Minimum extractable soil water for sowing (mm)\")]",
+                "        public double MinESW { get; set; }",
+                "",
+                "        [Description(\"Accumulated rainfall required for sowing (mm)\")]",
+                "        public double MinRain { get; set; }",
+                "",
+                "        [Description(\"Duration of rainfall accumulation (d)\")]",
+                "        public int RainDays { get; set; }",
+                "",
+                "        [Display(Type = DisplayType.CultivarName)]",
+                "        [Description(\"Cultivar to be sown\")]",
+                "        public string CultivarName { get; set; }",
+                "",
+                "        [Description(\"Sowing depth (mm)\")]",
+                "        public double SowingDepth { get; set; }",
+                "",
+                "        [Description(\"Row spacing (mm)\")]",
+                "        public double RowSpacing { get; set; }",
+                "",
+                "        [Description(\"Plant population (/m2)\")]",
+                "        public double Population { get; set; }",
+                "        ",
+                "        ",
+                "        [EventSubscribe(\"StartOfSimulation\")]",
+                "        private void OnSimulationCommencing(object sender, EventArgs e)",
+                "        {",
+                "            accumulatedRain = new Accumulator(this, \"[Weather].Rain\", RainDays);",
+                "        }",
+                "",
+                "        [EventSubscribe(\"DoManagement\")]",
+                "        private void OnDoManagement(object sender, EventArgs e)",
+                "        {",
+                "            accumulatedRain.Update();",
+                "            ",
+                "            if (DateUtilities.WithinDates(StartDate, Clock.Today, EndDate) &&",
+                "                !Crop.IsAlive &&",
+                "                MathUtilities.Sum(waterBalance.ESW) > MinESW &&",
+                "                accumulatedRain.Sum > MinRain)",
+                "            {",
+                "                Crop.Sow(population: Population, cultivar: CultivarName, depth: SowingDepth, rowSpacing: RowSpacing);    ",
+                "            }",
+                "        }",
+                "    }",
+                "}"
               ],
-              "Name": "SowingFertiliser",
-              "IncludeInDocumentation": true,
-              "Enabled": true,
-              "ReadOnly": false
-            },
-            {
-              "$type": "Models.Manager, Models",
-              "Code": "using APSIM.Shared.Utilities;\r\nusing Models.Utilities;\r\nusing Models.Soils.Nutrients;\r\nusing Models.Soils;\r\nusing Models.PMF;\r\nusing Models.Core;\r\nusing System;\r\nusing System.Linq;\r\n\r\nnamespace Models\r\n{\r\n    [Serializable]\r\n    public class Script : Model\r\n    {\r\n        [Link] Clock Clock;\r\n        [Link] Fertiliser Fertiliser;\r\n        [Link] Summary Summary;\r\n        [Link(ByName = true)] Plant Maize;\r\n        [Link] Soil Soil;\r\n        Accumulator accumulatedRain;\r\n        \r\n        [Description(\"Start of sowing window (d-mmm)\")]\r\n        public string StartDate { get; set; }\r\n        [Description(\"End of sowing window (d-mmm)\")]\r\n        public string EndDate { get; set; }\r\n        [Description(\"Minimum extractable soil water for sowing (mm)\")]\r\n        public double MinESW { get; set; }\r\n        [Description(\"Accumulated rainfall required for sowing (mm)\")]\r\n        public double MinRain { get; set; }\r\n        [Description(\"Duration of rainfall accumulation (d)\")]\r\n        public int RainDays { get; set; }\r\n        [Description(\"Cultivar to be sown\")]\r\n        [Display(Type=DisplayType.CultivarName, PlantName = \"Maize\")]\r\n        public string CultivarName { get; set; }\r\n        [Description(\"Sowing depth (mm)\")]\r\n        public double SowingDepth { get; set; }\r\n        [Description(\"Row spacing (mm)\")]\r\n        public double RowSpacing { get; set; }\r\n        [Description(\"Plant population (/m2)\")]\r\n        public double Population { get; set; }\r\n        \r\n        \r\n        [EventSubscribe(\"StartOfSimulation\")]\r\n        private void OnSimulationCommencing(object sender, EventArgs e)\r\n        {\r\n            accumulatedRain = new Accumulator(this, \"[Weather].Rain\", RainDays);\r\n        }\r\n        \r\n\r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n            accumulatedRain.Update();\r\n            \r\n            if (DateUtilities.WithinDates(StartDate, Clock.Today, EndDate) &&\r\n                !Maize.IsAlive &&\r\n                MathUtilities.Sum(Soil.SoilWater.ESW) > MinESW &&\r\n                accumulatedRain.Sum > MinRain)\r\n            {\r\n                Maize.Sow(population: Population, cultivar: CultivarName, depth: SowingDepth, rowSpacing: RowSpacing);    \r\n            }\r\n        \r\n        }\r\n        \r\n    }\r\n}\r\n",
               "Parameters": [
+                {
+                  "Key": "Crop",
+                  "Value": "Maize"
+                },
                 {
                   "Key": "StartDate",
                   "Value": "1-nov"
@@ -596,15 +669,15 @@
                 },
                 {
                   "Key": "MinESW",
-                  "Value": "100"
+                  "Value": 100.0
                 },
                 {
                   "Key": "MinRain",
-                  "Value": "25"
+                  "Value": 25.0
                 },
                 {
                   "Key": "RainDays",
-                  "Value": "7"
+                  "Value": 7
                 },
                 {
                   "Key": "CultivarName",
@@ -612,33 +685,123 @@
                 },
                 {
                   "Key": "SowingDepth",
-                  "Value": "30"
+                  "Value": 30.0
                 },
                 {
                   "Key": "RowSpacing",
-                  "Value": "750"
+                  "Value": 750.0
                 },
                 {
                   "Key": "Population",
-                  "Value": "6"
+                  "Value": 6.0
                 }
               ],
-              "Name": "SowingRule",
-              "IncludeInDocumentation": true,
+              "Name": "Sow using a variable rule",
+              "ResourceName": null,
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Manager, Models",
-              "Code": "using APSIM.Shared.Utilities;\r\nusing System.Xml.Serialization;\r\nusing Models;\r\nusing Models.PMF;\r\nusing Models.Soils.Nutrients;\r\nusing Models.Soils;\r\nusing System.Text;\r\nusing System.Collections.Generic;\r\nusing Models.Core;\r\nusing System;\r\nusing System.Linq;\r\n\r\nnamespace Models\r\n{\r\n    [Serializable] \r\n    public class Script : Model\r\n    {\r\n        [Link(ByName = true)] Plant Maize;\r\n        [Link] Zone zone;\r\n                    \r\n        \r\n        [EventSubscribe(\"StartOfSimulation\")]\r\n        private void OnSimulationCommencing(object sender, EventArgs e)\r\n        {\r\n        }\r\n        \r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n            if (Maize.Phenology.CurrentPhaseName == \"ReadyForHarvesting\")\r\n            {\r\n                Maize.Harvest();\r\n                Maize.EndCrop();\r\n            }\r\n        }\r\n        \r\n        [EventSubscribe(\"DoManagementCalculations\")]\r\n        private void OnDoManagementCalculations(object sender, EventArgs e)\r\n        {\r\n            \r\n        }\r\n    }\r\n}\r\n       \r\n",
-              "Parameters": [],
-              "Name": "Harvesting",
-              "IncludeInDocumentation": true,
+              "CodeArray": [
+                "using Models.Soils;",
+                "using System;",
+                "using System.Linq;",
+                "using Models.Core;",
+                "using Models.PMF;",
+                "namespace Models",
+                "{",
+                "    [Serializable]",
+                "    public class Script : Model",
+                "    {",
+                "        [Link] Clock Clock;",
+                "        [Link] Fertiliser Fertiliser;",
+                "        ",
+                "        [Description(\"Crop to be fertilised\")]",
+                "        public IPlant Crop { get; set; }",
+                "",
+                "        [Description(\"Type of fertiliser to apply? \")] ",
+                "        public Fertiliser.Types FertiliserType { get; set; }",
+                "    ",
+                "        [Description(\"Amount of fertiliser to be applied (kg/ha)\")]",
+                "        public double Amount { get; set; }",
+                "        ",
+                "        [EventSubscribe(\"Sowing\")]",
+                "        private void OnSowing(object sender, EventArgs e)",
+                "        {",
+                "            Model crop = sender as Model;",
+                "            if (Crop != null && crop.Name.ToLower() == (Crop as IModel).Name.ToLower())",
+                "                Fertiliser.Apply(Amount: Amount, Type: FertiliserType);",
+                "        }",
+                "    }",
+                "}"
+              ],
+              "Parameters": [
+                {
+                  "Key": "Crop",
+                  "Value": "Maize"
+                },
+                {
+                  "Key": "FertiliserType",
+                  "Value": "NO3N"
+                },
+                {
+                  "Key": "Amount",
+                  "Value": 160.0
+                }
+              ],
+              "Name": "Fertilise at sowing",
+              "ResourceName": null,
+              "Children": [],
+              "Enabled": true,
+              "ReadOnly": false
+            },
+            {
+              "$type": "Models.Manager, Models",
+              "CodeArray": [
+                "using APSIM.Shared.Utilities;",
+                "using Models.Utilities;",
+                "using Models.Soils;",
+                "using Models.PMF;",
+                "using Models.Core;",
+                "using System;",
+                "using System.Linq;",
+                "",
+                "namespace Models",
+                "{",
+                "    [Serializable] ",
+                "    public class Script : Model",
+                "    {",
+                "        [Description(\"Crop\")]",
+                "        public IPlant Crop { get; set; }",
+                "        ",
+                "        [EventSubscribe(\"DoManagement\")]",
+                "        private void OnDoManagement(object sender, EventArgs e)",
+                "        {",
+                "            if (Crop.IsReadyForHarvesting)",
+                "            {",
+                "                Crop.Harvest();",
+                "                Crop.EndCrop();",
+                "            }",
+                "        }",
+                "    }",
+                "}",
+                "       "
+              ],
+              "Parameters": [
+                {
+                  "Key": "Crop",
+                  "Value": "Maize"
+                }
+              ],
+              "Name": "Harvest",
+              "ResourceName": null,
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             }
           ],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
@@ -647,40 +810,40 @@
           "Caption": null,
           "Axis": [
             {
-              "$type": "Models.Axis, Models",
-              "Type": 3,
+              "$type": "APSIM.Shared.Graphing.Axis, APSIM.Shared",
               "Title": "Date",
+              "Position": 3,
               "Inverted": false,
-              "Minimum": "NaN",
-              "Maximum": "NaN",
-              "Interval": "NaN",
-              "DateTimeAxis": false,
-              "CrossesAtZero": false
+              "CrossesAtZero": false,
+              "Minimum": null,
+              "Maximum": null,
+              "Interval": null
             },
             {
-              "$type": "Models.Axis, Models",
-              "Type": 0,
-              "Title": null,
+              "$type": "APSIM.Shared.Graphing.Axis, APSIM.Shared",
+              "Title": "Yield (kg/ha)",
+              "Position": 0,
               "Inverted": false,
-              "Minimum": "NaN",
-              "Maximum": "NaN",
-              "Interval": "NaN",
-              "DateTimeAxis": false,
-              "CrossesAtZero": false
+              "CrossesAtZero": false,
+              "Minimum": null,
+              "Maximum": null,
+              "Interval": null
             }
           ],
           "LegendPosition": 0,
           "LegendOrientation": 0,
-          "DisabledSeries": [],
+          "AnnotationLocation": 0,
+          "DisabledSeries": null,
           "LegendOutsideGraph": false,
           "Name": "Maize Yield Time Series",
+          "ResourceName": null,
           "Children": [
             {
               "$type": "Models.Series, Models",
               "Type": 1,
               "XAxis": 3,
               "YAxis": 0,
-              "ColourArgb": -16776961,
+              "ColourArgb": -16777216,
               "FactorToVaryColours": null,
               "FactorToVaryMarkers": null,
               "FactorToVaryLines": null,
@@ -690,27 +853,25 @@
               "LineThickness": 0,
               "TableName": "Report",
               "XFieldName": "Clock.Today",
-              "YFieldName": "Maize.Grain.Wt",
-              "X2FieldName": "",
-              "Y2FieldName": "",
-              "ShowInLegend": true,
+              "YFieldName": "Yield",
+              "X2FieldName": null,
+              "Y2FieldName": null,
+              "ShowInLegend": false,
               "IncludeSeriesNameInLegend": false,
               "Cumulative": false,
               "CumulativeX": false,
               "Filter": null,
               "Name": "Maize Yield",
+              "ResourceName": null,
               "Children": [],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             }
           ],
-          "IncludeInDocumentation": false,
           "Enabled": true,
           "ReadOnly": false
         }
       ],
-      "IncludeInDocumentation": true,
       "Enabled": true,
       "ReadOnly": false
     },
@@ -719,13 +880,12 @@
       "useFirebird": false,
       "CustomFileName": null,
       "Name": "DataStore",
+      "ResourceName": null,
       "Children": [],
-      "IncludeInDocumentation": true,
       "Enabled": true,
       "ReadOnly": false
     }
   ],
-  "IncludeInDocumentation": true,
   "Enabled": true,
   "ReadOnly": false
 }

--- a/Examples/Mungbean.apsimx
+++ b/Examples/Mungbean.apsimx
@@ -1,20 +1,9 @@
 {
   "$type": "Models.Core.Simulations, Models",
-  "ExplorerWidth": 285,
-  "Version": 156,
+  "Version": 168,
   "Name": "Simulations",
   "ResourceName": null,
   "Children": [
-    {
-      "$type": "Models.Storage.DataStore, Models",
-      "useFirebird": false,
-      "CustomFileName": null,
-      "Name": "DataStore",
-      "ResourceName": null,
-      "Children": [],
-      "Enabled": true,
-      "ReadOnly": false
-    },
     {
       "$type": "Models.Core.Simulation, Models",
       "Descriptors": null,
@@ -23,9 +12,9 @@
       "Children": [
         {
           "$type": "Models.Clock, Models",
-          "Start": "1900-01-01T00:00:00",
-          "End": "2000-12-31T00:00:00",
-          "Name": "clock",
+          "Start": "1900-01-01T00:00",
+          "End": "2000-12-31T00:00",
+          "Name": "Clock",
           "ResourceName": null,
           "Children": [],
           "Enabled": true,
@@ -34,7 +23,7 @@
         {
           "$type": "Models.Summary, Models",
           "Verbosity": 100,
-          "Name": "summaryfile",
+          "Name": "Summary",
           "ResourceName": null,
           "Children": [],
           "Enabled": true,
@@ -44,7 +33,7 @@
           "$type": "Models.Climate.Weather, Models",
           "ConstantsFile": null,
           "FileName": "%root%\\Examples\\WeatherFiles\\Dalby.met",
-          "ExcelWorkSheetName": "",
+          "ExcelWorkSheetName": null,
           "Name": "Weather",
           "ResourceName": null,
           "Children": [],
@@ -53,23 +42,7 @@
         },
         {
           "$type": "Models.Soils.Arbitrator.SoilArbitrator, Models",
-          "Name": "Soil Arbitrator",
-          "ResourceName": null,
-          "Children": [],
-          "Enabled": true,
-          "ReadOnly": false
-        },
-        {
-          "$type": "Models.MicroClimate, Models",
-          "a_interception": 0.0,
-          "b_interception": 1.0,
-          "c_interception": 0.0,
-          "d_interception": 0.0,
-          "SoilHeatFluxFraction": 0.4,
-          "MinimumHeightDiffForNewLayer": 0.0,
-          "NightInterceptionFraction": 0.5,
-          "ReferenceHeight": 2.0,
-          "Name": "MicroClimate",
+          "Name": "SoilArbitrator",
           "ResourceName": null,
           "Children": [],
           "Enabled": true,
@@ -81,7 +54,7 @@
           "Slope": 0.0,
           "AspectAngle": 0.0,
           "Altitude": 50.0,
-          "Name": "paddock",
+          "Name": "Field",
           "ResourceName": null,
           "Children": [
             {
@@ -104,7 +77,7 @@
                 "[Mungbean].Harvesting"
               ],
               "GroupByVariableName": null,
-              "Name": "HarvestReport",
+              "Name": "Report",
               "ResourceName": null,
               "Children": [],
               "Enabled": true,
@@ -112,7 +85,7 @@
             },
             {
               "$type": "Models.Fertiliser, Models",
-              "Name": "fertiliser",
+              "Name": "Fertiliser",
               "ResourceName": "Fertiliser",
               "Children": [],
               "Enabled": true,
@@ -120,7 +93,7 @@
             },
             {
               "$type": "Models.Soils.Soil, Models",
-              "RecordNumber": 0,
+              "RecordNumber": 104,
               "ASCOrder": "Vertosol",
               "ASCSubOrder": "Black",
               "SoilType": "Clay",
@@ -135,9 +108,9 @@
               "Latitude": -27.581836,
               "Longitude": 151.320206,
               "LocationAccuracy": " +/- 20m",
-              "YearOfSampling": null,
+              "YearOfSampling": "0",
               "DataSource": "CSIRO Sustainable Ecosystems, Toowoomba; Characteriesd as part of the GRDC funded project\"Doing it better, doing it smarter, managing soil water in Australian agriculture' 2011",
-              "Comments": "OC, CLL for all crops estimated-based on Bongeen Mywybilla Soil No1",
+              "Comments": "Clay - OC, CLL for all crops estimated-based on Bongeen Mywybilla Soil No1",
               "Name": "Soil",
               "ResourceName": null,
               "Children": [
@@ -398,6 +371,7 @@
                   "PHUnits": 0,
                   "EC": null,
                   "ESP": null,
+                  "CEC": null,
                   "ECMetadata": null,
                   "CLMetadata": null,
                   "ESPMetadata": null,
@@ -428,7 +402,8 @@
                     0.457070570557793,
                     0.452331759845006
                   ],
-                  "RelativeTo": null,
+                  "InitialPAWmm": 361.2454283127387,
+                  "RelativeTo": "LL15",
                   "FilledFromTop": false,
                   "Name": "Water",
                   "ResourceName": null,
@@ -578,12 +553,84 @@
               "ReadOnly": false
             },
             {
+              "$type": "Models.MicroClimate, Models",
+              "a_interception": 0.0,
+              "b_interception": 1.0,
+              "c_interception": 0.0,
+              "d_interception": 0.0,
+              "SoilHeatFluxFraction": 0.4,
+              "MinimumHeightDiffForNewLayer": 0.0,
+              "NightInterceptionFraction": 0.5,
+              "ReferenceHeight": 2.0,
+              "Name": "MicroClimate",
+              "ResourceName": null,
+              "Children": [],
+              "Enabled": true,
+              "ReadOnly": false
+            },
+            {
+              "$type": "Models.PMF.Plant, Models",
+              "Name": "Mungbean",
+              "ResourceName": "Mungbean",
+              "Children": [],
+              "Enabled": true,
+              "ReadOnly": false
+            },
+            {
               "$type": "Models.Manager, Models",
-              "Code": "using APSIM.Shared.Utilities;\r\nusing Models.Utilities;\r\nusing Models.Soils;\r\nusing Models.PMF;\r\nusing Models.Core;\r\nusing System;\r\nusing System.Linq;\r\n\r\nnamespace Models\r\n{\r\n    [Serializable]\r\n    public class Script : Model\r\n    {\r\n        [Link] Clock Clock;\r\n        [Link] Fertiliser Fertiliser;\r\n        [Link] Summary Summary;\r\n        [Link] Soil Soil;\r\n        \r\n        [Description(\"Crop\")]\r\n        public IPlant Crop { get; set; }\r\n\r\n        [Description(\"Sowing date (d-mmm)\")]\r\n        public string SowDate { get; set; }\r\n\r\n        [Display(Type = DisplayType.CultivarName)]\r\n        [Description(\"Cultivar to be sown\")]\r\n        public string CultivarName { get; set; }\r\n\r\n        [Description(\"Sowing depth (mm)\")]\r\n        public double SowingDepth { get; set; }\r\n\r\n        [Description(\"Row spacing (mm)\")]\r\n        public double RowSpacing { get; set; }\r\n\r\n        [Description(\"Plant population (/m2)\")]\r\n        public double Population { get; set; }\r\n\r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n            if (DateUtilities.WithinDates(SowDate, Clock.Today, SowDate))\r\n            {\r\n                Crop.Sow(population: Population, cultivar: CultivarName, depth: SowingDepth, rowSpacing: RowSpacing);    \r\n            }\r\n        }\r\n    }\r\n}\r\n",
+              "CodeArray": [
+                "using APSIM.Shared.Utilities;",
+                "using Models.Utilities;",
+                "using Models.Soils;",
+                "using Models.PMF;",
+                "using Models.Core;",
+                "using System;",
+                "using System.Linq;",
+                "",
+                "namespace Models",
+                "{",
+                "    [Serializable]",
+                "    public class Script : Model",
+                "    {",
+                "        [Link] Clock Clock;",
+                "        [Link] Fertiliser Fertiliser;",
+                "        [Link] Summary Summary;",
+                "        [Link] Soil Soil;",
+                "        ",
+                "        [Description(\"Crop\")]",
+                "        public IPlant Crop { get; set; }",
+                "",
+                "        [Description(\"Sowing date (d-mmm)\")]",
+                "        public string SowDate { get; set; }",
+                "",
+                "        [Display(Type = DisplayType.CultivarName)]",
+                "        [Description(\"Cultivar to be sown\")]",
+                "        public string CultivarName { get; set; }",
+                "",
+                "        [Description(\"Sowing depth (mm)\")]",
+                "        public double SowingDepth { get; set; }",
+                "",
+                "        [Description(\"Row spacing (mm)\")]",
+                "        public double RowSpacing { get; set; }",
+                "",
+                "        [Description(\"Plant population (/m2)\")]",
+                "        public double Population { get; set; }",
+                "",
+                "        [EventSubscribe(\"DoManagement\")]",
+                "        private void OnDoManagement(object sender, EventArgs e)",
+                "        {",
+                "            if (DateUtilities.WithinDates(SowDate, Clock.Today, SowDate))",
+                "            {",
+                "                Crop.Sow(population: Population, cultivar: CultivarName, depth: SowingDepth, rowSpacing: RowSpacing);    ",
+                "            }",
+                "        }",
+                "    }",
+                "}"
+              ],
               "Parameters": [
                 {
                   "Key": "Crop",
-                  "Value": "[Mungbean]"
+                  "Value": "Mungbean"
                 },
                 {
                   "Key": "SowDate",
@@ -595,15 +642,15 @@
                 },
                 {
                   "Key": "SowingDepth",
-                  "Value": "30"
+                  "Value": 30.0
                 },
                 {
                   "Key": "RowSpacing",
-                  "Value": "250"
+                  "Value": 250.0
                 },
                 {
                   "Key": "Population",
-                  "Value": "30"
+                  "Value": 30.0
                 }
               ],
               "Name": "Sow on a fixed date",
@@ -614,23 +661,44 @@
             },
             {
               "$type": "Models.Manager, Models",
-              "Code": "using APSIM.Shared.Utilities;\r\nusing Models.Utilities;\r\nusing Models.Soils;\r\nusing Models.PMF;\r\nusing Models.Core;\r\nusing System;\r\nusing System.Linq;\r\n\r\nnamespace Models\r\n{\r\n    [Serializable] \r\n    public class Script : Model\r\n    {\r\n        [Description(\"Crop\")]\r\n        public IPlant Crop { get; set; }\r\n        \r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n            if (Crop.IsReadyForHarvesting)\r\n            {\r\n                Crop.Harvest();\r\n                Crop.EndCrop();\r\n            }\r\n        }\r\n    }\r\n}\r\n       \r\n",
+              "CodeArray": [
+                "using APSIM.Shared.Utilities;",
+                "using Models.Utilities;",
+                "using Models.Soils;",
+                "using Models.PMF;",
+                "using Models.Core;",
+                "using System;",
+                "using System.Linq;",
+                "",
+                "namespace Models",
+                "{",
+                "    [Serializable] ",
+                "    public class Script : Model",
+                "    {",
+                "        [Description(\"Crop\")]",
+                "        public IPlant Crop { get; set; }",
+                "        ",
+                "        [EventSubscribe(\"DoManagement\")]",
+                "        private void OnDoManagement(object sender, EventArgs e)",
+                "        {",
+                "            if (Crop.IsReadyForHarvesting)",
+                "            {",
+                "                Crop.Harvest();",
+                "                Crop.EndCrop();",
+                "            }",
+                "        }",
+                "    }",
+                "}",
+                "       "
+              ],
               "Parameters": [
                 {
                   "Key": "Crop",
-                  "Value": "[Mungbean]"
+                  "Value": "Mungbean"
                 }
               ],
-              "Name": "Harvesting",
+              "Name": "Harvest",
               "ResourceName": null,
-              "Children": [],
-              "Enabled": true,
-              "ReadOnly": false
-            },
-            {
-              "$type": "Models.PMF.Plant, Models",
-              "Name": "Mungbean",
-              "ResourceName": "Mungbean",
               "Children": [],
               "Enabled": true,
               "ReadOnly": false
@@ -655,7 +723,7 @@
             },
             {
               "$type": "APSIM.Shared.Graphing.Axis, APSIM.Shared",
-              "Title": null,
+              "Title": "Yield (kg/ha)",
               "Position": 0,
               "Inverted": false,
               "CrossesAtZero": false,
@@ -667,9 +735,9 @@
           "LegendPosition": 0,
           "LegendOrientation": 0,
           "AnnotationLocation": 0,
-          "DisabledSeries": [],
+          "DisabledSeries": null,
           "LegendOutsideGraph": false,
-          "Name": "Yield Time Series",
+          "Name": "Mungbean Yield Time Series",
           "ResourceName": null,
           "Children": [
             {
@@ -677,7 +745,7 @@
               "Type": 1,
               "XAxis": 3,
               "YAxis": 0,
-              "ColourArgb": -1663232,
+              "ColourArgb": -16777216,
               "FactorToVaryColours": null,
               "FactorToVaryMarkers": null,
               "FactorToVaryLines": null,
@@ -685,17 +753,17 @@
               "MarkerSize": 0,
               "Line": 0,
               "LineThickness": 0,
-              "TableName": "HarvestReport",
+              "TableName": "Report",
               "XFieldName": "Clock.Today",
-              "YFieldName": "Mungbean.Grain.Wt",
-              "X2FieldName": "",
-              "Y2FieldName": "",
+              "YFieldName": "Yield",
+              "X2FieldName": null,
+              "Y2FieldName": null,
               "ShowInLegend": false,
               "IncludeSeriesNameInLegend": false,
               "Cumulative": false,
               "CumulativeX": false,
               "Filter": null,
-              "Name": "Series",
+              "Name": "Mungbean Yield",
               "ResourceName": null,
               "Children": [],
               "Enabled": true,
@@ -706,6 +774,16 @@
           "ReadOnly": false
         }
       ],
+      "Enabled": true,
+      "ReadOnly": false
+    },
+    {
+      "$type": "Models.Storage.DataStore, Models",
+      "useFirebird": false,
+      "CustomFileName": null,
+      "Name": "DataStore",
+      "ResourceName": null,
+      "Children": [],
       "Enabled": true,
       "ReadOnly": false
     }

--- a/Examples/Mungbean.apsimx
+++ b/Examples/Mungbean.apsimx
@@ -12,8 +12,8 @@
       "Children": [
         {
           "$type": "Models.Clock, Models",
-          "Start": "1900-01-01T00:00",
-          "End": "2000-12-31T00:00",
+          "Start": "1900-01-01T00:00:00",
+          "End": "2000-12-31T00:00:00",
           "Name": "Clock",
           "ResourceName": null,
           "Children": [],
@@ -33,7 +33,7 @@
           "$type": "Models.Climate.Weather, Models",
           "ConstantsFile": null,
           "FileName": "%root%\\Examples\\WeatherFiles\\Dalby.met",
-          "ExcelWorkSheetName": null,
+          "ExcelWorkSheetName": "",
           "Name": "Weather",
           "ResourceName": null,
           "Children": [],
@@ -43,6 +43,22 @@
         {
           "$type": "Models.Soils.Arbitrator.SoilArbitrator, Models",
           "Name": "SoilArbitrator",
+          "ResourceName": null,
+          "Children": [],
+          "Enabled": true,
+          "ReadOnly": false
+        },
+        {
+          "$type": "Models.MicroClimate, Models",
+          "a_interception": 0.0,
+          "b_interception": 1.0,
+          "c_interception": 0.0,
+          "d_interception": 0.0,
+          "SoilHeatFluxFraction": 0.4,
+          "MinimumHeightDiffForNewLayer": 0.0,
+          "NightInterceptionFraction": 0.5,
+          "ReferenceHeight": 2.0,
+          "Name": "MicroClimate",
           "ResourceName": null,
           "Children": [],
           "Enabled": true,
@@ -71,6 +87,7 @@
                 "[Mungbean].Grain.Number",
                 "[Mungbean].Grain.Wt",
                 "[Mungbean].Grain.N",
+                "[Mungbean].Grain.Total.Wt",
                 "[Mungbean].Total.Wt"
               ],
               "EventNames": [
@@ -553,22 +570,6 @@
               "ReadOnly": false
             },
             {
-              "$type": "Models.MicroClimate, Models",
-              "a_interception": 0.0,
-              "b_interception": 1.0,
-              "c_interception": 0.0,
-              "d_interception": 0.0,
-              "SoilHeatFluxFraction": 0.4,
-              "MinimumHeightDiffForNewLayer": 0.0,
-              "NightInterceptionFraction": 0.5,
-              "ReferenceHeight": 2.0,
-              "Name": "MicroClimate",
-              "ResourceName": null,
-              "Children": [],
-              "Enabled": true,
-              "ReadOnly": false
-            },
-            {
               "$type": "Models.PMF.Plant, Models",
               "Name": "Mungbean",
               "ResourceName": "Mungbean",
@@ -642,15 +643,15 @@
                 },
                 {
                   "Key": "SowingDepth",
-                  "Value": 30.0
+                  "Value": "30.0"
                 },
                 {
                   "Key": "RowSpacing",
-                  "Value": 250.0
+                  "Value": "250.0"
                 },
                 {
                   "Key": "Population",
-                  "Value": 30.0
+                  "Value": "30.0"
                 }
               ],
               "Name": "Sow on a fixed date",
@@ -723,7 +724,7 @@
             },
             {
               "$type": "APSIM.Shared.Graphing.Axis, APSIM.Shared",
-              "Title": "Yield (kg/ha)",
+              "Title": null,
               "Position": 0,
               "Inverted": false,
               "CrossesAtZero": false,
@@ -735,9 +736,9 @@
           "LegendPosition": 0,
           "LegendOrientation": 0,
           "AnnotationLocation": 0,
-          "DisabledSeries": null,
+          "DisabledSeries": [],
           "LegendOutsideGraph": false,
-          "Name": "Mungbean Yield Time Series",
+          "Name": "Graph",
           "ResourceName": null,
           "Children": [
             {
@@ -755,7 +756,7 @@
               "LineThickness": 0,
               "TableName": "Report",
               "XFieldName": "Clock.Today",
-              "YFieldName": "Yield",
+              "YFieldName": "Mungbean.Grain.Total.Wt",
               "X2FieldName": null,
               "Y2FieldName": null,
               "ShowInLegend": false,
@@ -763,7 +764,7 @@
               "Cumulative": false,
               "CumulativeX": false,
               "Filter": null,
-              "Name": "Mungbean Yield",
+              "Name": "Series",
               "ResourceName": null,
               "Children": [],
               "Enabled": true,

--- a/Examples/Oats.apsimx
+++ b/Examples/Oats.apsimx
@@ -12,8 +12,8 @@
       "Children": [
         {
           "$type": "Models.Clock, Models",
-          "Start": "1900-01-01T00:00",
-          "End": "2000-12-31T00:00",
+          "Start": "1900-01-01T00:00:00",
+          "End": "2000-12-31T00:00:00",
           "Name": "Clock",
           "ResourceName": null,
           "Children": [],
@@ -33,7 +33,7 @@
           "$type": "Models.Climate.Weather, Models",
           "ConstantsFile": null,
           "FileName": "%root%\\Examples\\WeatherFiles\\Dalby.met",
-          "ExcelWorkSheetName": null,
+          "ExcelWorkSheetName": "",
           "Name": "Weather",
           "ResourceName": null,
           "Children": [],
@@ -43,6 +43,22 @@
         {
           "$type": "Models.Soils.Arbitrator.SoilArbitrator, Models",
           "Name": "SoilArbitrator",
+          "ResourceName": null,
+          "Children": [],
+          "Enabled": true,
+          "ReadOnly": false
+        },
+        {
+          "$type": "Models.MicroClimate, Models",
+          "a_interception": 0.0,
+          "b_interception": 1.0,
+          "c_interception": 0.0,
+          "d_interception": 0.0,
+          "SoilHeatFluxFraction": 0.4,
+          "MinimumHeightDiffForNewLayer": 0.0,
+          "NightInterceptionFraction": 0.5,
+          "ReferenceHeight": 2.0,
+          "Name": "MicroClimate",
           "ResourceName": null,
           "Children": [],
           "Enabled": true,
@@ -553,22 +569,6 @@
               "ReadOnly": false
             },
             {
-              "$type": "Models.MicroClimate, Models",
-              "a_interception": 0.0,
-              "b_interception": 1.0,
-              "c_interception": 0.0,
-              "d_interception": 0.0,
-              "SoilHeatFluxFraction": 0.4,
-              "MinimumHeightDiffForNewLayer": 0.0,
-              "NightInterceptionFraction": 0.5,
-              "ReferenceHeight": 2.0,
-              "Name": "MicroClimate",
-              "ResourceName": null,
-              "Children": [],
-              "Enabled": true,
-              "ReadOnly": false
-            },
-            {
               "$type": "Models.PMF.Plant, Models",
               "Name": "Oats",
               "ResourceName": "Oats",
@@ -671,15 +671,15 @@
                 },
                 {
                   "Key": "MinESW",
-                  "Value": 100.0
+                  "Value": "100.0"
                 },
                 {
                   "Key": "MinRain",
-                  "Value": 25.0
+                  "Value": "25.0"
                 },
                 {
                   "Key": "RainDays",
-                  "Value": 7
+                  "Value": "7"
                 },
                 {
                   "Key": "CultivarName",
@@ -687,15 +687,15 @@
                 },
                 {
                   "Key": "SowingDepth",
-                  "Value": 30.0
+                  "Value": "30.0"
                 },
                 {
                   "Key": "RowSpacing",
-                  "Value": 250.0
+                  "Value": "250.0"
                 },
                 {
                   "Key": "Population",
-                  "Value": 120.0
+                  "Value": "120.0"
                 }
               ],
               "Name": "Sow using a variable rule",
@@ -750,7 +750,7 @@
                 },
                 {
                   "Key": "Amount",
-                  "Value": 160.0
+                  "Value": "160.0"
                 }
               ],
               "Name": "Fertilise at sowing",
@@ -823,7 +823,7 @@
             },
             {
               "$type": "APSIM.Shared.Graphing.Axis, APSIM.Shared",
-              "Title": "Yield (kg/ha)",
+              "Title": null,
               "Position": 0,
               "Inverted": false,
               "CrossesAtZero": false,
@@ -835,9 +835,9 @@
           "LegendPosition": 0,
           "LegendOrientation": 0,
           "AnnotationLocation": 0,
-          "DisabledSeries": null,
+          "DisabledSeries": [],
           "LegendOutsideGraph": false,
-          "Name": "Oats Yield Time Series",
+          "Name": "Graph",
           "ResourceName": null,
           "Children": [
             {
@@ -855,7 +855,7 @@
               "LineThickness": 0,
               "TableName": "Report",
               "XFieldName": "Clock.Today",
-              "YFieldName": "Yield",
+              "YFieldName": "Oats.Grain.Total.Wt",
               "X2FieldName": null,
               "Y2FieldName": null,
               "ShowInLegend": false,
@@ -863,7 +863,7 @@
               "Cumulative": false,
               "CumulativeX": false,
               "Filter": null,
-              "Name": "Oats Yield",
+              "Name": "Series",
               "ResourceName": null,
               "Children": [],
               "Enabled": true,

--- a/Examples/Oats.apsimx
+++ b/Examples/Oats.apsimx
@@ -1,51 +1,50 @@
 {
   "$type": "Models.Core.Simulations, Models",
-  "ExplorerWidth": 296,
-  "Version": 100,
-  "ApsimVersion": "0.0.0.0",
+  "Version": 168,
   "Name": "Simulations",
+  "ResourceName": null,
   "Children": [
     {
       "$type": "Models.Core.Simulation, Models",
-      "IsRunning": false,
-      "Name": "OatExample",
+      "Descriptors": null,
+      "Name": "Simulation",
+      "ResourceName": null,
       "Children": [
         {
           "$type": "Models.Clock, Models",
-          "Start": "1900-01-01T00:00:00",
-          "End": "2000-12-31T00:00:00",
+          "Start": "1900-01-01T00:00",
+          "End": "2000-12-31T00:00",
           "Name": "Clock",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
         {
           "$type": "Models.Summary, Models",
-          "CaptureErrors": true,
-          "CaptureWarnings": true,
-          "CaptureSummaryText": true,
-          "Name": "SummaryFile",
+          "Verbosity": 100,
+          "Name": "Summary",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
         {
-          "$type": "Models.Weather, Models",
+          "$type": "Models.Climate.Weather, Models",
+          "ConstantsFile": null,
           "FileName": "%root%\\Examples\\WeatherFiles\\Dalby.met",
           "ExcelWorkSheetName": null,
           "Name": "Weather",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
         {
           "$type": "Models.Soils.Arbitrator.SoilArbitrator, Models",
           "Name": "SoilArbitrator",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
@@ -56,6 +55,7 @@
           "AspectAngle": 0.0,
           "Altitude": 50.0,
           "Name": "Field",
+          "ResourceName": null,
           "Children": [
             {
               "$type": "Models.Report, Models",
@@ -78,22 +78,22 @@
               ],
               "GroupByVariableName": null,
               "Name": "Report",
+              "ResourceName": null,
               "Children": [],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Fertiliser, Models",
               "Name": "Fertiliser",
+              "ResourceName": "Fertiliser",
               "Children": [],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Soils.Soil, Models",
-              "RecordNumber": 0,
+              "RecordNumber": 104,
               "ASCOrder": "Vertosol",
               "ASCSubOrder": "Black",
               "SoilType": "Clay",
@@ -108,21 +108,14 @@
               "Latitude": -27.581836,
               "Longitude": 151.320206,
               "LocationAccuracy": " +/- 20m",
+              "YearOfSampling": "0",
               "DataSource": "CSIRO Sustainable Ecosystems, Toowoomba; Characteriesd as part of the GRDC funded project\"Doing it better, doing it smarter, managing soil water in Australian agriculture' 2011",
-              "Comments": "OC, CLL for all crops estimated-based on Bongeen Mywybilla Soil No1",
+              "Comments": "Clay - OC, CLL for all crops estimated-based on Bongeen Mywybilla Soil No1",
               "Name": "Soil",
+              "ResourceName": null,
               "Children": [
                 {
                   "$type": "Models.Soils.Physical, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180"
-                  ],
                   "Thickness": [
                     150.0,
                     150.0,
@@ -135,6 +128,8 @@
                   "ParticleSizeClay": null,
                   "ParticleSizeSand": null,
                   "ParticleSizeSilt": null,
+                  "Rocks": null,
+                  "Texture": null,
                   "BD": [
                     1.01056473311131,
                     1.07145631083388,
@@ -195,7 +190,13 @@
                   "DULMetadata": null,
                   "SATMetadata": null,
                   "KSMetadata": null,
+                  "RocksMetadata": null,
+                  "TextureMetadata": null,
+                  "ParticleSizeSandMetadata": null,
+                  "ParticleSizeSiltMetadata": null,
+                  "ParticleSizeClayMetadata": null,
                   "Name": "Physical",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Soils.SoilCrop, Models",
@@ -230,13 +231,12 @@
                       "KLMetadata": null,
                       "XFMetadata": null,
                       "Name": "OatsSoil",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -254,9 +254,9 @@
                   "CN2Bare": 73.0,
                   "CNRed": 20.0,
                   "CNCov": 0.8,
-                  "Slope": "NaN",
                   "DischargeWidth": "NaN",
                   "CatchmentArea": "NaN",
+                  "PSIDul": -100.0,
                   "Thickness": [
                     150.0,
                     150.0,
@@ -276,23 +276,14 @@
                     0.3
                   ],
                   "KLAT": null,
-                  "ResourceName": "WaterBalance",
                   "Name": "SoilWater",
-                  "IncludeInDocumentation": true,
+                  "ResourceName": "WaterBalance",
+                  "Children": [],
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Soils.Organic, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180"
-                  ],
                   "FOMCNRatio": 40.0,
                   "Thickness": [
                     150.0,
@@ -312,6 +303,7 @@
                     0.12,
                     0.12
                   ],
+                  "CarbonUnits": 0,
                   "SoilCNRatio": [
                     12.0,
                     12.0,
@@ -340,31 +332,24 @@
                     1.0
                   ],
                   "FOM": [
-                    347.12903231275641,
+                    347.1290323127564,
                     270.3443621919937,
                     163.97214434990104,
-                    99.454132887040629,
-                    60.321980831124677,
-                    36.587130828674873,
+                    99.45413288704063,
+                    60.32198083112468,
+                    36.58713082867487,
                     22.1912165985086
                   ],
+                  "CarbonMetadata": null,
+                  "FOMMetadata": null,
                   "Name": "Organic",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Soils.Chemical, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180"
-                  ],
                   "Thickness": [
                     150.0,
                     150.0,
@@ -373,24 +358,6 @@
                     300.0,
                     300.0,
                     300.0
-                  ],
-                  "NO3N": [
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0
-                  ],
-                  "NH4N": [
-                    0.1,
-                    0.1,
-                    0.1,
-                    0.1,
-                    0.1,
-                    0.1,
-                    0.1
                   ],
                   "PH": [
                     8.0,
@@ -401,38 +368,22 @@
                     8.0,
                     8.0
                   ],
-                  "CL": null,
+                  "PHUnits": 0,
                   "EC": null,
                   "ESP": null,
+                  "CEC": null,
+                  "ECMetadata": null,
+                  "CLMetadata": null,
+                  "ESPMetadata": null,
+                  "PHMetadata": null,
                   "Name": "Chemical",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.Soils.InitialWater, Models",
-                  "PercentMethod": 1,
-                  "FractionFull": 1.0,
-                  "DepthWetSoil": "NaN",
-                  "RelativeTo": null,
-                  "Name": "InitialWater",
-                  "Children": [],
-                  "IncludeInDocumentation": true,
-                  "Enabled": true,
-                  "ReadOnly": false
-                },
-                {
-                  "$type": "Models.Soils.Sample, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180"
-                  ],
+                  "$type": "Models.Soils.Water, Models",
                   "Thickness": [
                     150.0,
                     150.0,
@@ -442,111 +393,162 @@
                     300.0,
                     300.0
                   ],
-                  "NO3N": null,
-                  "NH4N": null,
-                  "SW": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
+                  "InitialValues": [
+                    0.52100021807301,
+                    0.496723476938497,
+                    0.488437607673005,
+                    0.480296969355493,
+                    0.471583596524955,
+                    0.457070570557793,
+                    0.452331759845006
                   ],
-                  "OC": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "EC": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "CL": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "ESP": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "PH": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "SWUnits": 0,
-                  "OCUnits": 0,
-                  "PHUnits": 0,
-                  "Name": "InitialN",
+                  "InitialPAWmm": 361.2454283127387,
+                  "RelativeTo": "LL15",
+                  "FilledFromTop": false,
+                  "Name": "Water",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Soils.CERESSoilTemperature, Models",
-                  "Name": "CERESSoilTemperature",
+                  "Name": "Temperature",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Soils.Nutrients.Nutrient, Models",
-                  "ResourceName": "Nutrient",
                   "Name": "Nutrient",
-                  "IncludeInDocumentation": true,
+                  "ResourceName": "Nutrient",
+                  "Children": [],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Soils.Solute, Models",
+                  "Thickness": [
+                    150.0,
+                    150.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0
+                  ],
+                  "InitialValues": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "InitialValuesUnits": 0,
+                  "WaterTableConcentration": 0.0,
+                  "D0": 0.0,
+                  "Exco": null,
+                  "FIP": null,
+                  "DepthConstant": 0.0,
+                  "MaxDepthSoluteAccessible": 0.0,
+                  "RunoffEffectivenessAtMovingSolute": 0.0,
+                  "MaxEffectiveRunoff": 0.0,
+                  "Name": "NO3",
+                  "ResourceName": null,
+                  "Children": [],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Soils.Solute, Models",
+                  "Thickness": [
+                    150.0,
+                    150.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0
+                  ],
+                  "InitialValues": [
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1
+                  ],
+                  "InitialValuesUnits": 0,
+                  "WaterTableConcentration": 0.0,
+                  "D0": 0.0,
+                  "Exco": null,
+                  "FIP": null,
+                  "DepthConstant": 0.0,
+                  "MaxDepthSoluteAccessible": 0.0,
+                  "RunoffEffectivenessAtMovingSolute": 0.0,
+                  "MaxEffectiveRunoff": 0.0,
+                  "Name": "NH4",
+                  "ResourceName": null,
+                  "Children": [],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Soils.Solute, Models",
+                  "Thickness": [
+                    150.0,
+                    150.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0
+                  ],
+                  "InitialValues": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "InitialValuesUnits": 1,
+                  "WaterTableConcentration": 0.0,
+                  "D0": 0.0,
+                  "Exco": null,
+                  "FIP": null,
+                  "DepthConstant": 0.0,
+                  "MaxDepthSoluteAccessible": 0.0,
+                  "RunoffEffectivenessAtMovingSolute": 0.0,
+                  "MaxEffectiveRunoff": 0.0,
+                  "Name": "Urea",
+                  "ResourceName": null,
+                  "Children": [],
                   "Enabled": true,
                   "ReadOnly": false
                 }
               ],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Surface.SurfaceOrganicMatter, Models",
+              "SurfOM": [],
+              "Canopies": [],
               "InitialResidueName": "wheat_stubble",
               "InitialResidueType": "wheat",
               "InitialResidueMass": 500.0,
               "InitialStandingFraction": 0.0,
               "InitialCPR": 0.0,
               "InitialCNR": 100.0,
-              "ResourceName": "SurfaceOrganicMatter",
               "Name": "SurfaceOrganicMatter",
-              "IncludeInDocumentation": true,
-              "Enabled": true,
-              "ReadOnly": false
-            },
-            {
-              "$type": "Models.PMF.Plant, Models",
-              "ResourceName": "Oats",
-              "Name": "Oats",
-              "IncludeInDocumentation": true,
+              "ResourceName": "SurfaceOrganicMatter",
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             },
@@ -556,48 +558,109 @@
               "b_interception": 1.0,
               "c_interception": 0.0,
               "d_interception": 0.0,
-              "soil_albedo": 0.3,
               "SoilHeatFluxFraction": 0.4,
               "MinimumHeightDiffForNewLayer": 0.0,
               "NightInterceptionFraction": 0.5,
               "ReferenceHeight": 2.0,
               "Name": "MicroClimate",
+              "ResourceName": null,
               "Children": [],
-              "IncludeInDocumentation": true,
+              "Enabled": true,
+              "ReadOnly": false
+            },
+            {
+              "$type": "Models.PMF.Plant, Models",
+              "Name": "Oats",
+              "ResourceName": "Oats",
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Manager, Models",
-              "Code": "using Models.PMF;\r\nusing Models.Core;\r\nusing System;\r\nusing System.Linq;\r\nnamespace Models\r\n{\r\n    [Serializable]\r\n    public class Script : Model\r\n    {\r\n        [Link] Clock Clock;\r\n        [Link] Fertiliser Fertiliser;\r\n        [Link] Summary Summary;\r\n        \r\n        \r\n        [Description(\"Amount of fertiliser to be applied (kg/ha)\")]\r\n        public double Amount { get; set;}\r\n        \r\n        [Description(\"Crop to be fertilised\")]\r\n        public string CropName { get; set;}\r\n        \r\n        \r\n        \r\n\r\n        [EventSubscribe(\"Sowing\")]\r\n        private void OnSowing(object sender, EventArgs e)\r\n        {\r\n            Model crop = sender as Model;\r\n            if (crop.Name.ToLower()==CropName.ToLower())\r\n                Fertiliser.Apply(Amount: Amount, Type: Fertiliser.Types.NO3N);\r\n        }\r\n        \r\n    }\r\n}\r\n",
-              "Parameters": [
-                {
-                  "Key": "Amount",
-                  "Value": "160"
-                },
-                {
-                  "Key": "CropName",
-                  "Value": "Oats"
-                }
+              "CodeArray": [
+                "using Models.Interfaces;",
+                "using APSIM.Shared.Utilities;",
+                "using Models.Utilities;",
+                "using Models.Soils;",
+                "using Models.PMF;",
+                "using Models.Core;",
+                "using System;",
+                "using System.Linq;",
+                "using Models.Climate;",
+                "",
+                "namespace Models",
+                "{",
+                "    [Serializable]",
+                "    public class Script : Model",
+                "    {",
+                "        [Link] private Clock Clock;",
+                "        [Link] private Fertiliser Fertiliser;",
+                "        [Link] private Summary Summary;",
+                "        [Link] private Soil Soil;",
+                "        private Accumulator accumulatedRain;",
+                "        [Link]",
+                "        private ISoilWater waterBalance;",
+                "        ",
+                "        [Description(\"Crop\")]",
+                "        public IPlant Crop { get; set; }",
+                "",
+                "        [Description(\"Start of sowing window (d-mmm)\")]",
+                "        public string StartDate { get; set; }",
+                "",
+                "        [Description(\"End of sowing window (d-mmm)\")]",
+                "        public string EndDate { get; set; }",
+                "",
+                "        [Description(\"Minimum extractable soil water for sowing (mm)\")]",
+                "        public double MinESW { get; set; }",
+                "",
+                "        [Description(\"Accumulated rainfall required for sowing (mm)\")]",
+                "        public double MinRain { get; set; }",
+                "",
+                "        [Description(\"Duration of rainfall accumulation (d)\")]",
+                "        public int RainDays { get; set; }",
+                "",
+                "        [Display(Type = DisplayType.CultivarName)]",
+                "        [Description(\"Cultivar to be sown\")]",
+                "        public string CultivarName { get; set; }",
+                "",
+                "        [Description(\"Sowing depth (mm)\")]",
+                "        public double SowingDepth { get; set; }",
+                "",
+                "        [Description(\"Row spacing (mm)\")]",
+                "        public double RowSpacing { get; set; }",
+                "",
+                "        [Description(\"Plant population (/m2)\")]",
+                "        public double Population { get; set; }",
+                "        ",
+                "        ",
+                "        [EventSubscribe(\"StartOfSimulation\")]",
+                "        private void OnSimulationCommencing(object sender, EventArgs e)",
+                "        {",
+                "            accumulatedRain = new Accumulator(this, \"[Weather].Rain\", RainDays);",
+                "        }",
+                "",
+                "        [EventSubscribe(\"DoManagement\")]",
+                "        private void OnDoManagement(object sender, EventArgs e)",
+                "        {",
+                "            accumulatedRain.Update();",
+                "            ",
+                "            if (DateUtilities.WithinDates(StartDate, Clock.Today, EndDate) &&",
+                "                !Crop.IsAlive &&",
+                "                MathUtilities.Sum(waterBalance.ESW) > MinESW &&",
+                "                accumulatedRain.Sum > MinRain)",
+                "            {",
+                "                Crop.Sow(population: Population, cultivar: CultivarName, depth: SowingDepth, rowSpacing: RowSpacing);    ",
+                "            }",
+                "        }",
+                "    }",
+                "}"
               ],
-              "Name": "SowingFertiliser",
-              "IncludeInDocumentation": true,
-              "Enabled": true,
-              "ReadOnly": false
-            },
-            {
-              "$type": "Models.Manager, Models",
-              "Code": "using APSIM.Shared.Utilities;\r\nusing Models.Utilities;\r\nusing Models.Soils.Nutrients;\r\nusing Models.Soils;\r\nusing Models.PMF;\r\nusing Models.Core;\r\nusing System;\r\nusing System.Linq;\r\n\r\nnamespace Models\r\n{\r\n    [Serializable]\r\n    public class Script : Model\r\n    {\r\n        [Link(ByName = true)] Plant Oats;\r\n\r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n            if (Oats.IsReadyForHarvesting)\r\n            {\r\n               Oats.Harvest();\r\n               Oats.EndCrop();    \r\n            }\r\n        \r\n        }\r\n        \r\n    }\r\n}\r\n",
-              "Parameters": [],
-              "Name": "Harvest",
-              "IncludeInDocumentation": true,
-              "Enabled": true,
-              "ReadOnly": false
-            },
-            {
-              "$type": "Models.Manager, Models",
-              "Code": "using APSIM.Shared.Utilities;\r\nusing Models.Utilities;\r\nusing Models.Soils.Nutrients;\r\nusing Models.Soils;\r\nusing Models.PMF;\r\nusing Models.Core;\r\nusing System;\r\nusing System.Linq;\r\n\r\nnamespace Models\r\n{\r\n    [Serializable]\r\n    public class Script : Model\r\n    {\r\n        [Link] Clock Clock;\r\n        [Link] Fertiliser Fertiliser;\r\n        [Link] Summary Summary;\r\n        [Link(ByName = true)] Plant Oats;\r\n        [Link] Soil Soil; \r\n        Accumulator accumulatedRain;\r\n        \r\n        [Description(\"Start of sowing window (d-mmm)\")]\r\n        public string StartDate { get; set;}\r\n        [Description(\"End of sowing window (d-mmm)\")]\r\n        public string EndDate { get; set;}\r\n        [Description(\"Minimum extractable soil water for sowing (mm)\")]\r\n        public double MinESW { get; set;}\r\n        [Description(\"Accumulated rainfall required for sowing (mm)\")]\r\n        public double MinRain { get; set;}\r\n        [Description(\"Duration of rainfall accumulation (d)\")]\r\n        public int RainDays { get; set;}\r\n        [Description(\"Cultivar to be sown\")]\r\n        [Display(Type=DisplayType.CultivarName, PlantName = \"Oats\")]\r\n        public string CultivarName { get; set;}\r\n        [Description(\"Sowing depth (mm)\")]\r\n        public double SowingDepth { get; set;}        \r\n        [Description(\"Row spacing (mm)\")]\r\n        public double RowSpacing { get; set;}    \r\n        [Description(\"Plant population (/m2)\")]\r\n        public double Population { get; set;}    \r\n        \r\n        \r\n        [EventSubscribe(\"StartOfSimulation\")]\r\n        private void OnSimulationCommencing(object sender, EventArgs e)\r\n        {\r\n            accumulatedRain = new Accumulator(this, \"[Weather].Rain\", RainDays);\r\n        }\r\n        \r\n\r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n            accumulatedRain.Update();\r\n            \r\n            if (DateUtilities.WithinDates(StartDate,Clock.Today,EndDate) &&\r\n                !Oats.IsAlive &&\r\n                MathUtilities.Sum(Soil.SoilWater.ESW) > MinESW &&\r\n                accumulatedRain.Sum > MinRain)\r\n            {\r\n               Oats.Sow(population:Population, cultivar:CultivarName, depth:SowingDepth, rowSpacing:RowSpacing);    \r\n            }\r\n        \r\n        }\r\n        \r\n    }\r\n}\r\n",
               "Parameters": [
+                {
+                  "Key": "Crop",
+                  "Value": "Oats"
+                },
                 {
                   "Key": "StartDate",
                   "Value": "1-may"
@@ -608,15 +671,15 @@
                 },
                 {
                   "Key": "MinESW",
-                  "Value": "100"
+                  "Value": 100.0
                 },
                 {
                   "Key": "MinRain",
-                  "Value": "25"
+                  "Value": 25.0
                 },
                 {
                   "Key": "RainDays",
-                  "Value": "7"
+                  "Value": 7
                 },
                 {
                   "Key": "CultivarName",
@@ -624,24 +687,123 @@
                 },
                 {
                   "Key": "SowingDepth",
-                  "Value": "30"
+                  "Value": 30.0
                 },
                 {
                   "Key": "RowSpacing",
-                  "Value": "250"
+                  "Value": 250.0
                 },
                 {
                   "Key": "Population",
-                  "Value": "120"
+                  "Value": 120.0
                 }
               ],
-              "Name": "SowingRule1",
-              "IncludeInDocumentation": true,
+              "Name": "Sow using a variable rule",
+              "ResourceName": null,
+              "Children": [],
+              "Enabled": true,
+              "ReadOnly": false
+            },
+            {
+              "$type": "Models.Manager, Models",
+              "CodeArray": [
+                "using Models.Soils;",
+                "using System;",
+                "using System.Linq;",
+                "using Models.Core;",
+                "using Models.PMF;",
+                "namespace Models",
+                "{",
+                "    [Serializable]",
+                "    public class Script : Model",
+                "    {",
+                "        [Link] Clock Clock;",
+                "        [Link] Fertiliser Fertiliser;",
+                "        ",
+                "        [Description(\"Crop to be fertilised\")]",
+                "        public IPlant Crop { get; set; }",
+                "",
+                "        [Description(\"Type of fertiliser to apply? \")] ",
+                "        public Fertiliser.Types FertiliserType { get; set; }",
+                "    ",
+                "        [Description(\"Amount of fertiliser to be applied (kg/ha)\")]",
+                "        public double Amount { get; set; }",
+                "        ",
+                "        [EventSubscribe(\"Sowing\")]",
+                "        private void OnSowing(object sender, EventArgs e)",
+                "        {",
+                "            Model crop = sender as Model;",
+                "            if (Crop != null && crop.Name.ToLower() == (Crop as IModel).Name.ToLower())",
+                "                Fertiliser.Apply(Amount: Amount, Type: FertiliserType);",
+                "        }",
+                "    }",
+                "}"
+              ],
+              "Parameters": [
+                {
+                  "Key": "Crop",
+                  "Value": "Oats"
+                },
+                {
+                  "Key": "FertiliserType",
+                  "Value": "NO3N"
+                },
+                {
+                  "Key": "Amount",
+                  "Value": 160.0
+                }
+              ],
+              "Name": "Fertilise at sowing",
+              "ResourceName": null,
+              "Children": [],
+              "Enabled": true,
+              "ReadOnly": false
+            },
+            {
+              "$type": "Models.Manager, Models",
+              "CodeArray": [
+                "using APSIM.Shared.Utilities;",
+                "using Models.Utilities;",
+                "using Models.Soils;",
+                "using Models.PMF;",
+                "using Models.Core;",
+                "using System;",
+                "using System.Linq;",
+                "",
+                "namespace Models",
+                "{",
+                "    [Serializable] ",
+                "    public class Script : Model",
+                "    {",
+                "        [Description(\"Crop\")]",
+                "        public IPlant Crop { get; set; }",
+                "        ",
+                "        [EventSubscribe(\"DoManagement\")]",
+                "        private void OnDoManagement(object sender, EventArgs e)",
+                "        {",
+                "            if (Crop.IsReadyForHarvesting)",
+                "            {",
+                "                Crop.Harvest();",
+                "                Crop.EndCrop();",
+                "            }",
+                "        }",
+                "    }",
+                "}",
+                "       "
+              ],
+              "Parameters": [
+                {
+                  "Key": "Crop",
+                  "Value": "Oats"
+                }
+              ],
+              "Name": "Harvest",
+              "ResourceName": null,
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             }
           ],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
@@ -650,33 +812,33 @@
           "Caption": null,
           "Axis": [
             {
-              "$type": "Models.Axis, Models",
-              "Type": 3,
+              "$type": "APSIM.Shared.Graphing.Axis, APSIM.Shared",
               "Title": "Date",
+              "Position": 3,
               "Inverted": false,
-              "Minimum": "NaN",
-              "Maximum": "NaN",
-              "Interval": "NaN",
-              "DateTimeAxis": false,
-              "CrossesAtZero": false
+              "CrossesAtZero": false,
+              "Minimum": null,
+              "Maximum": null,
+              "Interval": null
             },
             {
-              "$type": "Models.Axis, Models",
-              "Type": 0,
+              "$type": "APSIM.Shared.Graphing.Axis, APSIM.Shared",
               "Title": "Yield (kg/ha)",
+              "Position": 0,
               "Inverted": false,
-              "Minimum": "NaN",
-              "Maximum": "NaN",
-              "Interval": "NaN",
-              "DateTimeAxis": false,
-              "CrossesAtZero": false
+              "CrossesAtZero": false,
+              "Minimum": null,
+              "Maximum": null,
+              "Interval": null
             }
           ],
           "LegendPosition": 0,
           "LegendOrientation": 0,
+          "AnnotationLocation": 0,
           "DisabledSeries": null,
           "LegendOutsideGraph": false,
           "Name": "Oats Yield Time Series",
+          "ResourceName": null,
           "Children": [
             {
               "$type": "Models.Series, Models",
@@ -694,26 +856,24 @@
               "TableName": "Report",
               "XFieldName": "Clock.Today",
               "YFieldName": "Yield",
-              "X2FieldName": "",
-              "Y2FieldName": "",
-              "ShowInLegend": true,
+              "X2FieldName": null,
+              "Y2FieldName": null,
+              "ShowInLegend": false,
               "IncludeSeriesNameInLegend": false,
               "Cumulative": false,
               "CumulativeX": false,
               "Filter": null,
-              "Name": "Series1",
+              "Name": "Oats Yield",
+              "ResourceName": null,
               "Children": [],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             }
           ],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         }
       ],
-      "IncludeInDocumentation": true,
       "Enabled": true,
       "ReadOnly": false
     },
@@ -722,13 +882,12 @@
       "useFirebird": false,
       "CustomFileName": null,
       "Name": "DataStore",
+      "ResourceName": null,
       "Children": [],
-      "IncludeInDocumentation": true,
       "Enabled": true,
       "ReadOnly": false
     }
   ],
-  "IncludeInDocumentation": true,
   "Enabled": true,
   "ReadOnly": false
 }

--- a/Examples/Soybean.apsimx
+++ b/Examples/Soybean.apsimx
@@ -12,8 +12,8 @@
       "Children": [
         {
           "$type": "Models.Clock, Models",
-          "Start": "1900-01-01T00:00",
-          "End": "2000-12-31T00:00",
+          "Start": "1900-01-01T00:00:00",
+          "End": "2000-12-31T00:00:00",
           "Name": "Clock",
           "ResourceName": null,
           "Children": [],
@@ -33,7 +33,7 @@
           "$type": "Models.Climate.Weather, Models",
           "ConstantsFile": null,
           "FileName": "%root%\\Examples\\WeatherFiles\\Dalby.met",
-          "ExcelWorkSheetName": null,
+          "ExcelWorkSheetName": "",
           "Name": "Weather",
           "ResourceName": null,
           "Children": [],
@@ -43,6 +43,22 @@
         {
           "$type": "Models.Soils.Arbitrator.SoilArbitrator, Models",
           "Name": "SoilArbitrator",
+          "ResourceName": null,
+          "Children": [],
+          "Enabled": true,
+          "ReadOnly": false
+        },
+        {
+          "$type": "Models.MicroClimate, Models",
+          "a_interception": 0.0,
+          "b_interception": 1.0,
+          "c_interception": 0.0,
+          "d_interception": 0.0,
+          "SoilHeatFluxFraction": 0.4,
+          "MinimumHeightDiffForNewLayer": 0.0,
+          "NightInterceptionFraction": 0.5,
+          "ReferenceHeight": 2.0,
+          "Name": "MicroClimate",
           "ResourceName": null,
           "Children": [],
           "Enabled": true,
@@ -553,22 +569,6 @@
               "ReadOnly": false
             },
             {
-              "$type": "Models.MicroClimate, Models",
-              "a_interception": 0.0,
-              "b_interception": 1.0,
-              "c_interception": 0.0,
-              "d_interception": 0.0,
-              "SoilHeatFluxFraction": 0.4,
-              "MinimumHeightDiffForNewLayer": 0.0,
-              "NightInterceptionFraction": 0.5,
-              "ReferenceHeight": 2.0,
-              "Name": "MicroClimate",
-              "ResourceName": null,
-              "Children": [],
-              "Enabled": true,
-              "ReadOnly": false
-            },
-            {
               "$type": "Models.PMF.Plant, Models",
               "Name": "Soybean",
               "ResourceName": "Soybean",
@@ -671,15 +671,15 @@
                 },
                 {
                   "Key": "MinESW",
-                  "Value": 100.0
+                  "Value": "100.0"
                 },
                 {
                   "Key": "MinRain",
-                  "Value": 25.0
+                  "Value": "25.0"
                 },
                 {
                   "Key": "RainDays",
-                  "Value": 7
+                  "Value": "7"
                 },
                 {
                   "Key": "CultivarName",
@@ -687,15 +687,15 @@
                 },
                 {
                   "Key": "SowingDepth",
-                  "Value": 50.0
+                  "Value": "50.0"
                 },
                 {
                   "Key": "RowSpacing",
-                  "Value": 750.0
+                  "Value": "750.0"
                 },
                 {
                   "Key": "Population",
-                  "Value": 38.0
+                  "Value": "38.0"
                 }
               ],
               "Name": "Sow using a variable rule",
@@ -750,7 +750,7 @@
                 },
                 {
                   "Key": "Amount",
-                  "Value": 10.0
+                  "Value": "10.0"
                 }
               ],
               "Name": "Fertilise at sowing",
@@ -823,7 +823,7 @@
             },
             {
               "$type": "APSIM.Shared.Graphing.Axis, APSIM.Shared",
-              "Title": "Yield (kg/ha)",
+              "Title": null,
               "Position": 0,
               "Inverted": false,
               "CrossesAtZero": false,
@@ -835,9 +835,9 @@
           "LegendPosition": 0,
           "LegendOrientation": 0,
           "AnnotationLocation": 0,
-          "DisabledSeries": null,
+          "DisabledSeries": [],
           "LegendOutsideGraph": false,
-          "Name": "Soybean Yield Time Series",
+          "Name": "Graph",
           "ResourceName": null,
           "Children": [
             {
@@ -855,7 +855,7 @@
               "LineThickness": 0,
               "TableName": "Report",
               "XFieldName": "Clock.Today",
-              "YFieldName": "Yield",
+              "YFieldName": "Soybean.Grain.Total.Wt",
               "X2FieldName": null,
               "Y2FieldName": null,
               "ShowInLegend": false,
@@ -863,7 +863,7 @@
               "Cumulative": false,
               "CumulativeX": false,
               "Filter": null,
-              "Name": "Soybean Yield",
+              "Name": "Series",
               "ResourceName": null,
               "Children": [],
               "Enabled": true,

--- a/Examples/Soybean.apsimx
+++ b/Examples/Soybean.apsimx
@@ -1,44 +1,31 @@
 {
   "$type": "Models.Core.Simulations, Models",
-  "ExplorerWidth": 296,
-  "Version": 129,
-  "ApsimVersion": "0.0.0.0",
+  "Version": 168,
   "Name": "Simulations",
+  "ResourceName": null,
   "Children": [
     {
-      "$type": "Models.Storage.DataStore, Models",
-      "useFirebird": false,
-      "CustomFileName": null,
-      "Name": "DataStore",
-      "Children": [],
-      "IncludeInDocumentation": true,
-      "Enabled": true,
-      "ReadOnly": false
-    },
-    {
       "$type": "Models.Core.Simulation, Models",
-      "IsRunning": false,
       "Descriptors": null,
       "Name": "Simulation",
+      "ResourceName": null,
       "Children": [
         {
           "$type": "Models.Clock, Models",
-          "Start": "1900-01-01T00:00:00",
-          "End": "2000-12-31T00:00:00",
-          "Name": "clock",
+          "Start": "1900-01-01T00:00",
+          "End": "2000-12-31T00:00",
+          "Name": "Clock",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
         {
           "$type": "Models.Summary, Models",
-          "CaptureErrors": true,
-          "CaptureWarnings": true,
-          "CaptureSummaryText": true,
-          "Name": "summaryfile",
+          "Verbosity": 100,
+          "Name": "Summary",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
@@ -46,18 +33,18 @@
           "$type": "Models.Climate.Weather, Models",
           "ConstantsFile": null,
           "FileName": "%root%\\Examples\\WeatherFiles\\Dalby.met",
-          "ExcelWorkSheetName": "",
+          "ExcelWorkSheetName": null,
           "Name": "Weather",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
         {
           "$type": "Models.Soils.Arbitrator.SoilArbitrator, Models",
-          "Name": "Soil Arbitrator",
+          "Name": "SoilArbitrator",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
@@ -67,7 +54,8 @@
           "Slope": 0.0,
           "AspectAngle": 0.0,
           "Altitude": 50.0,
-          "Name": "paddock",
+          "Name": "Field",
+          "ResourceName": null,
           "Children": [
             {
               "$type": "Models.Report, Models",
@@ -89,23 +77,23 @@
                 "[Soybean].Harvesting"
               ],
               "GroupByVariableName": null,
-              "Name": "HarvestReport",
+              "Name": "Report",
+              "ResourceName": null,
               "Children": [],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Fertiliser, Models",
+              "Name": "Fertiliser",
               "ResourceName": "Fertiliser",
-              "Name": "fertiliser",
-              "IncludeInDocumentation": true,
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Soils.Soil, Models",
-              "RecordNumber": 0,
+              "RecordNumber": 104,
               "ASCOrder": "Vertosol",
               "ASCSubOrder": "Black",
               "SoilType": "Clay",
@@ -120,22 +108,14 @@
               "Latitude": -27.581836,
               "Longitude": 151.320206,
               "LocationAccuracy": " +/- 20m",
-              "YearOfSampling": null,
+              "YearOfSampling": "0",
               "DataSource": "CSIRO Sustainable Ecosystems, Toowoomba; Characteriesd as part of the GRDC funded project\"Doing it better, doing it smarter, managing soil water in Australian agriculture' 2011",
-              "Comments": "OC, CLL for all crops estimated-based on Bongeen Mywybilla Soil No1",
+              "Comments": "Clay - OC, CLL for all crops estimated-based on Bongeen Mywybilla Soil No1",
               "Name": "Soil",
+              "ResourceName": null,
               "Children": [
                 {
                   "$type": "Models.Soils.Physical, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180"
-                  ],
                   "Thickness": [
                     150.0,
                     150.0,
@@ -216,6 +196,7 @@
                   "ParticleSizeSiltMetadata": null,
                   "ParticleSizeClayMetadata": null,
                   "Name": "Physical",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Soils.SoilCrop, Models",
@@ -250,13 +231,12 @@
                       "KLMetadata": null,
                       "XFMetadata": null,
                       "Name": "SoybeanSoil",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -276,6 +256,7 @@
                   "CNCov": 0.8,
                   "DischargeWidth": "NaN",
                   "CatchmentArea": "NaN",
+                  "PSIDul": -100.0,
                   "Thickness": [
                     150.0,
                     150.0,
@@ -295,23 +276,14 @@
                     0.3
                   ],
                   "KLAT": null,
-                  "ResourceName": "WaterBalance",
                   "Name": "SoilWater",
-                  "IncludeInDocumentation": true,
+                  "ResourceName": "WaterBalance",
+                  "Children": [],
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Soils.Organic, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180"
-                  ],
                   "FOMCNRatio": 40.0,
                   "Thickness": [
                     150.0,
@@ -331,6 +303,7 @@
                     0.12,
                     0.12
                   ],
+                  "CarbonUnits": 0,
                   "SoilCNRatio": [
                     12.0,
                     12.0,
@@ -370,22 +343,13 @@
                   "CarbonMetadata": null,
                   "FOMMetadata": null,
                   "Name": "Organic",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Soils.Chemical, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180"
-                  ],
                   "Thickness": [
                     150.0,
                     150.0,
@@ -394,24 +358,6 @@
                     300.0,
                     300.0,
                     300.0
-                  ],
-                  "NO3N": [
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0
-                  ],
-                  "NH4N": [
-                    0.1,
-                    0.1,
-                    0.1,
-                    0.1,
-                    0.1,
-                    0.1,
-                    0.1
                   ],
                   "PH": [
                     8.0,
@@ -422,42 +368,22 @@
                     8.0,
                     8.0
                   ],
-                  "CL": null,
+                  "PHUnits": 0,
                   "EC": null,
                   "ESP": null,
+                  "CEC": null,
                   "ECMetadata": null,
                   "CLMetadata": null,
                   "ESPMetadata": null,
                   "PHMetadata": null,
                   "Name": "Chemical",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.Soils.InitialWater, Models",
-                  "PercentMethod": 1,
-                  "FractionFull": 1.0,
-                  "DepthWetSoil": "NaN",
-                  "RelativeTo": null,
-                  "Name": "InitialWater",
-                  "Children": [],
-                  "IncludeInDocumentation": true,
-                  "Enabled": true,
-                  "ReadOnly": false
-                },
-                {
-                  "$type": "Models.Soils.Sample, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180"
-                  ],
+                  "$type": "Models.Soils.Water, Models",
                   "Thickness": [
                     150.0,
                     150.0,
@@ -467,111 +393,162 @@
                     300.0,
                     300.0
                   ],
-                  "NO3": null,
-                  "NH4": null,
-                  "SW": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
+                  "InitialValues": [
+                    0.52100021807301,
+                    0.496723476938497,
+                    0.488437607673005,
+                    0.480296969355493,
+                    0.471583596524955,
+                    0.457070570557793,
+                    0.452331759845006
                   ],
-                  "OC": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "EC": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "CL": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "ESP": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "PH": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "SWUnits": 0,
-                  "OCUnits": 0,
-                  "PHUnits": 0,
-                  "Name": "InitialN",
+                  "InitialPAWmm": 361.2454283127387,
+                  "RelativeTo": "LL15",
+                  "FilledFromTop": false,
+                  "Name": "Water",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Soils.CERESSoilTemperature, Models",
                   "Name": "Temperature",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Soils.Nutrients.Nutrient, Models",
-                  "ResourceName": "Nutrient",
                   "Name": "Nutrient",
-                  "IncludeInDocumentation": true,
+                  "ResourceName": "Nutrient",
+                  "Children": [],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Soils.Solute, Models",
+                  "Thickness": [
+                    150.0,
+                    150.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0
+                  ],
+                  "InitialValues": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "InitialValuesUnits": 0,
+                  "WaterTableConcentration": 0.0,
+                  "D0": 0.0,
+                  "Exco": null,
+                  "FIP": null,
+                  "DepthConstant": 0.0,
+                  "MaxDepthSoluteAccessible": 0.0,
+                  "RunoffEffectivenessAtMovingSolute": 0.0,
+                  "MaxEffectiveRunoff": 0.0,
+                  "Name": "NO3",
+                  "ResourceName": null,
+                  "Children": [],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Soils.Solute, Models",
+                  "Thickness": [
+                    150.0,
+                    150.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0
+                  ],
+                  "InitialValues": [
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1
+                  ],
+                  "InitialValuesUnits": 0,
+                  "WaterTableConcentration": 0.0,
+                  "D0": 0.0,
+                  "Exco": null,
+                  "FIP": null,
+                  "DepthConstant": 0.0,
+                  "MaxDepthSoluteAccessible": 0.0,
+                  "RunoffEffectivenessAtMovingSolute": 0.0,
+                  "MaxEffectiveRunoff": 0.0,
+                  "Name": "NH4",
+                  "ResourceName": null,
+                  "Children": [],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Soils.Solute, Models",
+                  "Thickness": [
+                    150.0,
+                    150.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0
+                  ],
+                  "InitialValues": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "InitialValuesUnits": 1,
+                  "WaterTableConcentration": 0.0,
+                  "D0": 0.0,
+                  "Exco": null,
+                  "FIP": null,
+                  "DepthConstant": 0.0,
+                  "MaxDepthSoluteAccessible": 0.0,
+                  "RunoffEffectivenessAtMovingSolute": 0.0,
+                  "MaxEffectiveRunoff": 0.0,
+                  "Name": "Urea",
+                  "ResourceName": null,
+                  "Children": [],
                   "Enabled": true,
                   "ReadOnly": false
                 }
               ],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Surface.SurfaceOrganicMatter, Models",
+              "SurfOM": [],
+              "Canopies": [],
               "InitialResidueName": "maize",
               "InitialResidueType": "maize",
               "InitialResidueMass": 100.0,
               "InitialStandingFraction": 0.0,
               "InitialCPR": 0.0,
               "InitialCNR": 55.0,
-              "ResourceName": "SurfaceOrganicMatter",
               "Name": "SurfaceOrganicMatter",
-              "IncludeInDocumentation": true,
-              "Enabled": true,
-              "ReadOnly": false
-            },
-            {
-              "$type": "Models.PMF.Plant, Models",
-              "ResourceName": "Soybean",
-              "Name": "Soybean",
-              "IncludeInDocumentation": true,
+              "ResourceName": "SurfaceOrganicMatter",
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             },
@@ -581,48 +558,109 @@
               "b_interception": 1.0,
               "c_interception": 0.0,
               "d_interception": 0.0,
-              "soil_albedo": 0.23,
               "SoilHeatFluxFraction": 0.4,
               "MinimumHeightDiffForNewLayer": 0.0,
               "NightInterceptionFraction": 0.5,
               "ReferenceHeight": 2.0,
               "Name": "MicroClimate",
+              "ResourceName": null,
               "Children": [],
-              "IncludeInDocumentation": true,
+              "Enabled": true,
+              "ReadOnly": false
+            },
+            {
+              "$type": "Models.PMF.Plant, Models",
+              "Name": "Soybean",
+              "ResourceName": "Soybean",
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Manager, Models",
-              "Code": "using Models.PMF;\r\nusing Models.Core;\r\nusing System;\r\nusing System.Linq;\r\nnamespace Models\r\n{\r\n    [Serializable]\r\n    public class Script : Model\r\n    {\r\n        [Link] Clock Clock;\r\n        [Link] Fertiliser Fertiliser;\r\n        [Link] Summary Summary;\r\n        \r\n        \r\n        [Description(\"Amount of fertiliser to be applied (kg/ha)\")]\r\n        public double Amount { get; set;}\r\n        \r\n        [Description(\"Crop to be fertilised\")]\r\n        public string CropName { get; set;}\r\n        \r\n        \r\n        \r\n\r\n        [EventSubscribe(\"Sowing\")]\r\n        private void OnSowing(object sender, EventArgs e)\r\n        {\r\n            Model crop = sender as Model;\r\n            if (crop.Name.ToLower()==CropName.ToLower())\r\n                Fertiliser.Apply(Amount: Amount, Type: Fertiliser.Types.NO3N);\r\n        }\r\n        \r\n    }\r\n}\r\n",
-              "Parameters": [
-                {
-                  "Key": "Amount",
-                  "Value": "10"
-                },
-                {
-                  "Key": "CropName",
-                  "Value": "soybean"
-                }
+              "CodeArray": [
+                "using Models.Interfaces;",
+                "using APSIM.Shared.Utilities;",
+                "using Models.Utilities;",
+                "using Models.Soils;",
+                "using Models.PMF;",
+                "using Models.Core;",
+                "using System;",
+                "using System.Linq;",
+                "using Models.Climate;",
+                "",
+                "namespace Models",
+                "{",
+                "    [Serializable]",
+                "    public class Script : Model",
+                "    {",
+                "        [Link] private Clock Clock;",
+                "        [Link] private Fertiliser Fertiliser;",
+                "        [Link] private Summary Summary;",
+                "        [Link] private Soil Soil;",
+                "        private Accumulator accumulatedRain;",
+                "        [Link]",
+                "        private ISoilWater waterBalance;",
+                "        ",
+                "        [Description(\"Crop\")]",
+                "        public IPlant Crop { get; set; }",
+                "",
+                "        [Description(\"Start of sowing window (d-mmm)\")]",
+                "        public string StartDate { get; set; }",
+                "",
+                "        [Description(\"End of sowing window (d-mmm)\")]",
+                "        public string EndDate { get; set; }",
+                "",
+                "        [Description(\"Minimum extractable soil water for sowing (mm)\")]",
+                "        public double MinESW { get; set; }",
+                "",
+                "        [Description(\"Accumulated rainfall required for sowing (mm)\")]",
+                "        public double MinRain { get; set; }",
+                "",
+                "        [Description(\"Duration of rainfall accumulation (d)\")]",
+                "        public int RainDays { get; set; }",
+                "",
+                "        [Display(Type = DisplayType.CultivarName)]",
+                "        [Description(\"Cultivar to be sown\")]",
+                "        public string CultivarName { get; set; }",
+                "",
+                "        [Description(\"Sowing depth (mm)\")]",
+                "        public double SowingDepth { get; set; }",
+                "",
+                "        [Description(\"Row spacing (mm)\")]",
+                "        public double RowSpacing { get; set; }",
+                "",
+                "        [Description(\"Plant population (/m2)\")]",
+                "        public double Population { get; set; }",
+                "        ",
+                "        ",
+                "        [EventSubscribe(\"StartOfSimulation\")]",
+                "        private void OnSimulationCommencing(object sender, EventArgs e)",
+                "        {",
+                "            accumulatedRain = new Accumulator(this, \"[Weather].Rain\", RainDays);",
+                "        }",
+                "",
+                "        [EventSubscribe(\"DoManagement\")]",
+                "        private void OnDoManagement(object sender, EventArgs e)",
+                "        {",
+                "            accumulatedRain.Update();",
+                "            ",
+                "            if (DateUtilities.WithinDates(StartDate, Clock.Today, EndDate) &&",
+                "                !Crop.IsAlive &&",
+                "                MathUtilities.Sum(waterBalance.ESW) > MinESW &&",
+                "                accumulatedRain.Sum > MinRain)",
+                "            {",
+                "                Crop.Sow(population: Population, cultivar: CultivarName, depth: SowingDepth, rowSpacing: RowSpacing);    ",
+                "            }",
+                "        }",
+                "    }",
+                "}"
               ],
-              "Name": "SowingFertiliser",
-              "IncludeInDocumentation": true,
-              "Enabled": true,
-              "ReadOnly": false
-            },
-            {
-              "$type": "Models.Manager, Models",
-              "Code": "using Models.PMF.Phen;\r\nusing APSIM.Shared.Utilities;\r\nusing System.Xml.Serialization;\r\nusing Models;\r\nusing Models.PMF;\r\nusing Models.Soils;\r\nusing System.Text;\r\nusing System.Collections.Generic;\r\nusing Models.Core;\r\nusing System;\r\nusing System.Linq;\r\nusing Models.Soils.Nutrients;\r\n\r\nnamespace Models\r\n{\r\n    [Serializable] \r\n    public class Script : Model\r\n    {\r\n        [Link] private Plant Soybean;\r\n        [Link] private Zone zone;\r\n        [Link(Type = LinkType.Path, Path = \"[Soybean].Phenology\")]\r\n        private Phenology phenology;\r\n                    \r\n        \r\n        [EventSubscribe(\"StartOfSimulation\")]\r\n        private void OnSimulationCommencing(object sender, EventArgs e)\r\n        {\r\n        }\r\n        \r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n            if (phenology.CurrentPhase.Name == \"ReadyForHarvesting\")\r\n            {\r\n                Soybean.Harvest();\r\n                Soybean.EndCrop();\r\n            }\r\n        }\r\n        \r\n        [EventSubscribe(\"DoManagementCalculations\")]\r\n        private void OnDoManagementCalculations(object sender, EventArgs e)\r\n        {\r\n            \r\n        }\r\n    }\r\n}\r\n       \r\n",
-              "Parameters": [],
-              "Name": "Harvesting",
-              "IncludeInDocumentation": true,
-              "Enabled": true,
-              "ReadOnly": false
-            },
-            {
-              "$type": "Models.Manager, Models",
-              "Code": "using Models.Interfaces;\r\nusing System;\r\nusing System.Linq;\r\nusing Models.Core;\r\nusing Models.PMF;\r\nusing Models.Soils;\r\nusing Models.Soils.Nutrients;\r\nusing Models.Utilities;\r\nusing APSIM.Shared.Utilities;\r\nusing Models.Climate;\r\n\r\nnamespace Models\r\n{\r\n    [Serializable]\r\n    public class Script : Model\r\n    {\r\n        [Link] private Clock Clock;\r\n        [Link] private Fertiliser Fertiliser;\r\n        [Link] private Summary Summary;\r\n        [Link] private Plant Soybean;\r\n        [Link] private Soil Soil;\r\n        private Accumulator accumulatedRain;\r\n        [Link]\r\n        private ISoilWater waterBalance;\r\n        \r\n        [Description(\"Start of sowing window (d-mmm)\")]\r\n        public string StartDate { get; set; }\r\n        [Description(\"End of sowing window (d-mmm)\")]\r\n        public string EndDate { get; set; }\r\n        [Description(\"Minimum extractable soil water for sowing (mm)\")]\r\n        public double MinESW { get; set; }\r\n        [Description(\"Accumulated rainfall required for sowing (mm)\")]\r\n        public double MinRain { get; set; }\r\n        [Description(\"Duration of rainfall accumulation (d)\")]\r\n        public int RainDays { get; set; }\r\n        [Description(\"Cultivar to be sown\")]\r\n        [Display(Type=DisplayType.CultivarName, PlantName = \"Soybean\")]\r\n        public string CultivarName { get; set; }\r\n        [Description(\"Sowing depth (mm)\")]\r\n        public double SowingDepth { get; set; }\r\n        [Description(\"Row spacing (mm)\")]\r\n        public double RowSpacing { get; set; }\r\n        [Description(\"Plant population (/m2)\")]\r\n        public double Population { get; set; }\r\n        \r\n        \r\n        [EventSubscribe(\"StartOfSimulation\")]\r\n        private void OnSimulationCommencing(object sender, EventArgs e)\r\n        {\r\n            accumulatedRain = new Accumulator(this, \"[Weather].Rain\", RainDays);\r\n        }\r\n        \r\n\r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n            accumulatedRain.Update();\r\n            \r\n            if (DateUtilities.WithinDates(StartDate, Clock.Today, EndDate) &&\r\n                !Soybean.IsAlive &&\r\n                MathUtilities.Sum(waterBalance.ESW) > MinESW &&\r\n                accumulatedRain.Sum > MinRain)\r\n            {\r\n                Soybean.Sow(population: Population, cultivar: CultivarName, depth: SowingDepth, rowSpacing: RowSpacing);    \r\n            }\r\n        \r\n        }\r\n        \r\n    }\r\n}\r\n",
               "Parameters": [
+                {
+                  "Key": "Crop",
+                  "Value": "Soybean"
+                },
                 {
                   "Key": "StartDate",
                   "Value": "1-sep"
@@ -633,15 +671,15 @@
                 },
                 {
                   "Key": "MinESW",
-                  "Value": "100"
+                  "Value": 100.0
                 },
                 {
                   "Key": "MinRain",
-                  "Value": "25"
+                  "Value": 25.0
                 },
                 {
                   "Key": "RainDays",
-                  "Value": "7"
+                  "Value": 7
                 },
                 {
                   "Key": "CultivarName",
@@ -649,24 +687,123 @@
                 },
                 {
                   "Key": "SowingDepth",
-                  "Value": "50"
+                  "Value": 50.0
                 },
                 {
                   "Key": "RowSpacing",
-                  "Value": "750"
+                  "Value": 750.0
                 },
                 {
                   "Key": "Population",
-                  "Value": "38"
+                  "Value": 38.0
                 }
               ],
-              "Name": "SowingRule",
-              "IncludeInDocumentation": true,
+              "Name": "Sow using a variable rule",
+              "ResourceName": null,
+              "Children": [],
+              "Enabled": true,
+              "ReadOnly": false
+            },
+            {
+              "$type": "Models.Manager, Models",
+              "CodeArray": [
+                "using Models.Soils;",
+                "using System;",
+                "using System.Linq;",
+                "using Models.Core;",
+                "using Models.PMF;",
+                "namespace Models",
+                "{",
+                "    [Serializable]",
+                "    public class Script : Model",
+                "    {",
+                "        [Link] Clock Clock;",
+                "        [Link] Fertiliser Fertiliser;",
+                "        ",
+                "        [Description(\"Crop to be fertilised\")]",
+                "        public IPlant Crop { get; set; }",
+                "",
+                "        [Description(\"Type of fertiliser to apply? \")] ",
+                "        public Fertiliser.Types FertiliserType { get; set; }",
+                "    ",
+                "        [Description(\"Amount of fertiliser to be applied (kg/ha)\")]",
+                "        public double Amount { get; set; }",
+                "        ",
+                "        [EventSubscribe(\"Sowing\")]",
+                "        private void OnSowing(object sender, EventArgs e)",
+                "        {",
+                "            Model crop = sender as Model;",
+                "            if (Crop != null && crop.Name.ToLower() == (Crop as IModel).Name.ToLower())",
+                "                Fertiliser.Apply(Amount: Amount, Type: FertiliserType);",
+                "        }",
+                "    }",
+                "}"
+              ],
+              "Parameters": [
+                {
+                  "Key": "Crop",
+                  "Value": "Soybean"
+                },
+                {
+                  "Key": "FertiliserType",
+                  "Value": "NO3N"
+                },
+                {
+                  "Key": "Amount",
+                  "Value": 10.0
+                }
+              ],
+              "Name": "Fertilise at sowing",
+              "ResourceName": null,
+              "Children": [],
+              "Enabled": true,
+              "ReadOnly": false
+            },
+            {
+              "$type": "Models.Manager, Models",
+              "CodeArray": [
+                "using APSIM.Shared.Utilities;",
+                "using Models.Utilities;",
+                "using Models.Soils;",
+                "using Models.PMF;",
+                "using Models.Core;",
+                "using System;",
+                "using System.Linq;",
+                "",
+                "namespace Models",
+                "{",
+                "    [Serializable] ",
+                "    public class Script : Model",
+                "    {",
+                "        [Description(\"Crop\")]",
+                "        public IPlant Crop { get; set; }",
+                "        ",
+                "        [EventSubscribe(\"DoManagement\")]",
+                "        private void OnDoManagement(object sender, EventArgs e)",
+                "        {",
+                "            if (Crop.IsReadyForHarvesting)",
+                "            {",
+                "                Crop.Harvest();",
+                "                Crop.EndCrop();",
+                "            }",
+                "        }",
+                "    }",
+                "}",
+                "       "
+              ],
+              "Parameters": [
+                {
+                  "Key": "Crop",
+                  "Value": "Soybean"
+                }
+              ],
+              "Name": "Harvest",
+              "ResourceName": null,
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             }
           ],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
@@ -675,40 +812,40 @@
           "Caption": null,
           "Axis": [
             {
-              "$type": "Models.Axis, Models",
-              "Type": 3,
+              "$type": "APSIM.Shared.Graphing.Axis, APSIM.Shared",
               "Title": "Date",
+              "Position": 3,
               "Inverted": false,
-              "Minimum": "NaN",
-              "Maximum": "NaN",
-              "Interval": "NaN",
-              "DateTimeAxis": false,
-              "CrossesAtZero": false
+              "CrossesAtZero": false,
+              "Minimum": null,
+              "Maximum": null,
+              "Interval": null
             },
             {
-              "$type": "Models.Axis, Models",
-              "Type": 0,
-              "Title": null,
+              "$type": "APSIM.Shared.Graphing.Axis, APSIM.Shared",
+              "Title": "Yield (kg/ha)",
+              "Position": 0,
               "Inverted": false,
-              "Minimum": "NaN",
-              "Maximum": "NaN",
-              "Interval": "NaN",
-              "DateTimeAxis": false,
-              "CrossesAtZero": false
+              "CrossesAtZero": false,
+              "Minimum": null,
+              "Maximum": null,
+              "Interval": null
             }
           ],
           "LegendPosition": 0,
           "LegendOrientation": 0,
-          "DisabledSeries": [],
+          "AnnotationLocation": 0,
+          "DisabledSeries": null,
           "LegendOutsideGraph": false,
           "Name": "Soybean Yield Time Series",
+          "ResourceName": null,
           "Children": [
             {
               "$type": "Models.Series, Models",
               "Type": 1,
               "XAxis": 3,
               "YAxis": 0,
-              "ColourArgb": -1663232,
+              "ColourArgb": -16777216,
               "FactorToVaryColours": null,
               "FactorToVaryMarkers": null,
               "FactorToVaryLines": null,
@@ -716,34 +853,41 @@
               "MarkerSize": 0,
               "Line": 0,
               "LineThickness": 0,
-              "TableName": "HarvestReport",
+              "TableName": "Report",
               "XFieldName": "Clock.Today",
-              "YFieldName": "Soybean.Grain.Total.Wt",
-              "X2FieldName": "",
-              "Y2FieldName": "",
+              "YFieldName": "Yield",
+              "X2FieldName": null,
+              "Y2FieldName": null,
               "ShowInLegend": false,
               "IncludeSeriesNameInLegend": false,
               "Cumulative": false,
               "CumulativeX": false,
               "Filter": null,
-              "Name": "Series 1",
+              "Name": "Soybean Yield",
+              "ResourceName": null,
               "Children": [],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             }
           ],
-          "IncludeInDocumentation": false,
           "Enabled": true,
           "ReadOnly": false
         }
       ],
-      "IncludeInDocumentation": true,
+      "Enabled": true,
+      "ReadOnly": false
+    },
+    {
+      "$type": "Models.Storage.DataStore, Models",
+      "useFirebird": false,
+      "CustomFileName": null,
+      "Name": "DataStore",
+      "ResourceName": null,
+      "Children": [],
       "Enabled": true,
       "ReadOnly": false
     }
   ],
-  "IncludeInDocumentation": true,
   "Enabled": true,
   "ReadOnly": false
 }

--- a/Examples/Wheat.apsimx
+++ b/Examples/Wheat.apsimx
@@ -12,8 +12,8 @@
       "Children": [
         {
           "$type": "Models.Clock, Models",
-          "Start": "1900-01-01T00:00",
-          "End": "2000-12-31T00:00",
+          "Start": "1900-01-01T00:00:00",
+          "End": "2000-12-31T00:00:00",
           "Name": "Clock",
           "ResourceName": null,
           "Children": [],
@@ -33,7 +33,7 @@
           "$type": "Models.Climate.Weather, Models",
           "ConstantsFile": null,
           "FileName": "%root%\\Examples\\WeatherFiles\\Dalby.met",
-          "ExcelWorkSheetName": null,
+          "ExcelWorkSheetName": "",
           "Name": "Weather",
           "ResourceName": null,
           "Children": [],
@@ -43,6 +43,22 @@
         {
           "$type": "Models.Soils.Arbitrator.SoilArbitrator, Models",
           "Name": "SoilArbitrator",
+          "ResourceName": null,
+          "Children": [],
+          "Enabled": true,
+          "ReadOnly": false
+        },
+        {
+          "$type": "Models.MicroClimate, Models",
+          "a_interception": 0.0,
+          "b_interception": 1.0,
+          "c_interception": 0.0,
+          "d_interception": 0.0,
+          "SoilHeatFluxFraction": 0.4,
+          "MinimumHeightDiffForNewLayer": 0.0,
+          "NightInterceptionFraction": 0.5,
+          "ReferenceHeight": 2.0,
+          "Name": "MicroClimate",
           "ResourceName": null,
           "Children": [],
           "Enabled": true,
@@ -554,22 +570,6 @@
               "ReadOnly": false
             },
             {
-              "$type": "Models.MicroClimate, Models",
-              "a_interception": 0.0,
-              "b_interception": 1.0,
-              "c_interception": 0.0,
-              "d_interception": 0.0,
-              "SoilHeatFluxFraction": 0.4,
-              "MinimumHeightDiffForNewLayer": 0.0,
-              "NightInterceptionFraction": 0.5,
-              "ReferenceHeight": 2.0,
-              "Name": "MicroClimate",
-              "ResourceName": null,
-              "Children": [],
-              "Enabled": true,
-              "ReadOnly": false
-            },
-            {
               "$type": "Models.PMF.Plant, Models",
               "Name": "Wheat",
               "ResourceName": "Wheat",
@@ -672,15 +672,15 @@
                 },
                 {
                   "Key": "MinESW",
-                  "Value": 100.0
+                  "Value": "100.0"
                 },
                 {
                   "Key": "MinRain",
-                  "Value": 25.0
+                  "Value": "25.0"
                 },
                 {
                   "Key": "RainDays",
-                  "Value": 7
+                  "Value": "7"
                 },
                 {
                   "Key": "CultivarName",
@@ -688,15 +688,15 @@
                 },
                 {
                   "Key": "SowingDepth",
-                  "Value": 30.0
+                  "Value": "30.0"
                 },
                 {
                   "Key": "RowSpacing",
-                  "Value": 250.0
+                  "Value": "250.0"
                 },
                 {
                   "Key": "Population",
-                  "Value": 120.0
+                  "Value": "120.0"
                 }
               ],
               "Name": "Sow using a variable rule",
@@ -751,7 +751,7 @@
                 },
                 {
                   "Key": "Amount",
-                  "Value": 160.0
+                  "Value": "160.0"
                 }
               ],
               "Name": "Fertilise at sowing",
@@ -824,7 +824,7 @@
             },
             {
               "$type": "APSIM.Shared.Graphing.Axis, APSIM.Shared",
-              "Title": "Yield (kg/ha)",
+              "Title": null,
               "Position": 0,
               "Inverted": false,
               "CrossesAtZero": false,
@@ -838,7 +838,7 @@
           "AnnotationLocation": 0,
           "DisabledSeries": null,
           "LegendOutsideGraph": false,
-          "Name": "Wheat Yield Time Series",
+          "Name": "Graph",
           "ResourceName": null,
           "Children": [
             {
@@ -856,7 +856,7 @@
               "LineThickness": 0,
               "TableName": "Report",
               "XFieldName": "Clock.Today",
-              "YFieldName": "Yield",
+              "YFieldName": "Wheat.Grain.Total.Wt",
               "X2FieldName": null,
               "Y2FieldName": null,
               "ShowInLegend": false,
@@ -864,7 +864,7 @@
               "Cumulative": false,
               "CumulativeX": false,
               "Filter": null,
-              "Name": "Wheat Yield",
+              "Name": "Series",
               "ResourceName": null,
               "Children": [],
               "Enabled": true,

--- a/Examples/Wheat.apsimx
+++ b/Examples/Wheat.apsimx
@@ -1,51 +1,50 @@
 {
   "$type": "Models.Core.Simulations, Models",
-  "ExplorerWidth": 296,
-  "Version": 100,
-  "ApsimVersion": "0.0.0.0",
+  "Version": 168,
   "Name": "Simulations",
+  "ResourceName": null,
   "Children": [
     {
       "$type": "Models.Core.Simulation, Models",
-      "IsRunning": false,
+      "Descriptors": null,
       "Name": "Simulation",
+      "ResourceName": null,
       "Children": [
         {
           "$type": "Models.Clock, Models",
-          "Start": "1900-01-01T00:00:00",
-          "End": "2000-12-31T00:00:00",
+          "Start": "1900-01-01T00:00",
+          "End": "2000-12-31T00:00",
           "Name": "Clock",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
         {
           "$type": "Models.Summary, Models",
-          "CaptureErrors": true,
-          "CaptureWarnings": true,
-          "CaptureSummaryText": true,
-          "Name": "SummaryFile",
+          "Verbosity": 100,
+          "Name": "Summary",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
         {
-          "$type": "Models.Weather, Models",
+          "$type": "Models.Climate.Weather, Models",
+          "ConstantsFile": null,
           "FileName": "%root%\\Examples\\WeatherFiles\\Dalby.met",
           "ExcelWorkSheetName": null,
           "Name": "Weather",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
         {
           "$type": "Models.Soils.Arbitrator.SoilArbitrator, Models",
           "Name": "SoilArbitrator",
+          "ResourceName": null,
           "Children": [],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
@@ -56,11 +55,13 @@
           "AspectAngle": 0.0,
           "Altitude": 50.0,
           "Name": "Field",
+          "ResourceName": null,
           "Children": [
             {
               "$type": "Models.Report, Models",
               "VariableNames": [
                 "[Clock].Today",
+                "[Wheat].LAI",
                 "[Wheat].Phenology.Zadok.Stage",
                 "[Wheat].Phenology.CurrentStageName",
                 "[Wheat].AboveGround.Wt",
@@ -78,22 +79,22 @@
               ],
               "GroupByVariableName": null,
               "Name": "Report",
+              "ResourceName": null,
               "Children": [],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Fertiliser, Models",
               "Name": "Fertiliser",
+              "ResourceName": "Fertiliser",
               "Children": [],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Soils.Soil, Models",
-              "RecordNumber": 0,
+              "RecordNumber": 104,
               "ASCOrder": "Vertosol",
               "ASCSubOrder": "Black",
               "SoilType": "Clay",
@@ -108,21 +109,14 @@
               "Latitude": -27.581836,
               "Longitude": 151.320206,
               "LocationAccuracy": " +/- 20m",
+              "YearOfSampling": "0",
               "DataSource": "CSIRO Sustainable Ecosystems, Toowoomba; Characteriesd as part of the GRDC funded project\"Doing it better, doing it smarter, managing soil water in Australian agriculture' 2011",
-              "Comments": "OC, CLL for all crops estimated-based on Bongeen Mywybilla Soil No1",
+              "Comments": "Clay - OC, CLL for all crops estimated-based on Bongeen Mywybilla Soil No1",
               "Name": "Soil",
+              "ResourceName": null,
               "Children": [
                 {
                   "$type": "Models.Soils.Physical, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180"
-                  ],
                   "Thickness": [
                     150.0,
                     150.0,
@@ -135,6 +129,8 @@
                   "ParticleSizeClay": null,
                   "ParticleSizeSand": null,
                   "ParticleSizeSilt": null,
+                  "Rocks": null,
+                  "Texture": null,
                   "BD": [
                     1.01056473311131,
                     1.07145631083388,
@@ -195,7 +191,13 @@
                   "DULMetadata": null,
                   "SATMetadata": null,
                   "KSMetadata": null,
+                  "RocksMetadata": null,
+                  "TextureMetadata": null,
+                  "ParticleSizeSandMetadata": null,
+                  "ParticleSizeSiltMetadata": null,
+                  "ParticleSizeClayMetadata": null,
                   "Name": "Physical",
+                  "ResourceName": null,
                   "Children": [
                     {
                       "$type": "Models.Soils.SoilCrop, Models",
@@ -230,13 +232,12 @@
                       "KLMetadata": null,
                       "XFMetadata": null,
                       "Name": "WheatSoil",
+                      "ResourceName": null,
                       "Children": [],
-                      "IncludeInDocumentation": true,
                       "Enabled": true,
                       "ReadOnly": false
                     }
                   ],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
@@ -254,9 +255,9 @@
                   "CN2Bare": 73.0,
                   "CNRed": 20.0,
                   "CNCov": 0.8,
-                  "Slope": "NaN",
                   "DischargeWidth": "NaN",
                   "CatchmentArea": "NaN",
+                  "PSIDul": -100.0,
                   "Thickness": [
                     150.0,
                     150.0,
@@ -276,23 +277,14 @@
                     0.3
                   ],
                   "KLAT": null,
-                  "ResourceName": "WaterBalance",
                   "Name": "SoilWater",
-                  "IncludeInDocumentation": true,
+                  "ResourceName": "WaterBalance",
+                  "Children": [],
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Soils.Organic, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180"
-                  ],
                   "FOMCNRatio": 40.0,
                   "Thickness": [
                     150.0,
@@ -312,6 +304,7 @@
                     0.12,
                     0.12
                   ],
+                  "CarbonUnits": 0,
                   "SoilCNRatio": [
                     12.0,
                     12.0,
@@ -340,31 +333,24 @@
                     1.0
                   ],
                   "FOM": [
-                    347.12903231275641,
+                    347.1290323127564,
                     270.3443621919937,
                     163.97214434990104,
-                    99.454132887040629,
-                    60.321980831124677,
-                    36.587130828674873,
+                    99.45413288704063,
+                    60.32198083112468,
+                    36.58713082867487,
                     22.1912165985086
                   ],
+                  "CarbonMetadata": null,
+                  "FOMMetadata": null,
                   "Name": "Organic",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Soils.Chemical, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180"
-                  ],
                   "Thickness": [
                     150.0,
                     150.0,
@@ -373,24 +359,6 @@
                     300.0,
                     300.0,
                     300.0
-                  ],
-                  "NO3N": [
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0,
-                    1.0
-                  ],
-                  "NH4N": [
-                    0.1,
-                    0.1,
-                    0.1,
-                    0.1,
-                    0.1,
-                    0.1,
-                    0.1
                   ],
                   "PH": [
                     8.0,
@@ -401,38 +369,22 @@
                     8.0,
                     8.0
                   ],
-                  "CL": null,
+                  "PHUnits": 0,
                   "EC": null,
                   "ESP": null,
+                  "CEC": null,
+                  "ECMetadata": null,
+                  "CLMetadata": null,
+                  "ESPMetadata": null,
+                  "PHMetadata": null,
                   "Name": "Chemical",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
-                  "$type": "Models.Soils.InitialWater, Models",
-                  "PercentMethod": 1,
-                  "FractionFull": 1.0,
-                  "DepthWetSoil": "NaN",
-                  "RelativeTo": null,
-                  "Name": "InitialWater",
-                  "Children": [],
-                  "IncludeInDocumentation": true,
-                  "Enabled": true,
-                  "ReadOnly": false
-                },
-                {
-                  "$type": "Models.Soils.Sample, Models",
-                  "Depth": [
-                    "0-15",
-                    "15-30",
-                    "30-60",
-                    "60-90",
-                    "90-120",
-                    "120-150",
-                    "150-180"
-                  ],
+                  "$type": "Models.Soils.Water, Models",
                   "Thickness": [
                     150.0,
                     150.0,
@@ -442,111 +394,162 @@
                     300.0,
                     300.0
                   ],
-                  "NO3N": null,
-                  "NH4N": null,
-                  "SW": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
+                  "InitialValues": [
+                    0.52100021807301,
+                    0.496723476938497,
+                    0.488437607673005,
+                    0.480296969355493,
+                    0.471583596524955,
+                    0.457070570557793,
+                    0.452331759845006
                   ],
-                  "OC": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "EC": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "CL": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "ESP": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "PH": [
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN",
-                    "NaN"
-                  ],
-                  "SWUnits": 0,
-                  "OCUnits": 0,
-                  "PHUnits": 0,
-                  "Name": "InitialN",
+                  "InitialPAWmm": 361.2454283127387,
+                  "RelativeTo": "LL15",
+                  "FilledFromTop": false,
+                  "Name": "Water",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Soils.CERESSoilTemperature, Models",
-                  "Name": "CERESSoilTemperature",
+                  "Name": "Temperature",
+                  "ResourceName": null,
                   "Children": [],
-                  "IncludeInDocumentation": true,
                   "Enabled": true,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Soils.Nutrients.Nutrient, Models",
-                  "ResourceName": "Nutrient",
                   "Name": "Nutrient",
-                  "IncludeInDocumentation": true,
+                  "ResourceName": "Nutrient",
+                  "Children": [],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Soils.Solute, Models",
+                  "Thickness": [
+                    150.0,
+                    150.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0
+                  ],
+                  "InitialValues": [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0
+                  ],
+                  "InitialValuesUnits": 0,
+                  "WaterTableConcentration": 0.0,
+                  "D0": 0.0,
+                  "Exco": null,
+                  "FIP": null,
+                  "DepthConstant": 0.0,
+                  "MaxDepthSoluteAccessible": 0.0,
+                  "RunoffEffectivenessAtMovingSolute": 0.0,
+                  "MaxEffectiveRunoff": 0.0,
+                  "Name": "NO3",
+                  "ResourceName": null,
+                  "Children": [],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Soils.Solute, Models",
+                  "Thickness": [
+                    150.0,
+                    150.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0
+                  ],
+                  "InitialValues": [
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.1
+                  ],
+                  "InitialValuesUnits": 0,
+                  "WaterTableConcentration": 0.0,
+                  "D0": 0.0,
+                  "Exco": null,
+                  "FIP": null,
+                  "DepthConstant": 0.0,
+                  "MaxDepthSoluteAccessible": 0.0,
+                  "RunoffEffectivenessAtMovingSolute": 0.0,
+                  "MaxEffectiveRunoff": 0.0,
+                  "Name": "NH4",
+                  "ResourceName": null,
+                  "Children": [],
+                  "Enabled": true,
+                  "ReadOnly": false
+                },
+                {
+                  "$type": "Models.Soils.Solute, Models",
+                  "Thickness": [
+                    150.0,
+                    150.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0,
+                    300.0
+                  ],
+                  "InitialValues": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ],
+                  "InitialValuesUnits": 1,
+                  "WaterTableConcentration": 0.0,
+                  "D0": 0.0,
+                  "Exco": null,
+                  "FIP": null,
+                  "DepthConstant": 0.0,
+                  "MaxDepthSoluteAccessible": 0.0,
+                  "RunoffEffectivenessAtMovingSolute": 0.0,
+                  "MaxEffectiveRunoff": 0.0,
+                  "Name": "Urea",
+                  "ResourceName": null,
+                  "Children": [],
                   "Enabled": true,
                   "ReadOnly": false
                 }
               ],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Surface.SurfaceOrganicMatter, Models",
+              "SurfOM": [],
+              "Canopies": [],
               "InitialResidueName": "wheat_stubble",
               "InitialResidueType": "wheat",
               "InitialResidueMass": 500.0,
               "InitialStandingFraction": 0.0,
               "InitialCPR": 0.0,
               "InitialCNR": 100.0,
-              "ResourceName": "SurfaceOrganicMatter",
               "Name": "SurfaceOrganicMatter",
-              "IncludeInDocumentation": true,
-              "Enabled": true,
-              "ReadOnly": false
-            },
-            {
-              "$type": "Models.PMF.Plant, Models",
-              "ResourceName": "Wheat",
-              "Name": "Wheat",
-              "IncludeInDocumentation": true,
+              "ResourceName": "SurfaceOrganicMatter",
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             },
@@ -556,48 +559,109 @@
               "b_interception": 1.0,
               "c_interception": 0.0,
               "d_interception": 0.0,
-              "soil_albedo": 0.3,
               "SoilHeatFluxFraction": 0.4,
               "MinimumHeightDiffForNewLayer": 0.0,
               "NightInterceptionFraction": 0.5,
               "ReferenceHeight": 2.0,
               "Name": "MicroClimate",
+              "ResourceName": null,
               "Children": [],
-              "IncludeInDocumentation": true,
+              "Enabled": true,
+              "ReadOnly": false
+            },
+            {
+              "$type": "Models.PMF.Plant, Models",
+              "Name": "Wheat",
+              "ResourceName": "Wheat",
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             },
             {
               "$type": "Models.Manager, Models",
-              "Code": "using Models.PMF;\r\nusing Models.Core;\r\nusing System;\r\nusing System.Linq;\r\nnamespace Models\r\n{\r\n    [Serializable]\r\n    public class Script : Model\r\n    {\r\n        [Link] Clock Clock;\r\n        [Link] Fertiliser Fertiliser;\r\n        [Link] Summary Summary;\r\n        \r\n        \r\n        [Description(\"Amount of fertiliser to be applied (kg/ha)\")]\r\n        public double Amount { get; set;}\r\n        \r\n        [Description(\"Crop to be fertilised\")]\r\n        public string CropName { get; set;}\r\n        \r\n        \r\n        \r\n\r\n        [EventSubscribe(\"Sowing\")]\r\n        private void OnSowing(object sender, EventArgs e)\r\n        {\r\n            Model crop = sender as Model;\r\n            if (crop.Name.ToLower()==CropName.ToLower())\r\n                Fertiliser.Apply(Amount: Amount, Type: Fertiliser.Types.NO3N);\r\n        }\r\n        \r\n    }\r\n}\r\n",
-              "Parameters": [
-                {
-                  "Key": "Amount",
-                  "Value": "160"
-                },
-                {
-                  "Key": "CropName",
-                  "Value": "wheat"
-                }
+              "CodeArray": [
+                "using Models.Interfaces;",
+                "using APSIM.Shared.Utilities;",
+                "using Models.Utilities;",
+                "using Models.Soils;",
+                "using Models.PMF;",
+                "using Models.Core;",
+                "using System;",
+                "using System.Linq;",
+                "using Models.Climate;",
+                "",
+                "namespace Models",
+                "{",
+                "    [Serializable]",
+                "    public class Script : Model",
+                "    {",
+                "        [Link] private Clock Clock;",
+                "        [Link] private Fertiliser Fertiliser;",
+                "        [Link] private Summary Summary;",
+                "        [Link] private Soil Soil;",
+                "        private Accumulator accumulatedRain;",
+                "        [Link]",
+                "        private ISoilWater waterBalance;",
+                "        ",
+                "        [Description(\"Crop\")]",
+                "        public IPlant Crop { get; set; }",
+                "",
+                "        [Description(\"Start of sowing window (d-mmm)\")]",
+                "        public string StartDate { get; set; }",
+                "",
+                "        [Description(\"End of sowing window (d-mmm)\")]",
+                "        public string EndDate { get; set; }",
+                "",
+                "        [Description(\"Minimum extractable soil water for sowing (mm)\")]",
+                "        public double MinESW { get; set; }",
+                "",
+                "        [Description(\"Accumulated rainfall required for sowing (mm)\")]",
+                "        public double MinRain { get; set; }",
+                "",
+                "        [Description(\"Duration of rainfall accumulation (d)\")]",
+                "        public int RainDays { get; set; }",
+                "",
+                "        [Display(Type = DisplayType.CultivarName)]",
+                "        [Description(\"Cultivar to be sown\")]",
+                "        public string CultivarName { get; set; }",
+                "",
+                "        [Description(\"Sowing depth (mm)\")]",
+                "        public double SowingDepth { get; set; }",
+                "",
+                "        [Description(\"Row spacing (mm)\")]",
+                "        public double RowSpacing { get; set; }",
+                "",
+                "        [Description(\"Plant population (/m2)\")]",
+                "        public double Population { get; set; }",
+                "        ",
+                "        ",
+                "        [EventSubscribe(\"StartOfSimulation\")]",
+                "        private void OnSimulationCommencing(object sender, EventArgs e)",
+                "        {",
+                "            accumulatedRain = new Accumulator(this, \"[Weather].Rain\", RainDays);",
+                "        }",
+                "",
+                "        [EventSubscribe(\"DoManagement\")]",
+                "        private void OnDoManagement(object sender, EventArgs e)",
+                "        {",
+                "            accumulatedRain.Update();",
+                "            ",
+                "            if (DateUtilities.WithinDates(StartDate, Clock.Today, EndDate) &&",
+                "                !Crop.IsAlive &&",
+                "                MathUtilities.Sum(waterBalance.ESW) > MinESW &&",
+                "                accumulatedRain.Sum > MinRain)",
+                "            {",
+                "                Crop.Sow(population: Population, cultivar: CultivarName, depth: SowingDepth, rowSpacing: RowSpacing);    ",
+                "            }",
+                "        }",
+                "    }",
+                "}"
               ],
-              "Name": "SowingFertiliser",
-              "IncludeInDocumentation": true,
-              "Enabled": true,
-              "ReadOnly": false
-            },
-            {
-              "$type": "Models.Manager, Models",
-              "Code": "using APSIM.Shared.Utilities;\r\nusing Models.Utilities;\r\nusing Models.Soils.Nutrients;\r\nusing Models.Soils;\r\nusing Models.PMF;\r\nusing Models.Core;\r\nusing System;\r\nusing System.Linq;\r\n\r\nnamespace Models\r\n{\r\n    [Serializable]\r\n    public class Script : Model\r\n    {\r\n        [Link] Plant Wheat;\r\n\r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n            if (Wheat.IsReadyForHarvesting)\r\n            {\r\n               Wheat.Harvest();\r\n               Wheat.EndCrop();    \r\n            }\r\n        \r\n        }\r\n        \r\n    }\r\n}\r\n",
-              "Parameters": null,
-              "Name": "Harvest",
-              "IncludeInDocumentation": true,
-              "Enabled": true,
-              "ReadOnly": false
-            },
-            {
-              "$type": "Models.Manager, Models",
-              "Code": "using APSIM.Shared.Utilities;\r\nusing Models.Utilities;\r\nusing Models.Soils.Nutrients;\r\nusing Models.Soils;\r\nusing Models.PMF;\r\nusing Models.Core;\r\nusing System;\r\nusing System.Linq;\r\n\r\nnamespace Models\r\n{\r\n    [Serializable]\r\n    public class Script : Model\r\n    {\r\n        [Link] Clock Clock;\r\n        [Link] Fertiliser Fertiliser;\r\n        [Link] Summary Summary;\r\n        [Link(ByName = true)] Plant Wheat;\r\n        [Link] Soil Soil; \r\n        Accumulator accumulatedRain;\r\n        \r\n        [Description(\"Start of sowing window (d-mmm)\")]\r\n        public string StartDate { get; set;}\r\n        [Description(\"End of sowing window (d-mmm)\")]\r\n        public string EndDate { get; set;}\r\n        [Description(\"Minimum extractable soil water for sowing (mm)\")]\r\n        public double MinESW { get; set;}\r\n        [Description(\"Accumulated rainfall required for sowing (mm)\")]\r\n        public double MinRain { get; set;}\r\n        [Description(\"Duration of rainfall accumulation (d)\")]\r\n        public int RainDays { get; set;}\r\n        [Description(\"Cultivar to be sown\")]\r\n        [Display(Type=DisplayType.CultivarName, PlantName = \"Wheat\")]\r\n        public string CultivarName { get; set;}\r\n        [Description(\"Sowing depth (mm)\")]\r\n        public double SowingDepth { get; set;}        \r\n        [Description(\"Row spacing (mm)\")]\r\n        public double RowSpacing { get; set;}    \r\n        [Description(\"Plant population (/m2)\")]\r\n        public double Population { get; set;}    \r\n        \r\n        \r\n        [EventSubscribe(\"StartOfSimulation\")]\r\n        private void OnSimulationCommencing(object sender, EventArgs e)\r\n        {\r\n            accumulatedRain = new Accumulator(this, \"[Weather].Rain\", RainDays);\r\n        }\r\n        \r\n\r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n            accumulatedRain.Update();\r\n            \r\n            if (DateUtilities.WithinDates(StartDate,Clock.Today,EndDate) &&\r\n                !Wheat.IsAlive &&\r\n                MathUtilities.Sum(Soil.SoilWater.ESW) > MinESW &&\r\n                accumulatedRain.Sum > MinRain)\r\n            {\r\n               Wheat.Sow(population:Population, cultivar:CultivarName, depth:SowingDepth, rowSpacing:RowSpacing);    \r\n            }\r\n        \r\n        }\r\n        \r\n    }\r\n}\r\n",
               "Parameters": [
+                {
+                  "Key": "Crop",
+                  "Value": "Wheat"
+                },
                 {
                   "Key": "StartDate",
                   "Value": "1-may"
@@ -608,15 +672,15 @@
                 },
                 {
                   "Key": "MinESW",
-                  "Value": "100"
+                  "Value": 100.0
                 },
                 {
                   "Key": "MinRain",
-                  "Value": "25"
+                  "Value": 25.0
                 },
                 {
                   "Key": "RainDays",
-                  "Value": "7"
+                  "Value": 7
                 },
                 {
                   "Key": "CultivarName",
@@ -624,24 +688,123 @@
                 },
                 {
                   "Key": "SowingDepth",
-                  "Value": "30"
+                  "Value": 30.0
                 },
                 {
                   "Key": "RowSpacing",
-                  "Value": "250"
+                  "Value": 250.0
                 },
                 {
                   "Key": "Population",
-                  "Value": "120"
+                  "Value": 120.0
                 }
               ],
-              "Name": "SowingRule1",
-              "IncludeInDocumentation": true,
+              "Name": "Sow using a variable rule",
+              "ResourceName": null,
+              "Children": [],
+              "Enabled": true,
+              "ReadOnly": false
+            },
+            {
+              "$type": "Models.Manager, Models",
+              "CodeArray": [
+                "using Models.Soils;",
+                "using System;",
+                "using System.Linq;",
+                "using Models.Core;",
+                "using Models.PMF;",
+                "namespace Models",
+                "{",
+                "    [Serializable]",
+                "    public class Script : Model",
+                "    {",
+                "        [Link] Clock Clock;",
+                "        [Link] Fertiliser Fertiliser;",
+                "        ",
+                "        [Description(\"Crop to be fertilised\")]",
+                "        public IPlant Crop { get; set; }",
+                "",
+                "        [Description(\"Type of fertiliser to apply? \")] ",
+                "        public Fertiliser.Types FertiliserType { get; set; }",
+                "    ",
+                "        [Description(\"Amount of fertiliser to be applied (kg/ha)\")]",
+                "        public double Amount { get; set; }",
+                "        ",
+                "        [EventSubscribe(\"Sowing\")]",
+                "        private void OnSowing(object sender, EventArgs e)",
+                "        {",
+                "            Model crop = sender as Model;",
+                "            if (Crop != null && crop.Name.ToLower() == (Crop as IModel).Name.ToLower())",
+                "                Fertiliser.Apply(Amount: Amount, Type: FertiliserType);",
+                "        }",
+                "    }",
+                "}"
+              ],
+              "Parameters": [
+                {
+                  "Key": "Crop",
+                  "Value": "Wheat"
+                },
+                {
+                  "Key": "FertiliserType",
+                  "Value": "NO3N"
+                },
+                {
+                  "Key": "Amount",
+                  "Value": 160.0
+                }
+              ],
+              "Name": "Fertilise at sowing",
+              "ResourceName": null,
+              "Children": [],
+              "Enabled": true,
+              "ReadOnly": false
+            },
+            {
+              "$type": "Models.Manager, Models",
+              "CodeArray": [
+                "using APSIM.Shared.Utilities;",
+                "using Models.Utilities;",
+                "using Models.Soils;",
+                "using Models.PMF;",
+                "using Models.Core;",
+                "using System;",
+                "using System.Linq;",
+                "",
+                "namespace Models",
+                "{",
+                "    [Serializable] ",
+                "    public class Script : Model",
+                "    {",
+                "        [Description(\"Crop\")]",
+                "        public IPlant Crop { get; set; }",
+                "        ",
+                "        [EventSubscribe(\"DoManagement\")]",
+                "        private void OnDoManagement(object sender, EventArgs e)",
+                "        {",
+                "            if (Crop.IsReadyForHarvesting)",
+                "            {",
+                "                Crop.Harvest();",
+                "                Crop.EndCrop();",
+                "            }",
+                "        }",
+                "    }",
+                "}",
+                "       "
+              ],
+              "Parameters": [
+                {
+                  "Key": "Crop",
+                  "Value": "Wheat"
+                }
+              ],
+              "Name": "Harvest",
+              "ResourceName": null,
+              "Children": [],
               "Enabled": true,
               "ReadOnly": false
             }
           ],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         },
@@ -650,33 +813,33 @@
           "Caption": null,
           "Axis": [
             {
-              "$type": "Models.Axis, Models",
-              "Type": 3,
+              "$type": "APSIM.Shared.Graphing.Axis, APSIM.Shared",
               "Title": "Date",
+              "Position": 3,
               "Inverted": false,
-              "Minimum": "NaN",
-              "Maximum": "NaN",
-              "Interval": "NaN",
-              "DateTimeAxis": false,
-              "CrossesAtZero": false
+              "CrossesAtZero": false,
+              "Minimum": null,
+              "Maximum": null,
+              "Interval": null
             },
             {
-              "$type": "Models.Axis, Models",
-              "Type": 0,
+              "$type": "APSIM.Shared.Graphing.Axis, APSIM.Shared",
               "Title": "Yield (kg/ha)",
+              "Position": 0,
               "Inverted": false,
-              "Minimum": "NaN",
-              "Maximum": "NaN",
-              "Interval": "NaN",
-              "DateTimeAxis": false,
-              "CrossesAtZero": false
+              "CrossesAtZero": false,
+              "Minimum": null,
+              "Maximum": null,
+              "Interval": null
             }
           ],
           "LegendPosition": 0,
           "LegendOrientation": 0,
+          "AnnotationLocation": 0,
           "DisabledSeries": null,
           "LegendOutsideGraph": false,
           "Name": "Wheat Yield Time Series",
+          "ResourceName": null,
           "Children": [
             {
               "$type": "Models.Series, Models",
@@ -694,26 +857,24 @@
               "TableName": "Report",
               "XFieldName": "Clock.Today",
               "YFieldName": "Yield",
-              "X2FieldName": "",
-              "Y2FieldName": "",
-              "ShowInLegend": true,
+              "X2FieldName": null,
+              "Y2FieldName": null,
+              "ShowInLegend": false,
               "IncludeSeriesNameInLegend": false,
               "Cumulative": false,
               "CumulativeX": false,
               "Filter": null,
               "Name": "Wheat Yield",
+              "ResourceName": null,
               "Children": [],
-              "IncludeInDocumentation": true,
               "Enabled": true,
               "ReadOnly": false
             }
           ],
-          "IncludeInDocumentation": true,
           "Enabled": true,
           "ReadOnly": false
         }
       ],
-      "IncludeInDocumentation": true,
       "Enabled": true,
       "ReadOnly": false
     },
@@ -722,13 +883,12 @@
       "useFirebird": false,
       "CustomFileName": null,
       "Name": "DataStore",
+      "ResourceName": null,
       "Children": [],
-      "IncludeInDocumentation": true,
       "Enabled": true,
       "ReadOnly": false
     }
   ],
-  "IncludeInDocumentation": true,
   "Enabled": true,
   "ReadOnly": false
 }


### PR DESCRIPTION
Resolves #8234

This pull requests standardises the simple crop simulations in Toowoomba (that use the `Dalby.met` weather file), including:

- [Barley](https://github.com/APSIMInitiative/ApsimX/blob/0fce476e9b16433dd2b1fa40047174cf04490c94/Examples/Barley.apsimx)
- [Maize](https://github.com/APSIMInitiative/ApsimX/blob/0fce476e9b16433dd2b1fa40047174cf04490c94/Examples/Maize.apsimx)
- [Mungbean](https://github.com/APSIMInitiative/ApsimX/blob/0fce476e9b16433dd2b1fa40047174cf04490c94/Examples/Mungbean.apsimx)
- [Oats](https://github.com/APSIMInitiative/ApsimX/blob/0fce476e9b16433dd2b1fa40047174cf04490c94/Examples/Oats.apsimx)
- [Soybean](https://github.com/APSIMInitiative/ApsimX/blob/0fce476e9b16433dd2b1fa40047174cf04490c94/Examples/Soybean.apsimx)
- [Wheat](https://github.com/APSIMInitiative/ApsimX/blob/0fce476e9b16433dd2b1fa40047174cf04490c94/Examples/Wheat.apsimx)

These simulations broadly followed the same structure. This pull request standardises the structure to be:

```
+- Simulations
    +- Simulation
    |   +- Clock
    |   +- Summary
    |   +- Weather
    |   +- SoilArbitrator
    |   +- Field
    |       +- Report
    |       +- Fertiliser
    |       +- Soil
    |       |   +- Physical
    |       |   |   +- <crop>Soil
    |       |   +- SoilWater
    |       |   +- Organic
    |       |   +- Chemical
    |       |   +- Water
    |       |   +- Temperature
    |       |   +- Nutrient
    |       |   +- NO3
    |       |   +- NH4
    |       |   +- Urea
    |       +- SurfaceOrganicMatter
    |       +- MicroClimate
    |       +- <crop>
    |       +- <sow>
    |       +- <fertilise>
    |       +- <harvest>
    |       +- Graph
    |           +- Series
    +- DataStore
```

This provides a consistency in model names and order across the included examples.

Additionally:

- All standardised examples use the ApSoil profile: `Soils/Australia/Queensland/Darling Downs and Granite Belt/Black Vertosol-Mywybilla (Norwin No900)`.
    - Note that the values in the ApSoil profile are *identical* to the original profile used in the simulations. The change only causes minor difference in the `Soil` model metadata which now mirror the ApSoil profile.

- All examples are updated so that `Report` outputs yield in `kg/ha`.
    - For some simulations, the line `[<crop>].Grain.Total.Wt*10 as Yield` was added

- The management actions (sowing, fertilising and harvesting) all use the most up-to-date scripts from the [ManagementToolbox](https://github.com/APSIMInitiative/ApsimX/blob/0fce476e9b16433dd2b1fa40047174cf04490c94/ApsimNG/Resources/Toolboxes/ManagementToolbox.apsimx).

- The standardised simulations output identical values to the old simulations. In cases where model names were changed or extra `Report` output was added, the output will differ in these minor ways.