### PR TITLE
8555 Limited zooming out on graph

### DIFF
--- a/ApsimNG/Presenters/GraphPresenter.cs
+++ b/ApsimNG/Presenters/GraphPresenter.cs
@@ -139,10 +139,6 @@
                 // Update axis maxima and minima
                 graphView.UpdateView();
 
-                // Format the axes.
-                foreach (APSIM.Shared.Graphing.Axis axis in graph.Axis)
-                    FormatAxis(axis);
-
                 //check if the axes are too small, update if so
                 const double tolerance = 0.00001;
                 foreach (APSIM.Shared.Graphing.Axis axis in graph.Axis)
@@ -153,15 +149,18 @@
                     {
                         axis.Minimum -= tolerance / 2;
                         axis.Maximum += tolerance / 2;
-                        FormatAxis(axis);
                     }
+                    FormatAxis(axis);
                 }
 
                 int pointsOutsideAxis = 0;
                 int pointsInsideAxis = 0;
                 foreach (SeriesDefinition definition in definitions)
                 {
-                    string seriesName = graph.Name + " (" + definition.Series.Name + ")";
+                    string seriesName = graph.Name;
+                    if (definition.Series != null)
+                        seriesName = graph.Name + " (" + definition.Series.Name + ")";
+
                     double xMin = graphView.AxisMinimum(definition.XAxis);
                     double xMax = graphView.AxisMaximum(definition.XAxis);
                     int xNaNCount = 0;

--- a/ApsimNG/Presenters/ProfilePresenter.cs
+++ b/ApsimNG/Presenters/ProfilePresenter.cs
@@ -184,9 +184,18 @@ namespace UserInterface.Presenters
                                      System.Drawing.Color.Red, LineType.Solid, MarkerType.None,
                                      LineThickness.Normal, MarkerSize.Normal, 1, true);
 
-            graph.FormatAxis(AxisPosition.Top, "Fresh organic matter (kg/ha)", inverted: false, double.NaN, double.NaN, double.NaN, false, false);
-            graph.FormatAxis(AxisPosition.Left, "Depth (mm)", inverted: true, 0, double.NaN, double.NaN, false, false);
-            graph.FormatAxis(AxisPosition.Bottom, "Fraction ", inverted: false, 0, 1, 0.2, false, false);
+            double padding = 0.01; //add 1% to bounds
+            double xTopMin = MathUtilities.Min(fom);
+            double xTopMax = MathUtilities.Max(fom);
+            xTopMin -= xTopMax * padding; 
+            xTopMax += xTopMax * padding;
+
+            double height = MathUtilities.Max(cumulativeThickness);
+            height += height * padding;
+
+            graph.FormatAxis(AxisPosition.Top, "Fresh organic matter (kg/ha)", inverted: false, xTopMin, xTopMax, double.NaN, false, false);
+            graph.FormatAxis(AxisPosition.Left, "Depth (mm)", inverted: true, 0, height, double.NaN, false, false);
+            graph.FormatAxis(AxisPosition.Bottom, "Fraction ", inverted: false, 0, 1.01, 0.2, false, false);
             graph.FormatLegend(LegendPosition.BottomRight, LegendOrientation.Vertical);
             graph.Refresh();
         }
@@ -201,8 +210,27 @@ namespace UserInterface.Presenters
                                      System.Drawing.Color.Blue, LineType.Solid, MarkerType.None,
                                      LineThickness.Normal, MarkerSize.Normal, 1, true);
 
