### PR TITLE
8873 Hide unfinished reformat option

### DIFF
--- a/ApsimNG/Presenters/ManagerPresenter.cs
+++ b/ApsimNG/Presenters/ManagerPresenter.cs
@@ -95,7 +95,7 @@ namespace UserInterface.Presenters
             managerView.Editor.LeaveEditor += OnEditorLeave;
             managerView.Editor.AddContextSeparator();
             managerView.Editor.AddContextActionWithAccel("Test compile", OnDoCompile, "Ctrl+T");
-            managerView.Editor.AddContextActionWithAccel("Reformat", OnDoReformat, "Ctrl+R");
+            //managerView.Editor.AddContextActionWithAccel("Reformat", OnDoReformat, "Ctrl+R");
             managerView.CursorLocation = manager.Cursor;
 
             presenter.CommandHistory.ModelChanged += CommandHistory_ModelChanged;


### PR DESCRIPTION
Working on #8873

This issue isn't a bug, it just hasn't been implemented yet. This PR just hides the reformat code option so that nobody tries to use it thinking it will work.

Issue changed to improvement, we'll need to come back and sort this out properly in the future.