### PR TITLE
8810 Fixed PropertyView bug

### DIFF
--- a/ApsimNG/Utility/SettingsDialog.cs
+++ b/ApsimNG/Utility/SettingsDialog.cs
@@ -1,19 +1,18 @@
+using APSIM.Shared.Utilities;
+using UserInterface.EventArguments;
+using UserInterface.Classes;
+using Gtk;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Utility;
+using System.Collections;
+using Models.Core;
+using System.Globalization;
+using System.Runtime.InteropServices;
+
 namespace UserInterface.Views
 {
-    using APSIM.Shared.Utilities;
-    using EventArguments;
-    using Classes;
-    using Gtk;
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
-    using Utility;
-    using System.Collections;
-    using Models.Core;
-    using System.Globalization;
-    using Extensions;
-
     /// <summary>
     /// A class for a dialog window for user settings.
     /// </summary>
@@ -77,9 +76,11 @@ namespace UserInterface.Views
 
         private IEnumerable<Property> GetProperties()
         {
+            bool isOSX = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
             foreach (PropertyInfo property in typeof(Configuration).GetProperties(BindingFlags.Public | BindingFlags.Instance))
-                if (IsUserInput(property))
-                    yield return GetProperty(property, Configuration.Settings);
+                if (!isOSX || property.Name.CompareTo("DarkTheme") != 0)
+                    if (IsUserInput(property))
+                        yield return GetProperty(property, Configuration.Settings);
         }
 
         private Property GetProperty(PropertyInfo property, object instance)

--- a/ApsimNG/Views/MainView.cs
+++ b/ApsimNG/Views/MainView.cs
@@ -227,6 +227,7 @@ namespace UserInterface.Views
             if (ProcessUtilities.CurrentOS.IsMac)
             {
                 InitMac();
+                Utility.Configuration.Settings.DarkTheme = false;
                 //Utility.Configuration.Settings.DarkTheme = Utility.MacUtilities.DarkThemeEnabled();
             }
 

--- a/ApsimNG/Views/PropertyView.cs
+++ b/ApsimNG/Views/PropertyView.cs
@@ -1,17 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using APSIM.Shared.Utilities;
+using UserInterface.Classes;
+using UserInterface.EventArguments;
+using Gtk;
+using UserInterface.Interfaces;
+using Utility;
+
 namespace UserInterface.Views
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Globalization;
-    using System.Linq;
-    using System.Runtime.InteropServices;
-    using APSIM.Shared.Utilities;
-    using Classes;
-    using EventArguments;
-    using Gtk;
-    using Interfaces;
-    using Utility;
-
     /// <summary>
     /// This view will display a list of properties to the user
     /// in a GtkTable, with each row containing a label and an
@@ -198,54 +197,46 @@ namespace UserInterface.Views
         /// <param name="columnOffset">The number of columns to offset for this propertygroup (0 = single. >0 multiply models reported as columns).</param>
         protected void AddPropertiesToTable(ref Grid table, PropertyGroup properties, ref int startRow, int columnOffset)
         {
-            bool isOSX = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
             // Using a regular for loop is not practical because we can
             // sometimes have multiple rows per property (e.g. if it has separators).
             foreach (Property property in properties.Properties.Where(p => p.Visible))
             {
-                // Required to remove dark mode from MacOS systems.
-                // Reasons:
-                //  1) Dark theme does not work on MacOS.
-                //  2) Causes axes, legend names, and axes tick issues with OxyPlot graphs (they won't appear).
-                if (property.Name != "Dark theme enabled" && isOSX)
+                if (property.Separators != null)
+                    foreach (string separator in property.Separators)
+                    {
+                        Label separatorLabel = new Label($"<b>{separator}</b>") { Xalign = 0, UseMarkup = true };
+                        separatorLabel.StyleContext.AddClass("separator");
+                        propertyTable.Attach(separatorLabel, 0, startRow, 3, 1);
+
+                        startRow++;
+                    }
+
+                if (columnOffset == 0) // only perform on first or only entry
                 {
-                    if (property.Separators != null)
-                        foreach (string separator in property.Separators)
-                        {
-                            Label separatorLabel = new Label($"<b>{separator}</b>") { Xalign = 0, UseMarkup = true };
-                            separatorLabel.StyleContext.AddClass("separator");
-                            propertyTable.Attach(separatorLabel, 0, startRow, 3, 1);
+                    Label label = new Label(property.Name);
+                    label.TooltipText = property.Tooltip;
+                    label.Xalign = 0;
 
-                            startRow++;
-                        }
-
-                    if (columnOffset == 0) // only perform on first or only entry
-                    {
-                        Label label = new Label(property.Name);
-                        label.TooltipText = property.Tooltip;
-                        label.Xalign = 0;
-
-                        label.MarginEnd = 10;
-                        propertyTable.Attach(label, 0, startRow, 1, 1);
-                    }
-
-                    if (!string.IsNullOrEmpty(property.Tooltip))
-                    {
-                        Button info = new Button(new Image(Stock.Info, IconSize.Button));
-                        info.TooltipText = property.Tooltip;
-                        propertyTable.Attach(info, 1, startRow, 1, 1);
-                        info.Clicked += OnInfoButtonClicked;
-                    }
-
-                    Widget inputWidget = GenerateInputWidget(property);
-                    inputWidget.Name = property.ID.ToString();
-                    inputWidget.TooltipText = property.Tooltip;
-
-                    propertyTable.Attach(inputWidget, 2 + columnOffset, startRow, 1, 1);
-                    inputWidget.Hexpand = true;
-
-                    startRow++;
+                    label.MarginEnd = 10;
+                    propertyTable.Attach(label, 0, startRow, 1, 1);
                 }
+
+                if (!string.IsNullOrEmpty(property.Tooltip))
+                {
+                    Button info = new Button(new Image(Stock.Info, IconSize.Button));
+                    info.TooltipText = property.Tooltip;
+                    propertyTable.Attach(info, 1, startRow, 1, 1);
+                    info.Clicked += OnInfoButtonClicked;
+                }
+
+                Widget inputWidget = GenerateInputWidget(property);
+                inputWidget.Name = property.ID.ToString();
+                inputWidget.TooltipText = property.Tooltip;
+
+                propertyTable.Attach(inputWidget, 2 + columnOffset, startRow, 1, 1);
+                inputWidget.Hexpand = true;
+
+                startRow++;
             }
 
             foreach (PropertyGroup subProperties in properties.SubModelProperties)


### PR DESCRIPTION
Resolves #8810
Resolves #7581

Moved OSX dark mode check to settings panel instead of property view. This also fixed the syntax highlighting as well.