### PR TITLE
8856 TreeProxy Spatial Grid fix

### DIFF
--- a/Models/Agroforestry/TreeProxy.cs
+++ b/Models/Agroforestry/TreeProxy.cs
@@ -255,7 +255,7 @@ namespace Models.Agroforestry
                 // Get the first soil. For now we're assuming all soils have the same structure.
                 var physical = zones.First().FindInScope<Physical>();
 
-                if (this.Table.Count == 0)
+                if (this.Table.Count < 2)
                 {
                     DataRow row = data.NewRow();
                     row["Parameter"] = "Shade (%)";
@@ -286,15 +286,21 @@ namespace Models.Agroforestry
                 }
                 else
                 {
-                    for (int y = 0; y < this.Table.Count-1; y++)
+                    for (int x = 0; x < this.Table[1].Count; x++)
                     {
-                        for (int x = 0; x < this.Table[y+1].Count; x++)
+                        //clean up any empty rows
+                        bool empty = true;
+                        DataRow row = data.NewRow();
+                        for (int y = 1; y < this.Table.Count; y++)
                         {
-                            if (y == 0)
-                                data.Rows.Add(data.NewRow());
-                            data.Rows[x][y] = this.Table[y+1][x];
+                            if (this.Table[y][x].ToString().Length > 0)
+                                empty = false;
+                            row[y-1] = this.Table[y][x];
                         }
+                        if (!empty)
+                            data.Rows.Add(row);
                     }
+                    
                     /*
                     // add Zones not in the table
                     IEnumerable<string> except = colNames.Except(forestryModel.Table[0]);
@@ -350,14 +356,14 @@ namespace Models.Agroforestry
             {
                 //add all datas
                 List<List<string>> newTable = new List<List<string>>();
-                for (int x = 0; x < dt.Rows.Count; x++)
+                for (int y = 0; y < dt.Rows.Count; y++)
                 {
-                    for (int y = 0; y < dt.Columns.Count; y++)
+                    List<string> row = new List<string>();
+                    for (int x = 0; x < dt.Columns.Count; x++)
                     {
-                        if (x == 0)
-                            newTable.Add(new List<string>());
-                        newTable[y].Add(dt.Rows[x][y].ToString());
+                        row.Add(dt.Rows[x][y].ToString());
                     }
+                    newTable.Add(row);
                 }
 
                 //add headers - Yes, this is how it's supposed to be


### PR DESCRIPTION
Resolves #8856

A bad line of code was adding an empty row in when it saved. Added code to fix those empty lines and fixed the bug that was causing them.

Graphs are also now working again.