### PR TITLE
GC Crash fix.

### DIFF
--- a/ApsimNG/Utility/Configuration.cs
+++ b/ApsimNG/Utility/Configuration.cs
@@ -283,7 +283,14 @@ namespace Utility
         /// <summary>Finalizes an instance of the <see cref="Configuration"/> class.</summary>
         ~Configuration()
         {
-            Save();
+            try
+            {
+                Save();
+            }
+            catch
+            {
+                // An uncaught exception could crash APSIM from the GC thread.
+            }
         }
 
         /// <summary>Gets the configuration settings.</summary>


### PR DESCRIPTION
Resolves #8384 
Not sure if this is the best way of going about resolving the issue. I also notice there are a couple of other classes with destructors (DataStore and R), but after taking a brief look at them it seems unlikely that they would throw. Still, it may be better safe than sorry.