### PR TITLE
8856 Tree Proxy Revert and Fix

### DIFF
--- a/ApsimNG/Presenters/TreeProxyPresenter.cs
+++ b/ApsimNG/Presenters/TreeProxyPresenter.cs
@@ -1,13 +1,7 @@
 ﻿using System.Collections.Generic;
-using System.Data;
-using System.Linq;
 using Models.Agroforestry;
-using Models.Core;
 using Models.Soils;
 using UserInterface.Views;
-using UserInterface.Commands;
-using UserInterface.EventArguments;
-using APSIM.Shared.Utilities;
 using Models.Utilities;
 
 namespace UserInterface.Presenters

--- a/ApsimNG/Presenters/TreeProxyPresenter.cs
+++ b/ApsimNG/Presenters/TreeProxyPresenter.cs
@@ -67,12 +67,12 @@ namespace UserInterface.Presenters
             List<GridTable> tables = forestryModel.Tables;
 
             spatialGridPresenter = new GridPresenter();
-            spatialGridPresenter.Attach(tables[0], forestryViewer.SpatialDataGrid, explorerPresenter);
+            spatialGridPresenter.Attach(tables[1], forestryViewer.SpatialDataGrid, explorerPresenter);
             spatialGridPresenter.CellChanged += OnCellChanged;
             spatialGridPresenter.AddContextMenuOptions(new string[] { "Cut", "Copy", "Paste", "Delete", "Select All" });
 
             temporalGridPresenter = new GridPresenter();
-            temporalGridPresenter.Attach(tables[1], forestryViewer.TemporalDataGrid, explorerPresenter);
+            temporalGridPresenter.Attach(tables[0], forestryViewer.TemporalDataGrid, explorerPresenter);
             temporalGridPresenter.CellChanged += OnCellChanged;
             temporalGridPresenter.AddContextMenuOptions(new string[] { "Cut", "Copy", "Paste", "Delete", "Select All" });
 

--- a/Models/Agroforestry/TreeProxy.cs
+++ b/Models/Agroforestry/TreeProxy.cs
@@ -197,12 +197,12 @@ namespace Models.Agroforestry
                 columns.Add(new GridTableColumn("Height", new VariableProperty(this, GetType().GetProperty("Heights"))));
                 columns.Add(new GridTableColumn("NDemand", new VariableProperty(this, GetType().GetProperty("NDemands"))));
                 columns.Add(new GridTableColumn("ShadeModifier", new VariableProperty(this, GetType().GetProperty("ShadeModifiers"))));
-                GridTable grid1 = new GridTable("TreeProxySpatial", columns, this);
+                GridTable grid1 = new GridTable("TreeProxyTemporal", columns, this);
                 grid1.SetUnits(1, "m");
                 grid1.SetUnits(3, "(>=0)");
 
                 columns = new List<GridTableColumn>();
-                GridTable grid2 = new GridTable("TreeProxyTemporal", columns, this);
+                GridTable grid2 = new GridTable("TreeProxySpatial", columns, this);
 
                 List<GridTable> list = new List<GridTable>() { grid1, grid2 };
                 return list;
