### PR TITLE
8632 CroptimizR Fixes

### DIFF
--- a/Examples/Optimisation/CroptimizRExample.apsimx
+++ b/Examples/Optimisation/CroptimizRExample.apsimx
@@ -2530,7 +2530,7 @@
                 {
                   "$type": "Models.Climate.Weather, Models",
                   "ConstantsFile": null,
-                  "FileName": "APS6.met",
+                  "FileName": "%root%/Examples/Optimisation/APS6.met",
                   "ExcelWorkSheetName": null,
                   "Name": "Weather",
                   "ResourceName": null,

--- a/Models/Core/ApsimFile/Converter.cs
+++ b/Models/Core/ApsimFile/Converter.cs
@@ -5373,10 +5373,14 @@ namespace Models.Core.ApsimFile
         {
             foreach (JObject NNP in JsonUtilities.ChildrenRecursively(root, "GerminatingPhase"))
             {
-                Constant value = new Constant();
-                value.Name = "MinSoilTemperature";
-                value.FixedValue = 0.0;
-                JsonUtilities.AddModel(NNP, value);
+                //check if child already has a MinSoilTemperature
+                if (JsonUtilities.ChildWithName(NNP, "MinSoilTemperature") == null)
+                {
+                    Constant value = new Constant();
+                    value.Name = "MinSoilTemperature";
+                    value.FixedValue = 0.0;
+                    JsonUtilities.AddModel(NNP, value);
+                }
             }
         }
     }

--- a/Models/Models.csproj
+++ b/Models/Models.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="NetMQ" Version="4.0.1.12" />
     <PackageReference Include="MessagePack" Version="2.5.108" />
     <ProjectReference Include="..\APSIM.Shared\APSIM.Shared.csproj" />
-
+    <PackageReference Include="System.Windows.Extensions" Version="6.0.0.0" />
     <PackageReference Include="ExcelDataReader.DataSet" Version="3.6.0" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />


### PR DESCRIPTION
Resolves #8632

A few problems were encountered here:
- The converter to v171 would add a minSoilTemperature node even if one already existed with that name and cause a duplicate
- The croptimizR example would not run on linux because it was missing a .net library reference
- The croptimizR example's weather did not have have a %root% reference so when you saved it elsewhere it didn't run.

Fixed all these issues and was able to run the sim from the issue and the croptimizR example.