### PR TITLE
8721 Added OrderBy to DataStore presenter

### DIFF
--- a/ApsimNG/Presenters/DataStorePresenter.cs
+++ b/ApsimNG/Presenters/DataStorePresenter.cs
@@ -42,6 +42,9 @@ namespace UserInterface.Presenters
         /// <summary>table name drop down.</summary>
         public DropDownView tableDropDown { get; private set; }
 
+        /// <summary>table name drop down.</summary>
+        public DropDownView orderByDropDown { get; private set; }
+
         /// <summary>Column filter edit box.</summary>
         private EditView columnFilterEditBox;
 
@@ -103,6 +106,7 @@ namespace UserInterface.Presenters
 
             checkpointDropDown = view.GetControl<DropDownView>("checkpointDropDown");
             tableDropDown = view.GetControl<DropDownView>("tableDropDown");
+            orderByDropDown = view.GetControl<DropDownView>("orderByDropDown");
             columnFilterEditBox = view.GetControl<EditView>("columnFilterEditBox");
             rowFilterEditBox = view.GetControl<EditView>("rowFilterEditBox");
             sheetContainer = view.GetControl<ContainerView>("grid");
@@ -127,8 +131,10 @@ namespace UserInterface.Presenters
                 }
                 tableDropDown.SelectedIndex = 0;
             }
+            UpdateSortBy();
 
             tableDropDown.Changed += this.OnTableSelected;
+            orderByDropDown.Changed += this.OnOrderBySelected;
             columnFilterEditBox.Leave += OnColumnFilterChanged;
             columnFilterEditBox.IntellisenseItemsNeeded += OnIntellisenseNeeded;
             rowFilterEditBox.Leave += OnColumnFilterChanged;
@@ -196,7 +202,8 @@ namespace UserInterface.Presenters
                                                              tableDropDown.SelectedValue,
                                                              simulationNames,
                                                              columnFilterEditBox.Text,
-                                                             filter);
+                                                             filter,
+                                                             orderByDropDown.SelectedValue);
                         dataProvider.PagingStart += (sender, args) => explorerPresenter.MainPresenter.ShowWaitCursor(true);
                         dataProvider.PagingEnd += (sender, args) => explorerPresenter.MainPresenter.ShowWaitCursor(false);
 
@@ -238,7 +245,33 @@ namespace UserInterface.Presenters
         /// <summary>The selected table has changed.</summary>
         /// <param name="sender">Sender of the event</param>
         /// <param name="e">Event arguments</param>
+        private void UpdateSortBy()
+        {
+            orderByDropDown.IsEditable = false;
+            List<string> columns = new List<string>();
+            columns.Add("");
+            if (dataStore != null)
+            {
+                foreach (Tuple<string, Type> column in dataStore.Reader.GetColumns(tableDropDown.SelectedValue)) 
+                    columns.Add(column.Item1);
+            }
+            orderByDropDown.Values = columns.ToArray();
+            orderByDropDown.SelectedIndex = 0;
+        }
+
+        /// <summary>The selected table has changed.</summary>
+        /// <param name="sender">Sender of the event</param>
+        /// <param name="e">Event arguments</param>
         private void OnTableSelected(object sender, EventArgs e)
+        {
+            UpdateSortBy();
+            PopulateGrid();
+        }
+
+        /// <summary>The selected order by has changed.</summary>
+        /// <param name="sender">Sender of the event</param>
+        /// <param name="e">Event arguments</param>
+        private void OnOrderBySelected(object sender, EventArgs e)
         {
             PopulateGrid();
         }

--- a/ApsimNG/Resources/Glade/DataStoreView.glade
+++ b/ApsimNG/Resources/Glade/DataStoreView.glade
@@ -10,7 +10,7 @@
       <object class="GtkTable" id="topTable">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="n_rows">2</property>
+        <property name="n_rows">3</property>
         <property name="n_columns">4</property>
         <child>
           <object class="GtkLabel" id="label2">
@@ -35,6 +35,20 @@
           <packing>
             <property name="top_attach">1</property>
             <property name="bottom_attach">2</property>
+            <property name="x_options">GTK_FILL</property>
+            <property name="y_options">GTK_FILL</property>
+            <property name="x_padding">8</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="label7">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="xalign">1</property>
+            <property name="label" translatable="yes">Order By:</property>
+          </object>
+          <packing>
+            <property name="top_attach">2</property>
             <property name="x_options">GTK_FILL</property>
             <property name="y_options">GTK_FILL</property>
             <property name="x_padding">8</property>
@@ -89,6 +103,18 @@
             <property name="active">1</property>
           </object>
           <packing>
