### PR TITLE
Attempt to fix reset error with evaporation model.

### DIFF
--- a/Models/Soils/WaterModel/EvaporationModel.cs
+++ b/Models/Soils/WaterModel/EvaporationModel.cs
@@ -127,7 +127,8 @@ namespace Models.WaterModel
             double cona = waterBalance.WinterCona;
             summerStartDate = DateUtilities.GetDate(waterBalance.SummerDate, 1900).AddDays(1); // AddDays(1) - to reproduce behaviour of DateUtilities.WithinDate
             winterStartDate = DateUtilities.GetDate(waterBalance.WinterDate, 1900);
-            isInSummer = !DateUtilities.WithinDates(waterBalance.WinterDate, clock.StartDate, waterBalance.SummerDate);
+            var today = clock.Today == DateTime.MinValue ? clock.StartDate : clock.Today;
+            isInSummer = !DateUtilities.WithinDates(waterBalance.WinterDate, today, waterBalance.SummerDate);
 
             if (IsSummer)
             {


### PR DESCRIPTION
Working on #8388 

My previous fix attempt (#8389) introduced a bug where EvaporationModel would run with wrong values after a reset under certain conditions. The other PR trying to fix my error (#8390) revealed a few tests are running without initialized Clocks, but that is another issue.