### PR TITLE
8699 Stops exception thrown when using string axis

### DIFF
--- a/ApsimNG/Presenters/GraphPresenter.cs
+++ b/ApsimNG/Presenters/GraphPresenter.cs
@@ -177,8 +177,11 @@
                         double xDouble = 0;
                         if (x is DateTime)
                             xDouble = ((DateTime)x).ToOADate();
+                        else if (x is string)
+                            xDouble = 0; //string axis are handled elsewhere, so just set this to 0
                         else
                             xDouble = Convert.ToDouble(x);
+
                         valuesX.Add(xDouble);
                     }
                     foreach (var y in definition.Y)
@@ -186,8 +189,11 @@
                         double yDouble = 0;
                         if (y is DateTime)
                             yDouble = ((DateTime)y).ToOADate();
+                        else if (y is string) 
+                            yDouble = 0; //string axis are handled elsewhere, so just set this to 0
                         else
                             yDouble = Convert.ToDouble(y);
+
                         valuesY.Add(yDouble);
                     }
 


### PR DESCRIPTION
Resolves #8699 

In the axis setup Convert.ToDouble was throwing an exception when given a string value. String axis are handled elsewhere, so if a string is given here, it should just be set to 0 and not give an error.