### PR TITLE
8626 Swim with Canola Error

### DIFF
--- a/Models/Soils/SWIM/Swim.cs
+++ b/Models/Soils/SWIM/Swim.cs
@@ -1867,7 +1867,7 @@ namespace Models.Soils
 
                 var plant = model as IPlant;
                 if (plant == null)
-                    plant = model.Parent as IPlant; // the canopy might be a leaf and it's parent is a plant.
+                    plant = model.FindAncestor<IPlant>(); // the canopy might be a leaf or energybalance and we need to find what plant it is on.
                 if (plant != null)
                 {
                     if (plant.IsAlive)
@@ -1885,7 +1885,7 @@ namespace Models.Soils
                     }
                 }
                 else
-                    throw new Exception($"A canopy was found that isn't a plant. Name: {(canopies[vegnum] as IModel).Name}");
+                    throw new Exception($"A canopy was found that isn't on a plant. Name: {(canopies[vegnum] as IModel).Name}");
             }
             crop_cover = 1.0 - bare;
         }


### PR DESCRIPTION
Resolves #8626 

The canola model has a canopy of type EnergyBalance under the shell organ, however when using swim, it cannot find the root plant node of canola when measuring the canopy.

I changed it to search for ancestors of type IPlant instead of just looking at the parent of the canopy, and that seems to have solved this error and lets swim work with canola.

@hut104 : It's not a big change, but you might want to check this before merge since it is a change to the swim code.