-            graph.FormatAxis(AxisPosition.Top, $"Initial {soluteName} (ppm)", inverted: false, 0, double.NaN, double.NaN, false, false);
-            graph.FormatAxis(AxisPosition.Left, "Depth (mm)", inverted: true, 0, double.NaN, double.NaN, false, false);
+            double padding = 0.01; //add 1% to bounds
+            double xTopMin = 0;
+            double xTopMax = MathUtilities.Max(values);
+            
+
+            double height = MathUtilities.Max(cumulativeThickness);
+            height += height * padding;
+
+            if (xTopMax == xTopMin)
+            {
+                xTopMin -= 0.5;
+                xTopMax += 0.5;
+            } 
+            else
+            {
+                xTopMin -= xTopMax * padding;
+                xTopMax += xTopMax * padding;
+            }
+
+            graph.FormatAxis(AxisPosition.Top, $"Initial {soluteName} (ppm)", inverted: false, xTopMin, xTopMax, double.NaN, false, false);
+            graph.FormatAxis(AxisPosition.Left, "Depth (mm)", inverted: true, 0, height, double.NaN, false, false);
             graph.FormatLegend(LegendPosition.BottomRight, LegendOrientation.Vertical);
             graph.Refresh();
         }
@@ -218,6 +246,8 @@ namespace UserInterface.Presenters
                                      "", "", null, null, AxisPosition.Top, AxisPosition.Left,
                                      ColourUtilities.ChooseColour(nColor++), LineType.Solid, MarkerType.None,
                                      LineThickness.Normal, MarkerSize.Normal, 1, true);
+
+            List<double> sols = new List<double>();
             foreach (var solute in solutes)
             {
                 double[] vals = solute.InitialValues;
@@ -228,12 +258,22 @@ namespace UserInterface.Presenters
                                          "", "", null, null, AxisPosition.Bottom, AxisPosition.Left,
                                          ColourUtilities.ChooseColour(nColor++), LineType.Solid, MarkerType.None,
                                          LineThickness.Normal, MarkerSize.Normal, 1, true);
-
+                foreach (double v in vals)
+                    sols.Add(v);
             }
 
+            double padding = 0.01; //add 1% to bounds
+            double xBottomMin = MathUtilities.Min(sols);
+            double xBottomMax = MathUtilities.Max(sols);
+            xBottomMin -= xBottomMax * padding;
+            xBottomMax += xBottomMax * padding;
+
+            double height = MathUtilities.Max(cumulativeThickness);
+            height += height * padding;
+
             graph.FormatAxis(AxisPosition.Top, $"pH ({units})", inverted: false, 2, 12, 2, false, false);
-            graph.FormatAxis(AxisPosition.Left, "Depth (mm)", inverted: true, 0, double.NaN, double.NaN, false, false);
-            graph.FormatAxis(AxisPosition.Bottom, "Initial solute (ppm) ", inverted: false, 0, double.NaN, double.NaN, false, false);
+            graph.FormatAxis(AxisPosition.Left, "Depth (mm)", inverted: true, 0, height, double.NaN, false, false);
+            graph.FormatAxis(AxisPosition.Bottom, "Initial solute (ppm) ", inverted: false, xBottomMin, xBottomMax, double.NaN, false, false);
             graph.FormatLegend(LegendPosition.BottomRight, LegendOrientation.Vertical);
             graph.Refresh();
         }

--- a/ApsimNG/Presenters/WaterPresenter.cs
+++ b/ApsimNG/Presenters/WaterPresenter.cs
@@ -6,6 +6,8 @@ using System.Globalization;
 using System.Linq;
 using UserInterface.Views;
 using Models.Interfaces;
