### PR TITLE
5275 Children Matching Property Names

### DIFF
--- a/ApsimNG/Presenters/ExplorerPresenter.cs
+++ b/ApsimNG/Presenters/ExplorerPresenter.cs
@@ -759,7 +759,7 @@ namespace UserInterface.Presenters
         {
             if (this.view.Tree.SelectedNode != string.Empty)
             {
-                object model = this.ApsimXFile.FindByPath(this.view.Tree.SelectedNode)?.Value;
+                object model = this.ApsimXFile.FindByPath(this.view.Tree.SelectedNode, LocatorFlags.ModelsOnly)?.Value;
 
                 if (model != null)
                 {

--- a/Models/Core/ILocator.cs
+++ b/Models/Core/ILocator.cs
@@ -37,6 +37,11 @@ namespace Models.Core
         /// If set, Report columns will be considered in the search; otherwise these are ignored
         /// </summary>
         IncludeReportVars = 16,
+
+        /// <summary>
+        /// If set, fetch only model references, do not return properties or methods of the same name
+        /// </summary>
+        ModelsOnly = 32,
     };
 
     /// <summary>

--- a/Models/Core/Locator.cs
+++ b/Models/Core/Locator.cs
@@ -147,7 +147,10 @@ namespace Models.Core
             bool ignoreCase = (flags & LocatorFlags.CaseSensitive) != LocatorFlags.CaseSensitive;
             StringComparison compareType = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
             bool throwOnError = (flags & LocatorFlags.ThrowOnError) == LocatorFlags.ThrowOnError;
+            bool onlyModelChildren = (flags & LocatorFlags.ModelsOnly) == LocatorFlags.ModelsOnly;
+            bool includeReportVars = (flags & LocatorFlags.IncludeReportVars) == LocatorFlags.IncludeReportVars;
 
+            //check if a path was given
             IVariable returnVariable = null;
             if (string.IsNullOrEmpty(namePath))
             {
@@ -157,330 +160,358 @@ namespace Models.Core
                     return null;
             }
 
-            // Look in cache first.
+            // check if path is in cache
             object value = null;
             if (cache.ContainsKey(cacheKey))
                 value = cache[cacheKey];
             if (value != null)
                 return value as IVariable;
 
+            //check if path is actually an expression
             if (IsExpression(namePath))
             {
                 returnVariable = new VariableExpression(namePath, relativeTo as Model);
+                cache.Add(cacheKey, returnVariable);
+                return returnVariable;
             }
-            else
+            
+            namePath = namePath.Replace("Value()", "Value().");
+
+            //If our name starts with [ or . we need to handle that formatting and figure out where that model is
+            if (namePath.StartsWith("[") || namePath.StartsWith("."))
             {
-                namePath = namePath.Replace("Value()", "Value().");
-                // Remove a square bracketed model name and change our relativeTo model to 
-                // the referenced model.
-                if (namePath.StartsWith("["))
+                relativeTo = GetInternalRelativeTo(relativeTo, namePath, compareType, throwOnError, includeReportVars, out string filteredNamePath);
+                namePath = filteredNamePath;
+            }
+            //if it doesn't start with those characters, it might be a report variable, so we need to search for that in the report columns
+            else if (includeReportVars)
+            {
+                // Try a report column.
+                foreach (Report report in relativeTo.FindAllInScope<Report>())
                 {
-                    int posCloseBracket = namePath.IndexOf(']');
-                    if (posCloseBracket == -1)
+                    IReportColumn column = report.Columns?.Find(c => c.Name == namePath);
+                    if (column != null && !((column is ReportColumn) && (column as ReportColumn).possibleRecursion))
                     {
-                        if (throwOnError)
-                            throw new Exception($"No closing square bracket in variable name '{namePath}'.");
-                        else
-                            return null;
-                    }
-                    string modelName = namePath.Substring(1, posCloseBracket - 1);
-                    namePath = namePath.Remove(0, posCloseBracket + 1);
-                    Model foundModel = relativeTo.FindInScope(modelName) as Model;
-                    if (foundModel == null)
-                    {
-                        // Didn't find a model with a name matching the square bracketed string so
-                        // now try and look for a model with a type matching the square bracketed string.
-                        Type[] modelTypes = ReflectionUtilities.GetTypeWithoutNameSpace(modelName, Assembly.GetExecutingAssembly());
-                        if (modelTypes.Length == 1)
-                            foundModel = relativeTo.FindAllInScope().FirstOrDefault(m => modelTypes[0].IsAssignableFrom(m.GetType())) as Model;
-                    }
-                    if (foundModel == null)
-                    {
-                        if (throwOnError)
-                            throw new Exception($"Unable to find any model with name or type {modelName} in scope of {relativeTo.Name}");
-                        else
-                            return null;
-                    }
-                    else
-                        relativeTo = foundModel;
-                }
-                else if (namePath.StartsWith("."))
-                {
-                    // Absolute path
-                    IModel root = relativeTo;
-                    while (root.Parent != null)
-                    {
-                        root = root.Parent as Model;
-                    }
-                    relativeTo = root;
-
-                    namePath = namePath.Remove(0, 1);
-                    int posPeriod = namePath.IndexOf('.');
-                    if (posPeriod == -1)
-                    {
-                        posPeriod = namePath.Length;
-                    }
-                    string rootName = namePath.Substring(0, posPeriod);
-                    if (relativeTo.Name.Equals(rootName, compareType))
-                        namePath = namePath.Remove(0, posPeriod);
-                    else
-                    {
-                        if (throwOnError)
-                            throw new Exception($"Incorrect root name in absolute path '.{namePath}'");
-                        else
-                            return null;
-                    }
-                    if (namePath.StartsWith("."))
-                    {
-                        namePath = namePath.Remove(0, 1);
-                    }
-                }
-                else if ((flags & LocatorFlags.IncludeReportVars) == LocatorFlags.IncludeReportVars)
-                {
-                    // Try a report column.
-                    foreach (Report report in relativeTo.FindAllInScope<Report>())
-                    {
-                        IReportColumn column = report.Columns?.Find(c => c.Name == namePath);
-                        if (column != null && !((column is ReportColumn) && (column as ReportColumn).possibleRecursion))
+                        // Things can get nasty here. The call below to column.GetValue(0) has the
+                        // potential to call this routine recursively. Consider as an example
+                        // a Report column with the contents "n + 1 as n". This is hard to catch
+                        // and handle, since it leads to a StackOverflowException which cannot be
+                        // caught. One way to prevent this problem is to check whether the
+                        // stack has grown unreasonably large, then throw our own Exception.
+                        //
+                        // This possiblity of recursion is also one reason why the "throwOnError" option
+                        // is not handled by exclosing the whole routine in a try block, then deciding
+                        // in the catch section whether to rethrow the exception or return null.
+                        int nFrames = new System.Diagnostics.StackTrace().FrameCount;
+                        if (nFrames > 1000)
                         {
-                            // Things can get nasty here. The call below to column.GetValue(0) has the
-                            // potential to call this routine recursively. Consider as an example
-                            // a Report column with the contents "n + 1 as n". This is hard to catch
-                            // and handle, since it leads to a StackOverflowException which cannot be
-                            // caught. One way to prevent this problem is to check whether the
-                            // stack has grown unreasonably large, then throw our own Exception.
-                            //
-                            // This possiblity of recursion is also one reason why the "throwOnError" option
-                            // is not handled by exclosing the whole routine in a try block, then deciding
-                            // in the catch section whether to rethrow the exception or return null.
-                            int nFrames = new System.Diagnostics.StackTrace().FrameCount;
-                            if (nFrames > 1000)
-                            {
-                                if (throwOnError)
-                                    throw new Exception("Recursion error");
-                                else
-                                    return null;
-                            }
-                            return new VariableObject(column.GetValue(0));
+                            if (throwOnError)
+                                throw new Exception("Recursion error");
+                            else
+                                return null;
                         }
+                        return new VariableObject(column.GetValue(0));
                     }
                 }
+            }
 
-                // Now walk the series of '.' separated path bits, assuming the path bits
-                // are child models. Stop when we can't find the child model.
-                string[] namePathBits = namePath.Split(".".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToArray();
-                if (namePathBits.Length == 0 && !string.IsNullOrEmpty(namePath))
-                {
-                    if (throwOnError)
-                        throw new Exception($"Invalid variable name: '{cacheKey}'");
-                    else
-                        return null;
-                }
-                int i;
-                bool includeDisabled = (flags & LocatorFlags.IncludeDisabled) == LocatorFlags.IncludeDisabled;
-                for (i = 0; i < namePathBits.Length; i++)
-                {
-                    IModel localModel = relativeTo.Children.FirstOrDefault(m => m.Name.Trim().Equals(namePathBits[i], compareType) && (includeDisabled || m.Enabled));
-                    if (localModel == null)
-                    {
-                        break;
-                    }
-                    else
-                    {
-                        relativeTo = localModel as Model;
-                    }
-                }
+            //exit here early if we don't have a starting point
+            if (relativeTo == null)
+            {
+                if (throwOnError)
+                    throw new Exception($"Unable to locate model {namePath}");
+                else
+                    return null;
+            }
 
-                // At this point there are only 2 possibilities. We have encountered a 
-                // PropertyInfo/MethodInfo or the path is invalid.
-                // We now need to loop through the remaining path bits and keep track of each
-                // section of the path as each section will have to be evaulated everytime a
-                // a get is done for this path. 
-                // The variable 'i' will point to the name path that cannot be found as a model.
-                object relativeToObject = relativeTo;
-                List<IVariable> properties = new List<IVariable>();
-                properties.Add(new VariableObject(relativeTo));
-                for (int j = i; j < namePathBits.Length; j++)
+            //chop the name path up into pieces that can each be searched for
+            string[] namePathBits = GetInternalNameBits(namePath, cacheKey, throwOnError);
+
+            // We now need to loop through the remaining path bits and keep track of each
+            // section of the path as each section will have to be evaulated everytime a
+            // a get is done for this path. 
+            object relativeToObject = relativeTo;
+            List<IVariable> properties = new List<IVariable>();
+            properties.Add(new VariableObject(relativeTo));
+            for (int j = 0; j < namePathBits.Length; j++)
+            {
+                object objectInfo = GetInternalObjectInfo(relativeToObject, namePathBits[j], properties, compareType, ignoreCase, throwOnError, onlyModelChildren, out List<object> argumentsList);
+
+                //Depending on the type we found, handle it
+                bool propertiesOnly = (flags & LocatorFlags.PropertiesOnly) == LocatorFlags.PropertiesOnly;
+                    
+                if ((objectInfo as PropertyInfo) != null)
                 {
+                    PropertyInfo propertyInfo = (objectInfo as PropertyInfo);
                     // look for an array specifier e.g. sw[2]
                     string arraySpecifier = null;
                     if (namePathBits[j].Contains("["))
-                    {
                         arraySpecifier = StringUtilities.SplitOffBracketedValue(ref namePathBits[j], '[', ']');
-                    }
 
-                    // Look for either a property or a child model.
-                    IModel localModel = null;
+                    VariableProperty property = new VariableProperty(relativeToObject, propertyInfo, arraySpecifier);
+                    properties.Add(property);
+                    if (propertiesOnly && j == namePathBits.Length - 1)
+                        break;
+                    relativeToObject = property.Value;
                     if (relativeToObject == null)
+                        return null;
+                }
+                else if ((objectInfo as MethodInfo) != null)
+                {
+                    MethodInfo methodInfo = (objectInfo as MethodInfo);
+                    VariableMethod method = null;
+                    if (argumentsList != null)
                     {
-                        if (throwOnError)
-                            throw new Exception($"Unable to locate model {namePath}");
-                        else
-                            return null;
+                        method = new VariableMethod(relativeToObject, methodInfo, argumentsList.ToArray<object>());
                     }
-                    // Check property info
-                    Type declaringType;
-                    if (properties.Any())
-                        declaringType = properties.Last().DataType;
                     else
-                        declaringType = relativeToObject.GetType();
-                    PropertyInfo propertyInfo = declaringType.GetProperty(namePathBits[j]);
-                    if (propertyInfo == null && ignoreCase) // If not found, try using a case-insensitive search
                     {
-                        propertyInfo = relativeToObject.GetType().GetProperty(namePathBits[j], BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance | BindingFlags.IgnoreCase);
+                        method = new VariableMethod(relativeToObject, methodInfo, null);
                     }
-
-                    // If not property info
-                    // Check method info
-                    MethodInfo methodInfo = null;
-                    List<object> argumentsList = null;
-                    if (propertyInfo == null)
-                    {
-                        if (namePathBits[j].IndexOf('(') > 0)
-                        {
-                            // before trying to access the method we need to identify the types of arguments to identify overloaded methods.
-                            // assume: presence of quotes is string
-                            // assume: tolower = false or true is boolean
-                            // assume: presence of . and tryparse is double
-                            // assume: tryparse is int32
-                            List<Type> argumentsTypes = new List<Type>();
-                            argumentsList = new List<object>();
-                            // get arguments and store in VariableMethod
-                            string args = namePathBits[j].Substring(namePathBits[j].IndexOf('('));
-                            args = args.Substring(0, args.IndexOf(')'));
-                            args = args.Replace("(", "").Replace(")", "");
-
-                            if (args.Length > 0)
-                            {
-                                args = args.Trim('(').Trim(')');
-                                var argList = args.Split(",".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).Select(a => a.Trim(' ')).ToArray();
-
-                                for (int argid = 0; argid < argList.Length; argid++)
-                                {
-                                    var trimmedarg = argList[argid].Trim(' ').Trim(new char[] { '(', ')' }).Trim(' ');
-                                    if (trimmedarg.Contains('"'))
-                                    {
-                                        argumentsTypes.Add(typeof(string));
-                                        argumentsList.Add(trimmedarg.Trim('\"'));
-                                    }
-                                    else if (trimmedarg.ToLower() == "false" || trimmedarg.ToLower() == "true")
-                                    {
-                                        argumentsTypes.Add(typeof(bool));
-                                        argumentsList.Add(Convert.ToBoolean(trimmedarg, CultureInfo.InvariantCulture));
-                                    }
-                                    else if (trimmedarg.Contains('.') && double.TryParse(trimmedarg, out _))
-                                    {
-                                        argumentsTypes.Add(typeof(double));
-                                        argumentsList.Add(Convert.ToDouble(trimmedarg, CultureInfo.InvariantCulture));
-                                    }
-                                    else if (Int32.TryParse(trimmedarg, out _))
-                                    {
-                                        argumentsTypes.Add(typeof(Int32));
-                                        argumentsList.Add(Convert.ToInt32(trimmedarg, CultureInfo.InvariantCulture));
-                                    }
-                                    else
-                                    {
-                                        if (throwOnError)
-                                            throw new ApsimXException(relativeToModel, $"Unable to determine the type of argument ({trimmedarg}) in Report method");
-                                        else
-                                            return null;
-                                    }
-                                }
-                            }
-
-                            // try get the method with identified arguments
-                            methodInfo = relativeToObject.GetType().GetMethod(namePathBits[j].Substring(0, namePathBits[j].IndexOf('(')), argumentsTypes.ToArray<Type>());
-                            if (methodInfo == null && ignoreCase) // If not found, try using a case-insensitive search
-                            {
-                                BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.Static | BindingFlags.IgnoreCase;
-                                methodInfo = relativeToObject.GetType().GetMethod(namePathBits[j].Substring(0, namePathBits[j].IndexOf('(')), argumentsTypes.Count(), bindingFlags, null, argumentsTypes.ToArray<Type>(), null);
-                            }
-                        }
-                    }
-
-                    bool propertiesOnly = (flags & LocatorFlags.PropertiesOnly) == LocatorFlags.PropertiesOnly;
-
+                    properties.Add(method);
+                    if (propertiesOnly && j == namePathBits.Length - 1)
+                        break;
+                    relativeToObject = method.Value;
+                    if (relativeToObject == null)
+                        return null;
+                }
+                else if ((objectInfo as IModel) != null)
+                {
+                    IModel localModel = (objectInfo as IModel);
                     if (relativeToObject is Models.Functions.IFunction && namePathBits[j] == "Value()")
                     {
                         MethodInfo method = relativeTo.GetType().GetMethod("Value");
                         properties.Add(new VariableMethod(relativeTo, method));
                     }
-                    else if (propertyInfo == null && methodInfo == null && relativeToObject is IModel model)
-                    {
-                        // Not a property, may be an unchecked method or a child model.
-                        localModel = model.Children.FirstOrDefault(m => m.Name.Equals(namePathBits[j], compareType));
-                        if (localModel == null)
-                        {
-                            // Not a model
-                            if (throwOnError)
-                                throw new Exception($"While locating model {namePath}: {namePathBits[j]} is not a child of {model.Name}");
-                            else
-                                return null;
-                        }
-                        else
-                        {
-                            properties.Add(new VariableObject(localModel));
-                            relativeToObject = localModel;
-                        }
-                    }
-                    else if (propertyInfo != null)
-                    {
-                        VariableProperty property = new VariableProperty(relativeToObject, propertyInfo, arraySpecifier);
-                        properties.Add(property);
-                        if (propertiesOnly && j == namePathBits.Length - 1)
-                            break;
-                        relativeToObject = property.Value;
-                        if (relativeToObject == null)
-                            return null;
-                    }
-                    else if (methodInfo != null)
-                    {
-                        VariableMethod method = null;
-                        if (argumentsList != null)
-                        {
-                            method = new VariableMethod(relativeToObject, methodInfo, argumentsList.ToArray<object>());
-                        }
-                        else
-                        {
-                            method = new VariableMethod(relativeToObject, methodInfo, null);
-                        }
-                        properties.Add(method);
-                        if (propertiesOnly && j == namePathBits.Length - 1)
-                            break;
-                        relativeToObject = method.Value;
-                        if (relativeToObject == null)
-                            return null;
-                    }
-                    else if (relativeToObject is IList)
-                    {
-                        // Special case: we are trying to get a property of an array(IList). In this case
-                        // we want to return the property value for all items in the array.
-                        VariableProperty property = new VariableProperty(relativeToObject, namePathBits[j]);
-                        properties.Add(property);
-                        if (propertiesOnly && j == namePathBits.Length - 1)
-                            break;
-                        relativeToObject = property.Value;
-                        if (relativeToObject == null)
-                            return null;
-                    }
-                    else
-                    {
-                        if (throwOnError)
-                            throw new Exception($"While locating model {namePath}: unknown model or property specification {namePathBits[j]}");
-                        else
-                            return null;
-                    }
+                    properties.Clear(); //we need to clear the properties list if this is a model
+                    properties.Add(new VariableObject(localModel));
+                    relativeToObject = localModel;
                 }
-
-                // We now have a list of IVariable instances that can be evaluated to 
-                // produce a return value for the given path. Wrap the list into an IVariable.
-                returnVariable = new VariableComposite(namePath, properties);
+                else if (relativeToObject is IList)
+                {
+                    // Special case: we are trying to get a property of an array(IList). In this case
+                    // we want to return the property value for all items in the array.
+                    VariableProperty property = new VariableProperty(relativeToObject, namePathBits[j]);
+                    properties.Add(property);
+                    if (propertiesOnly && j == namePathBits.Length - 1)
+                        break;
+                    relativeToObject = property.Value;
+                    if (relativeToObject == null)
+                        return null;
+                }
+                else
+                {
+                    if (throwOnError)
+                        throw new Exception($"While locating model {namePath}: unknown model or property specification {namePathBits[j]}");
+                    else
+                        return null;
+                }
             }
+
+            // We now have a list of IVariable instances that can be evaluated to 
+            // produce a return value for the given path. Wrap the list into an IVariable.
+            returnVariable = new VariableComposite(namePath, properties);
 
             // Add variable to cache.
             cache.Add(cacheKey, returnVariable);
-
             return returnVariable;
+        }
+
+        private IModel GetInternalRelativeTo(IModel relativeTo, string namePath, StringComparison compareType, bool throwOnError, bool includeReportVars, out string namePathFiltered)
+        {
+            string path = namePath;
+
+            // Remove a square bracketed model name and change our relativeTo model to 
+            // the referenced model.
+            if (path.StartsWith("["))
+            {
+                int posCloseBracket = path.IndexOf(']');
+                if (posCloseBracket == -1)
+                {
+                    namePathFiltered = path;
+                    if (throwOnError)
+                        throw new Exception($"No closing square bracket in variable name '{path}'.");
+                    else
+                        return null;
+                }
+                string modelName = path.Substring(1, posCloseBracket - 1);
+                path = path.Remove(0, posCloseBracket + 1);
+                Model foundModel = relativeTo.FindInScope(modelName) as Model;
+                if (foundModel == null)
+                {
+                    // Didn't find a model with a name matching the square bracketed string so
+                    // now try and look for a model with a type matching the square bracketed string.
+                    Type[] modelTypes = ReflectionUtilities.GetTypeWithoutNameSpace(modelName, Assembly.GetExecutingAssembly());
+                    if (modelTypes.Length == 1)
+                        foundModel = relativeTo.FindAllInScope().FirstOrDefault(m => modelTypes[0].IsAssignableFrom(m.GetType())) as Model;
+                }
+                if (foundModel == null)
+                {
+                    namePathFiltered = path;
+                    if (throwOnError)
+                        throw new Exception($"Unable to find any model with name or type {modelName} in scope of {relativeTo.Name}");
+                    else
+                        return null;
+                }
+                else
+                {
+                    namePathFiltered = path;
+                    return foundModel;
+                }
+                    
+            }
+            else if (path.StartsWith("."))
+            {
+                // Absolute path
+                IModel root = relativeTo;
+                while (root.Parent != null)
+                {
+                    root = root.Parent as Model;
+                }
+
+                path = path.Remove(0, 1);
+                int posPeriod = path.IndexOf('.');
+                if (posPeriod == -1)
+                {
+                    posPeriod = path.Length;
+                }
+                string rootName = path.Substring(0, posPeriod);
+                if (root.Name.Equals(rootName, compareType))
+                    path = path.Remove(0, posPeriod);
+                else
+                {
+                    namePathFiltered = path;
+                    if (throwOnError)
+                        throw new Exception($"Incorrect root name in absolute path '.{path}'");
+                    else
+                        return null;
+                }
+                if (path.StartsWith("."))
+                {
+                    path = path.Remove(0, 1);
+                }
+                namePathFiltered = path;
+                return root;
+            } 
+            else
+            {
+                namePathFiltered = path;
+                return null;
+            }
+        }
+        private string[] GetInternalNameBits(string namePath, string cacheKey, bool throwOnError)
+        {
+            // Now walk the series of '.' separated path bits, assuming the path bits
+            // are child models. Stop when we can't find the child model.
+            string[] namePathBits = namePath.Split(".".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToArray();
+            if (namePathBits.Length == 0 && !string.IsNullOrEmpty(namePath))
+            {
+                if (throwOnError)
+                    throw new Exception($"Invalid variable name: '{cacheKey}'");
+                else
+                    return null;
+            }
+
+            return namePathBits;
+        }
+
+        private object GetInternalObjectInfo(object relativeToObject, string name, List<IVariable> properties, StringComparison compareType, bool ignoreCase, bool throwOnError, bool onlyModelChildren, out List<object> argumentsList)
+        {
+
+            argumentsList = null;
+
+            if (!onlyModelChildren)
+            {
+                PropertyInfo propertyInfo = null;
+                // Check if property
+                Type declaringType;
+                if (properties.Any())
+                    declaringType = properties.Last().DataType;
+                else
+                    declaringType = relativeToObject.GetType();
+                propertyInfo = declaringType.GetProperty(name);
+                if (propertyInfo == null && ignoreCase) // If not found, try using a case-insensitive search
+                {
+                    propertyInfo = relativeToObject.GetType().GetProperty(name, BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance | BindingFlags.IgnoreCase);
+                }
+                if (propertyInfo != null)
+                    return propertyInfo;
+            }
+
+            if (!onlyModelChildren)
+            {
+                MethodInfo methodInfo = null;
+
+                if (name.IndexOf('(') > 0)
+                {
+                    // before trying to access the method we need to identify the types of arguments to identify overloaded methods.
+                    // assume: presence of quotes is string
+                    // assume: tolower = false or true is boolean
+                    // assume: presence of . and tryparse is double
+                    // assume: tryparse is int32
+                    List<Type> argumentsTypes = new List<Type>();
+                    argumentsList = new List<object>();
+                    // get arguments and store in VariableMethod
+                    string args = name.Substring(name.IndexOf('('));
+                    args = args.Substring(0, args.IndexOf(')'));
+                    args = args.Replace("(", "").Replace(")", "");
+
+                    if (args.Length > 0)
+                    {
+                        args = args.Trim('(').Trim(')');
+                        var argList = args.Split(",".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).Select(a => a.Trim(' ')).ToArray();
+
+                        for (int argid = 0; argid < argList.Length; argid++)
+                        {
+                            var trimmedarg = argList[argid].Trim(' ').Trim(new char[] { '(', ')' }).Trim(' ');
+                            if (trimmedarg.Contains('"'))
+                            {
+                                argumentsTypes.Add(typeof(string));
+                                argumentsList.Add(trimmedarg.Trim('\"'));
+                            }
+                            else if (trimmedarg.ToLower() == "false" || trimmedarg.ToLower() == "true")
+                            {
+                                argumentsTypes.Add(typeof(bool));
+                                argumentsList.Add(Convert.ToBoolean(trimmedarg, CultureInfo.InvariantCulture));
+                            }
+                            else if (trimmedarg.Contains('.') && double.TryParse(trimmedarg, out _))
+                            {
+                                argumentsTypes.Add(typeof(double));
+                                argumentsList.Add(Convert.ToDouble(trimmedarg, CultureInfo.InvariantCulture));
+                            }
+                            else if (Int32.TryParse(trimmedarg, out _))
+                            {
+                                argumentsTypes.Add(typeof(Int32));
+                                argumentsList.Add(Convert.ToInt32(trimmedarg, CultureInfo.InvariantCulture));
+                            }
+                            else
+                            {
+                                if (throwOnError)
+                                    throw new ApsimXException(relativeToModel, $"Unable to determine the type of argument ({trimmedarg}) in Report method");
+                                else
+                                    return null;
+                            }
+                        }
+                    }
+
+                    // try to get the method with identified arguments
+                    methodInfo = relativeToObject.GetType().GetMethod(name.Substring(0, name.IndexOf('(')), argumentsTypes.ToArray<Type>());
+                    if (methodInfo == null && ignoreCase) // If not found, try using a case-insensitive search
+                    {
+                        BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.Static | BindingFlags.IgnoreCase;
+                        methodInfo = relativeToObject.GetType().GetMethod(name.Substring(0, name.IndexOf('(')), argumentsTypes.Count(), bindingFlags, null, argumentsTypes.ToArray<Type>(), null);
+                    }
+                }
+
+                if (methodInfo != null)
+                    return methodInfo;
+            }
+
+            // Not a property or method, may be a child model.
+            if (relativeToObject as IModel != null)
+                return (relativeToObject as IModel).Children.FirstOrDefault(m => m.Name.Equals(name, compareType));
+            else
+                return null;
         }
     }
 }


### PR DESCRIPTION
Working #5275 

Previous if a child had the same name as a property of it's parent, the child would be referenced instead of the property in reports, but the opposite would be true in manager scripts.

This now makes the locator check property and methods first, before then looking at children. It may break things, so this is a run to see how jenkins responds.

Along with changing the Locator code, I also broke the very large GetInternal method into several smaller parts so it can better be tested. Will start on units tests as jenkins runs.