### PR TITLE
8363 Fix Playlist Crashes

### DIFF
--- a/ApsimNG/Presenters/PlaylistPresenter.cs
+++ b/ApsimNG/Presenters/PlaylistPresenter.cs
@@ -2,12 +2,10 @@
 using UserInterface.Views;
 using System;
 using System.Collections.Generic;
-using APSIM.Shared.Utilities;
 using Models.Core;
 using Models.Factorial;
 using System.Linq;
 using System.Threading.Tasks;
-using UserInterface.Interfaces;
 
 namespace UserInterface.Presenters
 {
@@ -54,6 +52,7 @@ namespace UserInterface.Presenters
         public void Attach(object model, object view, ExplorerPresenter parentPresenter)
         {
             playlistModel = model as Playlist;
+            playlistModel.ClearSearchCache();
 
             explorerPresenter = parentPresenter;
             explorerPresenter.CommandHistory.ModelChanged += this.OnModelChanged;
@@ -133,25 +132,36 @@ namespace UserInterface.Presenters
         {
             playlistView.SetOutputText("Matching Simulations:\nSearching...");
 
-            searchCounter += 1;
-            int id = searchCounter;
+            if (searchCounter >= 1)
+            {
+                searchCounter = 2;
+                return;
+            } 
+            else
+            {
+                searchCounter = 1;
+            }
 
             string[] names = (await GetSimNamesAsync());
 
-            //when the await returns, this will check against the search counter,
-            //and only allow the output field to update if this request is the latest.
-            if (id == searchCounter)
+            string output = $"Matching Simulations: {names.Length}\n";
+            if (names != null)
             {
-                string output = $"Matching Simulations: {names.Length}\n";
-                if (names != null)
-                {
-                    output += string.Join(", ", names);
-                }
-                else
-                {
-                    output += "[No Matches Found]";
-                }
-                playlistView.SetOutputText(output);
+                output += string.Join(", ", names);
+            }
+            else
+            {
+                output += "[No Matches Found]";
+            }
+            playlistView.SetOutputText(output);
+
+            if (searchCounter == 2) //if we have had another search pending
+            {
+                searchCounter = 0;
+                UpdateListOfSimulations();
+            } else
+            {
+                searchCounter = 0;
             }
         }
 

--- a/ApsimNG/Views/TreeView.cs
+++ b/ApsimNG/Views/TreeView.cs
@@ -986,6 +986,7 @@ namespace UserInterface.Views
         {
             try
             {
+                treeview1.CursorChanged -= OnAfterSelect;
                 nodePathBeforeRename = SelectedNode;
                 // TreeView.ContextMenuStrip = null;
                 // e.CancelEdit = false;
@@ -1016,6 +1017,7 @@ namespace UserInterface.Views
                     if (!args.CancelEdit)
                         previouslySelectedNodePath = args.NodePath;
                 }
+                treeview1.CursorChanged += OnAfterSelect;
             }
             catch (Exception err)
             {

--- a/Models/Core/Run/Playlist.cs
+++ b/Models/Core/Run/Playlist.cs
@@ -1,12 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Text.RegularExpressions;
-using System.Xml.Linq;
 using Models.Core;
 using Models.Factorial;
-using Models.PostSimulationTools;
+using Newtonsoft.Json;
 
 namespace Models
 {
@@ -20,9 +18,19 @@ namespace Models
     [ValidParent(ParentType = typeof(Simulations))]
     public class Playlist : Model
     {
+        private class PlaylistPrevSearch
+        {
+            public string searchString = null;
+            public string[] results = null;
+        }
+
         /// <summary>Link to simulations</summary>
         [Link]
         private Simulations Simulations = null;
+
+        /// <summary>Link to simulations</summary>
+        [JsonIgnore]
+        private List<PlaylistPrevSearch> searchCache = new List<PlaylistPrevSearch>();
 
         /// <summary>The Playlist text that is used for comparisions</summary>
         [Description("Text of the playlist")]
@@ -74,7 +82,10 @@ namespace Models
 
                 foreach (string part in parts)
                 {
-                    string expression = cleanString(part);
+                    List<string> resultsForThisPart = new List<string>();
+                    string cleanPart = cleanString(part);
+
+                    string expression = cleanPart;
                     
                     //convert our wildcard to regex symbol
                     expression = expression.Replace("*", "[\\s\\S]*");
@@ -82,40 +93,76 @@ namespace Models
                     expression = "^" + expression + "$";
                     Regex regex = new Regex(expression);
 
-                    foreach (Simulation sim in allSimulations)
+                    bool inCache = false;
+                    foreach (PlaylistPrevSearch search in searchCache)
                     {
-                        if (regex.IsMatch(sim.Name.ToLower()))
-                            if (sim.FindAncestor<Experiment>() == null) //don't add if under experiment
-                                if (names.Contains(sim.Name) == false)
-                                    names.Add(sim.Name);
+                        if (cleanPart == search.searchString)
+                        {
+                            inCache = true;
+                            for (int i = 0; i < search.results.Length; i++)
+                                names.Add(search.results[i]);
+                        }
                     }
 
-                    foreach (Experiment exp in allExperiments)
+                    if(!inCache)
                     {
-                        List<Core.Run.SimulationDescription> expNames = exp.GetSimulationDescriptions().ToList();
-                        //match experiment name
-                        if (regex.IsMatch(exp.Name.ToLower()))
+                        foreach (Simulation sim in allSimulations)
                         {
-                            if (names.Contains(exp.Name) == false)
+                            if (regex.IsMatch(sim.Name.ToLower()))
+                            {
+                                if (sim.FindAncestor<Experiment>() == null)//don't add if under experiment
+                                {
+                                    if (names.Contains(sim.Name) == false)
+                                    {
+                                        names.Add(sim.Name);
+                                        resultsForThisPart.Add(sim.Name);
+                                    }
+                                }
+                            }      
+                        }
+
+                        foreach (Experiment exp in allExperiments)
+                        {
+                            List<Core.Run.SimulationDescription> expNames = exp.GetSimulationDescriptions().ToList();
+                            //match experiment name
+                            if (regex.IsMatch(exp.Name.ToLower()))
+                            {
+                                if (names.Contains(exp.Name) == false)
+                                {
+                                    foreach (Core.Run.SimulationDescription expN in expNames)
+                                    {
+                                        if (names.Contains(expN.Name) == false)
+                                        {
+                                            names.Add(expN.Name);
+                                            resultsForThisPart.Add(expN.Name);
+                                        }
+                                    }
+                                }        
+                            }
+                            else
+                            {
+                                //match against the experiment variations
                                 foreach (Core.Run.SimulationDescription expN in expNames)
-                                    if (names.Contains(expN.Name) == false)
-                                        names.Add(expN.Name);
+                                {
+                                    if (regex.IsMatch(expN.Name.ToLower()))
+                                    {
+                                        if (names.Contains(expN.Name) == false)
+                                        {
+                                            names.Add(expN.Name);
+                                            resultsForThisPart.Add(expN.Name);
+                                        }
+                                    }
+                                }
+                            }
                         }
-                        else
-                        {
-                            //match against the experiment variations
-                            foreach (Core.Run.SimulationDescription expN in expNames)
-                                if (regex.IsMatch(expN.Name.ToLower()))
-                                    if (names.Contains(expN.Name) == false)
-                                        names.Add(expN.Name);
-                        }
+                        PlaylistPrevSearch search = new PlaylistPrevSearch();
+                        search.searchString = cleanPart;
+                        search.results = resultsForThisPart.ToArray();
+                        searchCache.Add(search);
                     }
                 }
             }
-            if (names.Count == 0)
-                return names.ToArray();
-            else
-                return names.ToArray();
+            return names.ToArray();
         }
 
         /// <summary>
@@ -130,6 +177,14 @@ namespace Models
 
             foreach (string line in lines)
                 Text += line + "\n";
+        }
+
+        /// <summary>
+        /// Clears the previous search cache so that new results can be searched for.
+        /// </summary>
+        public void ClearSearchCache()
+        {
+            searchCache = new List<PlaylistPrevSearch>();
         }
 
         private string cleanString(string input)

--- a/Tests/UnitTests/Core/Run/PlaylistTests.cs
+++ b/Tests/UnitTests/Core/Run/PlaylistTests.cs
@@ -137,5 +137,30 @@ namespace UnitTests.Core
                 
             }           
         }