+using APSIM.Shared.Utilities;
+using System.Collections.Generic;
 
 namespace UserInterface.Presenters
 {
@@ -265,6 +267,8 @@ namespace UserInterface.Presenters
             var swCumulativeThickness = APSIM.Shared.Utilities.SoilUtilities.ToCumThickness(swThickness);
             graph.Clear();
 
+            
+
             if (llsoil != null && llsoilsName != null)
             {       //draw the area relative to the water LL instead.
                 graph.DrawRegion($"PAW relative to {llsoilsName}", llsoil, swCumulativeThickness,
@@ -314,8 +318,31 @@ namespace UserInterface.Presenters
                         LineThickness.Normal, MarkerSize.Normal, 1, true);
             }
 
-            graph.FormatAxis(AxisPosition.Top, "Volumetric water (mm/mm)", inverted: false, double.NaN, double.NaN, double.NaN, false, false);
-            graph.FormatAxis(AxisPosition.Left, "Depth (mm)", inverted: true, 0, double.NaN, double.NaN, false, false);
+            List<double> vols = new List<double>();
+            foreach (double val in airdry)
+                vols.Add(val);
+            foreach (double val in cll)
+                vols.Add(val);
+            foreach (double val in dul)
+                vols.Add(val);
+            foreach (double val in sat)
+                vols.Add(val);
+
+            if (llsoil != null)
+                foreach (double val in llsoil)
+                    vols.Add(val);
+
+            double padding = 0.01; //add 1% to bounds
+            double xTopMin = MathUtilities.Min(vols);
+            double xTopMax = MathUtilities.Max(vols);
+            xTopMin -= xTopMax * padding;
+            xTopMax += xTopMax * padding;
+
+            double height = MathUtilities.Max(cumulativeThickness);
+            height += height * padding;
+
+            graph.FormatAxis(AxisPosition.Top, "Volumetric water (mm/mm)", inverted: false, xTopMin, xTopMax, double.NaN, false, false);
+            graph.FormatAxis(AxisPosition.Left, "Depth (mm)", inverted: true, 0, height, double.NaN, false, false);
             graph.FormatLegend(LegendPosition.RightBottom, LegendOrientation.Vertical);
             graph.Refresh();
         }

--- a/ApsimNG/Views/GraphView.cs
+++ b/ApsimNG/Views/GraphView.cs
@@ -1133,10 +1133,24 @@
                     oxyAxis.StartPosition = 0;
                     oxyAxis.EndPosition = 1;
                 }
+
+                double min = minimum;
                 if (!double.IsNaN(minimum))
                     oxyAxis.Minimum = minimum;
+                else
+                    min = AxisMinimum(axisType);
+
+                double max = maximum;
                 if (!double.IsNaN(maximum))
                     oxyAxis.Maximum = maximum;