+            <property name="left_attach">1</property>
+            <property name="right_attach">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkComboBox" id="orderByDropDown">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="active">1</property>
+          </object>
+          <packing>
+            <property name="top_attach">2</property>
             <property name="left_attach">1</property>
             <property name="right_attach">2</property>
           </packing>

--- a/ApsimNG/Views/Sheet/PagedDataProvider.cs
+++ b/ApsimNG/Views/Sheet/PagedDataProvider.cs
@@ -185,7 +185,7 @@ namespace UserInterface.Views
                 string orderBy = "SimulationID, \"Clock.Today\"";
                 if (sortBy.Length > 0)
                     orderBy = "\"" + sortBy + "\"";
-                sql += $"ORDER BY {orderBy}";
+                sql += $"ORDER BY {orderBy}, SimulationID";
                 dataStore.GetDataUsingSql(sql);
             }
             else if (connection is Firebird)

--- a/ApsimNG/Views/Sheet/PagedDataProvider.cs
+++ b/ApsimNG/Views/Sheet/PagedDataProvider.cs
@@ -193,7 +193,7 @@ namespace UserInterface.Views
             if (connection is SQLite)
             {
                 Cleanup();
-                sql = "CREATE TABLE keyset AS " +
+                sql = "CREATE TEMPORARY TABLE keyset AS " +
                          $"SELECT rowid FROM \"{tableName}\" ";
                 if (!string.IsNullOrEmpty(filter))
                     sql += $"WHERE {filter} ";

--- a/Models/Storage/DataStoreReader.cs
+++ b/Models/Storage/DataStoreReader.cs
@@ -241,9 +241,9 @@ namespace Models.Storage
 
             // Get orderby fields
             var orderByFields = new List<string>();
-            if (fieldNamesInTable.Contains("SimulationID"))
+            if (!fieldNamesInTable.Contains("SimulationID"))
                 orderByFields.Insert(0, "SimulationID");
-            if (fieldNamesInTable.Contains("Clock.Today"))
+            if (!fieldNamesInTable.Contains("Clock.Today"))
                 orderByFields.Insert(0, "Clock.Today");
             if (orderByFieldNames != null)
                 orderByFields.AddRange(orderByFieldNames);

--- a/Tests/UnitTests/Sheet/PagedDataProviderTests.cs
+++ b/Tests/UnitTests/Sheet/PagedDataProviderTests.cs
@@ -47,11 +47,7 @@
             CreateTable(database);
             
             var reader = new DataStoreReader(database);
-            var provider = new PagedDataProvider(reader, "Current", "Report", 
-                                                 null,
-                                                 null,
-                                                 null,
-                                                 2);
+            var provider = new PagedDataProvider(reader, "Current", "Report", null, null, null, "", 2);
 
             Assert.AreEqual(3, provider.ColumnCount);
             Assert.AreEqual("SimulationName", provider.GetCellContents(0, 0));
@@ -76,11 +72,7 @@
             CreateTable(database);
 
             var reader = new DataStoreReader(database);
-            var provider = new PagedDataProvider(reader, "Current", "Report",
-                                                 null,
-                                                 "Col2",
-                                                 null,
-                                                 2);
+            var provider = new PagedDataProvider(reader, "Current", "Report", null, "Col2", null, "", 2);
 
             Assert.AreEqual(2, provider.ColumnCount);
             Assert.AreEqual("SimulationName", provider.GetCellContents(0, 0));
@@ -103,11 +95,7 @@
             CreateTable(database);
 
             var reader = new DataStoreReader(database);
-            var provider = new PagedDataProvider(reader, "Current", "Report",
-                                                 new string[] { "Sim1" },
-                                                 "Col1,Col2",
-                                                 "Col1 > 2",
-                                                 2);
+            var provider = new PagedDataProvider(reader, "Current", "Report", new string[] { "Sim1" }, "Col1,Col2", "Col1 > 2", "", 2);
 
             Assert.AreEqual(3, provider.ColumnCount);
             Assert.AreEqual("SimulationName", provider.GetCellContents(0, 0));


### PR DESCRIPTION
Resolves #8721
Resolves #8519

The rowid's were stored in a temporary table that was then used to get out a small subset of the entire data for the presenter. However, when they were stored (which happened every time the datastore was opened in the gui), they were not sorted and just broke the sorting that was supposed to happen.

I added an OrderBy to that sql code and simplified the part where it pulls out 50 rows and now it gets the correct 50 rows out for that offset into the data.

While I was there, I then also added a dropdown to the interface to allow sorting by any column. By default it will do a simulationID and Clock.Today, but this just gives the user the ability to sort on whatever column they want specifically.

These changes actually improved the performance, as now it only does the sort once at the start, instead of every time you move the scroll bar.