+
+        /// <summary>Testing a number of variations of playlist text to make sure they run correctly.</summary>
+        [Test]
+        public void RunSimulationsWithPlaylistCheckCaching()
+        {
+            string[] expectedSimulations1 = new string[4] { "Sim", "Sim2", "Sim3", "Sim4" };
+            string[] expectedSimulations2 = new string[3] { "Sim", "Sim2", "Sim4" };
+
+            //read in our base test that we'll use for this
+            string json = ReflectionUtilities.GetResourceAsString("UnitTests.Core.Run.PlaylistTests.apsimx");
+            Simulations sims = FileFormat.ReadFromString<Simulations>(json, e => throw e, false).NewModel as Simulations;
+            Playlist playlist = sims.FindChild<Playlist>();
+            playlist.Text = "Sim*\n";
+
+            Assert.AreEqual(expectedSimulations1, playlist.GetListOfSimulations());
+
+            //now change the name of one of the simulations without clearing the cache,
+            //should give the same 4 names if reading from cache correctly.
+            sims.FindChild("Sim3").Name = "DifferentName";
+            Assert.AreEqual(expectedSimulations1, playlist.GetListOfSimulations());
+
+            //now clear the cache and run again, should only get 3 sims this time.
+            playlist.ClearSearchCache();
+            Assert.AreEqual(expectedSimulations2, playlist.GetListOfSimulations());
+        }
     }
 }


### PR DESCRIPTION
Resolves #8363 

Solves a couple of issues. The select node event in treeview is turned off when editing a node (was causing the presenter to be reloaded twice when editing a node).

A cache was added to playlist searching so if it has already search for a particular string, it stores the results and reads those back if that string is searched for again. This does mean the presenter has to clear the cache though when it opens (in case simulations have had their names changed in the GUI)

Lastly the async function was redesigned to only run one search at a time, and mark a flag for a pending search if another tried to run while one was still going. If a function ends and there was one pending, a new search is run then.