### PR TITLE
8856 Fixes date crash from TreeProxy table

### DIFF
--- a/APSIM.Shared/Utilities/DataTableUtilities.cs
+++ b/APSIM.Shared/Utilities/DataTableUtilities.cs
@@ -401,16 +401,41 @@ namespace APSIM.Shared.Utilities
         /// </summary>
         /// <param name="table">The data table that contains the data required</param>
         /// <param name="columnName">The name of the Date Column</param>
+        /// <param name="numValues"></param>
+        /// <param name="startRow"></param>
+        /// <returns>An array of dates</returns>
+        static public DateTime[] GetColumnAsDates(DataTable table, string columnName, int numValues, int startRow)
+        {
+            DateTime[] values = new DateTime[numValues];
+            int index = 0;
+            for (int row = startRow; row < table.Rows.Count && index < numValues; row++)
+            {
+                string date = DateUtilities.ValidateDateString(table.Rows[row][columnName].ToString());
+                if (date == null)
+                    values[index] = DateTime.MinValue;
+                else
+                    values[index] = DateUtilities.GetDate(date);
+                index++;
+            }
+            return values;
+        }
+
+        /// <summary>
+        /// Get a column as dates.
+        /// </summary>
+        /// <param name="table">The data table that contains the data required</param>
+        /// <param name="columnName">The name of the Date Column</param>
         /// <returns>An array of dates</returns>
         static public DateTime[] GetColumnAsDates(DataTable table, string columnName)
         {
             DateTime[] values = new DateTime[table.Rows.Count];
             for (int row = 0; row != table.Rows.Count; row++)
             {
-                if (Convert.IsDBNull(table.Rows[row][columnName]))
+                string date = DateUtilities.ValidateDateString(table.Rows[row][columnName].ToString());
+                if (date == null)
                     values[row] = DateTime.MinValue;
                 else
-                    values[row] = Convert.ToDateTime(table.Rows[row][columnName], CultureInfo.InvariantCulture);
+                    values[row] = DateUtilities.GetDate(date);
             }
             return values;
         }
@@ -426,10 +451,11 @@ namespace APSIM.Shared.Utilities
             DateTime[] values = new DateTime[view.Count];
             for (int row = 0; row != view.Count; row++)
             {
-                if (Convert.IsDBNull(view[row][columnName]))
+                string date = DateUtilities.ValidateDateString(view[row][columnName].ToString());
+                if (date == null)
                     values[row] = DateTime.MinValue;
                 else
-                    values[row] = Convert.ToDateTime(view[row][columnName], CultureInfo.InvariantCulture);
+                    values[row] = DateUtilities.GetDate(date);
             }
 
             return values;

--- a/APSIM.Shared/Utilities/DataTableUtilities.cs
+++ b/APSIM.Shared/Utilities/DataTableUtilities.cs
@@ -451,11 +451,10 @@ namespace APSIM.Shared.Utilities
             DateTime[] values = new DateTime[view.Count];
             for (int row = 0; row != view.Count; row++)
             {
-                string date = DateUtilities.ValidateDateString(view[row][columnName].ToString());
-                if (date == null)
+                if (Convert.IsDBNull(view[row][columnName]))
                     values[row] = DateTime.MinValue;
                 else
-                    values[row] = DateUtilities.GetDate(date);
+                    values[row] = Convert.ToDateTime(view[row][columnName], CultureInfo.InvariantCulture);
             }
 
             return values;

--- a/Models/Utilities/GridTableColumn.cs
+++ b/Models/Utilities/GridTableColumn.cs
@@ -202,10 +202,10 @@ namespace Models.Utilities
                                     string[] modifiedMetadata = SoilUtilities.DetermineMetadata(original, originalMetadata, modified, null);
                                     metadata.Value = modifiedMetadata;
                                 }
-                                    property.Value = modified;
+                                property.Value = modified;
                             }
                             else if (property.DataType == typeof(DateTime[]))
-                                property.Value = DataTableUtilities.GetColumnAsDates(data, Name); //todo: add numRows/startRow option for dates
+                                property.Value = DataTableUtilities.GetColumnAsDates(data, Name, numRows-startRow, startRow);
                         }
                     }
                 }


### PR DESCRIPTION
Resolves #8856

There was a comment next to the date parsing with "todo" that was causing an exception in the TreeProxy table where dates were used. So I finished that work up and the TreeProxy table can now be edited again.