### PR TITLE
8773 Soil Download Errors

### DIFF
--- a/ApsimNG/Presenters/SoilDownloadPresenter.cs
+++ b/ApsimNG/Presenters/SoilDownloadPresenter.cs
@@ -317,7 +317,7 @@ namespace UserInterface.Presenters
                 var values = dataView.GetRow(selectedIndex);
                 var soilName = (string)values[0];
                 Soil matchingSoil = Apsim.Clone<Soil>(allSoils.First(s => s.Soil.Name == soilName).Soil);
-
+                matchingSoil.Name = matchingSoil.Name.Trim();
                 if (!matchingSoil.Children.Any(c => c is INutrient))
                     matchingSoil.Children.Add(new Nutrient() { ResourceName = "Nutrient" });
                 ICommand addSoil = new AddModelCommand(model, matchingSoil, explorerPresenter.GetNodeDescription);

--- a/ApsimNG/Views/TreeView.cs
+++ b/ApsimNG/Views/TreeView.cs
@@ -648,10 +648,12 @@ namespace UserInterface.Views
                     TreePath selPath;
                     TreeViewColumn selCol;
                     treeview1.GetCursor(out selPath, out selCol);
-                    selectionChangedData.NewNodePath = GetFullPath(selPath);
-                    if (selectionChangedData.NewNodePath != selectionChangedData.OldNodePath)
-                        SelectedNodeChanged.Invoke(this, selectionChangedData);
-                    previouslySelectedNodePath = selectionChangedData.NewNodePath;
+                    if (selPath != null) {
+                        selectionChangedData.NewNodePath = GetFullPath(selPath);
+                        if (selectionChangedData.NewNodePath != selectionChangedData.OldNodePath)
+                            SelectedNodeChanged.Invoke(this, selectionChangedData);
+                        previouslySelectedNodePath = selectionChangedData.NewNodePath;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Resolves #8773

Two bugs here. One was a selection bug after adding a soil where a value could be null. The other was that soils with spaces at the end of their names broke the locator and make it impossible to interact with the soil.

Fixed both errors.