### PR TITLE
Evaporation initialize date

### DIFF
--- a/APSIM.Shared/Utilities/DateUtilities.cs
+++ b/APSIM.Shared/Utilities/DateUtilities.cs
@@ -271,8 +271,12 @@ namespace APSIM.Shared.Utilities
         /// <returns>true if within date window</returns>
         public static bool WithinDates(string ddMMM_start, DateTime today, string ddMMM_end)
         {
-            DateTime start = GetDate(ddMMM_start, today.Year);
-            DateTime end = GetDate(ddMMM_end, today.Year);
+            var year = today.Year;
+            // Avoid subtracting from year 1.
+            if (year == 1)
+                year = 1900;
+            DateTime start = GetDate(ddMMM_start, year);
+            DateTime end = GetDate(ddMMM_end, year);
 
             //if start after end (spans end-of-year boundary)
             if (start.CompareTo(end) > 0)

--- a/Models/Soils/WaterModel/EvaporationModel.cs
+++ b/Models/Soils/WaterModel/EvaporationModel.cs
@@ -127,7 +127,7 @@ namespace Models.WaterModel
             double cona = waterBalance.WinterCona;
             summerStartDate = DateUtilities.GetDate(waterBalance.SummerDate, 1900).AddDays(1); // AddDays(1) - to reproduce behaviour of DateUtilities.WithinDate
             winterStartDate = DateUtilities.GetDate(waterBalance.WinterDate, 1900);
-            isInSummer = !DateUtilities.WithinDates(waterBalance.WinterDate, clock.StartDate, waterBalance.SummerDate);
+            isInSummer = !DateUtilities.WithinDates(waterBalance.WinterDate, clock.Today, waterBalance.SummerDate);
 
             if (IsSummer)
             {


### PR DESCRIPTION
Working on #8388 

The previous PR relating to this issue (#8389) may have introduced an error where simulations using the reset feature could run with incorrect values for a time. 