### PR TITLE
Orderby statements removed to allow default behaviour.

### DIFF
--- a/ApsimNG/Presenters/DataStorePresenter.cs
+++ b/ApsimNG/Presenters/DataStorePresenter.cs
@@ -1,13 +1,13 @@
-﻿using UserInterface.EventArguments;
-using Models.Core;
-using Models.Factorial;
-using Models.Storage;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-using UserInterface.Views;
 using APSIM.Shared.Documentation.Extensions;
+using Models.Core;
+using Models.Factorial;
+using Models.Storage;
+using UserInterface.EventArguments;
+using UserInterface.Views;
 
 namespace UserInterface.Presenters
 {
@@ -148,7 +148,7 @@ namespace UserInterface.Presenters
         {
             //base.Detach();
             // Keep the column and row filters
-            explorerPresenter.KeepFilter(temporaryColumnFilters, temporaryRowFilters); 
+            explorerPresenter.KeepFilter(temporaryColumnFilters, temporaryRowFilters);
             temporaryRowFilters = rowFilterEditBox.Text;
             tableDropDown.Changed -= OnTableSelected;
             columnFilterEditBox.Leave -= OnColumnFilterChanged;

--- a/Models/Storage/DataStoreReader.cs
+++ b/Models/Storage/DataStoreReader.cs
@@ -5,8 +5,6 @@ using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using APSIM.Shared.Utilities;
-using SkiaSharp;
-using static Models.Core.ScriptCompiler;
 
 namespace Models.Storage
 {
@@ -241,10 +239,6 @@ namespace Models.Storage
 
             // Get orderby fields
             var orderByFields = new List<string>();
-            if (fieldNamesInTable.Contains("SimulationID"))
-                orderByFields.Insert(0, "SimulationID");
-            if (fieldNamesInTable.Contains("Clock.Today"))
-                orderByFields.Insert(0, "Clock.Today");
             if (orderByFieldNames != null)
                 orderByFields.AddRange(orderByFieldNames);
 


### PR DESCRIPTION
resolves #8519 

The current orderby statements ordered rows by SimulationId then Clock.Today.
These have been removed. The default behaviour now causes rows to be ordered by simulation name then date.