### PR TITLE
8421 Warns if points being graphed are outside the given axis values

### DIFF
--- a/ApsimNG/Presenters/SeriesPresenter.cs
+++ b/ApsimNG/Presenters/SeriesPresenter.cs
@@ -47,6 +47,8 @@
         /// <param name="explorerPresenter">The parent explorer presenter</param>
         public void Attach(object model, object view, ExplorerPresenter explorerPresenter)
         {
+            explorerPresenter.MainPresenter.ClearStatusPanel();
+
             this.series = model as Series;
             this.seriesView = view as SeriesView;
             this.explorerPresenter = explorerPresenter;
@@ -553,7 +555,6 @@
             // Populate filter textbox.
             this.seriesView.Filter.Text = series.Filter;
 
-            explorerPresenter.MainPresenter.ClearStatusPanel();
             if (warnings != null && warnings.Count > 0)
                 explorerPresenter.MainPresenter.ShowMessage(warnings, Simulation.MessageType.Warning);
         }


### PR DESCRIPTION
Resolves #8421

The provided file had an axis with set values that meant all the points were not visible on screen. This change will now provide an error if that is the case, and reset the axis if no points would be drawn. IF only some points are off screen, just a warning is displayed.

Also Series Presenter was clearing the status messages after the graph was drawn, which hides error messages from the graph. I've moved this clear to the start of the attach method so it does it before the graphs are drawn.