### PR TITLE
Fix relativeTo value in Canola example

### DIFF
--- a/Examples/Canola.apsimx
+++ b/Examples/Canola.apsimx
@@ -223,7 +223,7 @@
                   "PercentMethod": 1,
                   "FractionFull": 0.1,
                   "DepthWetSoil": "NaN",
-                  "RelativeTo": "CanolaSoil",
+                  "RelativeTo": "Canola",
                   "Name": "InitialWater",
                   "Children": [],
                   "Enabled": true,


### PR DESCRIPTION
resolves #8958

# Notes
- The canola example had the value `CanolaSoil` set for RelativeTo variable. This caused an issue where when searching for an appropriate CropSoil for the canola crop, it would be searching for CanolaSoilSoil. As the string `soil` is appended to the search string.