### PR TITLE
8859 Manager Parameter Saving

### DIFF
--- a/ApsimNG/Presenters/ManagerPresenter.cs
+++ b/ApsimNG/Presenters/ManagerPresenter.cs
@@ -25,11 +25,6 @@ namespace UserInterface.Presenters
         private Manager manager;
 
         /// <summary>
-        /// The compiled script model.
-        /// </summary>
-        private IModel scriptModel;
-
-        /// <summary>
         /// The view for the manager
         /// </summary>
         private IManagerView managerView;
@@ -70,12 +65,10 @@ namespace UserInterface.Presenters
                 }
             }
 
-            scriptModel = manager.Script;
-
             // See if manager script has a description attribute on it's class.
-            if (scriptModel != null)
+            if (manager.Script != null)
             {
-                DescriptionAttribute descriptionName = ReflectionUtilities.GetAttribute(scriptModel.GetType(), typeof(DescriptionAttribute), false) as DescriptionAttribute;
+                DescriptionAttribute descriptionName = ReflectionUtilities.GetAttribute(manager.Script.GetType(), typeof(DescriptionAttribute), false) as DescriptionAttribute;
                 if (descriptionName != null)
                     explorerPresenter.ShowDescriptionInRightHandPanel(descriptionName.ToString());
             }
@@ -83,7 +76,7 @@ namespace UserInterface.Presenters
             propertyPresenter = new PropertyPresenter();
             try
             {
-                propertyPresenter.Attach(scriptModel, managerView.PropertyEditor, presenter);
+                propertyPresenter.Attach(manager.Script, managerView.PropertyEditor, presenter);
             }
             catch (Exception err)
             {
@@ -113,27 +106,9 @@ namespace UserInterface.Presenters
             BuildScript();  // compiles and saves the script
 
             explorerPresenter.CommandHistory.ModelChanged -= CommandHistory_ModelChanged;
-            managerView.Editor.ContextItemsNeeded -= OnNeedVariableNames;
             managerView.Editor.LeaveEditor -= OnEditorLeave;
             intellisense.ItemSelected -= OnIntellisenseItemSelected;
             intellisense.Cleanup();
-        }
-
-        /// <summary>
-        /// The view is asking for variable names for its intellisense.
-        /// </summary>
-        /// <param name="sender">Sending object</param>
-        /// <param name="e">Context item arguments</param>
-        public void OnNeedVariableNames(object sender, NeedContextItemsArgs e)
-        {
-            try
-            {
-
-            }
-            catch (Exception err)
-            {
-                explorerPresenter.MainPresenter.ShowError(err);
-            }
         }
 
         /// <summary>
@@ -143,15 +118,8 @@ namespace UserInterface.Presenters
         /// <param name="e">The arguments</param>
         public void OnEditorLeave(object sender, EventArgs e)
         {
-            // explorerPresenter.CommandHistory.ModelChanged += CommandHistory_ModelChanged;
             if (!intellisense.Visible)
                 BuildScript();
-        }
-
-        private void RefreshProperties()
-        {
-            if (scriptModel != null && propertyPresenter != null)
-                propertyPresenter.RefreshView(scriptModel);
         }
 
         /// <summary>
@@ -189,17 +157,10 @@ namespace UserInterface.Presenters
                 }
 
                 explorerPresenter.MainPresenter.ShowMessage("\"" + manager.Name + "\" compiled successfully", Simulation.MessageType.Information);
-            }
-            catch (Exception err)
-            {
-                explorerPresenter.MainPresenter.ShowError(err);
-            }
 
-            try
-            {
                 // User could have added more inputs to manager script - therefore we update the property presenter.
-                scriptModel = manager.FindChild("Script") as Model;
-                RefreshProperties();
+                if (manager.Script != null && propertyPresenter != null)
+                    propertyPresenter.RefreshView(manager.Script);
             }
             catch (Exception err)
             {
@@ -216,14 +177,7 @@ namespace UserInterface.Presenters
         /// <param name="e">Event arguments</param>
         private void OnDoCompile(object sender, EventArgs e)
         {
-            try
-            {
-                BuildScript();
-            }
-            catch (Exception err)
-            {
-                explorerPresenter.MainPresenter.ShowError(err);
-            }
+            BuildScript();
         }
 
         /// <summary>


### PR DESCRIPTION
Resolves #8859 

Compiling the script caused the property presenter to be looking at an outdated reference. Fixed that bug and did a general cleanup on the manager presenter.