### PR TITLE
make physical label red and add further explanation

### DIFF
--- a/ApsimNG/Presenters/ProfilePresenter.cs
+++ b/ApsimNG/Presenters/ProfilePresenter.cs
@@ -78,10 +78,14 @@ namespace UserInterface.Presenters
             int paneWidth = view.MainWidget.ParentWindow.Width; //this should get the width of this view
             bottomPane.Position = (int)Math.Round(paneWidth * 0.75); //set the slider for the pane at about 75% across
 
-            Gtk.Label redValuesWarningLbl = new("Note: red values are estimates only.");
+            Gtk.Label redValuesWarningLbl = new("<span color=\"red\">Note: values in red are estimates only and needed for the simulation of soil temperature. Overwrite with local values wherever possible.</span>");
             if (model is Physical)
+            {
                 ((Gtk.Box)bottomPane.Child1).Add(redValuesWarningLbl);
+                redValuesWarningLbl.UseMarkup = true;
                 redValuesWarningLbl.Visible = true;
+            }
+
 
             numLayersLabel = view.GetControl<LabelView>("numLayersLabel");
 


### PR DESCRIPTION
resolves #8906 

# Notes
- Adds clearer explanation to physical nodes warning label.
- Makes the text red for better recognition.