### PR TITLE
8893 Check if an error page was returned

### DIFF
--- a/APSIM.Shared/Utilities/WebUtilities.cs
+++ b/APSIM.Shared/Utilities/WebUtilities.cs
@@ -1,19 +1,17 @@
-﻿namespace APSIM.Shared.Utilities
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace APSIM.Shared.Utilities
 {
-    using System;
-    using System.Globalization;
-    using System.IO;
-    using System.Net;
-    using System.Net.Http;
-    using System.Net.Http.Headers;
-    using System.Net.Sockets;
-    using System.Text;
-    using System.Text.Json;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using System.Xml.Serialization;
-
-
     /// <summary>
     /// A class containing some web utilities
     /// </summary>
@@ -142,6 +140,10 @@
                 
                 MemoryStream memStream = new MemoryStream();
                 result.CopyTo(memStream);
+
+                if (Encoding.UTF8.GetString(memStream.ToArray()).Contains("503 Service Unavailable"))
+                    throw new Exception();
+
                 return memStream;
             }
             catch (OperationCanceledException)


### PR DESCRIPTION
Resolves #8893

Server is back up again now so it's a bit hard to test this PR. But next time it goes down it should now respond with a useful error message instead of trying to parse a html page.