### PR TITLE
8482 Attaches Intellisense back to PropertyAndGridPresenter

### DIFF
--- a/ApsimNG/Presenters/GridPresenter.cs
+++ b/ApsimNG/Presenters/GridPresenter.cs
@@ -278,13 +278,7 @@ namespace UserInterface.Presenters
         }
 
         /// <summary>
-        /// Adds options to the right-click context menu, valid options are:
-        /// Cut - Any Editable Cell
-        /// Copy - Any Cell
-        /// Paste - Any Editable Cell
-        /// Delete - Any Editable Cell
-        /// Select All - Any Cell
-        /// Units - Change Units on Solute grids, only on row == 1
+        /// Adds intellisense to the grid. 
         /// </summary>
         public void AddIntellisense(Model model)
         {
@@ -588,6 +582,8 @@ namespace UserInterface.Presenters
                 string text = grid.Sheet.DataProvider.GetCellContents(columnIndex, rowIndex);
                 grid.Sheet.DataProvider.SetCellContents(columnIndex, rowIndex, text + args.ItemSelected);
                 grid.Sheet.CalculateBounds(columnIndex, rowIndex);
+
+                grid.Sheet.CellEditor.Edit(); //keep editting window open
             }
             catch (Exception err)
             {

--- a/ApsimNG/Presenters/PropertyAndGridPresenter.cs
+++ b/ApsimNG/Presenters/PropertyAndGridPresenter.cs
@@ -1,4 +1,5 @@
-﻿using Models.Interfaces;
+﻿using Models.Core;
+using Models.Interfaces;
 using UserInterface.Views;
 
 namespace UserInterface.Presenters
@@ -30,6 +31,7 @@ namespace UserInterface.Presenters
             gridPresenter = new GridPresenter();
             gridPresenter.Attach((model as IGridModel).Tables[0], view.Grid, parentPresenter);
             gridPresenter.AddContextMenuOptions(new string[] { "Cut", "Copy", "Paste", "Delete", "Select All" });
+            gridPresenter.AddIntellisense(model as Model);
             gridPresenter.CellChanged += OnCellChanged;
         }
 


### PR DESCRIPTION
Resolves #8482

Presenter needed to attach an intellisense, it was removed in the grid refactor. None of the other models using this presenter should have a problem with this, since they either should have it too, or were built in a way that it doesn't matter.