+                else
+                    max = AxisMaximum(axisType);
+
+                if (max <= min)
+                    max = min + 1;
+
+                oxyAxis.AbsoluteMinimum = min;
+                oxyAxis.AbsoluteMaximum = max;
 
                 if (oxyAxis is DateTimeAxis)
                 {

--- a/ApsimNG/Views/GraphView.cs
+++ b/ApsimNG/Views/GraphView.cs
@@ -1,32 +1,34 @@
-﻿namespace UserInterface.Views
+﻿using APSIM.Interop.Graphing.CustomSeries;
+using APSIM.Interop.Graphing.Extensions;
+using APSIM.Shared.Documentation.Extensions;
+using APSIM.Shared.Graphing;
+using APSIM.Shared.Utilities;
+using UserInterface.EventArguments;
+using Gtk;
+using UserInterface.Interfaces;
+using MathNet.Numerics.Statistics;
+using OxyPlot;
+using OxyPlot.Annotations;
+using OxyPlot.Axes;
+using OxyPlot.GtkSharp;
+using OxyPlot.Series;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Utility;
+using LegendPlacement = OxyPlot.Legends.LegendPlacement;
+using OxyLegendOrientation = OxyPlot.Legends.LegendOrientation;
+using OxyLegendPosition = OxyPlot.Legends.LegendPosition;
+
+using static Gdk.Cursor;
+using static Gdk.CursorType;
+
+namespace UserInterface.Views
 {
-    using APSIM.Interop.Graphing.CustomSeries;
-    using APSIM.Interop.Graphing.Extensions;
-    using APSIM.Shared.Documentation.Extensions;
-    using APSIM.Shared.Graphing;
-    using APSIM.Shared.Utilities;
-    using EventArguments;
-    using Gtk;
-    using Interfaces;
-    using MathNet.Numerics.Statistics;
-    using OxyPlot;
-    using OxyPlot.Annotations;
-    using OxyPlot.Axes;
-    using OxyPlot.GtkSharp;
-    using OxyPlot.Series;
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Drawing;
-    using System.Globalization;
-    using System.IO;
-    using System.Linq;
-    using Utility;
-    using LegendPlacement = OxyPlot.Legends.LegendPlacement;
-    using OxyLegendOrientation = OxyPlot.Legends.LegendOrientation;
-    using OxyLegendPosition = OxyPlot.Legends.LegendPosition;
-
-
     /// <summary>
     /// A view that contains a graph and click zones for the user to allow
     /// editing various parts of the graph.
@@ -152,6 +154,7 @@
             plot1.Model.MouseDown += OnChartClick;
             plot1.Model.MouseUp += OnChartMouseUp;
             plot1.Model.MouseMove += OnChartMouseMove;
+            plot1.Model.MouseLeave += OnChartMouseMove;
 #pragma warning restore CS0618
             popup.AttachToWidget(plot1, null);
 
@@ -183,6 +186,7 @@
                 plot1.Model.MouseDown -= OnChartClick;
                 plot1.Model.MouseUp -= OnChartMouseUp;
                 plot1.Model.MouseMove -= OnChartMouseMove;
+                plot1.Model.MouseLeave -= OnChartMouseMove;
 #pragma warning restore CS0618
                 if (captionEventBox != null)
                     captionEventBox.ButtonPressEvent -= OnCaptionLabelDoubleClick;
@@ -2011,6 +2015,44 @@
             {
                 e.Handled = false;
                 inRightClick = false;
+
+                //Change the cursor when hovering over an axis so users know to zoom
+                //The axis don't have events, so we need to measure them manually to do this.
+                bool showV = false;
+                bool showH = false;
+                double x = e.Position.X;
+                double y = e.Position.Y;
+                foreach (OxyPlot.Axes.Axis ax in plot1.Model.Axes)
+                {
+                    if (ax.Position == OxyPlot.Axes.AxisPosition.Top)
+                    {
+                        if (y > plot1.Model.TitleArea.Height && y < plot1.Model.Height - plot1.Model.PlotArea.Height - plot1.Model.ActualPlotMargins.Bottom)
+                            showH = true;
+                    }
+                    else if (ax.Position == OxyPlot.Axes.AxisPosition.Bottom)
+                    {
+                        if (y > (plot1.Model.TitleArea.Height + plot1.Model.PlotAndAxisArea.Height) - plot1.Model.ActualPlotMargins.Bottom &&
+                            y < (plot1.Model.TitleArea.Height + plot1.Model.PlotAndAxisArea.Height))
+                            showH = true;
+                    } 
+                    else if (ax.Position == OxyPlot.Axes.AxisPosition.Left)
+                    {
+                        if (x < plot1.Model.ActualPlotMargins.Left)
+                            showV = true;
+                    }
+                    else if (ax.Position == OxyPlot.Axes.AxisPosition.Right)
+                    {
+                        if (x > plot1.Model.PlotAndAxisArea.Width - plot1.Model.ActualPlotMargins.Right &&
+                            x < plot1.Model.PlotAndAxisArea.Width)
+                            showV = true;
+                    }
+                }
+                if (showV && !showH)
+                    mainWidget.Window.Cursor = new Gdk.Cursor(Gdk.CursorType.SbVDoubleArrow);
+                else if (!showV && showH)
+                    mainWidget.Window.Cursor = new Gdk.Cursor(Gdk.CursorType.SbHDoubleArrow);
+                else
+                    mainWidget.Window.Cursor = new Gdk.Cursor(Gdk.CursorType.Arrow);
             }
             catch (Exception err)
             {


### PR DESCRIPTION
Resolves #8555 

When the axis are set by a presenter, the oxyplot AbsoluteMinimum and AbsoluteMaximum are now set that restrict how far someone can zoom out. This also means that if someone zooms in, they can now zoom back out to the starting bounds and reset the view correctly. Previously you'd have to click off the graph node to get back to the normal view.

While in that code, I also added a cursor change for when the mouse is hovering over an axis, to show that you can zoom a particular axis when the mouse is over it, which I don't think people realised before (and was noted as a bug in the issue).