### PR TITLE
8371 Remove Delay from Playlist Run button

### DIFF
--- a/ApsimNG/Presenters/PlaylistPresenter.cs
+++ b/ApsimNG/Presenters/PlaylistPresenter.cs
@@ -168,7 +168,7 @@ namespace UserInterface.Presenters
         /// <summary>Async wrapper around GetListOfSimulations</summary>
         private async Task<string[]> GetSimNamesAsync()
         {
-            return await Task.Run(() => playlistModel.GetListOfSimulations(simNameCache, expNameCache));
+            return await Task.Run(() => playlistModel.GenerateListOfSimulations(simNameCache, expNameCache));
         }
 
         /// <summary>Detach the model from the view.</summary>

--- a/Models/Core/Run/Playlist.cs
+++ b/Models/Core/Run/Playlist.cs
@@ -32,9 +32,28 @@ namespace Models
         [JsonIgnore]
         private List<PlaylistPrevSearch> searchCache = new List<PlaylistPrevSearch>();
 
+        [JsonIgnore]
+        private string[] lastSearch = null;
+
         /// <summary>The Playlist text that is used for comparisions</summary>
         [Description("Text of the playlist")]
         public string Text { get; set; }
+
+        /// <summary>
+        /// Returns the last generated list of simulation names.
+        /// If that list has not been searched yet, this will generate the list.
+        /// </summary>
+        /// <returns>
+        /// An array of simulation and simulation variations names that were found during the last search. 
+        /// Will return an empty array if no matches are found.
+        /// </returns>
+        public string[] GetListOfSimulations()
+        {
+            if (lastSearch == null)
+                return GenerateListOfSimulations();
+            else
+                return lastSearch;
+        }
 
         /// <summary>
         /// Returns the name of all simulations that match the text
@@ -48,7 +67,7 @@ namespace Models
         /// An array of simulation and simulation variations names that match the text of this playlist. 
         /// Will return an empty array if no matches are found.
         /// </returns>
-        public string[] GetListOfSimulations(List<Simulation> allSimulations = null, List<Experiment> allExperiments = null)
+        public string[] GenerateListOfSimulations(List<Simulation> allSimulations = null, List<Experiment> allExperiments = null)
         {
             if (Simulations == null)
                 Simulations = this.FindAncestor<Simulations>();
@@ -162,7 +181,8 @@ namespace Models
                     }
                 }
             }
-            return names.ToArray();
+            lastSearch = names.ToArray();
+            return lastSearch;
         }
 
         /// <summary>

--- a/Tests/UnitTests/Core/Run/PlaylistTests.cs
+++ b/Tests/UnitTests/Core/Run/PlaylistTests.cs
@@ -151,15 +151,18 @@ namespace UnitTests.Core
             Playlist playlist = sims.FindChild<Playlist>();
             playlist.Text = "Sim*\n";
 
-            Assert.AreEqual(expectedSimulations1, playlist.GetListOfSimulations());
+            Assert.AreEqual(expectedSimulations1, playlist.GenerateListOfSimulations());
 
             //now change the name of one of the simulations without clearing the cache,
             //should give the same 4 names if reading from cache correctly.
             sims.FindChild("Sim3").Name = "DifferentName";
-            Assert.AreEqual(expectedSimulations1, playlist.GetListOfSimulations());
+            Assert.AreEqual(expectedSimulations1, playlist.GenerateListOfSimulations());
 
             //now clear the cache and run again, should only get 3 sims this time.
             playlist.ClearSearchCache();
+            Assert.AreEqual(expectedSimulations2, playlist.GenerateListOfSimulations());
+
+            //Check that GetListOfSimulations is working, should return the previous result again.
             Assert.AreEqual(expectedSimulations2, playlist.GetListOfSimulations());
         }
     }


### PR DESCRIPTION
Resolves #8371

The playlist will now return the last list of simulation names to be searched instead of rerunning the search when running the simulations. You can only run the playlist when the node is selected, so it will have always been searched, if not, then it will do the search itself anyway.