### PR TITLE
8454 Moved editting check code to drag end and reset variables

### DIFF
--- a/ApsimNG/Views/TreeView.cs
+++ b/ApsimNG/Views/TreeView.cs
@@ -827,8 +827,6 @@ namespace UserInterface.Views
         {
             try
             {
-                if (textRender.Editable) // If the node to be dragged is open for editing (renaming), close it now.
-                    textRender.StopEditing(true);
                 DragStartArgs args = new DragStartArgs();
                 args.NodePath = SelectedNode; // FullPath(e.Item as TreeNode);
                 if (DragStarted != null)
@@ -856,6 +854,14 @@ namespace UserInterface.Views
         {
             try
             {
+                if (textRender.Editable)// If the node to be dragged is open for editing (renaming), close it now.
+                {
+                    textRender.StopEditing(true);
+                    isEdittingNodeLabel = false;
+                    treeview1.CursorChanged += OnAfterSelect;
+                    nodePathBeforeRename = "";
+                }
+
                 if (dragSourceHandle.IsAllocated)
                 {
                     dragSourceHandle.Free();


### PR DESCRIPTION
Resolves #8454 

When dragging a node to duplicate it, it was possible for the name editing to start on the previous node. Then when you tried to rename the new node you just made, it would fire the renaming finished event on the original node instead.

This should fix it so that the node renaming is reset when dragging ends.