### PR TITLE
Add method to copy EXCO and FIP data to NextGen.

### DIFF
--- a/Models/Core/Apsim710File/Importer.cs
+++ b/Models/Core/Apsim710File/Importer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Xml;
@@ -333,6 +334,7 @@ namespace Models.Core.Apsim710File
                     newNode = CopyNode(compNode, destParent, "Swim3");
                     this.AddCompNode(destParent, "CERESSoilTemperature", "Temperature");
                     AddNutrients(compNode, ref destParent);
+                    AddSwimNutrientData(compNode, ref destParent);
                 }
                 else if (compNode.Name.ToLower() == "soilwater")
                 {
@@ -478,6 +480,41 @@ namespace Models.Core.Apsim710File
                 {
                     childNode.InnerText = "1";  // ensure kg/ha units
                 }
+            }
+        }
+
+        /// <summary>
+        /// Appends EXCO and FIP data to already existing solute nodes.
+        /// </summary>
+        /// <param name="compNode">Swim object being imported.</param>
+        /// <param name="destParent">New soil object being created.</param>
+        private void AddSwimNutrientData(XmlNode compNode, ref XmlNode destParent)
+        {
+            var sampleNode = XmlUtilities.FindByType(compNode.ParentNode, "Sample");
+            var swimSoluteNode = XmlUtilities.FindByType(compNode, "SwimSoluteParameters");
+            if (swimSoluteNode == null || sampleNode == null)
+                return;
+
+            var oldThickness = XmlUtilities.Values(swimSoluteNode, "Thickness/double").Select(Convert.ToDouble).ToArray();
+            var newThickness = XmlUtilities.Values(sampleNode, "Thickness/double").Select(Convert.ToDouble).ToArray();
+
+            XmlDocument helper = new();
+            foreach (var solute in destParent.SelectNodes("Solute").Cast<XmlNode>())
+            {
+                var name = solute.SelectSingleNode("Name")?.InnerXml;
+                if (string.IsNullOrEmpty(name))
+                    continue;
+                var target = $"{name}Exco";
+                var data = XmlUtilities.Values(swimSoluteNode, $"{target}/double").Select(Convert.ToDouble).ToArray();
+                var newData = SoilUtilities.MapConcentration(data, oldThickness, newThickness, data.Last());
+                helper.LoadXml($"<EXCO>{string.Join("", newData.Select(s => $"<double>{s}</double>"))}</EXCO>");
+                CopyNode(helper.DocumentElement, solute, "EXCO");
+
+                target = $"{name}FIP";
+                data = XmlUtilities.Values(swimSoluteNode, $"{target}/double").Select(Convert.ToDouble).ToArray();
+                newData = SoilUtilities.MapConcentration(data, oldThickness, newThickness, data.Last());
+                helper.LoadXml($"<FIP>{string.Join("", newData.Select(s => $"<double>{s}</double>"))}</FIP>");
+                CopyNode(helper.DocumentElement, solute, "FIP");
             }
         }
 


### PR DESCRIPTION
Resolves #8681 

Pasting the data on to the new Solute objects seems to allow it to stick around through the conversion process.