### PR TITLE
8838 _Factors table fixes

### DIFF
--- a/Models/Core/Simulation.cs
+++ b/Models/Core/Simulation.cs
@@ -381,7 +381,10 @@ namespace Models.Core
         /// <summary>Store descriptors in DataStore.</summary>
         private void StoreFactorsInDataStore()
         {
-            IDataStore storage = Services.OfType<IDataStore>().First();
+            IEnumerable<IDataStore> ss = Services.OfType<IDataStore>();
+            IDataStore storage = null;
+            if (ss != null && ss.Count() > 0)
+                storage = ss.First();
 
             if (storage != null && Descriptors != null)
             {

--- a/Models/Core/Simulation.cs
+++ b/Models/Core/Simulation.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Data;
 
 namespace Models.Core
 {
@@ -258,6 +259,8 @@ namespace Models.Core
                 // Resolve all links
                 links.Resolve(this, true, throwOnFail: true);
 
+                StoreFactorsInDataStore();
+
                 events.Publish("SubscribeToEvents", new object[] { this, EventArgs.Empty });
             }
             catch (Exception err)
@@ -373,6 +376,51 @@ namespace Models.Core
             // Check to make sure there is only one ISoilWater in each zone.
             foreach (IModel zone in parentZone.FindAllChildren<Models.Interfaces.IZone>())
                 CheckNotMultipleSoilWaterModels(zone);
+        }
+
+        /// <summary>Store descriptors in DataStore.</summary>
+        private void StoreFactorsInDataStore()
+        {
+            DataStore storage = Services.OfType<DataStore>().First();
+
+            if (storage != null && Descriptors != null)
+            {
+                var table = new DataTable("_Factors");
+                table.Columns.Add("ExperimentName", typeof(string));
+                table.Columns.Add("SimulationName", typeof(string));
+                table.Columns.Add("FolderName", typeof(string));
+                table.Columns.Add("FactorName", typeof(string));
+                table.Columns.Add("FactorValue", typeof(string));
+
+                var experimentDescriptor = Descriptors.Find(d => d.Name == "Experiment");
+                var simulationDescriptor = Descriptors.Find(d => d.Name == "SimulationName");
+                var folderDescriptor = Descriptors.Find(d => d.Name == "FolderName");
+
+                foreach (var descriptor in Descriptors)
+                {
+                    if (descriptor.Name != "Experiment" &&
+                        descriptor.Name != "SimulationName" &&
+                        descriptor.Name != "FolderName" &&
+                        descriptor.Name != "Zone")
+                    {
+                        var row = table.NewRow();
+                        if (experimentDescriptor != null)
+                            row[0] = experimentDescriptor.Value;
+                        if (simulationDescriptor != null)
+                            row[1] = simulationDescriptor.Value;
+                        if (folderDescriptor != null)
+                            row[2] = folderDescriptor.Value;
+                        row[3] = descriptor.Name;
+                        row[4] = descriptor.Value;
+                        table.Rows.Add(row);
+                    }
+                }
+
+                // Report tables are automatically cleaned before the simulation is run,
+                // as an optimisation specifically designed for this call to WriteTable().
+                // Therefore, we do not need to delete existing data here.
+                storage.Writer.WriteTable(table, false);
+            }
         }
     }
 }

--- a/Models/Core/Simulation.cs
+++ b/Models/Core/Simulation.cs
@@ -381,7 +381,7 @@ namespace Models.Core
         /// <summary>Store descriptors in DataStore.</summary>
         private void StoreFactorsInDataStore()
         {
-            DataStore storage = Services.OfType<DataStore>().First();
+            IDataStore storage = Services.OfType<IDataStore>().First();
 
             if (storage != null && Descriptors != null)
             {

--- a/Models/Report/Report.cs
+++ b/Models/Report/Report.cs
@@ -365,50 +365,6 @@ namespace Models
                 foreach (var descriptor in simulation.Descriptors)
                     if (descriptor.Name != "Zone" && descriptor.Name != "SimulationName")
                         this.Columns.Add(new ReportColumnConstantValue(descriptor.Name, descriptor.Value));
-                StoreFactorsInDataStore();
-            }
-        }
-
-        /// <summary>Store descriptors in DataStore.</summary>
-        private void StoreFactorsInDataStore()
-        {
-            if (storage != null && simulation != null && simulation.Descriptors != null)
-            {
-                var table = new DataTable("_Factors");
-                table.Columns.Add("ExperimentName", typeof(string));
-                table.Columns.Add("SimulationName", typeof(string));
-                table.Columns.Add("FolderName", typeof(string));
-                table.Columns.Add("FactorName", typeof(string));
-                table.Columns.Add("FactorValue", typeof(string));
-
-                var experimentDescriptor = simulation.Descriptors.Find(d => d.Name == "Experiment");
-                var simulationDescriptor = simulation.Descriptors.Find(d => d.Name == "SimulationName");
-                var folderDescriptor = simulation.Descriptors.Find(d => d.Name == "FolderName");
-
-                foreach (var descriptor in simulation.Descriptors)
-                {
-                    if (descriptor.Name != "Experiment" &&
-                        descriptor.Name != "SimulationName" &&
-                        descriptor.Name != "FolderName" &&
-                        descriptor.Name != "Zone")
-                    {
-                        var row = table.NewRow();
-                        if (experimentDescriptor != null)
-                            row[0] = experimentDescriptor.Value;
-                        if (simulationDescriptor != null)
-                            row[1] = simulationDescriptor.Value;
-                        if (folderDescriptor != null)
-                            row[2] = folderDescriptor.Value;
-                        row[3] = descriptor.Name;
-                        row[4] = descriptor.Value;
-                        table.Rows.Add(row);
-                    }
-                }
-
-                // Report tables are automatically cleaned before the simulation is run,
-                // as an optimisation specifically designed for this call to WriteTable().
-                // Therefore, we do not need to delete existing data here.
-                storage.Writer.WriteTable(table, false);
             }
         }
     }

--- a/Models/Storage/CleanCommand.cs
+++ b/Models/Storage/CleanCommand.cs
@@ -10,9 +10,10 @@ namespace Models.Storage
 {
     internal class CleanCommand : IRunnable
     {
-        private static readonly string[] otherTablesToClean = new string[2]
+        private static readonly string[] otherTablesToClean = new string[3]
         {
             "_Messages",
+            "_Factors",
             "_InitialConditions"
         };
 


### PR DESCRIPTION
Resolves #8838 

There were two things happening here. 

One was that the _Factors table was not being cleared at the start of a run, so running a simulation multiple times meant the table would just keep growing each time. That is despite having comments saying it should be cleared, so I added it to the list with _Messages and _IntialConditions to be cleared at the start of a run.

Then for the repeated lines, it turns out the factors were written for each report instead of for each simulation. So if a simulation had 4 reports, it would write the factors in 4 times to the table. To fix this I moved the code from Report over to simulation, however that may not be the most appropriate place for it, so would like some feedback.