### PR TITLE
8642 import issues

### DIFF
--- a/Models/Core/Apsim710File/Importer.cs
+++ b/Models/Core/Apsim710File/Importer.cs
@@ -1147,7 +1147,7 @@ namespace Models.Core.Apsim710File
 
                 string childText = string.Empty;
                 childNode = XmlUtilities.Find(oper, "date");
-                dateNode.InnerText = OperationDateToNGDate(childNode?.InnerText);
+                dateNode.InnerText = DateUtilities.ValidateDateString(childNode?.InnerText ?? string.Empty);
 
                 XmlNode actionNode = operationNode.AppendChild(destParent.OwnerDocument.CreateElement("Action"));
 
@@ -1200,27 +1200,6 @@ namespace Models.Core.Apsim710File
             } // next operation
 
             return newNode;
-        }
-
-        /// <Summary>
-        /// Method for parsing a date used by a classic Operations manager to
-        /// a format recognized by NG Operations.
-        /// </Summary>
-        /// <param name="date">The (possibly null or empty) date string.</param>
-        /// <returns>A date string recognized by NG's Operations.</returns>
-        private string OperationDateToNGDate(string date)
-        {
-            // This case occurs for an empty entry in classic's operations schedule.
-            // It is common for there to be a few, as they can't be deleted through classic's UI.
-            if (string.IsNullOrEmpty(date))
-                return "";
-
-            // Both classic and NextGen support annually repeating entries in the Operations module.
-            string[] dateFormatsAnnual = {"d-MMM", "d_MMM"};
-            if (DateTime.TryParseExact(date, dateFormatsAnnual, CultureInfo.InvariantCulture, DateTimeStyles.None, out _))
-                return date;
-
-            return DateUtilities.GetDate(date).ToString("yyyy-MM-dd");
         }
 
         /// <summary>

--- a/Models/Core/Apsim710File/Importer.cs
+++ b/Models/Core/Apsim710File/Importer.cs
@@ -652,6 +652,8 @@ namespace Models.Core.Apsim710File
             this.CopyNodeAndValueArray(childNode, newNode, "DUL", "DUL");
             childNode = XmlUtilities.Find(compNode, "SAT");
             this.CopyNodeAndValueArray(childNode, newNode, "SAT", "SAT");
+            childNode = XmlUtilities.Find(compNode, "KS");
+            this.CopyNodeAndValueArray(childNode, newNode, "KS", "KS");
 
             this.AddChildComponents(compNode, newNode);
 

--- a/Models/Core/Apsim710File/Importer.cs
+++ b/Models/Core/Apsim710File/Importer.cs
@@ -1210,23 +1210,17 @@ namespace Models.Core.Apsim710File
         /// <returns>A date string recognized by NG's Operations.</returns>
         private string OperationDateToNGDate(string date)
         {
-            string[] dateFormatsFixed = {"d/M/yyyy", "d-M-yyy", "d-MMM-yyyy", "d_MMM_yyyy"};
-            string[] dateFormatsAnnual = {"d-MMM", "d_MMM"};
-
+            // This case occurs for an empty entry in classic's operations schedule.
+            // It is common for there to be a few, as they can't be deleted through classic's UI.
             if (string.IsNullOrEmpty(date))
-                return "0001-01-01";
+                return "";
 
-            if (DateTime.TryParseExact(date, dateFormatsFixed, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime when))
-                return when.ToString("yyyy-MM-dd");
-
+            // Both classic and NextGen support annually repeating entries in the Operations module.
+            string[] dateFormatsAnnual = {"d-MMM", "d_MMM"};
             if (DateTime.TryParseExact(date, dateFormatsAnnual, CultureInfo.InvariantCulture, DateTimeStyles.None, out _))
                 return date;
 
-            var result  = DateUtilities.GetDateISO(date);
-            if (result == "0001-01-01")
-                result = DateUtilities.GetDate(date, startDate).ToString("yyyy-MM-dd");
-
-            return result;
+            return DateUtilities.GetDate(date).ToString("yyyy-MM-dd");
         }
 
         /// <summary>

--- a/Models/Core/ApsimFile/Converter.cs
+++ b/Models/Core/ApsimFile/Converter.cs
@@ -4383,6 +4383,9 @@ namespace Models.Core.ApsimFile
                     swimSolute["$type"] = "Models.Soils.Solute, Models";
             }
 
+            foreach (JObject swimWT in JsonUtilities.ChildrenRecursively(root, "SwimWaterTable"))
+                swimWT.Remove();
+
             // Make sure all solutes have the new $type
             foreach (JObject solute in JsonUtilities.ChildrenRecursively(root, "Solute"))
                 solute["$type"] = "Models.Soils.Solute, Models";


### PR DESCRIPTION
Resolves #8642 

There were other date formats accepted by classic's operations module (doy year), but I am not sure how widely used they were. I split date conversion into its own method so it will be easy to add them if desired. 

Also, not sure which file format version SwimWaterTable was removed in, so I stuck its deletion after the converter handles something with SwimSolutes. 