### PR TITLE
Replaced the defoliation manager in redclover example 

### DIFF
--- a/Examples/RedClover.apsimx
+++ b/Examples/RedClover.apsimx
@@ -1,7 +1,6 @@
 {
   "$type": "Models.Core.Simulations, Models",
-  "ExplorerWidth": 273,
-  "Version": 163,
+  "Version": 171,
   "Name": "Simulations",
   "ResourceName": null,
   "Children": [
@@ -234,9 +233,10 @@
                   "Operation": [
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-03-20",
                       "Action": "[RedClover].Sow(population: 500, cultivar: \"Colenso\", depth: 5, rowSpacing: 150)",
-                      "Enabled": true
+                      "Line": "2014-03-20 [RedClover].Sow(population: 500, cultivar: \"Colenso\", depth: 5, rowSpacing: 150)"
                     }
                   ],
                   "Name": "Sowing",
@@ -250,1035 +250,1207 @@
                   "Operation": [
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-10-31",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-10-31 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-11-03",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-11-03 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-11-05",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-11-05 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-11-07",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-11-07 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-11-10",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-11-10 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-11-11",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-11-11 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-11-12",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-11-12 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-11-17",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-11-17 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-11-18",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-11-18 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-11-19",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-11-19 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-11-24",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-11-24 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-11-25",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-11-25 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-11-27",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-11-27 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-12-01",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-12-01 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-12-02",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-12-02 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-12-04",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-12-04 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-12-08",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-12-08 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-12-09",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-12-09 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-12-12",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-12-12 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-12-15",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-12-15 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-12-17",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-12-17 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-12-19",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-12-19 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-12-20",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-12-20 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-12-21",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-12-21 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-12-22",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-12-22 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-12-25",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-12-25 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-12-26",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-12-26 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-12-27",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-12-27 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-12-28",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-12-28 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-12-29",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-12-29 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-12-30",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2014-12-30 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-01-02",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-01-02 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-01-05",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-01-05 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-01-08",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-01-08 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-01-09",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-01-09 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-01-12",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-01-12 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-01-13",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-01-13 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-01-16",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-01-16 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-01-19",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-01-19 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-01-20",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-01-20 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-01-21",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-01-21 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-01-26",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-01-26 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-01-27",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-01-27 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-01-29",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-01-29 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-02-02",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-02-02 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-02-04",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-02-04 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-02-05",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-02-05 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-02-09",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-02-09 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-02-11",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-02-11 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-02-12",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-02-12 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-02-16",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-02-16 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-02-17",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-02-17 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-02-18",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-02-18 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-02-24",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-02-24 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-02-26",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-02-26 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-02-27",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-02-27 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-03-02",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-03-02 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-03-03",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-03-03 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-03-05",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-03-05 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-03-10",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-03-10 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-03-12",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-03-12 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-03-13",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-03-13 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-03-16",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-03-16 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-03-19",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-03-19 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-03-20",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-03-20 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-03-23",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-03-23 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-03-24",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-03-24 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-03-26",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-03-26 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-03-30",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-03-30 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-04-02",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-04-02 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-04-03",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-04-03 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-04-06",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-04-06 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-04-08",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-04-08 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-04-17",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-04-17 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-05-20",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-05-20 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-06-09",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-06-09 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-09-09",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-09-09 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-09-30",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-09-30 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-10-02",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-10-02 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-10-06",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-10-06 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-10-09",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-10-09 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-10-12",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-10-12 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-10-13",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-10-13 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-10-16",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-10-16 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-10-20",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-10-20 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-10-21",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-10-21 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-10-23",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-10-23 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-10-26",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-10-26 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-10-27",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-10-27 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-11-02",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-11-02 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-11-03",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-11-03 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-11-04",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-11-04 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-11-06",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-11-06 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-11-09",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-11-09 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-11-11",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-11-11 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-11-16",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-11-16 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-11-18",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-11-18 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-11-20",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-11-20 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-11-23",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-11-23 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-11-24",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-11-24 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-11-25",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-11-25 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-11-27",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-11-27 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-11-30",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-11-30 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-12-01",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-12-01 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-12-04",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-12-04 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-12-07",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-12-07 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-12-09",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-12-09 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-12-10",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-12-10 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-12-22",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-12-22 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-12-24",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-12-24 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-12-26",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-12-26 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-12-29",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-12-29 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-12-31",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2015-12-31 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-01-01",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-01-01 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-01-07",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-01-07 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-01-09",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-01-09 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-01-11",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-01-11 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-01-12",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-01-12 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-01-13",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-01-13 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-01-15",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-01-15 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-01-21",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-01-21 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-01-25",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-01-25 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-01-30",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-01-30 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-02-02",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-02-02 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-02-03",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-02-03 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-02-05",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-02-05 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-02-08",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-02-08 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-02-11",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-02-11 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-02-12",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-02-12 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-02-15",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-02-15 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-02-16",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-02-16 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-02-22",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-02-22 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-02-23",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-02-23 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-02-25",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-02-25 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-02-26",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-02-26 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-03-01",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-03-01 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-03-02",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-03-02 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-03-04",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-03-04 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-03-07",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-03-07 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-03-08",
                       "Action": "[Irrigation].Apply(amount: 4, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-03-08 [Irrigation].Apply(amount: 4, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-03-10",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-03-10 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-03-14",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-03-14 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-03-15",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-03-15 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-03-18",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-03-18 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-03-21",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-03-21 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-03-22",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-03-22 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-03-23",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-03-23 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-03-28",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-03-28 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-04-02",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-04-02 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-04-08",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-04-08 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-05-04",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-05-04 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-08-31",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-08-31 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-09-30",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-09-30 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-10-01",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-10-01 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-10-05",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-10-05 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-10-12",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-10-12 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-10-18",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-10-18 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-10-19",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-10-19 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-10-27",
                       "Action": "[Irrigation].Apply(amount: 10, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-10-27 [Irrigation].Apply(amount: 10, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-10-31",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-10-31 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-11-01",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-11-01 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-11-03",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-11-03 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-11-08",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-11-08 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-11-10",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-11-10 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-11-11",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-11-11 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-11-14",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-11-14 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-11-21",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-11-21 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-11-22",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-11-22 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-11-23",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-11-23 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-11-24",
                       "Action": "[Irrigation].Apply(amount: 7, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-11-24 [Irrigation].Apply(amount: 7, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-11-28",
                       "Action": "[Irrigation].Apply(amount: 8, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-11-28 [Irrigation].Apply(amount: 8, efficiency: 0.8)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-11-29",
                       "Action": "[Irrigation].Apply(amount: 9, efficiency: 0.8)",
-                      "Enabled": true
+                      "Line": "2016-11-29 [Irrigation].Apply(amount: 9, efficiency: 0.8)"
                     }
                   ],
                   "Name": "IrrigationSchedule",
@@ -1301,114 +1473,1092 @@
                   "Operation": [
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-10-23",
                       "Action": "[DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)",
-                      "Enabled": true
+                      "Line": "2014-10-23 [DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-11-25",
                       "Action": "[DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)",
-                      "Enabled": true
+                      "Line": "2014-11-25 [DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2014-12-30",
                       "Action": "[DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)",
-                      "Enabled": true
+                      "Line": "2014-12-30 [DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-02-04",
                       "Action": "[DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)",
-                      "Enabled": true
+                      "Line": "2015-02-04 [DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-03-10",
                       "Action": "[DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)",
-                      "Enabled": true
+                      "Line": "2015-03-10 [DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-04-16",
                       "Action": "[DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)",
-                      "Enabled": true
+                      "Line": "2015-04-16 [DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-06-09",
                       "Action": "[DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)",
-                      "Enabled": true
+                      "Line": "2015-06-09 [DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-10-06",
                       "Action": "[DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)",
-                      "Enabled": true
+                      "Line": "2015-10-06 [DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-11-16",
                       "Action": "[DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)",
-                      "Enabled": true
+                      "Line": "2015-11-16 [DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2015-12-16",
                       "Action": "[DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)",
-                      "Enabled": true
+                      "Line": "2015-12-16 [DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-01-25",
                       "Action": "[DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)",
-                      "Enabled": true
+                      "Line": "2016-01-25 [DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-02-24",
                       "Action": "[DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)",
-                      "Enabled": true
+                      "Line": "2016-02-24 [DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-04-09",
                       "Action": "[DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)",
-                      "Enabled": true
+                      "Line": "2016-04-09 [DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-05-24",
                       "Action": "[DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)",
-                      "Enabled": true
+                      "Line": "2016-05-24 [DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-10-03",
                       "Action": "[DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)",
-                      "Enabled": true
+                      "Line": "2016-10-03 [DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)"
                     },
                     {
                       "$type": "Models.Operation, Models",
+                      "Enabled": true,
                       "Date": "2016-11-11",
                       "Action": "[DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)",
-                      "Enabled": true
+                      "Line": "2016-11-11 [DefoliationManager].Script.Defoliate(defoliationType: \"Cut\", amountDM: 40, amountType: \"ResidualDM\", duration: 1)"
                     }
                   ],
                   "Name": "DefoliationSchedule",
                   "ResourceName": null,
                   "Children": [],
