### PR TITLE
Importing old apsim files works when manager errors encountered

### DIFF
--- a/APSIM.Cli/Program.cs
+++ b/APSIM.Cli/Program.cs
@@ -131,7 +131,7 @@ namespace APSIM.Cli
             foreach (string file in files)
             {
                 var importer = new Importer();
-                importer.ProcessFile(file);
+                importer.ProcessFile(file, e=> { Console.WriteLine(e.ToString()); });
             }
         }
     }

--- a/ApsimNG/Presenters/MainPresenter.cs
+++ b/ApsimNG/Presenters/MainPresenter.cs
@@ -1149,15 +1149,23 @@ namespace UserInterface.Presenters
         /// <param name="leftTab">Should the file be opened in the left tabset?</param>
         public void Import(string fileName)
         {
+            // When an old .apsim file is imported, exceptions can occur when converting the file but the 
+            // file is still converted i.e. exception isn't fatal. Catch these exceptions and show to user
+            // in the 
+
+            List<Exception> importExceptions = new();
             try
             {
                 var importer = new Importer();
-                importer.ProcessFile(fileName);
+                importer.ProcessFile(fileName, e => { importExceptions.Add(e); });
             }
             catch (Exception err)
             {
                 throw new Exception("Error during Import: " + err.Message);
             }
+            string importExceptionsAsString = importExceptions.Join(Environment.NewLine);
+            if (!string.IsNullOrEmpty(importExceptionsAsString))
+                ShowMessage(importExceptionsAsString, Simulation.MessageType.Warning);
         }
 
         /// <summary>

--- a/Models/Core/Apsim710File/Importer.cs
+++ b/Models/Core/Apsim710File/Importer.cs
@@ -125,13 +125,14 @@ namespace Models.Core.Apsim710File
         /// Processes a file and writes the Simulation(s) to the .apsimx file
         /// </summary>
         /// <param name="filename">The name of the input file</param>
-        public void ProcessFile(string filename)
+        /// <param name="errorHandler">Action to be taken when an error occurs.</param>
+        public void ProcessFile(string filename, Action<Exception> errorHandler)
         {
             if (File.Exists(filename))
             {
                 try
                 {
-                    Simulations sims = this.CreateSimulations(filename);
+                    Simulations sims = this.CreateSimulations(filename, errorHandler);
                     sims.Write(Path.ChangeExtension(filename, ".apsimx"));
                     Console.WriteLine(filename + " --> " + Path.ChangeExtension(filename, ".apsimx"));
                 }
@@ -148,29 +149,16 @@ namespace Models.Core.Apsim710File
         }
 
         /// <summary>
-        /// Iterate through the directory and attempt to convert any .apsim files.
-        /// </summary>
-        /// <param name="dir">The directory to process</param>
-        public void ProcessDir(string dir)
-        {
-            DirectoryInfo dirInfo = new DirectoryInfo(dir);
-
-            foreach (FileInfo file in dirInfo.GetFiles("*.apsim"))
-            {
-                this.ProcessFile(file.FullName);
-            }
-        }
-
-        /// <summary>
         /// Interrogate the .apsim file XML and attempt to construct a
         /// useful APSIMX Simulation object(s). Uses a temporary file
         /// location.
         /// </summary>
         /// <param name="filename">Source file (.apsim)</param>
+        /// <param name="errorHandler">A handler for all exceptions encountered.</param>
         /// <returns>An APSIMX Simulations object</returns>
-        public Simulations CreateSimulations(string filename)
+        public Simulations CreateSimulations(string filename, Action<Exception> errorHandler)
         {
-            return CreateSimulationsFromXml(File.ReadAllText(filename));
+            return CreateSimulationsFromXml(File.ReadAllText(filename), errorHandler);
         }
 
         /// <summary>
@@ -179,8 +167,9 @@ namespace Models.Core.Apsim710File
         /// location.
         /// </summary>
         /// <param name="xml">Source APSIM 7.10 xml</param>
+        /// <param name="errorHandler">A handler for all exceptions encountered.</param>
         /// <returns>An APSIMX Simulations object</returns>
-        public Simulations CreateSimulationsFromXml(string xml)
+        public Simulations CreateSimulationsFromXml(string xml, Action<Exception> errorHandler)
         {
             string xfile = Path.GetTempFileName();
             Simulations newSimulations = null;
@@ -209,7 +198,7 @@ namespace Models.Core.Apsim710File
             xmlWriter.Write(XmlUtilities.FormattedXML(xdoc.OuterXml));
             xmlWriter.Close();
 
-            newSimulations = FileFormat.ReadFromFile<Simulations>(xfile, e => throw e, false).NewModel as Simulations;
+            newSimulations = FileFormat.ReadFromFile<Simulations>(xfile, errorHandler, false).NewModel as Simulations;
             File.Delete(xfile);
             return newSimulations;
         }


### PR DESCRIPTION
When importing old apsim files, don't stop import on manager compile errors.

Resolves #7300