### PR TITLE
8635 Standardised Solutes has link to parent

### DIFF
--- a/Models/Soils/Chemical.cs
+++ b/Models/Soils/Chemical.cs
@@ -117,16 +117,19 @@ namespace Models.Soils
         /// <returns></returns>
         public IEnumerable<Solute> GetStandardisedSolutes()
         {
-            var solutes = new List<Solute>();
+            List<Solute> solutes = new List<Solute>();
 
             // Add in child solutes.
-            foreach (var solute in Parent.FindAllChildren<Solute>())
+            foreach (Solute solute in Parent.FindAllChildren<Solute>())
             {
                 if (MathUtilities.AreEqual(Thickness, solute.Thickness))
                     solutes.Add(solute);
                 else
                 {
-                    var standardisedSolute = solute.Clone();
+                    Solute standardisedSolute = solute.Clone();
+                    if (standardisedSolute.Parent == null)
+                        standardisedSolute.Parent = solute.Parent;
+
                     if (solute.InitialValuesUnits == Solute.UnitsEnum.kgha)
                         standardisedSolute.InitialValues = SoilUtilities.MapMass(solute.InitialValues, solute.Thickness, Thickness, false);
                     else


### PR DESCRIPTION
Resolves #8635

Chemical's GetStandardisedSolutes function uses a clone to make a copy of the solute to do layer mapping with. However, if the physical model link has not been set yet, then the StandardisedSolute cannot look up the layer structure. This change gives it back a reference to the parent soil so it can find the other models it needs.