### PR TITLE
8773 NaN Correction and mapping length fix

### DIFF
--- a/Models/Core/ApsimFile/Converter.cs
+++ b/Models/Core/ApsimFile/Converter.cs
@@ -1239,7 +1239,7 @@ namespace Models.Core.ApsimFile
                     if (chemical["ParticleSizeSand"] != null && chemical["ParticleSizeSand"].HasValues)
                     {
                         var values = chemical["ParticleSizeSand"].Values<double>().ToArray();
-                        if (values.Length < physicalThickness.Length)
+                        if (values.Length < chemicalThickness.Length)
                             Array.Resize(ref values, chemicalThickness.Length);
                         var mappedValues = SoilUtilities.MapConcentration(values, chemicalThickness, physicalThickness, values.Last(), true);
                         physical["ParticleSizeSand"] = new JArray(mappedValues);
@@ -1248,7 +1248,7 @@ namespace Models.Core.ApsimFile
                     if (chemical["ParticleSizeSilt"] != null && chemical["ParticleSizeSilt"].HasValues)
                     {
                         var values = chemical["ParticleSizeSilt"].Values<double>().ToArray();
-                        if (values.Length < physicalThickness.Length)
+                        if (values.Length < chemicalThickness.Length)
                             Array.Resize(ref values, chemicalThickness.Length);
                         var mappedValues = SoilUtilities.MapConcentration(values, chemicalThickness, physicalThickness, values.Last(), true);
                         physical["ParticleSizeSilt"] = new JArray(mappedValues);
@@ -1257,7 +1257,7 @@ namespace Models.Core.ApsimFile
                     if (chemical["ParticleSizeClay"] != null && chemical["ParticleSizeClay"].HasValues)
                     {
                         var values = chemical["ParticleSizeClay"].Values<double>().ToArray();
-                        if (values.Length < physicalThickness.Length)
+                        if (values.Length < chemicalThickness.Length)
                             Array.Resize(ref values, chemicalThickness.Length);
                         var mappedValues = SoilUtilities.MapConcentration(values, chemicalThickness, physicalThickness, values.Last(), true);
                         physical["ParticleSizeClay"] = new JArray(mappedValues);
@@ -1265,8 +1265,13 @@ namespace Models.Core.ApsimFile
 
                     if (chemical["Rocks"] != null && chemical["Rocks"].HasValues)
                     {
+                        //Some soils from APSoil have NaN in their rock values
                         var values = chemical["Rocks"].Values<double>().ToArray();
-                        if (values.Length < physicalThickness.Length)
+                        for (int i = 0; i < values.Length; i++) {
+                            if (double.IsNaN(values[i]))
+                                values[i] = 0;
+                        }
+                        if (values.Length < chemicalThickness.Length)
                             Array.Resize(ref values, chemicalThickness.Length);
                         var mappedValues = SoilUtilities.MapConcentration(values, chemicalThickness, physicalThickness, values.Last(), true);
                         physical["Rocks"] = new JArray(mappedValues);


### PR DESCRIPTION
Resolves #8773

Some APSoil soils have NaN values in their Rocks array, this seems to happen when the physical thickness is different from the chemical thickness (when chemical has less elements). So I added a check to turn those NaNs into 0s in converter 65. 

I also noticed that it checked the length of the rocks array against physical, but then if it was less, set the rocks array length to the chemical length instead. This caused a crash in the remapping, as it didn't resize when it should have, as rocks needed to match the chemical thickness length, not physical in MapConcentration.

Seems to import the broken APSoil soils correctly now.