### PR TITLE
8478 Fixed split screen splitter position

### DIFF
--- a/ApsimNG/Interfaces/IMainView.cs
+++ b/ApsimNG/Interfaces/IMainView.cs
@@ -62,7 +62,6 @@ namespace UserInterface.Interfaces
         bool SplitWindowOn { get; set; }
 
         /// <summary>Position of split screen divider.</summary>
-        /// <remarks>Not sure what units this uses...might be pixels.</remarks>
         int SplitScreenPosition { get; set; }
 
         /// <summary

--- a/ApsimNG/Presenters/MainPresenter.cs
+++ b/ApsimNG/Presenters/MainPresenter.cs
@@ -93,7 +93,7 @@ namespace UserInterface.Presenters
 
             double width = this.view.WindowSize.Width;
             int savedWidth = Utility.Configuration.Settings.SplitScreenPosition;
-            if (savedHeight > 0.9 || savedHeight < 0.1)
+            if (savedWidth > 0.9 || savedWidth < 0.1)
                 this.view.SplitScreenPosition = (int)Math.Round(width * 0.5);
             else
                 this.view.SplitScreenPosition = (int)Math.Round(width * savedWidth);


### PR DESCRIPTION
Resolves #8478 

There was a typo where the wrong variable was being used for the splitter position, has been fixed.