### PR TITLE
8391 Added flag around events to protect RightHandView events

### DIFF
--- a/ApsimNG/Views/TreeView.cs
+++ b/ApsimNG/Views/TreeView.cs
@@ -36,6 +36,7 @@ namespace UserInterface.Views
         private CellRendererText textRender;
         private const string modelMime = "application/x-model-component";
         private Timer timer = new Timer();
+        private bool isEdittingNodeLabel = false;
 
         /// <summary>
         /// Keep track of whether the accelerator group is attached to the toplevel window.
@@ -1016,10 +1017,12 @@ namespace UserInterface.Views
         {
             try
             {
-                treeview1.CursorChanged -= OnAfterSelect;
-                nodePathBeforeRename = SelectedNode;
-                // TreeView.ContextMenuStrip = null;
-                // e.CancelEdit = false;
+                if (isEdittingNodeLabel == false)
+                {
+                    isEdittingNodeLabel = true;
+                    treeview1.CursorChanged -= OnAfterSelect;
+                    nodePathBeforeRename = SelectedNode;
+                }
             }
             catch (Exception err)
             {
@@ -1034,20 +1037,24 @@ namespace UserInterface.Views
         {
             try
             {
-                textRender.Editable = false;
-                // TreeView.ContextMenuStrip = this.PopupMenu;
-                if (Renamed != null && !string.IsNullOrEmpty(e.NewText))
+                if (isEdittingNodeLabel == true)
                 {
-                    NodeRenameArgs args = new NodeRenameArgs()
+                    isEdittingNodeLabel = false;
+                    textRender.Editable = false;
+                    // TreeView.ContextMenuStrip = this.PopupMenu;
+                    if (Renamed != null && !string.IsNullOrEmpty(e.NewText))
                     {
-                        NodePath = this.nodePathBeforeRename,
-                        NewName = e.NewText
-                    };
-                    Renamed(this, args);
-                    if (!args.CancelEdit)
-                        previouslySelectedNodePath = args.NodePath;
+                        NodeRenameArgs args = new NodeRenameArgs()
+                        {
+                            NodePath = this.nodePathBeforeRename,
+                            NewName = e.NewText
+                        };
+                        Renamed(this, args);
+                        if (!args.CancelEdit)
+                            previouslySelectedNodePath = args.NodePath;
+                    }
+                    treeview1.CursorChanged += OnAfterSelect;
                 }
-                treeview1.CursorChanged += OnAfterSelect;
             }
             catch (Exception err)
             {


### PR DESCRIPTION
Resolves #8391

Not 100% sure this will fix the problem, since it's such an intermittent bug and hard to test. But it seems that if clicking quickly in the tree view, it might be possible to have the OnBeforeLabelEdit and OnAfterLabelEdit events occur out of order, this then causes the CursorChanged event to get turn off and stops the right hand panel updating.

Manually disabling the OnAfterLabelEdit event did cause the same behaviour that we were seeing in this bug (view stops updating, but start working again after saving/refreshing the treeview).

This might be a fix that we just have to apply and then just wait and see if the bug still happens.

- 2nd attempt, first pull request was accidently branched off a working branch.