### PR TITLE
8395 Line, Marker and Colour dropdown on graphs no longer filter out data

### DIFF
--- a/ApsimNG/Presenters/GraphPresenter.cs
+++ b/ApsimNG/Presenters/GraphPresenter.cs
@@ -128,6 +128,9 @@
                 storage = graph.FindInScope<IDataStore>();
             if (graph != null && graph.Series != null)
             {
+                if (definitions.Count() == 0)
+                    explorerPresenter.MainPresenter.ShowMessage("No data matches the properties and filter set for this graph", Simulation.MessageType.Warning, true);
+
                 foreach (SeriesDefinition definition in definitions)
                 {
                     DrawOnView(definition);

--- a/ApsimNG/Views/GraphView.cs
+++ b/ApsimNG/Views/GraphView.cs
@@ -445,7 +445,12 @@
                 series = new Utility.LineSeriesWithTracker();
                 series.OnHoverOverPoint += OnHoverOverPoint;
                 if (showOnLegend)
-                    series.Title = title;
+                {
+                    if (String.IsNullOrEmpty(title))
+                        series.Title = "null";
+                    else
+                        series.Title = title;
+                }
                 else
                     series.ToolTip = title;
 
@@ -558,7 +563,12 @@
             {
                 var series = new ColumnXYSeries();
                 if (showOnLegend)
-                    series.Title = title;
+                {
+                    if (String.IsNullOrEmpty(title))
+                        series.Title = "null";
+                    else
+                        series.Title = title;
+                }
                 series.FillColor = OxyColor.FromArgb(colour.A, colour.R, colour.G, colour.B);
                 series.StrokeColor = OxyColor.FromArgb(colour.A, colour.R, colour.G, colour.B);
                 series.ItemsSource = this.PopulateDataPointSeries(x, y, xAxisType, yAxisType);
@@ -608,7 +618,12 @@
             List<DataPoint> points2 = this.PopulateDataPointSeries(x2, y2, xAxisType, yAxisType);
 
             if (showOnLegend)
-                series.Title = title;
+            {
+                if (String.IsNullOrEmpty(title))
+                    series.Title = "null";
+                else
+                    series.Title = title;
+            }
             if (points != null && points2 != null)
             {
                 foreach (DataPoint point in points)
@@ -799,7 +814,13 @@
                 BoxPlotSeries series = new BoxPlotSeries();
                 series.Items = GetBoxPlotItems(x, y, xAxisType, yAxisType);
                 if (showOnLegend)
-                    series.Title = title;
+                {
+                    if (String.IsNullOrEmpty(title))
+                        series.Title = "null";
+                    else
+                        series.Title = title;
+                }
+                    
 
                 // Line style
                 if (Enum.TryParse(lineType.ToString(), out LineStyle oxyLineType))

--- a/Models/Graph/SeriesDefinition.cs
+++ b/Models/Graph/SeriesDefinition.cs
@@ -397,7 +397,13 @@ namespace Models
                 foreach (var descriptor in Descriptors)
                 {
                     if (fieldsThatExist.Contains(descriptor.Name))
-                        filter = AddToFilter(filter, $"[{descriptor.Name}] = '{descriptor.Value}'");
+                    {
+                        if (string.IsNullOrEmpty(descriptor.Value))
+                            filter = AddToFilter(filter, $"[{descriptor.Name}] IS NULL");
+                        else
+                            filter = AddToFilter(filter, $"[{descriptor.Name}] = '{descriptor.Value}'");
+                    }
+                        
                 }
             }
             if (!string.IsNullOrEmpty(userFilter))


### PR DESCRIPTION
Resolves #8395 

Previously the line type, marker type and colour type dropdowns would filter out points with a null value in the column if a "vary by" option was chosen. This would happen even if the row of data had an x and y value and could potentially be plotted. To fix this I made it so they would be plotted under a series named "null" so that it is obvious that the data is there, just missing a value to group it into a series.

![image](https://github.com/APSIMInitiative/ApsimX/assets/130029141/71b5151f-7cf5-48cc-9a81-7c5d72735b28)

To achieve a similar behaviour from before, a user filter can be used such as: Wheat.Phenology.CurrentStageName IS NOT NULL
And the null series will not be shown:

![image](https://github.com/APSIMInitiative/ApsimX/assets/130029141/9d31aef5-37b2-496f-8dd3-7f2b6250ead0)

This solution also has the added benefit of not having the graphs crash or display everything in one series when it encounters a null value in a column like this. Obviously if the x or y values for a point are null they still won't be displayed as we would expect.
