### PR TITLE
8862 Version and Help cmd errors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,11 +18,24 @@
             "name": "APSIM.Cli: Debug",
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "build",
+            "preLaunchTask": "debug",
             "program": "${workspaceFolder}/bin/Debug/net6.0/apsim.dll",
             "args": [
                 "document",
                 "${workspaceFolder}/Examples/Wheat.apsimx"
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "Models: Debug",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "debug",
+            "program": "${workspaceFolder}/bin/Debug/net6.0/Models.exe",
+            "args": [
+                "--help"
             ],
             "cwd": "${workspaceFolder}",
             "console": "internalConsole",

--- a/Models/Main.cs
+++ b/Models/Main.cs
@@ -83,8 +83,12 @@ namespace Models
             // To help with Jenkins only errors.
             foreach (var error in errors)
             {
-                Console.WriteLine("Console error output: " + error.ToString());
-                Trace.WriteLine("Trace error output: " + error.ToString());
+                //We need to exclude these as the nuget package has a bug that causes them to appear even if there is no error.
+                if (error as VersionRequestedError == null && error as HelpRequestedError == null) 
+                {
+                    Console.WriteLine("Console error output: " + error.ToString());
+                    Trace.WriteLine("Trace error output: " + error.ToString());
+                }
             }
 
             if (!(errors.IsHelp() || errors.IsVersion()))


### PR DESCRIPTION
Resolves #8862

We use the CommandLineParser nuget package to handle command line arguments. It currently has a bug with the help and version auto-arguments that causes it to always print an error when those are used. 
https://github.com/commandlineparser/commandline/issues/630

I've basically done the same thing as suggested in that issue which is to just not print out the error on those two arguments. They shouldn't throw an error anyway and do still work.