### PR TITLE
Found the correct option eventually

### DIFF
--- a/Models/Core/ScriptCompiler.cs
+++ b/Models/Core/ScriptCompiler.cs
@@ -156,8 +156,10 @@ namespace Models.Core
                                 peStream: ms,
                                 pdbStream: withDebug ? pdbStream : null,
                                 xmlDocumentationStream: xmlDocumentationStream,
-                                embeddedTexts: embeddedTexts
+                                embeddedTexts: embeddedTexts,
+                                options: new EmitOptions(debugInformationFormat: DebugInformationFormat.PortablePdb)
                                 );
+
                             if (!emitResult.Success)
                             {
                                 // Errors were found. Add then to the return error string.
@@ -183,6 +185,7 @@ namespace Models.Core
                                     previousCompilations.Add(compilation);
                                 }
 
+                                /*
                                 // Write the assembly to disk if this is a GUI run. Only need the .dll for debugging runs.
                                 if (Path.GetFileName(Assembly.GetEntryAssembly().Location) == "ApsimNG.dll")
                                 {
@@ -196,7 +199,14 @@ namespace Models.Core
                                     xmlDocumentationStream.Seek(0, SeekOrigin.Begin);
                                     using (FileStream documentationWriter = new FileStream(documentationFile, FileMode.Create, FileAccess.Write))
                                         xmlDocumentationStream.WriteTo(documentationWriter);
+
+                                    // Write pdb Documentation file.
+                                    string pdbFile = Path.ChangeExtension(fileName, ".pdb");
+                                    pdbStream.Seek(0, SeekOrigin.Begin);
+                                    using (FileStream pdbWriter = new FileStream(pdbFile, FileMode.Create, FileAccess.Write))
+                                        pdbStream.WriteTo(pdbWriter);
                                 }
+                                */
                                 // Set the compilation properties.
                                 ms.Seek(0, SeekOrigin.Begin);
                                 pdbStream.Seek(0, SeekOrigin.Begin);


### PR DESCRIPTION
Resolves #8956

Needed to provide a specific option to the emit step of compiling so that it will always output a cross-platform portable pdb 'file' with the symbols for a manager script.

It also had code in there to output the dll and xml for a script to %TEMP% when running the gui, however these files weren't actually used for anything (the code and pdb were loaded from data buffers) so I've disabled that with this so we aren't making hundreds of little script files that aren't used every time we run a simulation.

Have tested that System.Diagnositics.Debugger.Break() works on my system, so this should be good to go.