### PR TITLE
8402 Changed GetBorderOfRightHandView to work with CLEM

### DIFF
--- a/ApsimNG/Resources/Glade/CLEMGridView.glade
+++ b/ApsimNG/Resources/Glade/CLEMGridView.glade
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk+" version="2.24"/>
+  <!-- interface-naming-policy project-wide -->
+  <object class="GtkHBox" id="hbox1">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkHPaned" id="hpaned1">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <child>
+          <object class="GtkFrame" id="frame1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label_xalign">0</property>
+            <property name="shadow_type">in</property>
+            <child>
+              <object class="GtkScrolledWindow" id="scrolledwindow2">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="hscrollbar_policy">automatic</property>
+                <property name="vscrollbar_policy">automatic</property>
+                <child>
+                  <object class="GtkTreeView" id="fixedcolview">
+                    <property name="height_request">1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="enable_grid_lines">both</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child type="label_item">
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="resize">False</property>
+            <property name="shrink">True</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkFrame" id="frame2">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label_xalign">0</property>
+            <property name="shadow_type">in</property>
+            <child>
+              <object class="GtkScrolledWindow" id="scrolledwindow1">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="hscrollbar_policy">automatic</property>
+                <property name="vscrollbar_policy">automatic</property>
+                <child>
+                  <object class="GtkTreeView" id="gridview">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="enable_grid_lines">both</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child type="label_item">
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="resize">True</property>
+            <property name="shrink">True</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">True</property>
+        <property name="fill">True</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
+  </object>
+</interface>

--- a/ApsimNG/Utility/GtkUtilities.cs
+++ b/ApsimNG/Utility/GtkUtilities.cs
@@ -205,12 +205,21 @@ namespace Utility
         /// Bottom is the top of the status window
         /// Top is the bottom of the menu bar
         /// </summary>
