### PR TITLE
8324 Allow Manager scripts to link to models when used under a factor

### DIFF
--- a/ApsimNG/Classes/Property.cs
+++ b/ApsimNG/Classes/Property.cs
@@ -276,6 +276,8 @@ namespace UserInterface.Classes
                         plant = model.FindInScope<IPlant>();
                     if (plant != null)
                         DropDownOptions = PropertyPresenterHelpers.GetCultivarNames(plant);
+                    else
+                        DropDownOptions = new string[] { };
                     break;
                 case DisplayType.SCRUMcropName:
                     DisplayMethod = PropertyType.DropDown;

--- a/Models/Core/Model.cs
+++ b/Models/Core/Model.cs
@@ -451,28 +451,9 @@ namespace Models.Core
         public IEnumerable<IModel> FindAllInScope()
         {
             Simulation sim = FindAncestor<Simulation>();
-            Experiment exp = null;
-            if (sim == null) //if model is under an experiment factor, look for the simulation under the experiment
-            {
-                exp = FindAncestor<Experiment>();
-                if (exp != null)
-                    sim = exp.FindChild<Simulation>();
-            }
-
             ScopingRules scope = sim?.Scope ?? new ScopingRules();
             foreach (IModel result in scope.FindAll(this))
                 yield return result;
-
-            //scope may not work for models under experiment (that need to link back to the actual sim)
-            //so first we find models that are in scope (aka, also under the factor), then also return
-            //the descendants of the simulation
-            if (exp != null)
-            {   
-                IEnumerable<IModel> descendants = sim.FindAllDescendants();
-                foreach (IModel result in descendants)
-                    yield return result;
-            }
-            
         }
 
         /// <summary>

--- a/Models/Core/Model.cs
+++ b/Models/Core/Model.cs
@@ -451,9 +451,28 @@ namespace Models.Core
         public IEnumerable<IModel> FindAllInScope()
         {
             Simulation sim = FindAncestor<Simulation>();
+            Experiment exp = null;
+            if (sim == null) //if model is under an experiment factor, look for the simulation under the experiment
+            {
+                exp = FindAncestor<Experiment>();
+                if (exp != null)
+                    sim = exp.FindChild<Simulation>();
+            }
+
             ScopingRules scope = sim?.Scope ?? new ScopingRules();
             foreach (IModel result in scope.FindAll(this))
                 yield return result;
+
+            //scope may not work for models under experiment (that need to link back to the actual sim)
+            //so first we find models that are in scope (aka, also under the factor), then also return
+            //the descendants of the simulation
+            if (exp != null)
+            {   
+                IEnumerable<IModel> descendants = sim.FindAllDescendants();
+                foreach (IModel result in descendants)
+                    yield return result;
+            }
+            
         }
 
         /// <summary>

--- a/Models/Core/Scope.cs
+++ b/Models/Core/Scope.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Models.Factorial;
 
 namespace Models.Core
 {
@@ -60,6 +61,19 @@ namespace Models.Core
 
             if (!modelsInScope.Contains(scopedParent))
                 modelsInScope.Add(scopedParent); // top level simulation
+
+            //scope may not work for models under experiment (that need to link back to the actual sim)
+            //so first we find models that are in scope (aka, also under the factor), then also return
+            //the descendants of the simulation
+            Experiment exp = relativeTo.FindAncestor<Experiment>();
+            if (exp != null)
+            {
+                Simulation sim = exp.FindChild<Simulation>();
+
+                IEnumerable<IModel> descendants = sim.FindAllDescendants();
+                foreach (IModel result in descendants)
+                    modelsInScope.Add(result);
+            }
 
             // add to cache for next time.
             cache.Add(relativeToFullPath, modelsInScope);


### PR DESCRIPTION
Resolves #8324 

A bit of a weird bug where the FindAllInScope method didn't work when the calling manager script was located under a factor in an experiment. 

To fix this, if the script didn't have a simulation as an ancestor, it would then look for an experiment instead and use that to find the simulation model. Then when returning all models in scope, it would return the models in scope under the factor first, before then also returning the models under the simulation so the script could link to models back in the simulation. This is a bit slower, but also fairly rare to do, and better than modifying the existing FindAll function in the Scope class.