### PR TITLE
Fix invisible manager script

### DIFF
--- a/Models/Management/Manager.cs
+++ b/Models/Management/Manager.cs
@@ -152,9 +152,7 @@ namespace Models
         {
             base.OnCreated();
             afterCreation = true;
-
-            //if (TryGetCompiler())
-            //    RebuildScriptModel(true);
+            afterCreation = true;
         }
 
         /// <summary>

--- a/Models/Management/Manager.cs
+++ b/Models/Management/Manager.cs
@@ -153,8 +153,8 @@ namespace Models
             base.OnCreated();
             afterCreation = true;
 
-            if (TryGetCompiler())
-                RebuildScriptModel(true);
+            //if (TryGetCompiler())
+            //    RebuildScriptModel(true);
         }
 
         /// <summary>


### PR DESCRIPTION
working on #8476 

- when copy/pasting a manager node with erroneous script it's OnCreated() method would attempt to compile the script, interrupting the adding process. This would mean the explorerView's tree wouldn't be updated but the manager node would still be added regardless.