### PR TITLE
8764 Sharable vscode configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,6 @@ ActivitiesPerformedSummary.html
 LabourAllocationSummary.html
 CurrentDescriptiveSummary.html
 /Docs/.hugo_build.lock
-/.vscode/tasks.json
 Tools/TestSuiteScrapper/Properties/launchSettings.json
 launchSettings.json
 /testEnvironments.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,21 +5,21 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": ".NET Core Launch (GUI)",
+            "name": "ApsimNG: Debug",
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "build",
+            "preLaunchTask": "debug",
             "program": "${workspaceFolder}/bin/Debug/net6.0/ApsimNG.dll",
             "cwd": "${workspaceFolder}",
             "console": "internalConsole",
             "stopAtEntry": false,
         },
         {
-            "name": "Autodocs",
+            "name": ".NET Core Launch (GUI)",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/bin/Debug/net6.0/APSIM.Documentation.dll",
+            "program": "${workspaceFolder}/bin/Debug/net6.0/ApsimNG.dll",
             "cwd": "${workspaceFolder}",
             "console": "internalConsole",
             "stopAtEntry": false,
@@ -73,6 +73,16 @@
             "request": "attach",
             "address": "localhost",
             "port": 55555
+        },
+        {
+            "name": "Autodocs",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/bin/Debug/net6.0/APSIM.Documentation.dll",
+            "cwd": "${workspaceFolder}",
+            "console": "internalConsole",
+            "stopAtEntry": false,
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,33 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "debug clean",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "clean"
+            ]
+        },
+        {
+            "label": "debug build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/ApsimX.sln",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label":"debug",
+            "dependsOrder": "sequence",
+            "dependsOn":[
+                "debug clean",
+                "debug build"
+            ]
+        }
+    ]
+}

--- a/ApsimNG/ApsimNG.csproj
+++ b/ApsimNG/ApsimNG.csproj
@@ -6,26 +6,14 @@
     <BaseOutputPath>../bin</BaseOutputPath>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ApplicationIcon>ApsimLogo.ico</ApplicationIcon>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
     <Platform Condition="'$(Platform)'==''">Any CPU</Platform>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <WarningsAsErrors />
-    <NoWarn>CS1591,CS1572</NoWarn>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>CS1591,CS1572</NoWarn>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <SelfContained>false</SelfContained>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-    <SelfContained>false</SelfContained>
-  </PropertyGroup>
-  
-  <PropertyGroup>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
   


### PR DESCRIPTION
Resolves #8764 

Some of these already existed in the repo from other vscode users, but this will let us have a unified set of configuration options for apsim debugging through vscode. I've added a ApsimNG: Debug config option that does a clean and build for debugging as @ric394 and I were encountering times when vscode wouldn't use the latest code changes when it built and ran without cleaning.