### PR TITLE
8865 Allow keyboard on manager node

### DIFF
--- a/ApsimNG/Views/TreeView.cs
+++ b/ApsimNG/Views/TreeView.cs
@@ -689,27 +689,34 @@ namespace UserInterface.Views
                 timer.Stop();
                 if (e.Event.Button == 1 && e.Event.Type == Gdk.EventType.ButtonPress)
                 {
-                    TreePath path;
-                    TreeViewColumn col;
-                    // Get the clicked location
-                    if (treeview1.GetPathAtPos((int)e.Event.X, (int)e.Event.Y, out path, out col))
+                    if(treeview1.IsFocus) 
                     {
-                        // See if the click was on the current selection
-                        TreePath selPath;
-                        TreeViewColumn selCol;
-                        treeview1.GetCursor(out selPath, out selCol);
-                        if (selPath != null && path.Compare(selPath) == 0)
+                        TreePath path;
+                        TreeViewColumn col;
+                        // Get the clicked location
+                        if (treeview1.GetPathAtPos((int)e.Event.X, (int)e.Event.Y, out path, out col))
                         {
-                            // Check where on the row we are located, allowing 16 pixels for the image, and 2 for its border
-                            Gdk.Rectangle rect = treeview1.GetCellArea(path, col);
-                            if (e.Event.X > rect.X + 18)
+                            // See if the click was on the current selection
+                            TreePath selPath;
+                            TreeViewColumn selCol;
+                            treeview1.GetCursor(out selPath, out selCol);
+                            if (selPath != null && path.Compare(selPath) == 0)
                             {
-                                // We want this to be a bit longer than the double-click interval, which is normally 250 milliseconds
-                                timer.Interval = Settings.Default.DoubleClickTime + 10;
-                                timer.AutoReset = false;
-                                timer.Start();
+                                // Check where on the row we are located, allowing 16 pixels for the image, and 2 for its border
+                                Gdk.Rectangle rect = treeview1.GetCellArea(path, col);
+                                if (e.Event.X > rect.X + 18)
+                                {
+                                    // We want this to be a bit longer than the double-click interval, which is normally 250 milliseconds
+                                    timer.Interval = Settings.Default.DoubleClickTime + 10;
+                                    timer.AutoReset = false;
+                                    timer.Start();
+                                }
                             }
                         }
+                    }
+                    else
+                    {
+                        treeview1.GrabFocus();
                     }
                 }
             }


### PR DESCRIPTION
Resolves #8865

When showing a manager script, the script would grab the focus of the keyboard and block out keyboard controls for the node in the tree. This just adds a check to see if the double-click rename node has focus, and if not, give it focus so that you can click on the node to give it back keyboard focus without it going straight to renaming the node.