-                  "Enabled": true,
+                  "Enabled": false,
                   "ReadOnly": false
                 },
                 {
                   "$type": "Models.Manager, Models",
-                  "Code": "// Performs defoliations, or removes biomass, from any existing plant (PMF and/or AgPasture) based on a set of given rules.  \r\n// Defoliations can be triggered automatically by this manager or be called from another Script or a Schedule model.\r\n// Developed by RCichota, last updated in 31/Mar/2019\r\n\r\nnamespace Models\r\n{\r\nusing Models.PMF.Interfaces;\r\nusing Models.Soils.Nutrients;\r\nusing System;\r\nusing System.Xml.Serialization;\r\nusing System.Collections.Generic;\r\nusing APSIM.Shared.Utilities;\r\nusing Models.Core;\r\nusing Models.Soils;\r\nusing Models.PMF;\r\nusing Models.Interfaces;\r\nusing Models.PMF.Interfaces;\r\nusing System.Linq;\r\nusing Newtonsoft.Json;\nusing Models.ForageDigestibility;\r\n\r\n    [Serializable]\r\n    public class Script : Model\r\n    {\r\n        [Link] private Clock clock;\r\n        [Link] private Zone myZone;\r\n        [Link] private Soil mySoil;\r\n        [Link(ByName = true)] private ISolute Urea;\r\n        [Link] private ISummary mySummary;\n        [Link] private Forages forages;\r\n        public event BiomassRemovedDelegate BiomassRemoved;\r\n        private string baseDefoliationType;\r\n        private string typeOfDefoliation;\r\n        private string baseAmountType;\r\n        private string typeOfAmount;\r\n        private double amountGiven;\r\n        private double herbageToRemove;\r\n\r\n        private int durationOfDefoliation;\r\n        private int daysDefoliating;\r\n        private double cumAmountHarvested;\r\n        private double atZ0;\r\n        private double atZ1;\r\n        private double fractionToRemove;\r\n        private double fractionToResidue;\r\n        private double speciesHarvestedWt;\r\n        private double speciesHarvestedN;\r\n        private double speciesFractionToRemove;\r\n        [Link]\r\n        private IPhysical soilPhysical;\r\n        //> Links to other Apsim models\r\n        //Auxiliary 'links'\r\n        private List<Plant> PMFSpecies = new List<Plant>();\r\n        private List<AgPasture.PastureSpecies> AgPSpecies = new List<AgPasture.PastureSpecies>();\r\n\r\n        //> Events raised by this manager\r\n\r\n        //> User inputs from properties tab\r\n        [Separator(\"Generic defoliation management - removes biomass from PMF and AgPasture species, plus residue management\")]\r\n        [Description(\"Allow this manager to control defoliations? \")]\r\n        public bool AutomaticManagementIsEnabled { get; set; }\r\n        [Description(\"Date to start the defoliation management (dd/mm/yyyy): \")]\r\n        public DateTime DefoliationRotationStartDate { get; set; }\r\n        [Description(\"Date to end the defoliation management (dd/mm/yyyy): \")]\r\n        public DateTime DefoliationRotationEndDate { get; set; }\r\n\r\n        [Separator(\"Parameters defining how the defoliation is managed\")]\r\n        [Description(\"What type of defoliation should be triggered? \")]\r\n        public DefoliationTypes DefoliateType { get; set; }\r\n        [Description(\"How the defoliations should be triggered? \")]\r\n        public DefoliationTriggerTypes DefoliationTriggerType { get; set; }\r\n        [Description(\"  Minimum number of days between defoliations, used if trigger is an interval: \")]\r\n        public int IntervalBetweenDefoliations { get; set; }\r\n        [Description(\"  Minimum standing biomass to start defoliations, used if trigger is DM target(g/m2): \")]\r\n        public int TargetStandingBiomass { get; set; }\r\n        [Description(\"Duration of each defoliation event (days): \")]\r\n        public int DurationOfEachDefoliation { get; set; }\r\n        [Description(\"Which amount is being defined? \")]\r\n        public DefoliateAmountTypes RemoveAmountType { get; set; }\r\n        [Description(\"DM amount to use (g/m2): \")]\r\n        public double AmountForEachDefoliation { get; set; }\r\n        [Description(\"For PMF species, allow all biomass to be removed? \")]\r\n        public bool RemoveAllBiomassIsEnabled { get; set; }\r\n\r\n        [Separator(\"Parameters defining the management of the defoliated biomass\")]\r\n        [Description(\"How much of the DM defoliated is to be removed from the field? \")]\r\n        public DMRemovalTypes DMRemoveType { get; set; }\r\n        [Description(\"  Fraction of DM to remove off field, if using UserDefinedFraction (0-1): \")]\r\n        public double FractionDMToRemove { get; set; }\r\n        [Description(\"How much of the N defoliated is to be removed from the field? \")]\r\n        public NRemovalTypes NRemoveType { get; set; }\r\n        [Description(\"  Fraction of N to remove off field, if using UserDefinedFraction (0-1): \")]\r\n        public double FractionNToRemove { get; set; }\r\n        [Description(\"How the non-removed material is returned to the field? \")]\r\n        public ReturnAsTypes ReturnType { get; set; }\r\n\r\n        [Separator(\"Parameters for partitioning non-removed N into urine and dung\")]\r\n        [Description(\"How the partition of N to dung and urine is defined? \")]\r\n        public DungNContentTypes NDungType { get; set; }\r\n        [Description(\"  Proportion of N returned in dung, if using DefineProportion (0-1): \")]\r\n        public double ProportionN2Dung { get; set; }\r\n        [Description(\"  The C:N of dung, if using DefineCNratio (typically around 20): \")]\r\n        public double CNRatioDung { get; set; }\r\n        [Description(\"Soil depth down to which urine should be applied (mm): \")]\r\n        public double UrineDepth { get; set; }\r\n\r\n        //> Outputs from this manager\r\n        [JsonIgnore][Units(\"g/m2\")] // Pasture DM defoliated (removed from plants) today\r\n        public double DefoliatedWt{ get; set; }\r\n        [JsonIgnore][Units(\"g/m2\")] // N in the pasture material defoliated today\r\n        public double DefoliatedN{ get; set; }\r\n        [JsonIgnore][Units(\"g/m2\")] // Pasture DM harvested (removed from plants minus direct residue) today\r\n        public double HarvestedWt{ get; set; }\r\n        [JsonIgnore][Units(\"g/m2\")] // N in the pasture material harvested today\r\n        public double HarvestedN{ get; set; }\r\n        [JsonIgnore][Units(\"g/m2\")] // Pasture DM actually removed from the field\r\n        public double RemovedWt{ get; set; }\r\n        [JsonIgnore][Units(\"g/m2\")] // N in the pasture material removed from the field\r\n        public double RemovedN{ get; set; }\r\n        [JsonIgnore][Units(\"g/m2\")] // Pasture DM returned by this manager to the field\r\n        public double ReturnedWt{ get; set; }\r\n        [JsonIgnore][Units(\"g/m2\")] // N in the pasture material returned by this manager to the field\r\n        public double ReturnedN{ get; set; }\r\n        [JsonIgnore][Units(\"g/m2\")] // Non-removed N returned as dung (to SurfaceOM)\r\n        public double NReturnedInDung{ get; set; }\r\n        [JsonIgnore][Units(\"g/m2\")] // Non-removed N returned as urine (soil urea)\r\n        public double NReturnedInUrine{ get; set; }\r\n        [JsonIgnore][Units(\"days\")] // Number of days since the end of last defoliation event\r\n        public int DaysSinceLastDefoliation{ get; set; }\r\n        [JsonIgnore][Units(\"g/m2\")] // Total standing aboveground DM before a defoliation\r\n        public double PreHarvestDM{ get; set; }\r\n        [JsonIgnore][Units(\"g/m2\")] // Total standing aboveground DM after a defoliation\r\n        public double PostHarvestDM{ get; set; }\r\n        [JsonIgnore][Units(\"g/m2\")] // Total pasture DM harvested over a complete defoliation event\r\n        public double RotationHarvestedDM{ get; set; }\r\n\r\n        //> Internal variables\r\n        private double[] urineFraction;                  // fraction of urine to be applied in each soil layer\r\n        // auxiliary boolean\r\n        private bool aDefoliationHasHappened = false; // flag whether a defoliation has happened in this simulation run\r\n\r\n        // auxiliary - lists of species and removal fractions\r\n        private string[] swardSpeciesName;              // name of each species in the sward\r\n        private string[] swardSpeciesType;              // type of each species in the sward (PMF or AgPasture)\r\n        private double[] speciesFraction;              // biomass fraction of harvestable material of each species\r\n\r\n        [EventSubscribe(\"StartOfSimulation\")]\r\n        private void OnSimulationCommencing(object sender, EventArgs e)\r\n        {\r\n            // check the type of defoliation given\r\n            if (DefoliateType == DefoliationTypes.Cut)\r\n                baseDefoliationType = \"Cut\";\r\n            else if (DefoliateType == DefoliationTypes.Graze)\r\n                baseDefoliationType = \"Graze\";\r\n            else\r\n                baseDefoliationType = \"Harvest\";\r\n\r\n            // check the type of amount given\r\n            if (RemoveAmountType == DefoliateAmountTypes.DMToRemove)\r\n                baseAmountType = \"DMToRemove\";\r\n            else if (RemoveAmountType == DefoliateAmountTypes.ResidualDM)\r\n                baseAmountType = \"ResidualDM\";\r\n            else\r\n                baseAmountType = \"UseDefoliationFractions\";\r\n\r\n            // check the interval between events\r\n            if (IntervalBetweenDefoliations < 1)\r\n                throw new Exception(\"The interval between defoliation events must be at least one day\");\r\n\r\n            // check the duration for each defoliation\r\n            if(DurationOfEachDefoliation <= 0)\r\n                throw new Exception(\"The duration of defoliations cannot be zero or negative!\");\r\n\r\n            // check the fraction of defoliated material to remove from the field\r\n            if (DMRemoveType == DMRemovalTypes.RemoveAll)\r\n                FractionDMToRemove = 1.0;\r\n            else if (DMRemoveType == DMRemovalTypes.RemoveNone)\r\n                FractionDMToRemove = 0.0;\r\n            else if (DMRemoveType == DMRemovalTypes.BasedOnDigestibility)\r\n                FractionDMToRemove = -1.0;  // will be calculated dynamically\r\n            else // DMRemoveType == DMRemovalTypes.UserDefinedFraction\r\n            {\r\n                if (FractionDMToRemove < 0.0)\r\n                    throw new Exception(\"The fraction of DM defoliated to remove from the field cannot be negative!\");\r\n            }\r\n\r\n            // check the fraction of defoliated N to remove from the field\r\n            if (NRemoveType == NRemovalTypes.RemoveAll)\r\n                FractionNToRemove = 1.0;\r\n            else if (NRemoveType == NRemovalTypes.RemoveNone)\r\n                FractionNToRemove = 0.0;\r\n            else if (NRemoveType == NRemovalTypes.ProportionalToDM)\r\n                FractionNToRemove = FractionDMToRemove;\r\n            else // NRemoveType == NRemovalTypes.UserDefinedFraction\r\n            {\r\n                if (FractionNToRemove < 0.0)\r\n                    throw new Exception(\"The fraction of defoliated N to remove from the field cannot be negative!\");\r\n            }\r\n\r\n            // set up the links to all plant species\r\n            PMFSpecies = myZone.FindAllChildren<Plant>().ToList();\r\n            AgPSpecies = myZone.FindAllChildren<AgPasture.PastureSpecies>().ToList();\r\n\r\n            int numPlants = PMFSpecies.Count + AgPSpecies.Count;\r\n            swardSpeciesName = new string[numPlants];\r\n            swardSpeciesType = new string[numPlants];\r\n            int i = 0;\r\n            foreach (Plant species in myZone.FindAllChildren<Plant>().OfType<IModel>().ToList())\r\n            {\r\n                swardSpeciesName[i] = species.Name;\r\n                swardSpeciesType[i] = \"PMF\";\r\n                i += 1;\r\n            }\r\n            foreach (AgPasture.PastureSpecies species in myZone.FindAllChildren<AgPasture.PastureSpecies>().OfType<IModel>().ToList())\r\n            {\r\n                swardSpeciesName[i] = species.Name;\r\n                swardSpeciesType[i] = \"AgPasture\";\r\n                i += 1;\r\n            }\r\n\r\n            // initialise some variables\r\n            speciesFraction = new double[numPlants];\r\n            \r\n            DaysSinceLastDefoliation = 0;\r\n            durationOfDefoliation = -1;\r\n            daysDefoliating = 0;\r\n            resetMyOutputs();\r\n\r\n            // set the fraction of urine for each layer\r\n            if (ReturnType == ReturnAsTypes.AsDungUrine)\r\n            {\r\n                double depthFromSurface = 0.0;\r\n                for (int layer = 0; layer < soilPhysical.Thickness.Length; layer++)\r\n                {\r\n                    depthFromSurface += soilPhysical.Thickness[layer];\r\n                    if (depthFromSurface >= UrineDepth)\r\n                    { // bottom layer found\r\n                        urineFraction = new double[layer + 1];\r\n                        double distFactor = 1.5;\r\n                        double totalProp = UrineDepth * Math.Pow(1.0, distFactor) / (distFactor + 1.0);\r\n                        depthFromSurface = 0.0;\r\n                        atZ1 = (UrineDepth - depthFromSurface) * Math.Pow(1.0 - depthFromSurface / UrineDepth, distFactor) / (distFactor + 1.0);\r\n                        for (int z = 0; z < layer+1; z++)\r\n                        {\r\n                            atZ0 = atZ1;\r\n                            depthFromSurface += soilPhysical.Thickness[z];\r\n                            atZ1 = (UrineDepth - depthFromSurface) * Math.Pow(1.0 - depthFromSurface / UrineDepth, distFactor) / (distFactor + 1);\r\n                            if (1.0 - (depthFromSurface / UrineDepth) < 0.0)\r\n                                atZ1 = 0;\r\n                            urineFraction[z] = (atZ0 - atZ1) / totalProp;\r\n                        }\r\n                        layer = soilPhysical.Thickness.Length;\r\n                    }\r\n                }\r\n            }\r\n\r\n            // write message in summary\r\n            mySummary.WriteMessage(this,\" Automatic defoliation manager initialised\", MessageType.Diagnostic);\r\n            if (AutomaticManagementIsEnabled)\r\n            {\r\n                mySummary.WriteMessage(this, \"   Defoliations will happen between \" + DefoliationRotationStartDate.ToShortDateString()\r\n                                          + \" and \" + DefoliationRotationEndDate.ToShortDateString() + \".\", MessageType.Diagnostic);\r\n                mySummary.WriteMessage(this, \"   Biomass from the sward will be defoliated simulating a \\\"\" + baseDefoliationType + \"\\\" rotation.\", MessageType.Diagnostic);\r\n                if (DefoliationTriggerType == DefoliationTriggerTypes.TargetStandingBiomass)\r\n                    mySummary.WriteMessage(this, \"   Events will happen whenever aboveground biomass surpasses \" + TargetStandingBiomass.ToString(\"#0.0\") + \" g/m2.\", MessageType.Diagnostic);\r\n                else\r\n                    mySummary.WriteMessage(this, \"   Events will happen every \" + IntervalBetweenDefoliations + \" days, if there is enough biomass.\", MessageType.Diagnostic);\r\n                if(baseAmountType == \"ResidualDM\")\r\n                    mySummary.WriteMessage(this, \"   Removing biomass down to a residual amount of \" + AmountForEachDefoliation.ToString(\"#.0\") + \" g/m2 over \" \r\n                                             + DurationOfEachDefoliation + \" days.\", MessageType.Diagnostic);\r\n                else\r\n                    mySummary.WriteMessage(this, \"   Removing \" + AmountForEachDefoliation.ToString(\"#.0\") + \" g/m2 of biomass per day over \" \r\n                                             + DurationOfEachDefoliation + \" days.\", MessageType.Diagnostic);\r\n            }\r\n            else\r\n            {\r\n                mySummary.WriteMessage(this,\"   Automatic defoliations are currently disabled, though defoliations can be triggered by another manager\", MessageType.Diagnostic);\r\n                mySummary.WriteMessage(this,\"   If called, the manager will remove biomass from the sward simulating a \\\"\" + baseDefoliationType + \"\\\" event.\", MessageType.Diagnostic);\r\n            }\r\n\r\n            if(ReturnType == ReturnAsTypes.AsDungUrine)\r\n            {\r\n                mySummary.WriteMessage(this,\"   Non-removed material will be returned as dung and urine. Urine added to soil according to proportions: \"\r\n                + string.Join(\", \",urineFraction), MessageType.Diagnostic);\r\n            }\r\n            else\r\n                mySummary.WriteMessage(this,\"   Non-removed material will be returned as residue.\", MessageType.Diagnostic);\r\n        }\r\n\r\n        [EventSubscribe(\"DoManagement\")]\r\n        private void OnDoManagement(object sender, EventArgs e)\r\n        {\r\n            // check whether we need to continue defoliationg, i.e. within a multi-day defoliation event (need to check this first in the day)\r\n            if ((daysDefoliating > 0) && (daysDefoliating < durationOfDefoliation))\r\n            {\r\n                // reset outputs\r\n                resetMyOutputs();\r\n\r\n                // re-check the amount to defoliate\r\n                double harvestableBiomass = harvestableSwardBiomass(\"All\", \"Harvestable\");\r\n                if (typeOfAmount == \"DMToRemove\")\r\n                {\r\n                    if(harvestableBiomass > 0.001)\r\n                        herbageToRemove = Math.Min(harvestableBiomass, (amountGiven - cumAmountHarvested) / (durationOfDefoliation - daysDefoliating));\r\n                }\r\n                else if (typeOfAmount == \"ResidualDM\")\r\n                {\r\n                    double currentDM = standingSwardBiomassWt;\r\n                    if (currentDM > amountGiven)\r\n                        herbageToRemove = Math.Min(harvestableBiomass, (currentDM - amountGiven) / (durationOfDefoliation - daysDefoliating));\r\n                }\r\n\r\n                // remove plant biomass and return residue\r\n                if (Math.Abs(herbageToRemove) >= 0.001)\r\n                {\r\n                    // set biomass removal\r\nmySummary.WriteMessage(this, \"   Defoliation initialised on DoManagement - \" + clock.Today.Date.ToShortDateString(), MessageType.Diagnostic);\r\n                    defoliateSward(herbageToRemove, typeOfDefoliation);\r\n\r\n                    // return residue or excreta\r\n                    if(ReturnedWt + ReturnedN > 0.0)\r\n                    {\r\n                        if (ReturnType == ReturnAsTypes.AsResidue)\r\n                            returnResidues();\r\n                        else\r\n                            returnExcreta();\r\n                    }\r\n\r\n                    // gather amount removed this event\r\n                    cumAmountHarvested += HarvestedWt;\r\n                }\r\n\r\n                daysDefoliating += 1;\r\n            }\r\n\r\n            // check whether a defoliation ended yesterday\r\n            if (daysDefoliating < 0)\r\n            { // clean up variables\r\n                resetMyOutputs();\r\n                daysDefoliating = 0;\r\n            }\r\n\r\n            // check whether automatic defoliations are enabled\r\n            if (AutomaticManagementIsEnabled)\r\n            {\r\n                // check whether we are within the period in which defoliations can happen\r\n                if ((clock.Today.Date >= DefoliationRotationStartDate.Date) && (clock.Today.Date <= DefoliationRotationEndDate.Date))\r\n                {\r\n                    if (clock.Today.Date == DefoliationRotationStartDate.Date)\r\n                        DaysSinceLastDefoliation = IntervalBetweenDefoliations;\r\n\r\n                    // check whether we should start a defoliation event\r\n                    if (DefoliationTriggerType == DefoliationTriggerTypes.FixedInterval)\r\n                    {\r\n                        if (DaysSinceLastDefoliation == IntervalBetweenDefoliations)\r\n                            Defoliate(baseDefoliationType, AmountForEachDefoliation, baseAmountType, DurationOfEachDefoliation);\r\n                    }\r\n                    else if (DefoliationTriggerType == DefoliationTriggerTypes.TargetInterval)\r\n                    {\r\n                        if (DaysSinceLastDefoliation >= IntervalBetweenDefoliations)\r\n                            Defoliate(baseDefoliationType, AmountForEachDefoliation, baseAmountType, DurationOfEachDefoliation);\r\n                    }\r\n                    else  //DefoliationTriggerType == DefoliationTriggerTypes.TargetStandingBiomass\r\n                    {\r\n                        if (standingSwardBiomassWt >= TargetStandingBiomass)\r\n                            Defoliate(baseDefoliationType, AmountForEachDefoliation, baseAmountType, DurationOfEachDefoliation);\r\n                    }\r\n                }\r\n                //// Note: Only the code above, responsible for triggering automatic events, is limited by 'AutomaticManagementIsEnabled'. \r\n                ////       The rest of the code is still available to perform one-off defoliations.\r\n                ////       It can be called from another manager or a schedulle thingy via Defoliate().\r\n            }\r\n        }\r\n\r\n        [EventSubscribe(\"DoManagementCalculations\")]\r\n        private void OnDoManagementCalculations(object sender, EventArgs e)\r\n        {\r\n            // check whether a defoliation event has just been completed\r\n            if (daysDefoliating == durationOfDefoliation)\r\n            {\r\n                // get amount of biomass remaining and zero counters\r\n                PostHarvestDM = standingSwardBiomassWt;\r\n                RotationHarvestedDM = cumAmountHarvested;\r\n                aDefoliationHasHappened = true;\r\n                daysDefoliating = -1;\r\n            }\r\n\r\n            // count the days after a defoliation\r\n            if (aDefoliationHasHappened && (daysDefoliating == 0))\r\n                DaysSinceLastDefoliation += 1;\r\n        }\r\n\r\n        /// <summary>Sets up a defoliation event.</summary>\r\n        /// <param name=\"defoliationType\">Type of defoliation (cut, graze, or harvest)</param>\r\n        /// <param name=\"amountDM\">Amount of biomass to use (g/m2)</param>\r\n        /// <param name=\"amountType\">How the DM amount is interpreted (toRemove, residual)</param>\r\n        /// <param name=\"duration\">Number of days to defoliate over</param>\r\n        public void Defoliate(string defoliationType, double amountDM, string amountType, int duration)\r\n        {\r\n            // check whether there are plants in the sward that can be defoliated\r\n            if (swardHasLivingPlants)\r\n            {\r\n                // check the defoliation type\r\n                if (defoliationType.ToLower() == \"cut\")\r\n                    typeOfDefoliation = \"Cut\";\r\n                else if (defoliationType.ToLower() == \"graze\")\r\n                    typeOfDefoliation = \"Graze\";\r\n                else if (defoliationType.ToLower() == \"harvest\")\r\n                    typeOfDefoliation = \"Harvest\";\r\n                else\r\n                    throw new Exception(\"Defoliation type should be either \\\"Cut\\\", \\\"Graze\\\", or \\\"Harvest\\\"!\");\r\n\r\n                // check DM amount given\r\n                if (amountDM < 0.0)\r\n                    throw new Exception(\"Amount to defoliate cannot be negative!\");\r\n                else\r\n                    amountGiven = amountDM;\r\n\r\n                // check the type of amount given\r\n                if (amountType.ToLower() == \"dmtoremove\")\r\n                    typeOfAmount = \"DMToRemove\";\r\n                else if (amountType.ToLower() == \"residualdm\")\r\n                    typeOfAmount = \"ResidualDM\";\r\n                else if (amountType.ToLower() == \"usedefoliationfractions\")\r\n                    typeOfAmount = \"UseDefoliationFractions\";\r\n                else\r\n                    throw new Exception(\"Amount type should be \\\"DMToRemove\\\", \\\"ResidualDM\\\", or \\\"UseDefoliationFractions\\\"!\");\r\n\r\n                // check duration given\r\n                if (duration <= 0)\r\n                    throw new Exception(\"Duration of defoliation cannot be zero or negative!\");\r\n                else\r\n                    durationOfDefoliation = duration;\r\n\r\n                // check existing biomass and amount to remove\r\n                PreHarvestDM = standingSwardBiomassWt;\r\n                herbageToRemove = 0.0;\r\n                double harvestableBiomass = harvestableSwardBiomass(\"All\", \"Harvestable\");\r\n                if (typeOfAmount == \"UseDefoliationFractions\")\r\n                { // amount given is ignored, removal based on fractions\r\n                    amountGiven = 0.0;\r\n                    if (harvestableBiomass > 0.0)\r\n                        herbageToRemove = -1.0;\r\n\r\n                    mySummary.WriteMessage(this, \"   Defoliation triggered, removing biomass using the removal fractions (set or default), during \" + durationOfDefoliation + \" days\", MessageType.Diagnostic);\r\n                }\r\n                else if (typeOfAmount == \"DMToRemove\")\r\n                {\r\n                    if (amountGiven > 0.001)\r\n                    { // a meaningful amount was given, check whether all can be removed\r\n                        if (harvestableBiomass > 0.001)\r\n                            herbageToRemove = Math.Min(harvestableBiomass, amountGiven / durationOfDefoliation);\r\n\r\n                        mySummary.WriteMessage(this, \"   Defoliation triggered, attempting to remove \" + amountGiven.ToString(\"#0.0\") + \" g/m2 of biomass over \" + durationOfDefoliation + \" days\", MessageType.Diagnostic);\r\n                    }\r\n                }\r\n                else if (typeOfAmount == \"ResidualDM\")\r\n                {\r\n                    // check how much biomass will be removed\r\n                    if (PreHarvestDM > amountGiven)\r\n                        herbageToRemove = Math.Min(harvestableBiomass, (PreHarvestDM - amountGiven) / durationOfDefoliation);\r\n\r\n                    mySummary.WriteMessage(this, \"   Defoliation triggered, attempting to remove biomass down to \" + amountGiven.ToString(\"#0.0\") + \" g/m2 over \" + durationOfDefoliation + \" days\", MessageType.Diagnostic);\r\n                }\r\n\r\n                // can defoliation begin?\r\n                if (Math.Abs(herbageToRemove) >= 0.001)\r\n                {\r\n                    // set off first defoliation\r\nmySummary.WriteMessage(this, \"   Defoliation initialised on Defoliate - \" + clock.Today.Date.ToShortDateString(), MessageType.Diagnostic);\r\n                    defoliateSward(herbageToRemove, typeOfDefoliation);\r\n\r\n                    // return residue or excreta\r\n                    if(ReturnedWt + ReturnedN > 0.0)\r\n                    {\r\n                        if (ReturnType == ReturnAsTypes.AsResidue)\r\n                            returnResidues();\r\n                        else\r\n                            returnExcreta();\r\n                    }\r\n\r\n                    // gather values for this event\r\n                    cumAmountHarvested = HarvestedWt;\r\n                    daysDefoliating = 1;\r\n                    DaysSinceLastDefoliation = 0;\r\n                }\r\n                else\r\n                {\r\n                    // abort command as there is not enough biomass, check interval type\r\n                    if (DefoliationTriggerType == DefoliationTriggerTypes.FixedInterval)\r\n                    { // count the event as if it did happen\r\n                        cumAmountHarvested = 0.0;\r\n                        daysDefoliating = 1;\r\n                        DaysSinceLastDefoliation = 0;\r\n                    }\r\n\r\n                    mySummary.WriteMessage(this, \"   Defoliation did not happend because current biomass (\" + PreHarvestDM.ToString(\"#0.0\") + \" g/m2) is too low (total harvestable = \" + harvestableBiomass.ToString(\"#0.0\") + \" g/m2)\", MessageType.Diagnostic);\r\n                }\r\n            }\r\n            else\r\n            {\r\n                mySummary.WriteMessage(this, \"   Defoliation did not happend because there is no growing plants in the sward\", MessageType.Diagnostic);\r\n            }\r\n        }\r\n\r\n        /// <summary>Resets the values of outputs.</summary>\r\n        private void resetMyOutputs()\r\n        {\r\n            DefoliatedWt = 0.0;\r\n            DefoliatedN = 0.0;\r\n            HarvestedWt = 0.0;\r\n            HarvestedN = 0.0;\r\n            RemovedWt = 0.0;\r\n            RemovedN = 0.0;\r\n            ReturnedWt = 0.0;\r\n            ReturnedN = 0.0;\r\n            NReturnedInDung = 0.0;\r\n            NReturnedInUrine = 0.0;\r\n            RotationHarvestedDM = 0.0;\r\n        }\r\n\r\n        /// <summary>Flags whether there is any living plant in the sward.</summary>\r\n        private bool swardHasLivingPlants\r\n        {\r\n            get\r\n            {\r\n                bool result = false;\r\n                foreach (Plant species in PMFSpecies)\r\n                       result |= species.IsAlive;\r\n                foreach (AgPasture.PastureSpecies species in AgPSpecies)\r\n                       result |= species.IsAlive;\r\n                return result;\r\n            }\r\n        }\r\n\r\n        /// <summary>Amount of plant biomass aboveground (g/m2).</summary>\r\n        private double standingSwardBiomassWt\r\n        {\r\n            get\r\n            {\r\n                double result = 0.0;\r\n                foreach (Plant species in PMFSpecies)\r\n                   result += (double)myZone.Get(species.Name+\".AboveGround.Wt\");\r\n                foreach (AgPasture.PastureSpecies species in AgPSpecies)\r\n                    result += species.Standing.Wt*0.1;\r\n                return result;\r\n            }\r\n        }\r\n\r\n        /// <summary>Amount of N in plant's biomass aboveground (g/m2).</summary>\r\n        private double standingSwardBiomassN\r\n        {\r\n            get\r\n            {\r\n                double result = 0.0;\r\n                foreach (Plant species in PMFSpecies)\r\n                   result += (double)myZone.Get(species.Name+\".AboveGround.N\");\r\n                foreach (AgPasture.PastureSpecies species in AgPSpecies)\r\n                    result += species.Standing.N*0.1;\r\n                return result;\r\n            }\r\n        }\r\n\r\n        /// <summary>Amount of plant biomass from all organs available for defoliation (g/m2).</summary>\r\n        /// <remarks>Assumes that organs with a BiomassRemoval.FractionToRemove > 0 are harvestable.\r\n        /// For AgPasture, harvestable is based on minimum DM.</remarks>\r\n        /// <param name=\"plantName\">The name of the plant to retrieve its biomass</param>\r\n        /// <param name=\"fractionType\">The type of fraction to use (harvestable or total)</param>\r\n        private double harvestableSwardBiomass(string plantName, string fractionType)\r\n        {\r\n            double amountWt = 0.0;\r\n            double fraction = 0.0;\r\n        \tforeach (var forage in forages.ModelsWithDigestibleBiomass)\n        \t{\n        \t\tif (plantName == \"All\" || forage.Name == plantName)\n        \t\t{\n\t\t    \t\tforeach (var material in forage.Material) \n\t\t    \t\t{\n\t\t    \t\t\tif (fractionType == \"Total\")\n\t\t    \t\t\t\tamountWt += material.Total.Wt;\n\t\t    \t\t\telse\n\t\t    \t\t\t\tamountWt += material.Consumable.Wt;\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t}\n\t\t\t\r\n            return amountWt;\r\n        }\r\n\r\n        /// <summary>Triggers the actual biomass removal and gather DM and N amounts.</summary>\r\n        /// <param name=\"amountToRemove\">The total DM amount to remove (g/m2)</param>\r\n        /// <param name=\"removalType\">The type of removal (Cut, Graze, Harvest)</param>\r\n        private void defoliateSward(double amountToRemove, string removalType)\r\n        {\r\n            // get the amounts of biomass and N before today's defoliation\r\n            double preRemovalDM = standingSwardBiomassWt;\r\n            double preRemovalN = standingSwardBiomassN;\r\n            double fractionToRemove = 0.0;\r\n\r\n            // gather the actual biomass removal fractions, checking whether they need to be adjusted\r\n            double totalHarvestableAmount = harvestableSwardBiomass(\"All\", \"Harvestable\");\r\n            if (amountToRemove > 0.0)\r\n            { // an amount was given for defoliation, adjust removal fractions for each species in order to remove the amount specified\r\n                fractionToRemove = amountToRemove / totalHarvestableAmount;\r\n            }\r\n            else if (amountToRemove < 0.0)\r\n            { // defoliation is not based on an amount, removal is determined simply by the removal fractions\r\n                fractionToRemove = 1.0;\r\n            }\r\n\r\n            for (int i = 0; i < swardSpeciesName.Length; i++)\r\n            {\r\n                speciesFraction[i] = harvestableSwardBiomass(swardSpeciesName[i], \"Harvestable\") / totalHarvestableAmount;\r\n                if (swardSpeciesType[i] == \"PMF\")\r\n                {\r\n                    // check whether the plant is alive\r\n                    bool speciesIsAlive = (bool)myZone.Get(swardSpeciesName[i]+\".IsEmerged\");\r\n                    if (speciesIsAlive)\r\n                    {\r\n                        // set removal fractions (these overrides the default removals in the plant)\r\n                        setRemoveFraction(swardSpeciesName[i], fractionToRemove);\r\n\r\n                        // do the actual biomass removal\r\n                        foreach (Plant species in PMFSpecies)\r\n                        {\r\n                            if(species.Name == swardSpeciesName[i])\r\n                            {\r\n\r\n                                break;\r\n                            }\r\n                        }\r\n                    }\r\n                }\r\n                else\r\n                {\r\n                    // check whether the plant is alive\r\n                    bool speciesIsAlive = (bool)myZone.Get(swardSpeciesName[i]+\".IsAlive\");\r\n                    if (speciesIsAlive)\r\n                    {\r\n                        // set removal amount (needs to be in kg/ha)\r\n                        double amountRequired = (double)myZone.Get(swardSpeciesName[i]+\".Harvestable.Wt\");\r\n                        if (amountToRemove > 0.0)\r\n                            amountRequired = amountToRemove * speciesFraction[i] * 10.0;\r\n\r\n                        // do the actual biomass removal\r\n                        foreach (AgPasture.PastureSpecies species in AgPSpecies)\r\n                        {\r\n                            if(species.Name == swardSpeciesName[i])\r\n                            {\r\n                                species.RemoveBiomass(amount: amountRequired, type: \"SetRemoveAmount\");\r\n                                break;\r\n                            }\r\n                        }\r\n                    }\r\n                }\r\n            }\r\n\r\n            // get the amounts of biomass and N after today's defoliation\r\n            double postRemovalDM = standingSwardBiomassWt;\r\n            double postRemovalN = standingSwardBiomassN;\r\n\r\n            // get total defoliation (total plant stuff lost)\r\n            DefoliatedWt = preRemovalDM - postRemovalDM;\r\n            DefoliatedN = preRemovalN - postRemovalN;\r\n\r\n            // get amounts harvested, removed, and returned\r\n            manageDefoliatedBiomass();\r\n        }\r\n\r\n        /// <summary>Sets the biomass removal fractions for PMF plants.</summary>\r\n        /// <param name=\"plantName\">The name of PMF species</param>\r\n        /// <param name=\"fractionHarvestable\">The fraction of harvestable biomass to be removed (0-1)</param>\r\n        private void setRemoveFraction(string plantName, double fractionHarvestable)\r\n        {\r\n            /*foreach (Plant species in PMFSpecies)\r\n            {\r\n                if ((species.Name == plantName) && (species.IsAlive))\r\n                {\r\n\r\n                    // set removal fractions (these overrides the default removals in the plant)\r\n                    foreach (IOrgan organ in species.FindAllChildren<IOrgan>().OfType<IModel>().ToList())\r\n                    {\r\n                        // first get the removal for Live material\r\n                        fractionToRemove = (double)myZone.Get(species.Name + \".\" + organ.Name + \".BiomassRemovalDefaults.\" + typeOfDefoliation + \".FractionLiveToRemove\");\r\n                        if (RemoveAllBiomassIsEnabled && (fractionToRemove > 0.0))\r\n                            fractionToRemove = 0.95;\r\n                        fractionToRemove = fractionHarvestable * fractionToRemove;\r\n                        fractionToRemove = Math.Min(1.0, fractionToRemove);\r\n                        defoliationFractions.SetFractionToRemove(organ.Name, fractionToRemove, \"Live\");\r\n                        if (RemoveAllBiomassIsEnabled)\r\n                            fractionToResidue = 0.0;\r\n                        else\r\n                            fractionToResidue = (double)myZone.Get(species.Name + \".\" + organ.Name + \".BiomassRemovalDefaults.\" + typeOfDefoliation + \".FractionLiveToResidue\");\r\n                        fractionToResidue = Math.Min(fractionHarvestable * fractionToResidue, 1.0 - fractionToRemove);\r\n                        defoliationFractions.SetFractionToResidue(organ.Name, fractionToResidue, \"Live\");\r\n\r\n                        // then get the removal for Dead material\r\n                        fractionToRemove = (double)myZone.Get(species.Name + \".\" + organ.Name + \".BiomassRemovalDefaults.\" + typeOfDefoliation + \".FractionDeadToRemove\");\r\n                        if (RemoveAllBiomassIsEnabled && (fractionToRemove > 0.0))\r\n                            fractionToRemove = 0.95;\r\n                        fractionToRemove = fractionHarvestable * fractionToRemove;\r\n                        fractionToRemove = Math.Min(1.0, fractionToRemove);\r\n                        defoliationFractions.SetFractionToRemove(organ.Name, fractionToRemove, \"Dead\");\r\n                        if (RemoveAllBiomassIsEnabled)\r\n                            fractionToResidue = 0.0;\r\n                        else\r\n                            fractionToResidue = (double)myZone.Get(species.Name + \".\" + organ.Name + \".BiomassRemovalDefaults.\" + typeOfDefoliation + \".FractionDeadToResidue\");\r\n                        fractionToResidue = Math.Min(fractionHarvestable * fractionToResidue, 1.0 - fractionToRemove);\r\n                        defoliationFractions.SetFractionToResidue(organ.Name, fractionToResidue, \"Dead\");\r\n                    }\r\n                }\r\n            }*/\r\n        }\r\n\r\n        /// <summary>Gathers the DM and N amounts harvested, to be removed, and to be returned.</summary>\r\n        private void manageDefoliatedBiomass()\r\n        {\r\n            double digestibilityStructural = 0.65;\r\n            double digestibilityNonStrucutural = 1.0;\r\n\r\n            if (DefoliatedWt > 0.0)\r\n            {\r\n                HarvestedWt = 0.0;\r\n                HarvestedN = 0.0;\r\n                RemovedWt = 0.0;\r\n                RemovedN = 0.0;\r\n\r\n                foreach (Plant species in PMFSpecies)\r\n                {\r\n                    if(species.AboveGround.Wt > 0.0)\r\n                    {\r\n                        // get the amount harvested (plant stuff removed from plants)\r\n                        speciesHarvestedWt = 0.0;\r\n                        speciesHarvestedN = 0.0;\r\n                        foreach (IOrgan organ in species.FindAllChildren<IOrgan>().OfType<IModel>().ToList())\r\n                        {\r\n                            speciesHarvestedWt += (double)myZone.Get(species.Name+\".\"+organ.Name+\".Removed.Wt\");\r\n                            speciesHarvestedN += (double)myZone.Get(species.Name+\".\"+organ.Name+\".Removed.N\");\r\n                        }\r\n\r\n                        HarvestedWt += speciesHarvestedWt;\r\n                        HarvestedN += speciesHarvestedN;\r\n\r\n                        // get the DM fraction to be removed\r\n                        if(FractionDMToRemove>=0.0)\r\n                        {\r\n                            speciesFractionToRemove = FractionDMToRemove;\r\n                        }\r\n                        else\r\n                        { // use digestibility to define the fraction\r\n                            double fracStructural = species.AboveGround.StructuralWt/species.AboveGround.Wt;\r\n                            speciesFractionToRemove = (1.0 - fracStructural)*digestibilityNonStrucutural + fracStructural*digestibilityStructural;\r\n                            speciesFractionToRemove = Math.Min(1.0, Math.Max(0.0, speciesFractionToRemove));\r\n                        }\r\n\r\n                        // get the amounts actually removed from field\r\n                        RemovedWt += speciesHarvestedWt * speciesFractionToRemove;\r\n                        RemovedN += speciesHarvestedN * FractionNToRemove;\r\n                   }\r\n                }\r\n\r\n                foreach (AgPasture.PastureSpecies species in AgPSpecies)\r\n                {\r\n                    if(species.AboveGroundWt > 0.0)\r\n                    {\r\n                        // get the amount harvested\r\n                        speciesHarvestedWt = species.HarvestedWt*0.1;\r\n                        speciesHarvestedN = species.HarvestedN*0.1;\r\n                        HarvestedWt += speciesHarvestedWt;\r\n                        HarvestedN += speciesHarvestedN;\r\n\r\n                        // get fraction to be removed\r\n                        if(FractionDMToRemove>=0.0)\r\n                        {\r\n                            speciesFractionToRemove = FractionDMToRemove;\r\n                        }\r\n                        else\r\n                        { // use digestibility to define the fraction\r\n                            speciesFractionToRemove = species.HarvestedDigestibility;\r\n                        }\r\n\r\n                        // get the amounts actually removed from field\r\n                        RemovedWt += speciesHarvestedWt * speciesFractionToRemove;\r\n                        RemovedN += speciesHarvestedN * FractionNToRemove;\r\n                    }\r\n                }\r\n\r\n                // get the amounts to be returned to the field (as residue or dung+urine)\r\n                ReturnedWt = HarvestedWt - RemovedWt;\r\n                ReturnedN = HarvestedN - RemovedN;\r\n                if (ReturnType == ReturnAsTypes.AsDungUrine)\r\n                {\r\n                    if (NDungType == DungNContentTypes.DefineProportion)\r\n                        NReturnedInDung = ReturnedN * ProportionN2Dung;\r\n                    else\r\n                        NReturnedInDung = Math.Min(ReturnedN, ReturnedWt * 0.4 / CNRatioDung);\r\n                    NReturnedInDung = Math.Min(NReturnedInDung, ReturnedN);\r\n                    NReturnedInUrine = ReturnedN - NReturnedInDung;\r\n                }\r\n                else\r\n                {\r\n                    NReturnedInDung = 0.0;\r\n                    NReturnedInUrine = 0.0;\r\n                }\r\n            }\r\n        }\r\n\r\n        /// <summary>Returns the material not removed off field as residue.</summary>\r\n        private void returnResidues()\r\n        {\r\n            if ((ReturnedWt > 0.0) || (ReturnedN > 0.0))\r\n            {\r\n                PMF.BiomassRemovedType BiomassResidue = new PMF.BiomassRemovedType();\r\n                string[] type = new string[] { \"Grass\" };\r\n                float[] dltdm = new float[] { (float)(10.0 * ReturnedWt) };\r\n                float[] dltn = new float[] { (float)(10.0 * ReturnedN) };\r\n                float[] dltp = new float[] { 0 };\r\n                float[] fraction = new float[] { 1 };     // fraction is always 1.0 here\r\n\r\n                BiomassResidue.crop_type = \"Grass\";\r\n                BiomassResidue.dm_type = type;\r\n                BiomassResidue.dlt_crop_dm = dltdm;\r\n                BiomassResidue.dlt_dm_n = dltn;\r\n                BiomassResidue.dlt_dm_p = dltp;\r\n                BiomassResidue.fraction_to_residue = fraction;\r\n                BiomassRemoved.Invoke(BiomassResidue);\r\n            }\r\n        }\r\n\r\n        /// <summary>Returns the material not removed off field as dung and urine).</summary>\r\n        private void returnExcreta()\r\n        {\r\n            if ((ReturnedWt > 0.0) || (NReturnedInDung > 0.0))\r\n            {\r\n                PMF.BiomassRemovedType BiomassDung = new PMF.BiomassRemovedType();\r\n                string[] type = new string[] { \"RuminantDung_PastureFed\" };\r\n                float[] dltdm = new float[] { (float)(10.0 * ReturnedWt) };\r\n                float[] dltn = new float[] { (float)(10.0 * NReturnedInDung) };\r\n                float[] dltp = new float[] { 0 };\r\n                float[] fraction = new float[] { 1 };     // fraction is always 1.0 here\r\n\r\n                BiomassDung.crop_type = \"RuminantDung_PastureFed\";\r\n                BiomassDung.dm_type = type;\r\n                BiomassDung.dlt_crop_dm = dltdm;\r\n                BiomassDung.dlt_dm_n = dltn;\r\n                BiomassDung.dlt_dm_p = dltp;\r\n                BiomassDung.fraction_to_residue = fraction;\r\n                BiomassRemoved.Invoke(BiomassDung);\r\n            }\r\n\r\n            if (NReturnedInUrine > 0.0)\r\n            {\r\n                double[] myUrineDeposition = new double[soilPhysical.Thickness.Length];\r\n                for (int z = 0; z < urineFraction.Length; z++)\r\n                    myUrineDeposition[z] = NReturnedInUrine * 10.0 * urineFraction[z];\r\n                Urea.AddKgHaDelta(SoluteSetterType.Fertiliser, myUrineDeposition);\r\n            }\r\n        }\r\n\r\n        // Auxiliary bits and pieces  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -\r\n\r\n        /// <summary>Type of defoliation to use</summary>\r\n        public enum DefoliationTypes\r\n        {\r\n            /// <summary>Cut</summary>\r\n            Cut,\r\n            /// <summary>Graze</summary>\r\n            Graze,\r\n            /// <summary>Harvest</summary>\r\n            Harvest\r\n        }\r\n\r\n        /// <summary>Flag how defoliations will be triggered</summary>\r\n        public enum DefoliationTriggerTypes\r\n        {\r\n            /// <summary>Setting a fixed interval</summary>\r\n            FixedInterval,\r\n            /// <summary>Setting a target (minimum) inteval</summary>\r\n            TargetInterval,\r\n            /// <summary>Setting a target (maximum) standing biomass</summary>\r\n            TargetStandingBiomass\r\n        }\r\n\r\n        /// <summary>How the DM amount given is interpreted</summary>\r\n        public enum DefoliateAmountTypes\r\n        {\r\n            /// <summary>Setting a DM amount to remove</summary>\r\n            DMToRemove,\r\n            /// <summary>Setting the residual DM amount</summary>\r\n            ResidualDM,\r\n            /// <summary>Remove according to crop's BiomassRemovalFractions</summary>\r\n            None_UseDefoliationFractions\r\n        }\r\n\r\n        /// <summary>Fraction of defoliated DM to remove from field</summary>\r\n        public enum DMRemovalTypes\r\n        {\r\n            /// <summary>Remove all DM</summary>\r\n            RemoveAll,\r\n            /// <summary>Remove no DM</summary>\r\n            RemoveNone,\r\n            /// <summary>Remove a user-defined fraction</summary>\r\n            UserDefinedFraction,\r\n            /// <summary>Remove a fraction based on plant digestibility</summary>\r\n            BasedOnDigestibility\r\n        }\r\n\r\n        /// <summary>Fraction of N in the defoliated material to remove from field</summary>\r\n        public enum NRemovalTypes\r\n        {\r\n            /// <summary>Remove all N</summary>\r\n            RemoveAll,\r\n            /// <summary>Remove no N</summary>\r\n            RemoveNone,\r\n            /// <summary>Remove a user-defined fraction</summary>\r\n            UserDefinedFraction,\r\n            /// <summary>Remove a fraction equal to DM removed</summary>\r\n            ProportionalToDM\r\n        }\r\n\r\n        /// <summary>Define how the non-removed material is returned to the field</summary>\r\n        public enum ReturnAsTypes\r\n        {\r\n            /// <summary>Return plant material as residue</summary>\r\n            AsResidue,\r\n            /// <summary>Return meterial as dung and urine</summary>\r\n            AsDungUrine\r\n        }\r\n\r\n        /// <summary>Define how the proportion of N in dung is defined</summary>\r\n        public enum DungNContentTypes\r\n        {\r\n            /// <summary>Define the proportion of N returned as dung</summary>\r\n            DefineProportion,\r\n            /// <summary>Define the C:N of dung</summary>\r\n            DefineCNratio\r\n        }\r\n    }\r\n}\r\n",
+                  "CodeArray": [
+                    "// Performs defoliations, or removes biomass, from any existing plant (PMF and/or AgPasture) based on a set of given rules.  ",
+                    "// Defoliations can be triggered automatically by this manager or be called from another Script or a Schedule model.",
+                    "// Developed by RCichota, last updated in 31/Mar/2019",
+                    "",
+                    "namespace Models",
+                    "{",
+                    "using Models.PMF.Interfaces;",
+                    "using Models.Soils.Nutrients;",
+                    "using System;",
+                    "using System.Xml.Serialization;",
+                    "using System.Collections.Generic;",
+                    "using APSIM.Shared.Utilities;",
+                    "using Models.Core;",
+                    "using Models.Soils;",
+                    "using Models.PMF;",
+                    "using Models.Interfaces;",
+                    "using Models.PMF.Interfaces;",
+                    "using System.Linq;",
+                    "using Newtonsoft.Json;",
+                    "using Models.ForageDigestibility;",
+                    "",
+                    "    [Serializable]",
+                    "    public class Script : Model",
+                    "    {",
+                    "        [Link] private Clock clock;",
+                    "        [Link] private Zone myZone;",
+                    "        [Link] private Soil mySoil;",
+                    "        [Link(ByName = true)] private ISolute Urea;",
+                    "        [Link] private ISummary mySummary;",
+                    "        [Link] private Forages forages;",
+                    "        public event BiomassRemovedDelegate BiomassRemoved;",
+                    "        private string baseDefoliationType;",
+                    "        private string typeOfDefoliation;",
+                    "        private string baseAmountType;",
+                    "        private string typeOfAmount;",
+                    "        private double amountGiven;",
+                    "        private double herbageToRemove;",
+                    "",
+                    "        private int durationOfDefoliation;",
+                    "        private int daysDefoliating;",
+                    "        private double cumAmountHarvested;",
+                    "        private double atZ0;",
+                    "        private double atZ1;",
+                    "        private double fractionToRemove;",
+                    "        private double fractionToResidue;",
+                    "        private double speciesHarvestedWt;",
+                    "        private double speciesHarvestedN;",
+                    "        private double speciesFractionToRemove;",
+                    "        [Link]",
+                    "        private IPhysical soilPhysical;",
+                    "        //> Links to other Apsim models",
+                    "        //Auxiliary 'links'",
+                    "        private List<Plant> PMFSpecies = new List<Plant>();",
+                    "        private List<AgPasture.PastureSpecies> AgPSpecies = new List<AgPasture.PastureSpecies>();",
+                    "",
+                    "        //> Events raised by this manager",
+                    "",
+                    "        //> User inputs from properties tab",
+                    "        [Separator(\"Generic defoliation management - removes biomass from PMF and AgPasture species, plus residue management\")]",
+                    "        [Description(\"Allow this manager to control defoliations? \")]",
+                    "        public bool AutomaticManagementIsEnabled { get; set; }",
+                    "        [Description(\"Date to start the defoliation management (dd/mm/yyyy): \")]",
+                    "        public DateTime DefoliationRotationStartDate { get; set; }",
+                    "        [Description(\"Date to end the defoliation management (dd/mm/yyyy): \")]",
+                    "        public DateTime DefoliationRotationEndDate { get; set; }",
+                    "",
+                    "        [Separator(\"Parameters defining how the defoliation is managed\")]",
+                    "        [Description(\" Defoliation fractions (e.g. Leaf.FractionLiveToResidue=0.1\")]",
+                    "        [Display(Type=DisplayType.MultiLineText)]",
+                    "        public string[] DefoliationFractions { get; set; }",
+                    "        [Description(\"How the defoliations should be triggered? \")]",
+                    "        public DefoliationTriggerTypes DefoliationTriggerType { get; set; }",
+                    "        [Description(\"  Minimum number of days between defoliations, used if trigger is an interval: \")]",
+                    "        public int IntervalBetweenDefoliations { get; set; }",
+                    "        [Description(\"  Minimum standing biomass to start defoliations, used if trigger is DM target(g/m2): \")]",
+                    "        public int TargetStandingBiomass { get; set; }",
+                    "        [Description(\"Duration of each defoliation event (days): \")]",
+                    "        public int DurationOfEachDefoliation { get; set; }",
+                    "        [Description(\"Which amount is being defined? \")]",
+                    "        public DefoliateAmountTypes RemoveAmountType { get; set; }",
+                    "        [Description(\"DM amount to use (g/m2): \")]",
+                    "        public double AmountForEachDefoliation { get; set; }",
+                    "        [Description(\"For PMF species, allow all biomass to be removed? \")]",
+                    "        public bool RemoveAllBiomassIsEnabled { get; set; }",
+                    "",
+                    "        [Separator(\"Parameters defining the management of the defoliated biomass\")]",
+                    "        [Description(\"How much of the DM defoliated is to be removed from the field? \")]",
+                    "        public DMRemovalTypes DMRemoveType { get; set; }",
+                    "        [Description(\"  Fraction of DM to remove off field, if using UserDefinedFraction (0-1): \")]",
+                    "        public double FractionDMToRemove { get; set; }",
+                    "        [Description(\"How much of the N defoliated is to be removed from the field? \")]",
+                    "        public NRemovalTypes NRemoveType { get; set; }",
+                    "        [Description(\"  Fraction of N to remove off field, if using UserDefinedFraction (0-1): \")]",
+                    "        public double FractionNToRemove { get; set; }",
+                    "        [Description(\"How the non-removed material is returned to the field? \")]",
+                    "        public ReturnAsTypes ReturnType { get; set; }",
+                    "",
+                    "        [Separator(\"Parameters for partitioning non-removed N into urine and dung\")]",
+                    "        [Description(\"How the partition of N to dung and urine is defined? \")]",
+                    "        public DungNContentTypes NDungType { get; set; }",
+                    "        [Description(\"  Proportion of N returned in dung, if using DefineProportion (0-1): \")]",
+                    "        public double ProportionN2Dung { get; set; }",
+                    "        [Description(\"  The C:N of dung, if using DefineCNratio (typically around 20): \")]",
+                    "        public double CNRatioDung { get; set; }",
+                    "        [Description(\"Soil depth down to which urine should be applied (mm): \")]",
+                    "        public double UrineDepth { get; set; }",
+                    "",
+                    "        //> Outputs from this manager",
+                    "        [JsonIgnore][Units(\"g/m2\")] // Pasture DM defoliated (removed from plants) today",
+                    "        public double DefoliatedWt{ get; set; }",
+                    "        [JsonIgnore][Units(\"g/m2\")] // N in the pasture material defoliated today",
+                    "        public double DefoliatedN{ get; set; }",
+                    "        [JsonIgnore][Units(\"g/m2\")] // Pasture DM harvested (removed from plants minus direct residue) today",
+                    "        public double HarvestedWt{ get; set; }",
+                    "        [JsonIgnore][Units(\"g/m2\")] // N in the pasture material harvested today",
+                    "        public double HarvestedN{ get; set; }",
+                    "        [JsonIgnore][Units(\"g/m2\")] // Pasture DM actually removed from the field",
+                    "        public double RemovedWt{ get; set; }",
+                    "        [JsonIgnore][Units(\"g/m2\")] // N in the pasture material removed from the field",
+                    "        public double RemovedN{ get; set; }",
+                    "        [JsonIgnore][Units(\"g/m2\")] // Pasture DM returned by this manager to the field",
+                    "        public double ReturnedWt{ get; set; }",
+                    "        [JsonIgnore][Units(\"g/m2\")] // N in the pasture material returned by this manager to the field",
+                    "        public double ReturnedN{ get; set; }",
+                    "        [JsonIgnore][Units(\"g/m2\")] // Non-removed N returned as dung (to SurfaceOM)",
+                    "        public double NReturnedInDung{ get; set; }",
+                    "        [JsonIgnore][Units(\"g/m2\")] // Non-removed N returned as urine (soil urea)",
+                    "        public double NReturnedInUrine{ get; set; }",
+                    "        [JsonIgnore][Units(\"days\")] // Number of days since the end of last defoliation event",
+                    "        public int DaysSinceLastDefoliation{ get; set; }",
+                    "        [JsonIgnore][Units(\"g/m2\")] // Total standing aboveground DM before a defoliation",
+                    "        public double PreHarvestDM{ get; set; }",
+                    "        [JsonIgnore][Units(\"g/m2\")] // Total standing aboveground DM after a defoliation",
+                    "        public double PostHarvestDM{ get; set; }",
+                    "        [JsonIgnore][Units(\"g/m2\")] // Total pasture DM harvested over a complete defoliation event",
+                    "        public double RotationHarvestedDM{ get; set; }",
+                    "",
+                    "        //> Internal variables",
+                    "        private double[] urineFraction;                  // fraction of urine to be applied in each soil layer",
+                    "        // auxiliary boolean",
+                    "        private bool aDefoliationHasHappened = false; // flag whether a defoliation has happened in this simulation run",
+                    "",
+                    "        // auxiliary - lists of species and removal fractions",
+                    "        private string[] swardSpeciesName;              // name of each species in the sward",
+                    "        private string[] swardSpeciesType;              // type of each species in the sward (PMF or AgPasture)",
+                    "        private double[] speciesFraction;              // biomass fraction of harvestable material of each species",
+                    "        private Dictionary<string, double> fractions = new Dictionary<string,double>();",
+                    "    ",
+                    "        [EventSubscribe(\"StartOfSimulation\")]",
+                    "        private void OnSimulationCommencing(object sender, EventArgs e)",
+                    "        {",
+                    "            foreach (var fractionString in DefoliationFractions)",
+                    "            {              ",
+                    "               string[] tokens = fractionString.Split('=');",
+                    "               if (tokens.Length != 2)",
+                    "                  throw new Exception($\"Unknown defoliation fraction string: {fractionString}\");            ",
+                    "            ",
+                    "               fractions.Add(tokens[0], Convert.ToDouble(tokens[1]));",
+                    "            }",
+                    "",
+                    "            // check the type of amount given",
+                    "            if (RemoveAmountType == DefoliateAmountTypes.DMToRemove)",
+                    "                baseAmountType = \"DMToRemove\";",
+                    "            else if (RemoveAmountType == DefoliateAmountTypes.ResidualDM)",
+                    "                baseAmountType = \"ResidualDM\";",
+                    "            else",
+                    "                baseAmountType = \"UseDefoliationFractions\";",
+                    "",
+                    "            // check the interval between events",
+                    "            if (IntervalBetweenDefoliations < 1)",
+                    "                throw new Exception(\"The interval between defoliation events must be at least one day\");",
+                    "",
+                    "            // check the duration for each defoliation",
+                    "            if(DurationOfEachDefoliation <= 0)",
+                    "                throw new Exception(\"The duration of defoliations cannot be zero or negative!\");",
+                    "",
+                    "            // check the fraction of defoliated material to remove from the field",
+                    "            if (DMRemoveType == DMRemovalTypes.RemoveAll)",
+                    "                FractionDMToRemove = 1.0;",
+                    "            else if (DMRemoveType == DMRemovalTypes.RemoveNone)",
+                    "                FractionDMToRemove = 0.0;",
+                    "            else if (DMRemoveType == DMRemovalTypes.BasedOnDigestibility)",
+                    "                FractionDMToRemove = -1.0;  // will be calculated dynamically",
+                    "            else // DMRemoveType == DMRemovalTypes.UserDefinedFraction",
+                    "            {",
+                    "                if (FractionDMToRemove < 0.0)",
+                    "                    throw new Exception(\"The fraction of DM defoliated to remove from the field cannot be negative!\");",
+                    "            }",
+                    "",
+                    "            // check the fraction of defoliated N to remove from the field",
+                    "            if (NRemoveType == NRemovalTypes.RemoveAll)",
+                    "                FractionNToRemove = 1.0;",
+                    "            else if (NRemoveType == NRemovalTypes.RemoveNone)",
+                    "                FractionNToRemove = 0.0;",
+                    "            else if (NRemoveType == NRemovalTypes.ProportionalToDM)",
+                    "                FractionNToRemove = FractionDMToRemove;",
+                    "            else // NRemoveType == NRemovalTypes.UserDefinedFraction",
+                    "            {",
+                    "                if (FractionNToRemove < 0.0)",
+                    "                    throw new Exception(\"The fraction of defoliated N to remove from the field cannot be negative!\");",
+                    "            }",
+                    "",
+                    "            // set up the links to all plant species",
+                    "            PMFSpecies = myZone.FindAllChildren<Plant>().ToList();",
+                    "            AgPSpecies = myZone.FindAllChildren<AgPasture.PastureSpecies>().ToList();",
+                    "",
+                    "            int numPlants = PMFSpecies.Count + AgPSpecies.Count;",
+                    "            swardSpeciesName = new string[numPlants];",
+                    "            swardSpeciesType = new string[numPlants];",
+                    "            int i = 0;",
+                    "            foreach (Plant species in myZone.FindAllChildren<Plant>().OfType<IModel>().ToList())",
+                    "            {",
+                    "                swardSpeciesName[i] = species.Name;",
+                    "                swardSpeciesType[i] = \"PMF\";",
+                    "                i += 1;",
+                    "            }",
+                    "            foreach (AgPasture.PastureSpecies species in myZone.FindAllChildren<AgPasture.PastureSpecies>().OfType<IModel>().ToList())",
+                    "            {",
+                    "                swardSpeciesName[i] = species.Name;",
+                    "                swardSpeciesType[i] = \"AgPasture\";",
+                    "                i += 1;",
+                    "            }",
+                    "",
+                    "            // initialise some variables",
+                    "            speciesFraction = new double[numPlants];",
+                    "            ",
+                    "            DaysSinceLastDefoliation = IntervalBetweenDefoliations;",
+                    "            durationOfDefoliation = -1;",
+                    "            daysDefoliating = 0;",
+                    "            resetMyOutputs();",
+                    "",
+                    "            // set the fraction of urine for each layer",
+                    "            if (ReturnType == ReturnAsTypes.AsDungUrine)",
+                    "            {",
+                    "                double depthFromSurface = 0.0;",
+                    "                for (int layer = 0; layer < soilPhysical.Thickness.Length; layer++)",
+                    "                {",
+                    "                    depthFromSurface += soilPhysical.Thickness[layer];",
+                    "                    if (depthFromSurface >= UrineDepth)",
+                    "                    { // bottom layer found",
+                    "                        urineFraction = new double[layer + 1];",
+                    "                        double distFactor = 1.5;",
+                    "                        double totalProp = UrineDepth * Math.Pow(1.0, distFactor) / (distFactor + 1.0);",
+                    "                        depthFromSurface = 0.0;",
+                    "                        atZ1 = (UrineDepth - depthFromSurface) * Math.Pow(1.0 - depthFromSurface / UrineDepth, distFactor) / (distFactor + 1.0);",
+                    "                        for (int z = 0; z < layer+1; z++)",
+                    "                        {",
+                    "                            atZ0 = atZ1;",
+                    "                            depthFromSurface += soilPhysical.Thickness[z];",
+                    "                            atZ1 = (UrineDepth - depthFromSurface) * Math.Pow(1.0 - depthFromSurface / UrineDepth, distFactor) / (distFactor + 1);",
+                    "                            if (1.0 - (depthFromSurface / UrineDepth) < 0.0)",
+                    "                                atZ1 = 0;",
+                    "                            urineFraction[z] = (atZ0 - atZ1) / totalProp;",
+                    "                        }",
+                    "                        layer = soilPhysical.Thickness.Length;",
+                    "                    }",
+                    "                }",
+                    "            }",
+                    "",
+                    "            // write message in summary",
+                    "            mySummary.WriteMessage(this,\" Automatic defoliation manager initialised\", MessageType.Diagnostic);",
+                    "            if (AutomaticManagementIsEnabled)",
+                    "            {",
+                    "                mySummary.WriteMessage(this, \"   Defoliations will happen between \" + DefoliationRotationStartDate.ToShortDateString()",
+                    "                                          + \" and \" + DefoliationRotationEndDate.ToShortDateString() + \".\", MessageType.Diagnostic);",
+                    "                mySummary.WriteMessage(this, \"   Biomass from the sward will be defoliated simulating a \\\"\" + baseDefoliationType + \"\\\" rotation.\", MessageType.Diagnostic);",
+                    "                if (DefoliationTriggerType == DefoliationTriggerTypes.TargetStandingBiomass)",
+                    "                    mySummary.WriteMessage(this, \"   Events will happen whenever aboveground biomass surpasses \" + TargetStandingBiomass.ToString(\"#0.0\") + \" g/m2.\", MessageType.Diagnostic);",
+                    "                else",
+                    "                    mySummary.WriteMessage(this, \"   Events will happen every \" + IntervalBetweenDefoliations + \" days, if there is enough biomass.\", MessageType.Diagnostic);",
+                    "                if(baseAmountType == \"ResidualDM\")",
+                    "                    mySummary.WriteMessage(this, \"   Removing biomass down to a residual amount of \" + AmountForEachDefoliation.ToString(\"#.0\") + \" g/m2 over \" ",
+                    "                                             + DurationOfEachDefoliation + \" days.\", MessageType.Diagnostic);",
+                    "                else",
+                    "                    mySummary.WriteMessage(this, \"   Removing \" + AmountForEachDefoliation.ToString(\"#.0\") + \" g/m2 of biomass per day over \" ",
+                    "                                             + DurationOfEachDefoliation + \" days.\", MessageType.Diagnostic);",
+                    "            }",
+                    "            else",
+                    "            {",
+                    "                mySummary.WriteMessage(this,\"   Automatic defoliations are currently disabled, though defoliations can be triggered by another manager\", MessageType.Diagnostic);",
+                    "                mySummary.WriteMessage(this,\"   If called, the manager will remove biomass from the sward simulating a \\\"\" + baseDefoliationType + \"\\\" event.\", MessageType.Diagnostic);",
+                    "            }",
+                    "",
+                    "            if(ReturnType == ReturnAsTypes.AsDungUrine)",
+                    "            {",
+                    "                mySummary.WriteMessage(this,\"   Non-removed material will be returned as dung and urine. Urine added to soil according to proportions: \"",
+                    "                + string.Join(\", \",urineFraction), MessageType.Diagnostic);",
+                    "            }",
+                    "            else",
+                    "                mySummary.WriteMessage(this,\"   Non-removed material will be returned as residue.\", MessageType.Diagnostic);",
+                    "        }",
+                    "",
+                    "        [EventSubscribe(\"DoManagement\")]",
+                    "        private void OnDoManagement(object sender, EventArgs e)",
+                    "        {",
+                    "            // check whether we need to continue defoliationg, i.e. within a multi-day defoliation event (need to check this first in the day)",
+                    "            if ((daysDefoliating > 0) && (daysDefoliating < durationOfDefoliation))",
+                    "            {",
+                    "                // reset outputs",
+                    "                resetMyOutputs();",
+                    "",
+                    "                // re-check the amount to defoliate",
+                    "                double harvestableBiomass = harvestableSwardBiomass(\"All\", \"Harvestable\");",
+                    "                if (typeOfAmount == \"DMToRemove\")",
+                    "                {",
+                    "                    if(harvestableBiomass > 0.001)",
+                    "                        herbageToRemove = Math.Min(harvestableBiomass, (amountGiven - cumAmountHarvested) / (durationOfDefoliation - daysDefoliating));",
+                    "                }",
+                    "                else if (typeOfAmount == \"ResidualDM\")",
+                    "                {",
+                    "                    double currentDM = standingSwardBiomassWt;",
+                    "                    if (currentDM > amountGiven)",
+                    "                        herbageToRemove = Math.Min(harvestableBiomass, (currentDM - amountGiven) / (durationOfDefoliation - daysDefoliating));",
+                    "                }",
+                    "",
+                    "                // remove plant biomass and return residue",
+                    "                if (Math.Abs(herbageToRemove) >= 0.001)",
+                    "                {",
+                    "                    // set biomass removal",
+                    "mySummary.WriteMessage(this, \"   Defoliation initialised on DoManagement - \" + clock.Today.Date.ToShortDateString(), MessageType.Diagnostic);",
+                    "                    defoliateSward(herbageToRemove, typeOfDefoliation);",
+                    "",
+                    "                    // return residue or excreta",
+                    "                    if(ReturnedWt + ReturnedN > 0.0)",
+                    "                    {",
+                    "                        if (ReturnType == ReturnAsTypes.AsResidue)",
+                    "                            returnResidues();",
+                    "                        else",
+                    "                            returnExcreta();",
+                    "                    }",
+                    "",
+                    "                    // gather amount removed this event",
+                    "                    cumAmountHarvested += HarvestedWt;",
+                    "                }",
+                    "",
+                    "                daysDefoliating += 1;",
+                    "            }",
+                    "",
+                    "            // check whether a defoliation ended yesterday",
+                    "            if (daysDefoliating < 0)",
+                    "            { // clean up variables",
+                    "                resetMyOutputs();",
+                    "                daysDefoliating = 0;",
+                    "            }",
+                    "",
+                    "            // check whether automatic defoliations are enabled",
+                    "            if (AutomaticManagementIsEnabled)",
+                    "            {",
+                    "                // check whether we are within the period in which defoliations can happen",
+                    "                if ((clock.Today.Date >= DefoliationRotationStartDate.Date) && (clock.Today.Date <= DefoliationRotationEndDate.Date))",
+                    "                {",
+                    "                    // check whether we should start a defoliation event",
+                    "                    if (DefoliationTriggerType == DefoliationTriggerTypes.FixedInterval)",
+                    "                    {",
+                    "                        if (DaysSinceLastDefoliation == IntervalBetweenDefoliations)",
+                    "                            Defoliate(AmountForEachDefoliation, baseAmountType, DurationOfEachDefoliation);",
+                    "                    }",
+                    "                    else if (DefoliationTriggerType == DefoliationTriggerTypes.TargetInterval)",
+                    "                    {",
+                    "                        if (DaysSinceLastDefoliation >= IntervalBetweenDefoliations)",
+                    "                            Defoliate(AmountForEachDefoliation, baseAmountType, DurationOfEachDefoliation);",
+                    "                    }",
+                    "                    else  //DefoliationTriggerType == DefoliationTriggerTypes.TargetStandingBiomass",
+                    "                    {",
+                    "                        if (standingSwardBiomassWt >= TargetStandingBiomass)",
+                    "                            Defoliate(AmountForEachDefoliation, baseAmountType, DurationOfEachDefoliation);",
+                    "                    }",
+                    "                }",
+                    "                //// Note: Only the code above, responsible for triggering automatic events, is limited by 'AutomaticManagementIsEnabled'. ",
+                    "                ////       The rest of the code is still available to perform one-off defoliations.",
+                    "                ////       It can be called from another manager or a schedulle thingy via Defoliate().",
+                    "            }",
+                    "        }",
+                    "",
+                    "        [EventSubscribe(\"DoManagementCalculations\")]",
+                    "        private void OnDoManagementCalculations(object sender, EventArgs e)",
+                    "        {",
+                    "            // check whether a defoliation event has just been completed",
+                    "            if (daysDefoliating == durationOfDefoliation)",
+                    "            {",
+                    "                // get amount of biomass remaining and zero counters",
+                    "                PostHarvestDM = standingSwardBiomassWt;",
+                    "                RotationHarvestedDM = cumAmountHarvested;",
+                    "                aDefoliationHasHappened = true;",
+                    "                daysDefoliating = -1;",
+                    "            }",
+                    "",
+                    "            // count the days after a defoliation",
+                    "            if (aDefoliationHasHappened && (daysDefoliating == 0))",
+                    "                DaysSinceLastDefoliation += 1;",
+                    "        }",
+                    "",
+                    "        /// <summary>Sets up a defoliation event.</summary>",
+                    "        /// <param name=\"defoliationType\">Type of defoliation (cut, graze, or harvest)</param>",
+                    "        /// <param name=\"amountDM\">Amount of biomass to use (g/m2)</param>",
+                    "        /// <param name=\"amountType\">How the DM amount is interpreted (toRemove, residual)</param>",
+                    "        /// <param name=\"duration\">Number of days to defoliate over</param>",
+                    "        public void Defoliate(double amountDM, string amountType, int duration)",
+                    "        {",
+                    "            // check whether there are plants in the sward that can be defoliated",
+                    "            if (swardHasLivingPlants)",
+                    "            {",
+                    "                // check DM amount given",
+                    "                if (amountDM < 0.0)",
+                    "                    throw new Exception(\"Amount to defoliate cannot be negative!\");",
+                    "                else",
+                    "                    amountGiven = amountDM;",
+                    "",
+                    "                // check the type of amount given",
+                    "                if (amountType.ToLower() == \"dmtoremove\")",
+                    "                    typeOfAmount = \"DMToRemove\";",
+                    "                else if (amountType.ToLower() == \"residualdm\")",
+                    "                    typeOfAmount = \"ResidualDM\";",
+                    "                else if (amountType.ToLower() == \"usedefoliationfractions\")",
+                    "                    typeOfAmount = \"UseDefoliationFractions\";",
+                    "                else",
+                    "                    throw new Exception(\"Amount type should be \\\"DMToRemove\\\", \\\"ResidualDM\\\", or \\\"UseDefoliationFractions\\\"!\");",
+                    "",
+                    "                // check duration given",
+                    "                if (duration <= 0)",
+                    "                    throw new Exception(\"Duration of defoliation cannot be zero or negative!\");",
+                    "                else",
+                    "                    durationOfDefoliation = duration;",
+                    "",
+                    "                // check existing biomass and amount to remove",
+                    "                PreHarvestDM = standingSwardBiomassWt;",
+                    "                herbageToRemove = 0.0;",
+                    "                double harvestableBiomass = harvestableSwardBiomass(\"All\", \"Harvestable\");",
+                    "                if (typeOfAmount == \"UseDefoliationFractions\")",
+                    "                { // amount given is ignored, removal based on fractions",
+                    "                    amountGiven = 0.0;",
+                    "                    if (harvestableBiomass > 0.0)",
+                    "                        herbageToRemove = -1.0;",
+                    "",
+                    "                    mySummary.WriteMessage(this, \"   Defoliation triggered, removing biomass using the removal fractions (set or default), during \" + durationOfDefoliation + \" days\", MessageType.Diagnostic);",
+                    "                }",
+                    "                else if (typeOfAmount == \"DMToRemove\")",
+                    "                {",
+                    "                    if (amountGiven > 0.001)",
+                    "                    { // a meaningful amount was given, check whether all can be removed",
+                    "                        if (harvestableBiomass > 0.001)",
+                    "                            herbageToRemove = Math.Min(harvestableBiomass, amountGiven / durationOfDefoliation);",
+                    "",
+                    "                        mySummary.WriteMessage(this, \"   Defoliation triggered, attempting to remove \" + amountGiven.ToString(\"#0.0\") + \" g/m2 of biomass over \" + durationOfDefoliation + \" days\", MessageType.Diagnostic);",
+                    "                    }",
+                    "                }",
+                    "                else if (typeOfAmount == \"ResidualDM\")",
+                    "                {",
+                    "                    // check how much biomass will be removed",
+                    "                    if (PreHarvestDM > amountGiven)",
+                    "                        herbageToRemove = Math.Min(harvestableBiomass, (PreHarvestDM - amountGiven) / durationOfDefoliation);",
+                    "",
+                    "                    mySummary.WriteMessage(this, \"   Defoliation triggered, attempting to remove biomass down to \" + amountGiven.ToString(\"#0.0\") + \" g/m2 over \" + durationOfDefoliation + \" days\", MessageType.Diagnostic);",
+                    "                }",
+                    "",
+                    "                // can defoliation begin?",
+                    "                if (Math.Abs(herbageToRemove) >= 0.001)",
+                    "                {",
+                    "                    // set off first defoliation",
+                    "mySummary.WriteMessage(this, \"   Defoliation initialised on Defoliate - \" + clock.Today.Date.ToShortDateString(), MessageType.Diagnostic);",
+                    "                    defoliateSward(herbageToRemove, typeOfDefoliation);",
+                    "",
+                    "                    // return residue or excreta",
+                    "                    if(ReturnedWt + ReturnedN > 0.0)",
+                    "                    {",
+                    "                        if (ReturnType == ReturnAsTypes.AsResidue)",
+                    "                            returnResidues();",
+                    "                        else",
+                    "                            returnExcreta();",
+                    "                    }",
+                    "",
+                    "                    // gather values for this event",
+                    "                    cumAmountHarvested = HarvestedWt;",
+                    "                    daysDefoliating = 1;",
+                    "                    DaysSinceLastDefoliation = 0;",
+                    "                }",
+                    "                else",
+                    "                {",
+                    "                    // abort command as there is not enough biomass, check interval type",
+                    "                    if (DefoliationTriggerType == DefoliationTriggerTypes.FixedInterval)",
+                    "                    { // count the event as if it did happen",
+                    "                        cumAmountHarvested = 0.0;",
+                    "                        daysDefoliating = 1;",
+                    "                        DaysSinceLastDefoliation = 0;",
+                    "                    }",
+                    "",
+                    "                    mySummary.WriteMessage(this, \"   Defoliation did not happend because current biomass (\" + PreHarvestDM.ToString(\"#0.0\") + \" g/m2) is too low (total harvestable = \" + harvestableBiomass.ToString(\"#0.0\") + \" g/m2)\", MessageType.Diagnostic);",
+                    "                }",
+                    "            }",
+                    "            else",
+                    "            {",
+                    "                mySummary.WriteMessage(this, \"   Defoliation did not happend because there is no growing plants in the sward\", MessageType.Diagnostic);",
+                    "            }",
+                    "        }",
+                    "",
+                    "        /// <summary>Resets the values of outputs.</summary>",
+                    "        private void resetMyOutputs()",
+                    "        {",
+                    "            DefoliatedWt = 0.0;",
+                    "            DefoliatedN = 0.0;",
+                    "            HarvestedWt = 0.0;",
+                    "            HarvestedN = 0.0;",
+                    "            RemovedWt = 0.0;",
+                    "            RemovedN = 0.0;",
+                    "            ReturnedWt = 0.0;",
+                    "            ReturnedN = 0.0;",
+                    "            NReturnedInDung = 0.0;",
+                    "            NReturnedInUrine = 0.0;",
+                    "            RotationHarvestedDM = 0.0;",
+                    "        }",
+                    "",
+                    "        /// <summary>Flags whether there is any living plant in the sward.</summary>",
+                    "        private bool swardHasLivingPlants",
+                    "        {",
+                    "            get",
+                    "            {",
+                    "                bool result = false;",
+                    "                foreach (Plant species in PMFSpecies)",
+                    "                       result |= species.IsAlive;",
+                    "                foreach (AgPasture.PastureSpecies species in AgPSpecies)",
+                    "                       result |= species.IsAlive;",
+                    "                return result;",
+                    "            }",
+                    "        }",
+                    "",
+                    "        /// <summary>Amount of plant biomass aboveground (g/m2).</summary>",
+                    "        private double standingSwardBiomassWt",
+                    "        {",
+                    "            get",
+                    "            {",
+                    "                double result = 0.0;",
+                    "                foreach (Plant species in PMFSpecies)",
+                    "                   result += (double)myZone.Get(species.Name+\".AboveGround.Wt\");",
+                    "                foreach (AgPasture.PastureSpecies species in AgPSpecies)",
+                    "                    result += species.Standing.Wt*0.1;",
+                    "                return result;",
+                    "            }",
+                    "        }",
+                    "",
+                    "        /// <summary>Amount of N in plant's biomass aboveground (g/m2).</summary>",
+                    "        private double standingSwardBiomassN",
+                    "        {",
+                    "            get",
+                    "            {",
+                    "                double result = 0.0;",
+                    "                foreach (Plant species in PMFSpecies)",
+                    "                   result += (double)myZone.Get(species.Name+\".AboveGround.N\");",
+                    "                foreach (AgPasture.PastureSpecies species in AgPSpecies)",
+                    "                    result += species.Standing.N*0.1;",
+                    "                return result;",
+                    "            }",
+                    "        }",
+                    "",
+                    "        /// <summary>Amount of plant biomass from all organs available for defoliation (g/m2).</summary>",
+                    "        /// <remarks>Assumes that organs with a BiomassRemoval.FractionToRemove > 0 are harvestable.",
+                    "        /// For AgPasture, harvestable is based on minimum DM.</remarks>",
+                    "        /// <param name=\"plantName\">The name of the plant to retrieve its biomass</param>",
+                    "        /// <param name=\"fractionType\">The type of fraction to use (harvestable or total)</param>",
+                    "        private double harvestableSwardBiomass(string plantName, string fractionType)",
+                    "        {",
+                    "            double amountWt = 0.0;",
+                    "            double fraction = 0.0;",
+                    "            foreach (var forage in forages.ModelsWithDigestibleBiomass)",
+                    "            {",
+                    "                if (plantName == \"All\" || forage.Name == plantName)",
+                    "                {",
+                    "                    foreach (var material in forage.Material) ",
+                    "                    {",
+                    "                        string liveDead = \"Dead\";",
+                    "                        if (material.IsLive)",
+                    "                            liveDead = \"Live\";",
+                    "                            ",
+                    "                        // consider only amounts toRemove",
+                    "                        fractions.TryGetValue($\"{forage.Name}.Fraction{liveDead}ToRemove\", out fraction);",
+                    "                        if ((fractionType == \"Total\") && (fraction > 0.0))",
+                    "                        { // to return all biomass, for any organ that has some removable fraction",
+                    "                            fraction = 1.0;",
+                    "                        }",
+                    "                        else if (RemoveAllBiomassIsEnabled && (fraction > 0.0))",
+                    "                        { // theoretical to return, and remove, all biomass, but will assume a minimum of 5% left behind",
+                    "                            fraction = 0.95;",
+                    "                        }",
+                    "",
+                    "                        if (fractionType == \"Total\")",
+                    "                            amountWt += material.Total.Wt * fraction;",
+                    "                        else",
+                    "                            amountWt += material.Consumable.Wt * fraction;",
+                    "                    }",
+                    "                }",
+                    "            }",
+                    "            ",
+                    "            return amountWt;",
+                    "        }",
+                    "",
+                    "        /// <summary>Triggers the actual biomass removal and gather DM and N amounts.</summary>",
+                    "        /// <param name=\"amountToRemove\">The total DM amount to remove (g/m2)</param>",
+                    "        /// <param name=\"removalType\">The type of removal (Cut, Graze, Harvest)</param>",
+                    "        private void defoliateSward(double amountToRemove, string removalType)",
+                    "        {",
+                    "            // get the amounts of biomass and N before today's defoliation",
+                    "            double preRemovalDM = standingSwardBiomassWt;",
+                    "            double preRemovalN = standingSwardBiomassN;",
+                    "            double fractionToRemove = 0.0;",
+                    "",
+                    "            // gather the actual biomass removal fractions, checking whether they need to be adjusted",
+                    "            double totalHarvestableAmount = harvestableSwardBiomass(\"All\", \"Harvestable\");",
+                    "            if (amountToRemove > 0.0)",
+                    "            { // an amount was given for defoliation, adjust removal fractions for each species in order to remove the amount specified",
+                    "                fractionToRemove = amountToRemove / totalHarvestableAmount;",
+                    "            }",
+                    "            else if (amountToRemove < 0.0)",
+                    "            { // defoliation is not based on an amount, removal is determined simply by the removal fractions",
+                    "                fractionToRemove = 1.0;",
+                    "            }",
+                    "",
+                    "            for (int i = 0; i < swardSpeciesName.Length; i++)",
+                    "            {",
+                    "                speciesFraction[i] = harvestableSwardBiomass(swardSpeciesName[i], \"Harvestable\") / totalHarvestableAmount;",
+                    "                if (swardSpeciesType[i] == \"PMF\")",
+                    "                {",
+                    "                    // check whether the plant is alive",
+                    "                    bool speciesIsAlive = (bool)myZone.Get(swardSpeciesName[i]+\".IsEmerged\");",
+                    "                    if (speciesIsAlive)",
+                    "                    {",
+                    "                        // set removal fractions (these overrides the default removals in the plant)",
+                    "                        RemoveBiomass(swardSpeciesName[i], fractionToRemove);",
+                    "",
+                    "                    }",
+                    "                }",
+                    "                else",
+                    "                {",
+                    "                    // check whether the plant is alive",
+                    "                    bool speciesIsAlive = (bool)myZone.Get(swardSpeciesName[i]+\".IsAlive\");",
+                    "                    if (speciesIsAlive)",
+                    "                    {",
+                    "                        // set removal amount (needs to be in kg/ha)",
+                    "                        double amountRequired = (double)myZone.Get(swardSpeciesName[i]+\".Harvestable.Wt\");",
+                    "                        if (amountToRemove > 0.0)",
+                    "                            amountRequired = amountToRemove * speciesFraction[i] * 10.0;",
+                    "",
+                    "                        // do the actual biomass removal",
+                    "                        foreach (AgPasture.PastureSpecies species in AgPSpecies)",
+                    "                        {",
+                    "                            if(species.Name == swardSpeciesName[i])",
+                    "                            {",
+                    "                                species.RemoveBiomass(amount: amountRequired, type: \"SetRemoveAmount\");",
+                    "                                break;",
+                    "                            }",
+                    "                        }",
+                    "                    }",
+                    "                }",
+                    "            }",
+                    "",
+                    "            // get the amounts of biomass and N after today's defoliation",
+                    "            double postRemovalDM = standingSwardBiomassWt;",
+                    "            double postRemovalN = standingSwardBiomassN;",
+                    "",
+                    "            // get total defoliation (total plant stuff lost)",
+                    "            DefoliatedWt = preRemovalDM - postRemovalDM;",
+                    "            DefoliatedN = preRemovalN - postRemovalN;",
+                    "",
+                    "            // get amounts harvested, removed, and returned",
+                    "            manageDefoliatedBiomass();",
+                    "        }",
+                    "",
+                    "        /// <summary>Sets the biomass removal fractions for PMF plants.</summary>",
+                    "        /// <param name=\"plantName\">The name of PMF species</param>",
+                    "        /// <param name=\"fractionHarvestable\">The fraction of harvestable biomass to be removed (0-1)</param>",
+                    "        private void RemoveBiomass(string plantName, double fractionHarvestable)",
+                    "        {",
+                    "            double fractionToRemove;",
+                    "            double fractionToResidue;",
+                    "            foreach (Plant species in PMFSpecies)",
+                    "            {",
+                    "                if ((species.Name == plantName) && (species.IsAlive))",
+                    "                {",
+                    "                    // set removal fractions (these overrides the default removals in the plant)",
+                    "                    foreach (IOrgan organ in species.FindAllChildren<IOrgan>().OfType<IModel>().ToList())",
+                    "                    {",
+                    "                        // first get the removal for Live material",
+                    "                        if (!fractions.TryGetValue(organ.Name + \".FractionLiveToRemove\", out fractionToRemove))",
+                    "                            fractionToRemove = 0;",
+                    "                        if (RemoveAllBiomassIsEnabled && (fractionToRemove > 0.0))",
+                    "                        { // assuming that 5% is left behind",
+                    "                            fractionToRemove = 0.95;",
+                    "                        }",
+                    "",
+                    "                        fractionToRemove = fractionHarvestable * fractionToRemove;",
+                    "                        fractionToRemove = Math.Min(1.0, fractionToRemove);",
+                    "                        if (RemoveAllBiomassIsEnabled)",
+                    "                        {",
+                    "                            fractionToResidue = 0.0;",
+                    "                        }",
+                    "                        else",
+                    "                        {",
+                    "                            if (!fractions.TryGetValue(organ.Name + \".FractionLiveToResidue\", out fractionToResidue))",
+                    "                                fractionToResidue = 0;",
+                    "",
+                    "                        }",
+                    "",
+                    "                        fractionToResidue = Math.Min(fractionHarvestable * fractionToResidue, 1.0 - fractionToRemove);",
+                    "",
+                    "                        (organ as IHasDamageableBiomass).RemoveBiomass(liveToRemove: fractionToRemove, liveToResidue: fractionToResidue);",
+                    "",
+                    "                        // then get the removal for Dead material",
+                    "                        if (!fractions.TryGetValue(organ.Name + \".FractionDeadToRemove\", out fractionToRemove))",
+                    "                            fractionToRemove = 0;",
+                    "                        if (RemoveAllBiomassIsEnabled && (fractionToRemove > 0.0))",
+                    "                        { // assuming that 5% is left behind",
+                    "                            fractionToRemove = 0.95;",
+                    "                        }",
+                    "",
+                    "                        fractionToRemove = fractionHarvestable * fractionToRemove;",
+                    "                        fractionToRemove = Math.Min(1.0, fractionToRemove);",
+                    "                        if (RemoveAllBiomassIsEnabled)",
+                    "                        {",
+                    "                            fractionToResidue = 0.0;",
+                    "                        }",
+                    "                        else",
+                    "                        {",
+                    "                            if (!fractions.TryGetValue(organ.Name + \".FractionDeadToResidue\", out fractionToResidue))",
+                    "                                fractionToResidue = 0;",
+                    "                        }",
+                    "",
+                    "                        fractionToResidue = Math.Min(fractionHarvestable * fractionToResidue, 1.0 - fractionToRemove);",
+                    "                        ",
+                    "                        (organ as IHasDamageableBiomass).RemoveBiomass(deadToRemove: fractionToRemove, deadToResidue: fractionToResidue);",
+                    "",
+                    "                    }",
+                    "                }",
+                    "            }",
+                    "        }",
+                    "",
+                    "        /// <summary>Gathers the DM and N amounts harvested, to be removed, and to be returned.</summary>",
+                    "        private void manageDefoliatedBiomass()",
+                    "        {",
+                    "            double digestibilityStructural = 0.65;",
+                    "            double digestibilityNonStrucutural = 1.0;",
+                    "",
+                    "            if (DefoliatedWt > 0.0)",
+                    "            {",
+                    "                HarvestedWt = 0.0;",
+                    "                HarvestedN = 0.0;",
+                    "                RemovedWt = 0.0;",
+                    "                RemovedN = 0.0;",
+                    "",
+                    "                foreach (Plant species in PMFSpecies)",
+                    "                {",
+                    "                    if(species.AboveGround.Wt > 0.0)",
+                    "                    {",
+                    "                        // get the amount harvested (plant stuff removed from plants)",
+                    "                        speciesHarvestedWt = 0.0;",
+                    "                        speciesHarvestedN = 0.0;",
+                    "                        foreach (IOrgan organ in species.FindAllChildren<IOrgan>().OfType<IModel>().ToList())",
+                    "                        {",
+                    "                            speciesHarvestedWt += (double)myZone.Get(species.Name+\".\"+organ.Name+\".Removed.Wt\");",
+                    "                            speciesHarvestedN += (double)myZone.Get(species.Name+\".\"+organ.Name+\".Removed.N\");",
+                    "                        }",
+                    "",
+                    "                        HarvestedWt += speciesHarvestedWt;",
+                    "                        HarvestedN += speciesHarvestedN;",
+                    "",
+                    "                        // get the DM fraction to be removed",
+                    "                        if(FractionDMToRemove>=0.0)",
+                    "                        {",
+                    "                            speciesFractionToRemove = FractionDMToRemove;",
+                    "                        }",
+                    "                        else",
+                    "                        { // use digestibility to define the fraction",
+                    "                            double fracStructural = species.AboveGround.StructuralWt/species.AboveGround.Wt;",
+                    "                            speciesFractionToRemove = (1.0 - fracStructural)*digestibilityNonStrucutural + fracStructural*digestibilityStructural;",
+                    "                            speciesFractionToRemove = Math.Min(1.0, Math.Max(0.0, speciesFractionToRemove));",
+                    "                        }",
+                    "",
+                    "                        // get the amounts actually removed from field",
+                    "                        RemovedWt += speciesHarvestedWt * speciesFractionToRemove;",
+                    "                        RemovedN += speciesHarvestedN * FractionNToRemove;",
+                    "                   }",
+                    "                }",
+                    "",
+                    "                foreach (AgPasture.PastureSpecies species in AgPSpecies)",
+                    "                {",
+                    "                    if(species.AboveGroundWt > 0.0)",
+                    "                    {",
+                    "                        // get the amount harvested",
+                    "                        speciesHarvestedWt = species.HarvestedWt*0.1;",
+                    "                        speciesHarvestedN = species.HarvestedN*0.1;",
+                    "                        HarvestedWt += speciesHarvestedWt;",
+                    "                        HarvestedN += speciesHarvestedN;",
+                    "",
+                    "                        // get fraction to be removed",
+                    "                        if(FractionDMToRemove>=0.0)",
+                    "                        {",
+                    "                            speciesFractionToRemove = FractionDMToRemove;",
+                    "                        }",
+                    "                        else",
+                    "                        { // use digestibility to define the fraction",
+                    "                            speciesFractionToRemove = species.HarvestedDigestibility;",
+                    "                        }",
+                    "",
+                    "                        // get the amounts actually removed from field",
+                    "                        RemovedWt += speciesHarvestedWt * speciesFractionToRemove;",
+                    "                        RemovedN += speciesHarvestedN * FractionNToRemove;",
+                    "                    }",
+                    "                }",
+                    "",
+                    "                // get the amounts to be returned to the field (as residue or dung+urine)",
+                    "                ReturnedWt = HarvestedWt - RemovedWt;",
+                    "                ReturnedN = HarvestedN - RemovedN;",
+                    "                if (ReturnType == ReturnAsTypes.AsDungUrine)",
+                    "                {",
+                    "                    if (NDungType == DungNContentTypes.DefineProportion)",
+                    "                        NReturnedInDung = ReturnedN * ProportionN2Dung;",
+                    "                    else",
+                    "                        NReturnedInDung = Math.Min(ReturnedN, ReturnedWt * 0.4 / CNRatioDung);",
+                    "                    NReturnedInDung = Math.Min(NReturnedInDung, ReturnedN);",
+                    "                    NReturnedInUrine = ReturnedN - NReturnedInDung;",
+                    "                }",
+                    "                else",
+                    "                {",
+                    "                    NReturnedInDung = 0.0;",
+                    "                    NReturnedInUrine = 0.0;",
+                    "                }",
+                    "            }",
+                    "        }",
+                    "",
+                    "        /// <summary>Returns the material not removed off field as residue.</summary>",
+                    "        private void returnResidues()",
+                    "        {",
+                    "            if ((ReturnedWt > 0.0) || (ReturnedN > 0.0))",
+                    "            {",
+                    "                PMF.BiomassRemovedType BiomassResidue = new PMF.BiomassRemovedType();",
+                    "                string[] type = new string[] { \"Grass\" };",
+                    "                float[] dltdm = new float[] { (float)(10.0 * ReturnedWt) };",
+                    "                float[] dltn = new float[] { (float)(10.0 * ReturnedN) };",
+                    "                float[] dltp = new float[] { 0.0f };",
+                    "                float[] fraction = new float[] { 1.0f };     // fraction is always 1.0 here",
+                    "",
+                    "                BiomassResidue.crop_type = \"Grass\";",
+                    "                BiomassResidue.dm_type = type;",
+                    "                BiomassResidue.dlt_crop_dm = dltdm;",
+                    "                BiomassResidue.dlt_dm_n = dltn;",
+                    "                BiomassResidue.dlt_dm_p = dltp;",
+                    "                BiomassResidue.fraction_to_residue = fraction;",
+                    "                BiomassRemoved.Invoke(BiomassResidue);",
+                    "            }",
+                    "        }",
+                    "",
+                    "        /// <summary>Returns the material not removed off field as dung and urine).</summary>",
+                    "        private void returnExcreta()",
+                    "        {",
+                    "            if ((ReturnedWt > 0.0) || (NReturnedInDung > 0.0))",
+                    "            {",
+                    "                PMF.BiomassRemovedType BiomassDung = new PMF.BiomassRemovedType();",
+                    "                string[] type = new string[] { \"RuminantDung_PastureFed\" };",
+                    "                float[] dltdm = new float[] { (float)(10.0 * ReturnedWt) };",
+                    "                float[] dltn = new float[] { (float)(10.0 * NReturnedInDung) };",
+                    "                float[] dltp = new float[] { 0.0f };",
+                    "                float[] fraction = new float[] { 1.0f };     // fraction is always 1.0 here",
+                    "",
+                    "                BiomassDung.crop_type = \"RuminantDung_PastureFed\";",
+                    "                BiomassDung.dm_type = type;",
+                    "                BiomassDung.dlt_crop_dm = dltdm;",
+                    "                BiomassDung.dlt_dm_n = dltn;",
+                    "                BiomassDung.dlt_dm_p = dltp;",
+                    "                BiomassDung.fraction_to_residue = fraction;",
+                    "                BiomassRemoved.Invoke(BiomassDung);",
+                    "            }",
+                    "",
+                    "            if (NReturnedInUrine > 0.0)",
+                    "            {",
+                    "                double[] myUrineDeposition = new double[soilPhysical.Thickness.Length];",
+                    "                for (int z = 0; z < urineFraction.Length; z++)",
+                    "                {",
+                    "                    myUrineDeposition[z] = NReturnedInUrine * 10.0 * urineFraction[z];",
+                    "                }",
+                    "",
+                    "                Urea.AddKgHaDelta(SoluteSetterType.Fertiliser, myUrineDeposition);",
+                    "            }",
+                    "        }",
+                    "",
+                    "        // Auxiliary bits and pieces  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -",
+                    "",
+                    "        /// <summary>Type of defoliation to use</summary>",
+                    "        public enum DefoliationTypes",
+                    "        {",
+                    "            /// <summary>Cut</summary>",
+                    "            Cut,",
+                    "            /// <summary>Graze</summary>",
+                    "            Graze,",
+                    "            /// <summary>Harvest</summary>",
+                    "            Harvest",
+                    "        }",
+                    "",
+                    "        /// <summary>Flag how defoliations will be triggered</summary>",
+                    "        public enum DefoliationTriggerTypes",
+                    "        {",
+                    "            /// <summary>Setting a fixed interval</summary>",
+                    "            FixedInterval,",
+                    "            /// <summary>Setting a target (minimum) inteval</summary>",
+                    "            TargetInterval,",
+                    "            /// <summary>Setting a target (maximum) standing biomass</summary>",
+                    "            TargetStandingBiomass",
+                    "        }",
+                    "",
+                    "        /// <summary>How the DM amount given is interpreted</summary>",
+                    "        public enum DefoliateAmountTypes",
+                    "        {",
+                    "            /// <summary>Setting a DM amount to remove</summary>",
+                    "            DMToRemove,",
+                    "            /// <summary>Setting the residual DM amount</summary>",
+                    "            ResidualDM,",
+                    "            /// <summary>Remove according to crop's BiomassRemovalFractions</summary>",
+                    "            None_UseDefoliationFractions",
+                    "        }",
+                    "",
+                    "        /// <summary>Fraction of defoliated DM to remove from field</summary>",
+                    "        public enum DMRemovalTypes",
+                    "        {",
+                    "            /// <summary>Remove all DM</summary>",
+                    "            RemoveAll,",
+                    "            /// <summary>Remove no DM</summary>",
+                    "            RemoveNone,",
+                    "            /// <summary>Remove a user-defined fraction</summary>",
+                    "            UserDefinedFraction,",
+                    "            /// <summary>Remove a fraction based on plant digestibility</summary>",
+                    "            BasedOnDigestibility",
+                    "        }",
+                    "",
+                    "        /// <summary>Fraction of N in the defoliated material to remove from field</summary>",
+                    "        public enum NRemovalTypes",
+                    "        {",
+                    "            /// <summary>Remove all N</summary>",
+                    "            RemoveAll,",
+                    "            /// <summary>Remove no N</summary>",
+                    "            RemoveNone,",
+                    "            /// <summary>Remove a user-defined fraction</summary>",
+                    "            UserDefinedFraction,",
+                    "            /// <summary>Remove a fraction equal to DM removed</summary>",
+                    "            ProportionalToDM",
+                    "        }",
+                    "",
+                    "        /// <summary>Define how the non-removed material is returned to the field</summary>",
+                    "        public enum ReturnAsTypes",
+                    "        {",
+                    "            /// <summary>Return plant material as residue</summary>",
+                    "            AsResidue,",
+                    "            /// <summary>Return meterial as dung and urine</summary>",
+                    "            AsDungUrine",
+                    "        }",
+                    "",
+                    "        /// <summary>Define how the proportion of N in dung is defined</summary>",
+                    "        public enum DungNContentTypes",
+                    "        {",
+                    "            /// <summary>Define the proportion of N returned as dung</summary>",
+                    "            DefineProportion,",
+                    "            /// <summary>Define the C:N of dung</summary>",
+                    "            DefineCNratio",
+                    "        }",
+                    "    }",
+                    "}"
+                  ],
                   "Parameters": [
                     {
                       "Key": "AutomaticManagementIsEnabled",
-                      "Value": "False"
+                      "Value": "True"
                     },
                     {
                       "Key": "DefoliationRotationStartDate",
@@ -1419,8 +2569,8 @@
                       "Value": "12/31/2100 00:00:00"
                     },
                     {
-                      "Key": "DefoliateType",
-                      "Value": "Graze"
+                      "Key": "DefoliationFractions",
+                      "Value": "Leaf.FractionLiveToRemove=0.65, Leaf.FractionDeadToRemove=0.52, Petiole.FractionLiveToRemove=0.65, Petiole.FractionDeadToRemove=0.52, Stem.FractionLiveToRemove=0.68, Stem.FractionDeadToRemove=0.55, Inflorescence.FractionLiveToResidue=0.68, Nodule.FractionLiveToResidue=0.1, TapRoot.FractionLiveToResidue=0.03, Root.FractionLiveToResidue=0.05"
                     },
                     {
                       "Key": "DefoliationTriggerType",
@@ -1495,7 +2645,22 @@
                 },
                 {
                   "$type": "Models.Manager, Models",
-                  "Code": "// This will be replaced by the \"ExtraVariables\" section in \"Replacements\"\r\n\r\nusing Models.Soils;\r\nusing System.Linq;\r\nusing System;\r\nusing Models.Core;\r\n\r\nnamespace Models\r\n{\r\n    [Serializable] \r\n    public class Script : Model\r\n    {\r\n    }\r\n}\r\n",
+                  "CodeArray": [
+                    "// This will be replaced by the \"ExtraVariables\" section in \"Replacements\"",
+                    "",
+                    "using Models.Soils;",
+                    "using System.Linq;",
+                    "using System;",
+                    "using Models.Core;",
+                    "",
+                    "namespace Models",
+                    "{",
+                    "    [Serializable] ",
+                    "    public class Script : Model",
+                    "    {",
+                    "    }",
+                    "}"
+                  ],
                   "Parameters": [],
                   "Name": "ExtraVariables",
                   "ResourceName": null,
@@ -2104,6 +3269,7 @@
               "Position": 3,
               "Inverted": false,
               "CrossesAtZero": false,
+              "LabelOnOneLine": false,
               "Minimum": null,
               "Maximum": null,
               "Interval": null
@@ -2114,6 +3280,7 @@
               "Position": 0,
               "Inverted": false,
               "CrossesAtZero": false,
+              "LabelOnOneLine": false,
               "Minimum": null,
               "Maximum": null,
               "Interval": null
@@ -2228,6 +3395,7 @@
               "Position": 3,
               "Inverted": false,
               "CrossesAtZero": false,
+              "LabelOnOneLine": false,
               "Minimum": null,
               "Maximum": null,
               "Interval": null
@@ -2238,6 +3406,7 @@
               "Position": 0,
               "Inverted": false,
               "CrossesAtZero": false,
+              "LabelOnOneLine": false,
               "Minimum": null,
               "Maximum": null,
               "Interval": null
@@ -2410,6 +3579,7 @@
               "Position": 3,
               "Inverted": false,
               "CrossesAtZero": false,
+              "LabelOnOneLine": false,
               "Minimum": null,
               "Maximum": null,
               "Interval": null
@@ -2420,6 +3590,7 @@
               "Position": 0,
               "Inverted": false,
               "CrossesAtZero": false,
+              "LabelOnOneLine": false,
               "Minimum": null,
               "Maximum": null,
               "Interval": null
@@ -2430,6 +3601,7 @@
               "Position": 2,
               "Inverted": false,
               "CrossesAtZero": false,
+              "LabelOnOneLine": false,
               "Minimum": null,
               "Maximum": null,
               "Interval": null
@@ -2515,6 +3687,7 @@
               "Position": 3,
               "Inverted": false,
               "CrossesAtZero": false,
+              "LabelOnOneLine": false,
               "Minimum": null,
               "Maximum": null,
               "Interval": null
@@ -2525,6 +3698,7 @@
               "Position": 0,
               "Inverted": false,
               "CrossesAtZero": false,
+              "LabelOnOneLine": false,
               "Minimum": null,
               "Maximum": null,
               "Interval": null


### PR DESCRIPTION
I used the one in the redclover validation. They have the same user interface except now the user needs to specify fractions of biomass in each organ to remove. Previously these were defaults in each plant organ. It was decided to expose these to the user in the hope they would know how to set them.

Resolves #8353 