### PR TITLE
Node expanding now scrolls to show first few children rather than last.

### DIFF
--- a/ApsimNG/Views/TreeView.cs
+++ b/ApsimNG/Views/TreeView.cs
@@ -1,11 +1,11 @@
-using APSIM.Shared.Utilities;
-using Gtk;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Timers;
+using APSIM.Shared.Utilities;
+using Gtk;
 using UserInterface.Interfaces;
 using Utility;
 using TreeModel = Gtk.ITreeModel;
@@ -784,16 +784,6 @@ namespace UserInterface.Views
             {
                 TreePath path = e.Path.Copy();
                 path.Down();
-                bool stop = false;
-                while (!stop)
-                {
-                    path.Next();
-                    treeview1.Model.GetIter(out TreeIter iter, path);
-                    var value = treeview1.Model.GetValue(iter, 0);
-                    if (value == null)
-                        stop = true;
-                }
-                path.Prev();
                 treeview1.ScrollToCell(path, null, false, 0, 0);
             }
             catch (Exception err)


### PR DESCRIPTION
resolves #8508

The expanding of a node was causing the explorer view to scroll to the last child of the expanded node. Now it will scroll to show the first few children.