### PR TITLE
8832 Fixing Water Graph On SoilCrop

### DIFF
--- a/ApsimNG/Presenters/ProfilePresenter.cs
+++ b/ApsimNG/Presenters/ProfilePresenter.cs
@@ -129,11 +129,9 @@ namespace UserInterface.Presenters
                         if (model is SoilCrop)
                         {
                             llsoilName = (model as SoilCrop).Name;
-                            llsoilName = llsoilName.Substring(0, llsoilName.IndexOf("Soil"));
-                            llsoilName = llsoilName + " LL";
-
+                            string cropName = llsoilName.Substring(0, llsoilName.IndexOf("Soil"));
+                            llsoilName = cropName + " LL";
                             llsoil = (model as SoilCrop).LL;
-
                         }
                         //Since we can view the soil relative to water, lets not have the water node graphing options effect this graph.
                         WaterPresenter.PopulateWaterGraph(graph, physical.Thickness, physical.AirDry, physical.LL15, physical.DUL, physical.SAT,

--- a/ApsimNG/Presenters/WaterPresenter.cs
+++ b/ApsimNG/Presenters/WaterPresenter.cs
@@ -259,23 +259,11 @@ namespace UserInterface.Presenters
             var swCumulativeThickness = APSIM.Shared.Utilities.SoilUtilities.ToCumThickness(swThickness);
             graph.Clear();
 
-
-
-            if (llsoil != null && llsoilsName != null)
-            {       //draw the area relative to the water LL instead.
-                graph.DrawRegion($"PAW relative to {llsoilsName}", llsoil, swCumulativeThickness,
-                             sw, swCumulativeThickness,
-                             AxisPosition.Top, AxisPosition.Left,
-                             System.Drawing.Color.LightSkyBlue, true);
-            }
-            else
-            {       //draw the area relative to whatever the water node is currently relative to
+            //draw the area relative to whatever the water node is currently relative to
                 graph.DrawRegion($"PAW relative to {cllName}", cll, swCumulativeThickness,
                             sw, swCumulativeThickness,
                             AxisPosition.Top, AxisPosition.Left,
                             System.Drawing.Color.LightSkyBlue, true);
-            }
-
 
             graph.DrawLineAndMarkers("Airdry", airdry,
                                      cumulativeThickness,

--- a/Models/Soils/Water.cs
+++ b/Models/Soils/Water.cs
@@ -209,17 +209,20 @@ namespace Models.Soils
             get => relativeToCheck;
             set
             {
+                string newValue = value;
+                if (newValue == null)
+                    newValue = "LL15";
                 // This structure is required to create a 'source of truth' to ensure
                 // a stack overflow does not occurs.
-                if (relativeToCheck != value)
+                if (relativeToCheck != newValue)
                 {
                     double percent = FractionFull;
-                    relativeToCheck = value;
+                    relativeToCheck = newValue;
                     UpdateInitialValuesFromFractionFull(percent);
                 }
                 else
                 {
-                    relativeToCheck = value;
+                    relativeToCheck = newValue;
                 }
             }
         }

--- a/Models/Soils/Water.cs
+++ b/Models/Soils/Water.cs
@@ -201,7 +201,7 @@ namespace Models.Soils
         }
 
         [JsonIgnore]
-        private string relativeToCheck;
+        private string relativeToCheck = "LL15";
 
         /// <summary>The crop name (or LL15) that fraction full is relative to</summary>
         public string RelativeTo
@@ -213,8 +213,9 @@ namespace Models.Soils
                 // a stack overflow does not occurs.
                 if (relativeToCheck != value)
                 {
+                    double percent = FractionFull;
                     relativeToCheck = value;
-                    UpdateInitialValuesFromFractionFull(FractionFull);
+                    UpdateInitialValuesFromFractionFull(percent);
                 }
                 else
                 {
@@ -227,7 +228,7 @@ namespace Models.Soils
         public IEnumerable<string> AllowedRelativeTo => (GetAllowedRelativeToStrings());
 
         [JsonIgnore]
-        private bool filledFromTop;
+        private bool filledFromTop = false;
 
         /// <summary>Distribute the water at the top of the profile when setting fraction full.</summary>
         public bool FilledFromTop
@@ -235,9 +236,10 @@ namespace Models.Soils
             get => filledFromTop;
             set
             {
+                double percent = FractionFull;
                 filledFromTop = value;
                 if(Physical != null)
-                    UpdateInitialValuesFromFractionFull(FractionFull);
+                    UpdateInitialValuesFromFractionFull(percent);
             }
         }
 
@@ -256,7 +258,7 @@ namespace Models.Soils
                         return 0;
                     else
                     {
-                        if (RelativeTo != null && RelativeTo != "LL15")
+                        if (RelativeTo != "LL15")
                         {
                             //Get layer indices that have a XF as 0.
                             var plantCrop = FindInScope<SoilCrop>(RelativeTo + "Soil");
@@ -320,7 +322,9 @@ namespace Models.Soils
                 double depthSoFar = 0;
                 for (int layer = 0; layer < Thickness.Length; layer++)
                 {
-                    var prop = (InitialValues[layer] - ll[layer]) / (dul[layer] - ll[layer]);
+                    double prop = 0;
+                    if (dul[layer] - ll[layer] != 0)
+                        prop = (InitialValues[layer] - ll[layer]) / (dul[layer] - ll[layer]);
 
                     if (MathUtilities.IsGreaterThanOrEqual(prop, 1.0))
                         depthSoFar += Thickness[layer];


### PR DESCRIPTION
Resolves #8832

The graph would draw from the crop LL to initial water value even if the initial water was relative to LL15 (which made it go backwards). This change makes the SoilCrop always colour in from LL15 so that you can see where the crop LL goes above and below the actual set water values.