### PR TITLE
8505 Cleanup of node selection events

### DIFF
--- a/ApsimNG/Presenters/ExplorerPresenter.cs
+++ b/ApsimNG/Presenters/ExplorerPresenter.cs
@@ -1044,11 +1044,9 @@ namespace UserInterface.Presenters
                         Model model = this.ApsimXFile.FindByPath(e.NodePath)?.Value as Model;
                         if (model != null && model.GetType().Name != "Simulations" && e.NewName != string.Empty)
                         {
-                            this.HideRightHandPanel();
                             this.ApsimXFile.Locator.ClearEntry(model.FullPath);
                             RenameModelCommand cmd = new RenameModelCommand(model, e.NewName);
                             CommandHistory.Add(cmd);
-                            this.ShowRightHandPanel();
                             e.CancelEdit = model.Name != e.NewName;
                         }
                     }

--- a/ApsimNG/Views/TreeView.cs
+++ b/ApsimNG/Views/TreeView.cs
@@ -387,11 +387,7 @@ namespace UserInterface.Views
                 expandedRows.Add(path.ToString());
             }));
 
-            treeview1.CursorChanged -= OnAfterSelect;
-
             treemodel.Clear();
-
-            treeview1.CursorChanged += OnAfterSelect;
 
             TreeIter iter = treemodel.AppendNode();
             RefreshNode(iter, nodeDescriptions, false);
@@ -402,8 +398,9 @@ namespace UserInterface.Views
             {
                 expandedRows.ForEach(row => treeview1.ExpandRow(new TreePath(row), false));
             }
-            catch
+            catch (Exception err)
             {
+                ShowError(err);
             }
 
             if (ContextMenu != null)
@@ -643,7 +640,7 @@ namespace UserInterface.Views
         {
             try
             {
-                if (SelectedNodeChanged != null)
+                if (SelectedNodeChanged != null && treeview1 != null)
                 {
                     treeview1.CursorChanged -= OnAfterSelect;
                     NodeSelectedArgs selectionChangedData = new NodeSelectedArgs();
@@ -858,7 +855,6 @@ namespace UserInterface.Views
                 {
                     textRender.StopEditing(true);
                     isEdittingNodeLabel = false;
-                    treeview1.CursorChanged += OnAfterSelect;
                     nodePathBeforeRename = "";
                 }
 
@@ -1026,7 +1022,6 @@ namespace UserInterface.Views
                 if (isEdittingNodeLabel == false)
                 {
                     isEdittingNodeLabel = true;
-                    treeview1.CursorChanged -= OnAfterSelect;
                     nodePathBeforeRename = SelectedNode;
                 }
             }
@@ -1059,7 +1054,6 @@ namespace UserInterface.Views
                         if (!args.CancelEdit)
                             previouslySelectedNodePath = args.NodePath;
                     }
-                    treeview1.CursorChanged += OnAfterSelect;
                 }
             }
             catch (Exception err)


### PR DESCRIPTION
Resolves #8505

I've still not been able to replicate this bug on my machine since I put in PR #8401, but considering it's still happening there must be something in particular that happens when the GUI is in use that is causing this.

I've gone through and followed the node selection events from the TreeView through to the RightHandPanel updates and done:
- Cleanup of times the event was disabled when it didn't need to be
- Changes so it is always enabled again when it is disabled, even if an error is thrown
- Removed an empty try-catch that was hiding errors
- Checked when right hand panel is updated to make sure it's being handled correctly

As with last time, we might need to merge this in and see if it's still happening to others. I'll leave the issue open until we've confirmed if this has solved the problem or not.

**Update**

This PR fixes the method Julian found to replicate the bug, so we should merge it in and see if anyone else still reports it as an issue.