-        public static System.Drawing.Rectangle GetBorderOfRightHandView(ExplorerView explorerView)
+        public static System.Drawing.Rectangle GetBorderOfRightHandView(ViewBase view)
         {
-            int top = GtkUtilities.GetPositionOfWidget(explorerView.MainWidget).Y;
-            int bottom = (explorerView.Owner as MainView).StatusPanelPosition;
-            int left = GtkUtilities.GetPositionOfWidget(explorerView.MainWidget).X;
-            int right = explorerView.MainWidget.AllocatedWidth + left;
+            ViewBase mainView = view;
+            while (mainView as MainView == null)
+            {
+                if (mainView == null) //return a box if this could not compute correctly.
+                    return new Rectangle(0, 0, 100, 100);
+                else
+                    mainView = mainView.Owner;
+            }                
+
+            int top = GtkUtilities.GetPositionOfWidget(view.MainWidget).Y;
+            int bottom = (mainView as MainView).StatusPanelPosition;
+            int left = GtkUtilities.GetPositionOfWidget(view.MainWidget).X;
+            int right = view.MainWidget.AllocatedWidth + left;
 
             int width = right - left;
             int height = bottom - top;

--- a/ApsimNG/Views/CLEM/ActivityLedgerGridView.cs
+++ b/ApsimNG/Views/CLEM/ActivityLedgerGridView.cs
@@ -50,7 +50,7 @@ namespace UserInterface.Views
         /// </summary>
         public ActivityLedgerGridView(ViewBase owner) : base(owner)
         {
-            Builder builder = ViewBase.BuilderFromResource("ApsimNG.Resources.Glade.GridView.glade");
+            Builder builder = ViewBase.BuilderFromResource("ApsimNG.Resources.Glade.CLEMGridView.glade");
             hbox1 = (HBox)builder.GetObject("hbox1");
             scrolledwindow1 = (ScrolledWindow)builder.GetObject("scrolledwindow1");
             Grid = (Gtk.TreeView)builder.GetObject("gridview");

--- a/ApsimNG/Views/ReportView.cs
+++ b/ApsimNG/Views/ReportView.cs
@@ -81,7 +81,7 @@ namespace UserInterface.Views
             commonReportFrequencyVariableList.DoubleClicked += OnCommonReportFrequencyVariableListDoubleClicked;
             commonFrequencyBox.PackStart((commonReportFrequencyVariableList as ViewBase).MainWidget, true, true, 0);
 
-            Rectangle bounds = GtkUtilities.GetBorderOfRightHandView(owner as ExplorerView);
+            Rectangle bounds = GtkUtilities.GetBorderOfRightHandView(owner);
             double? horizontalSplitter = Configuration.Settings.ReportSplitterPosition;
             int horizontalPos = (int)Math.Round(bounds.Width * 0.7);
             if (horizontalSplitter != null)
@@ -94,7 +94,7 @@ namespace UserInterface.Views
             int verticalPos = (int)Math.Round(bounds.Height * 0.7);
             if (verticalSplitter != null)
                 if (verticalSplitter > 0.1 && verticalSplitter < 0.9)
-                    verticalPos = (int)(bounds.Width * verticalSplitter);
+                    verticalPos = (int)(bounds.Height * verticalSplitter);
             panel.Position = verticalPos;
 
             dataStoreView1 = new ViewBase(this, "ApsimNG.Resources.Glade.DataStoreView.glade");
@@ -133,7 +133,7 @@ namespace UserInterface.Views
             this.reportVariablesVPaned.Position = reportFrequencyVPaned.Position;
             if (args.Property == "position")
             {
-                Rectangle bounds = GtkUtilities.GetBorderOfRightHandView(owner as ExplorerView);
+                Rectangle bounds = GtkUtilities.GetBorderOfRightHandView(owner);
                 double percentage = (double)reportVariablesVPaned.Position / (double)bounds.Width;
                 Configuration.Settings.ReportSplitterPosition = percentage;
                 Configuration.Settings.Save();
@@ -149,7 +149,7 @@ namespace UserInterface.Views
             this.reportFrequencyVPaned.Position = reportVariablesVPaned.Position;
             if (args.Property == "position")
             {
-                Rectangle bounds = GtkUtilities.GetBorderOfRightHandView(owner as ExplorerView);
+                Rectangle bounds = GtkUtilities.GetBorderOfRightHandView(owner);
                 double percentage = (double)reportFrequencyVPaned.Position / (double)bounds.Width;
                 Configuration.Settings.ReportSplitterPosition = percentage;
                 Configuration.Settings.Save();
@@ -165,7 +165,7 @@ namespace UserInterface.Views
         {
             if (args.Property == "position")
             {
-                Rectangle bounds = GtkUtilities.GetBorderOfRightHandView(owner as ExplorerView);
+                Rectangle bounds = GtkUtilities.GetBorderOfRightHandView(owner);
                 double percentage = (double)panel.Position / (double)bounds.Height;
                 Configuration.Settings.ReportSplitterVerticalPosition = percentage;
                 Configuration.Settings.Save();

--- a/ApsimNG/Views/TextAndCodeView.cs
+++ b/ApsimNG/Views/TextAndCodeView.cs
@@ -39,7 +39,7 @@ namespace UserInterface.Views
             ScrolledWindow sw = (ScrolledWindow)builder.GetObject("scrolledwindow2");
             sw.Add((editorView as ViewBase).MainWidget);
 
-            Rectangle bounds = GtkUtilities.GetBorderOfRightHandView(owner as ExplorerView);
+            Rectangle bounds = GtkUtilities.GetBorderOfRightHandView(owner);
             box1 = (VPaned)builder.GetObject("vpaned1");
             box1.Position = (int)Math.Round(bounds.Height * 0.8);
 


### PR DESCRIPTION
Resolves #8402

CLEM uses a different system instead of explorerview for it's view. Made the function more generic so that it could work with clem views as well. Checked as many CLEM nodes as I could find in the examples and also fixed a glade reference bug introduced with the grid refactor.