@@ -220,7 +220,7 @@ namespace Models.Agroforestry
         /// </summary>
         public DataTable ConvertModelToDisplay(DataTable dt)
         {
-            if (dt.TableName.Equals("TreeProxySpatial"))
+            if (dt.TableName.Equals("TreeProxyTemporal"))
             {
                 //convert height in mm to height in metres
                 //first row is units, so skip
@@ -230,7 +230,7 @@ namespace Models.Agroforestry
                 return dt;
             }
             //this is a special case, we need to manually handle the changes to Table
-            else if (dt.TableName.Equals("TreeProxyTemporal"))
+            else if (dt.TableName.Equals("TreeProxySpatial"))
             {
                 var data = new DataTable();
                 data.TableName = dt.TableName;
@@ -343,7 +343,7 @@ namespace Models.Agroforestry
         /// </summary>
         public DataTable ConvertDisplayToModel(DataTable dt)
         {
-            if (dt.TableName.Equals("TreeProxySpatial"))
+            if (dt.TableName.Equals("TreeProxyTemporal"))
             {
                 //convert height in m to height in mm
                 //first row is units, so skip
@@ -352,14 +352,14 @@ namespace Models.Agroforestry
                         dt.Rows[i]["Height"] = Convert.ToDouble(dt.Rows[i]["Height"]) * 1000;
                 return dt;
             }
-            else if (dt.TableName.Equals("TreeProxyTemporal"))
+            else if (dt.TableName.Equals("TreeProxySpatial"))
             {
                 //add all datas
                 List<List<string>> newTable = new List<List<string>>();
                 for (int y = 0; y < dt.Rows.Count; y++)
                 {
                     List<string> row = new List<string>();
-                    for (int x = 0; x < dt.Columns.Count; x++)
+                    for (int x = 1; x < dt.Columns.Count; x++)
                     {
                         row.Add(dt.Rows[x][y].ToString());
                     }
@@ -483,6 +483,9 @@ namespace Models.Agroforestry
 
             for (int i = 2; i < Table.Count; i++)
             {
+                if (Table[i][0].Length == 0)
+                    throw new Exception($"Cell at position [{Table[0][i-2]}, {Table[1][i]}] is empty");
+
                 shade.Add(THCutoffs[i - 2], Convert.ToDouble(Table[i][0],
                                                              System.Globalization.CultureInfo.InvariantCulture));
                 List<double> getRLDs = new List<double>();

--- a/Tests/UnitTests/Plant/TreeProxyTests.cs
+++ b/Tests/UnitTests/Plant/TreeProxyTests.cs
@@ -49,54 +49,54 @@ namespace UnitTests.Core
             List<GridTable> tables = treeProxy.Tables;
             Assert.AreEqual(2, tables.Count);
 
-            DataTable dtSpatial = tables[0].Data;
-            DataTable dtSpatial2 = new DataTable("TreeProxySpatial");
-            dtSpatial2.Columns.Add("Date");
-            dtSpatial2.Columns.Add("Height");
-            dtSpatial2.Columns.Add("NDemand");
-            dtSpatial2.Columns.Add("ShadeModifier");
-            dtSpatial2.Rows.Add(null, "m", "g/m2", "(>=0)");
-            dtSpatial2.Rows.Add("1900/01/01", "1", "0.100", "1.000");
-            dtSpatial2.Rows.Add("1900/03/01", "2", "0.100", "1.000");
-            dtSpatial2.Rows.Add("1900/06/01", "3", "0.100", "1.000");
-            dtSpatial2.Rows.Add("1900/09/01", "4", "0.100", "1.000");
-            dtSpatial2.Rows.Add("1900/12/31", "5", "0.100", "1.000");
-            for (int i = 0; i < dtSpatial2.Rows.Count; i++)
-            {
-                for (int j = 0; j < dtSpatial2.Columns.Count; j++)
-                {
-                    Assert.AreEqual(dtSpatial2.Rows[i].ItemArray[j], dtSpatial.Rows[i].ItemArray[j]);
-                }
-            }
-
-            DataTable dtTemporal = tables[1].Data;
-            DataTable dtTemporal2 = new DataTable("TreeProxyTemporal");
-            dtTemporal2.Columns.Add("Parameter");
-            dtTemporal2.Columns.Add("0");
-            dtTemporal2.Columns.Add("0.5h");
-            dtTemporal2.Columns.Add("1h");
-            dtTemporal2.Columns.Add("1.5h");
-            dtTemporal2.Columns.Add("2h");
-            dtTemporal2.Columns.Add("2.5h");
-            dtTemporal2.Columns.Add("3h");
-            dtTemporal2.Columns.Add("4h");
-            dtTemporal2.Columns.Add("5h");
-            dtTemporal2.Columns.Add("6h");
-            dtTemporal2.Rows.Add("Shade (%)", "60", "50", "40", "30", "20", "0", "0", "0", "0", "0");
-            dtTemporal2.Rows.Add("Root Length Density (cm/cm3)", null, null, null, null, null, null, null, null, null, null);
-            dtTemporal2.Rows.Add("Depth (cm)", null, null, null, null, null, null, null, null, null, null);
-            dtTemporal2.Rows.Add("0-15", "6", "6", "5", "4", "3", "2", "1", "0", "0", "0");
-            dtTemporal2.Rows.Add("15-30", "5", "5", "4", "3", "2", "1", ".5", "0", "0", "0");
-            dtTemporal2.Rows.Add("30-60", "4", "4", "3.5", "3", "2", "1", ".2", "0", "0", "0");
-            dtTemporal2.Rows.Add("60-90", "2", "2", "2", "1.5", "1", "0", "0", "0", "0", "0");
-            dtTemporal2.Rows.Add("90-120", "1.5", "1.5", "1.5", "1", "0", "0", "0", "0", "0", "0");
-            dtTemporal2.Rows.Add("120-150", "1", "1", "1", "1", "0", "0", "0", "0", "0", "0");
-            dtTemporal2.Rows.Add("150-180", "1", "0", "0", "0", "0", "0", "0", "0", "0", "0");
+            DataTable dtTemporal = tables[0].Data;
+            DataTable dtTemporal2 = new DataTable("TreeProxySpatial");
+            dtTemporal2.Columns.Add("Date");
+            dtTemporal2.Columns.Add("Height");
+            dtTemporal2.Columns.Add("NDemand");
+            dtTemporal2.Columns.Add("ShadeModifier");
+            dtTemporal2.Rows.Add(null, "m", "g/m2", "(>=0)");
+            dtTemporal2.Rows.Add("1900/01/01", "1", "0.100", "1.000");
+            dtTemporal2.Rows.Add("1900/03/01", "2", "0.100", "1.000");
+            dtTemporal2.Rows.Add("1900/06/01", "3", "0.100", "1.000");
+            dtTemporal2.Rows.Add("1900/09/01", "4", "0.100", "1.000");
+            dtTemporal2.Rows.Add("1900/12/31", "5", "0.100", "1.000");
             for (int i = 0; i < dtTemporal2.Rows.Count; i++)
             {
                 for (int j = 0; j < dtTemporal2.Columns.Count; j++)
                 {
                     Assert.AreEqual(dtTemporal2.Rows[i].ItemArray[j], dtTemporal.Rows[i].ItemArray[j]);
+                }
+            }
+
+            DataTable dtSpatial = tables[1].Data;
+            DataTable dtSpatial2 = new DataTable("TreeProxyTemporal");
+            dtSpatial2.Columns.Add("Parameter");
+            dtSpatial2.Columns.Add("0");
+            dtSpatial2.Columns.Add("0.5h");
+            dtSpatial2.Columns.Add("1h");
+            dtSpatial2.Columns.Add("1.5h");
+            dtSpatial2.Columns.Add("2h");
+            dtSpatial2.Columns.Add("2.5h");
+            dtSpatial2.Columns.Add("3h");
+            dtSpatial2.Columns.Add("4h");
+            dtSpatial2.Columns.Add("5h");
+            dtSpatial2.Columns.Add("6h");
+            dtSpatial2.Rows.Add("Shade (%)", "60", "50", "40", "30", "20", "0", "0", "0", "0", "0");
+            dtSpatial2.Rows.Add("Root Length Density (cm/cm3)", null, null, null, null, null, null, null, null, null, null);
+            dtSpatial2.Rows.Add("Depth (cm)", null, null, null, null, null, null, null, null, null, null);
+            dtSpatial2.Rows.Add("0-15", "6", "6", "5", "4", "3", "2", "1", "0", "0", "0");
+            dtSpatial2.Rows.Add("15-30", "5", "5", "4", "3", "2", "1", ".5", "0", "0", "0");
+            dtSpatial2.Rows.Add("30-60", "4", "4", "3.5", "3", "2", "1", ".2", "0", "0", "0");
+            dtSpatial2.Rows.Add("60-90", "2", "2", "2", "1.5", "1", "0", "0", "0", "0", "0");
+            dtSpatial2.Rows.Add("90-120", "1.5", "1.5", "1.5", "1", "0", "0", "0", "0", "0", "0");
+            dtSpatial2.Rows.Add("120-150", "1", "1", "1", "1", "0", "0", "0", "0", "0", "0");
+            dtSpatial2.Rows.Add("150-180", "1", "0", "0", "0", "0", "0", "0", "0", "0", "0");
+            for (int i = 0; i < dtSpatial2.Rows.Count; i++)
+            {
+                for (int j = 0; j < dtSpatial2.Columns.Count; j++)
+                {
+                    Assert.AreEqual(dtSpatial2.Rows[i].ItemArray[j], dtSpatial.Rows[i].ItemArray[j]);
                 }
             }
 


### PR DESCRIPTION
Resolves #8856

I accidently flipped the temporal and spatial displays in the last fix, so I've reverted that here. I also checked that the provided simulation was able to edited and ran and it seems to be correct now.

Hoping this is the final fix this needs. We might need to look at a new structure for the TreeProxy data down the line as it doesn't fit into our GridTable system very well and needs a lot of converting work at the moment to make it work. That's where a lot of these bugs are coming from.