### PR TITLE
Disable stylecop directive and unused parameter warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -170,7 +170,7 @@
 ; csharp_style_expression_bodied_local_functions = false:silent
 ; csharp_indent_labels = one_less_than_current
 csharp_indent_labels = one_less_than_current
-csharp_using_directive_placement = outside_namespace:warning
+csharp_using_directive_placement = outside_namespace:suggestion
 csharp_prefer_simple_using_statement = true:suggestion
 csharp_prefer_braces = true:silent
 csharp_style_namespace_declarations = block_scoped:silent
@@ -393,6 +393,7 @@ csharp_style_prefer_extended_property_pattern = true:suggestion
 csharp_style_var_for_built_in_types = false:silent
 csharp_style_var_when_type_is_apparent = false:silent
 csharp_style_var_elsewhere = false:silent
+csharp_style_prefer_primary_constructors = true:suggestion
 
 [*.{cs,vb}]
 ; dotnet_style_coalesce_expression = true:suggestion
@@ -474,7 +475,7 @@ dotnet_style_predefined_type_for_member_access = true:silent
 dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
 dotnet_style_allow_multiple_blank_lines_experimental = true:silent
 dotnet_style_allow_statement_immediately_after_block_experimental = true:silent
-dotnet_code_quality_unused_parameters = all:warning
+dotnet_code_quality_unused_parameters = all:suggestion
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent


### PR DESCRIPTION
resolves #8253
working on #1281

Warnings were cluttering up error window in VS. Will turn on warnings once StyleCop rules are being worked on in the future.