### PR TITLE
Added log switch to command line 

### DIFF
--- a/Models/Options.cs
+++ b/Models/Options.cs
@@ -133,6 +133,12 @@ namespace Models
         public string Playlist { get; set; }
 
         /// <summary>
+        /// Sets the verbosity level of all summary files.
+        /// </summary>
+        [Option('l', "log", HelpText = "Sets the verbosity level of all summary nodes in file(s).")]
+        public string Log { get; set; }
+
+        /// <summary>
         /// Type of runner used to run the simulations.
         /// </summary>
         public Models.Core.Run.Runner.RunTypeEnum RunType
@@ -169,6 +175,12 @@ namespace Models
                                          {
                                              Files = new[] { "/path/to/file.apsimx" },
                                              EditFilePath = "/path/to/config/file.txt"
+                                         });
+                yield return new Example("Reconfigure a file with a config file",
+                                         new Options()
+                                         {
+                                             Files = new[] { "/path/to/file.apsimx" },
+                                             Apply = "/path/to/config/file.txt"
                                          });
             }
         }

--- a/Tests/UnitTests/CommandLineArgsTests.cs
+++ b/Tests/UnitTests/CommandLineArgsTests.cs
@@ -841,5 +841,32 @@ run";
 
 
         }
+
+        /// <summary>
+        /// Test log switch works as expected.
+        /// </summary>
+        [Test]
+        public void LogSwitch_ChangesVerbosity_ToError()
+        {
+            Simulations sims = Utilities.GetRunnableSim();
+            string simName = sims.FileName;
+            string tempFilePath = Path.GetTempPath();
+            Utilities.RunModels($"{simName} --log error");
+            Simulations simAfterVerbosityChange = FileFormat.ReadFromFile<Simulations>(simName, e => throw e, true).NewModel as Simulations;
+            Summary summary = simAfterVerbosityChange.FindDescendant<Summary>();
+            Assert.True(summary.Verbosity == MessageType.Error);
+        }
+
+        /// <summary>
+        /// Test log switch throws an exception when a bad string is included.
+        /// </summary>
+        [Test]
+        public void LogSwitch_ThrowsException_When_NonMatchingVerbosityType_IsUsed()
+        {
+            Simulations sims = Utilities.GetRunnableSim();
+            string simName = sims.FileName;
+            string tempFilePath = Path.GetTempPath();
+            Assert.Throws<Exception>(() => Utilities.RunModels($"{simName} --log xyz"));
+        }
     }
 }


### PR DESCRIPTION
resolves #8480 

# Notes
- Command line will have the option to modify the Verbosity level of the summary node from the command line.

## Usage

`Models.exe file.apsimx --log error`

`Models.exe file.apsimx -l all`
