### PR TITLE
Context menu allows pasting any model bug fix

### DIFF
--- a/Models/Core/ApsimFile/Structure.cs
+++ b/Models/Core/ApsimFile/Structure.cs
@@ -30,12 +30,13 @@ namespace Models.Core.ApsimFile
             // Ensure the model name is valid.
             EnsureNameIsUnique(modelToAdd);
 
-            parent.Children.Add(modelToAdd);
-
-            // Call OnCreated
+            if(parent.IsChildAllowable(modelToAdd.GetType()))
+            {
+                parent.Children.Add(modelToAdd);
+            }
+            else throw new ArgumentException($"A {modelToAdd.GetType().Name} cannot be added to a {parent.GetType().Name}.");
+                       
             modelToAdd.OnCreated();
-            foreach (IModel model in modelToAdd.FindAllDescendants().ToList())
-                model.OnCreated();
 
             // If the model is being added at runtime then need to resolve links and events.
             Simulation parentSimulation = parent.FindAncestor<Simulation>();

--- a/Models/Core/ApsimFile/Structure.cs
+++ b/Models/Core/ApsimFile/Structure.cs
@@ -38,6 +38,9 @@ namespace Models.Core.ApsimFile
                        
             modelToAdd.OnCreated();
 
+            foreach (IModel model in modelToAdd.FindAllDescendants().ToList())
+                model.OnCreated();
+
             // If the model is being added at runtime then need to resolve links and events.
             Simulation parentSimulation = parent.FindAncestor<Simulation>();
             if (parentSimulation != null && parentSimulation.IsRunning)

--- a/Models/Core/Model.cs
+++ b/Models/Core/Model.cs
@@ -495,15 +495,20 @@ namespace Models.Core
             if (!typeof(IModel).IsAssignableFrom(type))
                 return false;
 
-            // Functions are currently allowable anywhere
-            // Note - IFunction does have a [ValidParent(DropAnywhere = true)]
-            // attribute, but the GetAttributes method doesn't look in interfaces.
-            if (type.GetInterface("IFunction") != null)
-                return true;
+            List<Type> modelParentTypes = new();
+            foreach(ValidParentAttribute validParent in ReflectionUtilities.GetAttributes(typeof(Model), typeof(ValidParentAttribute), true))
+                modelParentTypes.Add(validParent.ParentType);
+
+            bool hasValidParents = false;
 
             // Is allowable if one of the valid parents of this type (t) matches the parent type.
             foreach (ValidParentAttribute validParent in ReflectionUtilities.GetAttributes(type, typeof(ValidParentAttribute), true))
             {
+                // Used to make objects that have no explicit ValidParent attributes allowed
+                // to be placed anywhere.
+                if (!modelParentTypes.Contains(validParent.ParentType))
+                    hasValidParents = true;
+
                 if (validParent != null)
                 {
                     if (validParent.DropAnywhere)
@@ -513,7 +518,12 @@ namespace Models.Core
                         return true;
                 }
             }
-            return false;
+            
+            // If it doesn't have any valid parents, it should be able to be placed anywhere.
+            if(hasValidParents)
+                return false;
+            else 
+                return true;
         }
 
         /// <summary>

--- a/Models/Soils/Nutrients/Nutrient.cs
+++ b/Models/Soils/Nutrients/Nutrient.cs
@@ -3,6 +3,7 @@ using APSIM.Shared.Graphing;
 using APSIM.Shared.Utilities;
 using Models.Core;
 using Models.Interfaces;
+using Models.Soils.NutrientPatching;
 using Models.Surface;
 using System;
 using System.Collections.Generic;
@@ -29,6 +30,7 @@ namespace Models.Soils.Nutrients
     /// </solutes>
     [Serializable]
     [ScopedModel]
+    [ValidParent(ParentType = typeof(NutrientPatchManager))]
     [ValidParent(ParentType = typeof(Soil))]
     [ViewName("UserInterface.Views.DirectedGraphView")]
     [PresenterName("UserInterface.Presenters.DirectedGraphPresenter")]

--- a/Tests/UnitTests/Core/ApsimFile/StructureTests.cs
+++ b/Tests/UnitTests/Core/ApsimFile/StructureTests.cs
@@ -81,11 +81,12 @@
         public void StructureTests_EnsureAPSOILSoilHasInitWaterAdded()
         {
             Simulation simulation = new Simulation();
-
+            Zone zone = new Zone();
             string soilXml = ReflectionUtilities.GetResourceAsString("UnitTests.Core.ApsimFile.StructureTestsAPSoilSoil.xml");
-            Structure.Add(soilXml, simulation);
+            Structure.Add(soilXml, zone);
+            Structure.Add(zone, simulation);
             Assert.AreEqual(simulation.Children.Count, 1);
-            Soil soil = simulation.Children[0] as Soil;
+            Soil soil = simulation.Children[0].Children[0] as Soil;
             Assert.AreEqual(11, soil.Children.Count);
             Assert.IsTrue(soil.Children[5] is Water);
             Assert.IsTrue(soil.Children[6] is Solute);
@@ -145,12 +146,14 @@
             // Get official wheat model.
             string json = ReflectionUtilities.GetResourceAsString(typeof(IModel).Assembly, "Models.Resources.Wheat.json");
             Simulations file = new Simulations();
-            Structure.Add(json, file);
+            Folder folder = new Folder();
+            Structure.Add(json, folder);
+            Structure.Add(folder, file);
 
             // Should have 1 child, of type replacements.
-            Assert.NotNull(file.Children);
-            Assert.AreEqual(1, file.Children.Count);
-            Assert.AreEqual(typeof(Models.PMF.Plant), file.Children[0].GetType());
+            Assert.NotNull(folder.Children);
+            Assert.AreEqual(1, folder.Children.Count);
+            Assert.AreEqual(typeof(Models.PMF.Plant), folder.Children[0].GetType());
         }
 
         [Serializable]

--- a/Tests/UnitTests/Core/ModelTests.cs
+++ b/Tests/UnitTests/Core/ModelTests.cs
@@ -1387,8 +1387,8 @@ namespace UnitTests.Core
             Assert.True(new NoValidParents().IsChildAllowable(typeof(CanAddToNoValidParents)));
             Assert.True(new NoValidParents().IsChildAllowable(typeof(DropAnywhere)));
             Assert.True(new MockModel().IsChildAllowable(typeof(DropAnywhere)));
-            Assert.False(new NoValidParents().IsChildAllowable(typeof(NoValidParents)));
-            Assert.False(new MockModel().IsChildAllowable(typeof(NoValidParents)));
+            Assert.True(new NoValidParents().IsChildAllowable(typeof(NoValidParents)));
+            Assert.True(new MockModel().IsChildAllowable(typeof(NoValidParents)));
             Assert.False(new CanAddToNoValidParents().IsChildAllowable(typeof(CanAddToNoValidParents)));
             Assert.True(new CanAddToNoValidParents().IsChildAllowable(typeof(DropAnywhere)));
             Assert.True(new MockModel().IsChildAllowable(typeof(DropAnywhere)));


### PR DESCRIPTION
resolves #8943

# Notes
- Extra checks have been added to prevent this bug from occurring.
- `Models.cs` was updated to allow models with no `[ValidParent()]` attributes to be handled properly.
- Tests updated to work with new functionality.
- `Nutrient`'s  had NutrientPatchManager added as valid parent.