### PR TITLE
8533 Fixed "Not An Error" Exception

### DIFF
--- a/APSIM.Shared/Utilities/DBMerger.cs
+++ b/APSIM.Shared/Utilities/DBMerger.cs
@@ -75,38 +75,41 @@
         public static void Merge(IDatabaseConnection source, SQLite destination)
         {
             destination.BeginTransaction();
-
-            if (source.GetTableNames().Contains("_Simulations"))
-            {
-                var sourceData = source.ExecuteQuery("SELECT * FROM _Simulations");
-                var destinationData = destination.ExecuteQuery("SELECT * FROM _Simulations");
-                var simulationNameIDMapping = destinationData
-                                                  .AsEnumerable()
-                                                  .ToDictionary(row => row.Field<string>(1),
-                                                                row => row.Field<int>(0));
-
-                var oldIDNewIDMapping = new Dictionary<int, int>();
-                var columnNames = DataTableUtilities.GetColumnNames(destinationData).ToList();
-                foreach (DataRow simulationRow in sourceData.Rows)
+            try {
+                if (source.GetTableNames().Contains("_Simulations"))
                 {
-                    string name = simulationRow["Name"].ToString();
-                    if (!simulationNameIDMapping.TryGetValue(name, out int id))
+                    var sourceData = source.ExecuteQuery("SELECT * FROM _Simulations");
+                    var destinationData = destination.ExecuteQuery("SELECT * FROM _Simulations");
+                    var simulationNameIDMapping = destinationData
+                                                      .AsEnumerable()
+                                                      .ToDictionary(row => row.Field<string>(1),
+                                                                    row => row.Field<int>(0));
+
+                    var oldIDNewIDMapping = new Dictionary<int, int>();
+                    var columnNames = DataTableUtilities.GetColumnNames(destinationData).ToList();
+                    foreach (DataRow simulationRow in sourceData.Rows)
                     {
-                        // Add a new row to destination.
-                        var newID = simulationNameIDMapping.Values.Max() + 1;
-                        simulationNameIDMapping.Add(name, newID);
-                        var oldID = Convert.ToInt32(simulationRow["ID"]);
-                        oldIDNewIDMapping.Add(oldID, newID);
-                        simulationRow["ID"] = newID;
-                        destination.InsertRows("_Simulations", columnNames, new List<object[]>() { simulationRow.ItemArray });
+                        string name = simulationRow["Name"].ToString();
+                        if (!simulationNameIDMapping.TryGetValue(name, out int id))
+                        {
+                            // Add a new row to destination.
+                            var newID = simulationNameIDMapping.Values.Max() + 1;
+                            simulationNameIDMapping.Add(name, newID);
+                            var oldID = Convert.ToInt32(simulationRow["ID"]);
+                            oldIDNewIDMapping.Add(oldID, newID);
+                            simulationRow["ID"] = newID;
+                            destination.InsertRows("_Simulations", columnNames, new List<object[]>() { simulationRow.ItemArray });
+                        }
                     }
+
+                    foreach (var tableName in source.GetTableNames().Where(t => t != "_Simulations" && t != "_Checkpoints"))
+                        MergeTable(source, destination, tableName, oldIDNewIDMapping);
                 }
-
-                foreach (var tableName in source.GetTableNames().Where(t => t != "_Simulations" && t != "_Checkpoints"))
-                    MergeTable(source, destination, tableName, oldIDNewIDMapping);
             }
-
-            destination.EndTransaction();
+            finally
+            {
+                destination.EndTransaction();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Resolves #8533
Resolves #8625

It was possible for one thread to try and clean an sqlite database while another was still trying to read or write causing two transactions to try and run at the same time. SQLite would throw an exception with a variety of names when this happened.

Solution was to add a locking mechanism to the Begin and End calls to only allow one thread at a time to do a transaction, and then encapsulate the uses of those functions with try...finally blocks so that the locks would always unlock if and respond with the error message if an exception was thrown.