### PR TITLE
Report's vertical splitter position issue fix

### DIFF
--- a/ApsimNG/Presenters/ReportPresenter.cs
+++ b/ApsimNG/Presenters/ReportPresenter.cs
@@ -184,7 +184,12 @@ namespace UserInterface.Presenters
             this.view.SplitterChanged += OnSplitterChanged;
             this.view.SplitterPosition = Configuration.Settings.ReportSplitterPosition;
             this.view.VerticalSplitterChanged += OnVerticalSplitterChanged;
-            this.view.VerticalSplitterPosition = Configuration.Settings.ReportSplitterVerticalPosition;
+            // Below check required to prevent commonReportVariables/Events
+            // windows from occuping whole screen.
+            if (Configuration.Settings.ReportSplitterVerticalPosition != 0)
+                this.view.VerticalSplitterPosition = Configuration.Settings.ReportSplitterVerticalPosition;
+            else
+                this.view.VerticalSplitterPosition = 800;
             this.explorerPresenter.CommandHistory.ModelChanged += OnModelChanged;
             this.view.CommonReportVariablesList.DoubleClicked += OnCommonReportVariableListDoubleClicked;
             this.view.CommonReportFrequencyVariablesList.DoubleClicked += OnCommonReportFrequencyVariablesListDoubleClicked;


### PR DESCRIPTION
resolves #8309

# Issue

The vertical position starts off not set making the common report and events windows take up the entire report view.

# Fix

Added check if the position is not set yet, to make it a sufficient number to make all report views seen.