### PR TITLE
8941 Added SWIM solute error message

### DIFF
--- a/Models/Soils/SWIM/Swim.cs
+++ b/Models/Soils/SWIM/Swim.cs
@@ -1785,6 +1785,11 @@ namespace Models.Soils
                 var soluteParam = Parent.FindChild<Solute>(solute_names[i]);
                 if (soluteParam == null)
                     throw new Exception("Could not find parameters for solute called " + solute_names[i]);
+                if (soluteParam.FIP == null || double.IsNaN(MathUtilities.Sum(soluteParam.FIP)))
+                    throw new Exception("Solute " + solute_names[i] + " does not have FIP values.");
+                if (soluteParam.Exco == null || double.IsNaN(MathUtilities.Sum(soluteParam.Exco)))
+                    throw new Exception("Solute " + solute_names[i] + " does not have EXCO values.");
+
                 fip[i] = SoilUtilities.MapConcentration(soluteParam.FIP, soluteParam.Thickness, physical.Thickness, double.NaN);
                 exco[i] = SoilUtilities.MapConcentration(soluteParam.Exco, soluteParam.Thickness, physical.Thickness, double.NaN);
                 ex[i] = MathUtilities.Multiply(exco[i], physical.BD);


### PR DESCRIPTION
Resolves #8941

Will check the FIP and EXCO arrays for values before trying to use them and give an error message if they can't be read.