### PR TITLE
8956 VSCode Breakpoints working in Manager Scripts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,21 +4,36 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
+        
         {
             "name": "ApsimNG: Debug",
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "debug",
+            "preLaunchTask": "Build Debug",
             "program": "${workspaceFolder}/bin/Debug/net6.0/ApsimNG.dll",
             "cwd": "${workspaceFolder}",
-            "console": "internalConsole",
-            "stopAtEntry": false,
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "requireExactSource": true,
+            "logging": {
+                "moduleLoad": false,
+                "threadExit": false
+            }
+        },
+        {
+            "name": "ApsimNG: Release",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build Release",
+            "program": "${workspaceFolder}/bin/Release/net6.0/ApsimNG.dll",
+            "cwd": "${workspaceFolder}",
+            "requireExactSource": true
         },
         {
             "name": "APSIM.Cli: Debug",
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "debug",
+            "preLaunchTask": "Clean Debug",
             "program": "${workspaceFolder}/bin/Debug/net6.0/apsim.dll",
             "args": [
                 "document",
@@ -32,7 +47,7 @@
             "name": "Models: Debug",
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "debug",
+            "preLaunchTask": "Clean Debug",
             "program": "${workspaceFolder}/bin/Debug/net6.0/Models.exe",
             "args": [
                 "--help"
@@ -45,7 +60,7 @@
             "name": "APSIM Server: Debug",
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "debug",
+            "preLaunchTask": "Clean Debug",
             "program": "${workspaceFolder}/bin/Debug/net6.0/ApsimZMQServer.dll",
             "args": [
                 "-v", "-a", "127.0.0.1", 
@@ -66,7 +81,7 @@
             "name": "Mono Launch",
             "type": "mono",
             "request": "launch",
-            "preLaunchTask": "debug",
+            "preLaunchTask": "Clean Debug",
             "program": "${workspaceRoot}/bin/Debug/net472/ApsimNG.exe",
             "cwd": "${workspaceRoot}"
         },
@@ -81,7 +96,7 @@
             "name": "Autodocs",
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "debug",
+            "preLaunchTask": "Clean Debug",
             "program": "${workspaceFolder}/bin/Debug/net6.0/APSIM.Documentation.dll",
             "cwd": "${workspaceFolder}",
             "console": "internalConsole",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,7 +2,7 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "debug clean",
+            "label": "Clean",
             "command": "dotnet",
             "type": "process",
             "args": [
@@ -10,11 +10,16 @@
             ]
         },
         {
-            "label": "debug build",
+            "label": "Build Debug",
             "command": "dotnet",
             "type": "process",
             "args": [
                 "build",
+                "--configuration",
+                "Debug",
+                "--verbosity",
+                "minimal",
+                "--nologo",
                 "${workspaceFolder}/ApsimX.sln",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
@@ -22,11 +27,22 @@
             "problemMatcher": "$msCompile"
         },
         {
-            "label":"debug",
+            "label": "Build Release",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "-c",
+                "Release",
+                "${workspaceFolder}/ApsimX.sln"
+            ]
+        },
+        {
+            "label":"Clean Debug",
             "dependsOrder": "sequence",
             "dependsOn":[
-                "debug clean",
-                "debug build"
+                "Clean",
+                "Build Debug"            
             ]
         }
     ]

--- a/Models/Core/ScriptCompiler.cs
+++ b/Models/Core/ScriptCompiler.cs
@@ -135,93 +135,81 @@ namespace Models.Core
                         string sourceName;
                         Compilation compiled = CompileTextToAssembly(modifiedCode, assemblies, out sourceName);
 
-                        List<EmbeddedText> embeddedTexts = null;
-                        if (withDebug)
-                        {
-                            System.Text.Encoding encoding = System.Text.Encoding.UTF8;
-
-                            byte[] buffer = encoding.GetBytes(modifiedCode);
-                            SourceText sourceText = SourceText.From(buffer, buffer.Length, encoding, canBeEmbedded: true);
-                            embeddedTexts = new List<EmbeddedText>
-                            {
-                                EmbeddedText.FromSource(sourceName, sourceText),
-                            };
-                        }
-
                         MemoryStream ms = new MemoryStream();
+                        MemoryStream xmlDocumentationStream = new MemoryStream();
                         MemoryStream pdbStream = new MemoryStream();
-                        using (MemoryStream xmlDocumentationStream = new MemoryStream())
+                        
+                        EmitResult emitResult = compiled.Emit(
+                            peStream: ms,
+                            pdbStream: withDebug ? pdbStream : null,
+                            xmlDocumentationStream: xmlDocumentationStream,
+                            options: new EmitOptions(debugInformationFormat: DebugInformationFormat.PortablePdb)
+                            );
+
+                        if (!emitResult.Success)
                         {
-                            EmitResult emitResult = compiled.Emit(
-                                peStream: ms,
-                                pdbStream: withDebug ? pdbStream : null,
-                                xmlDocumentationStream: xmlDocumentationStream,
-                                embeddedTexts: embeddedTexts,
-                                options: new EmitOptions(debugInformationFormat: DebugInformationFormat.PortablePdb)
-                                );
+                            // Errors were found. Add then to the return error string.
+                            errors = null;
+                            foreach (Diagnostic diag in emitResult.Diagnostics)
+                                if (diag.Severity == DiagnosticSeverity.Error)
+                                    errors += $"{diag.ToString()}{Environment.NewLine}";
 
-                            if (!emitResult.Success)
+                            compilation = null;
+                        }
+                        else
+                        {
+                            // No errors.
+                            // If we don't have a previous compilation, create one.
+                            if (compilation == null)
                             {
-                                // Errors were found. Add then to the return error string.
-                                errors = null;
-                                foreach (Diagnostic diag in emitResult.Diagnostics)
-                                    if (diag.Severity == DiagnosticSeverity.Error)
-                                        errors += $"{diag.ToString()}{Environment.NewLine}";
+                                compilation = new PreviousCompilation() { ModelFullPath = model.FullPath };
+                                if (previousCompilations == null)
+                                    previousCompilations = new List<PreviousCompilation>();
+                                previousCompilations.Add(compilation);
+                            }
 
-                                // Because we have errors, remove the previous compilation if there is one.
-                                if (compilation != null)
-                                    previousCompilations.Remove(compilation);
-                                compilation = null;
+                            // Write the assembly to disk if this is a GUI run.
+                            if (Path.GetFileName(Assembly.GetEntryAssembly().Location) == "ApsimNG.dll" && withDebug)
+                            {
+                                // Write pdb Documentation file.
+                                ms.Seek(0, SeekOrigin.Begin);
+                                string fileName = Path.Combine(Path.GetTempPath(), compiled.AssemblyName + ".dll");
+                                using (FileStream file = new FileStream(fileName, FileMode.Create, FileAccess.Write))
+                                    ms.WriteTo(file);
+
+                                // Write XML Documentation file.
+                                string documentationFile = Path.ChangeExtension(fileName, ".xml");
+                                xmlDocumentationStream.Seek(0, SeekOrigin.Begin);
+                                using (FileStream documentationWriter = new FileStream(documentationFile, FileMode.Create, FileAccess.Write))
+                                    xmlDocumentationStream.WriteTo(documentationWriter);
+
+                                // Write pdb Documentation file.
+                                string pdbFile = Path.ChangeExtension(fileName, ".pdb");
+                                pdbStream.Seek(0, SeekOrigin.Begin);
+                                using (FileStream pdbWriter = new FileStream(pdbFile, FileMode.Create, FileAccess.Write))
+                                    pdbStream.WriteTo(pdbWriter);
+
+                                compilation.Code = code;
+                                compilation.Reference = compiled.ToMetadataReference();
+                                compilation.CompiledAssembly = Assembly.LoadFile(fileName);
                             }
                             else
                             {
-                                // No errors.
-                                // If we don't have a previous compilation, create one.
-                                if (compilation == null)
-                                {
-                                    compilation = new PreviousCompilation() { ModelFullPath = model.FullPath };
-                                    if (previousCompilations == null)
-                                        previousCompilations = new List<PreviousCompilation>();
-                                    previousCompilations.Add(compilation);
-                                }
-
-                                /*
-                                // Write the assembly to disk if this is a GUI run. Only need the .dll for debugging runs.
-                                if (Path.GetFileName(Assembly.GetEntryAssembly().Location) == "ApsimNG.dll")
-                                {
-                                    ms.Seek(0, SeekOrigin.Begin);
-                                    string fileName = Path.Combine(Path.GetTempPath(), compiled.AssemblyName + ".dll");
-                                    using (FileStream file = new FileStream(fileName, FileMode.Create, FileAccess.Write))
-                                        ms.WriteTo(file);
-
-                                    // Write XML Documentation file.
-                                    string documentationFile = Path.ChangeExtension(fileName, ".xml");
-                                    xmlDocumentationStream.Seek(0, SeekOrigin.Begin);
-                                    using (FileStream documentationWriter = new FileStream(documentationFile, FileMode.Create, FileAccess.Write))
-                                        xmlDocumentationStream.WriteTo(documentationWriter);
-
-                                    // Write pdb Documentation file.
-                                    string pdbFile = Path.ChangeExtension(fileName, ".pdb");
-                                    pdbStream.Seek(0, SeekOrigin.Begin);
-                                    using (FileStream pdbWriter = new FileStream(pdbFile, FileMode.Create, FileAccess.Write))
-                                        pdbStream.WriteTo(pdbWriter);
-                                }
-                                */
                                 // Set the compilation properties.
                                 ms.Seek(0, SeekOrigin.Begin);
                                 pdbStream.Seek(0, SeekOrigin.Begin);
                                 compilation.Code = code;
                                 compilation.Reference = compiled.ToMetadataReference();
                                 compilation.CompiledAssembly = System.Runtime.Loader.AssemblyLoadContext.Default.LoadFromStream(ms, pdbStream);
-                                
-                                // We have a compiled assembly so get the class name.
-                                var regEx = new Regex(@"class\s+(\w+)\s");
-                                var match = regEx.Match(modifiedCode);
-                                if (!match.Success)
-                                    throw new Exception($"Cannot find a class declaration in script:{Environment.NewLine}{modifiedCode}");
-                                compilation.ClassName = match.Groups[1].Value;
-                                compilation.InstanceType = compilation.CompiledAssembly.GetTypes().ToList().Find(t => t.Name == compilation.ClassName);
                             }
+                            
+                            // We have a compiled assembly so get the class name.
+                            var regEx = new Regex(@"class\s+(\w+)\s");
+                            var match = regEx.Match(modifiedCode);
+                            if (!match.Success)
+                                throw new Exception($"Cannot find a class declaration in script:{Environment.NewLine}{modifiedCode}");
+                            compilation.ClassName = match.Groups[1].Value;
+                            compilation.InstanceType = compilation.CompiledAssembly.GetTypes().ToList().Find(t => t.Name == compilation.ClassName);
                         }
                     }
                     else 
@@ -309,40 +297,38 @@ namespace Models.Core
         {
             string assemblyFileNameToCreate = Path.ChangeExtension(Path.Combine(Path.GetTempPath(), tempFileNamePrefix + Guid.NewGuid().ToString()), ".dll");
 
-            bool VB = code.IndexOf("Imports System") != -1;
             Compilation compilation;
-            if (VB)
-            {
-                sourceName = Path.GetFileNameWithoutExtension(assemblyFileNameToCreate) + ".vb";
-                SyntaxTree syntaxTree = VisualBasicSyntaxTree.ParseText(
-                    code,
-                    new VisualBasicParseOptions(),
-                    path: sourceName);
+            sourceName = Path.GetFileNameWithoutExtension(assemblyFileNameToCreate) + ".cs";
 
-                VisualBasicSyntaxNode syntaxRootNode = syntaxTree.GetRoot() as VisualBasicSyntaxNode;
-                var encoded = VisualBasicSyntaxTree.Create(syntaxRootNode, null, sourceName, System.Text.Encoding.UTF8);
-                compilation = VisualBasicCompilation.Create(
+            System.Text.Encoding encoding = System.Text.Encoding.UTF8;
+            byte[] buffer = encoding.GetBytes(code);
+            string fileName = Path.Combine(Path.GetTempPath() + sourceName);
+            using (FileStream file = new FileStream(fileName, FileMode.Create, FileAccess.Write))
+                file.Write(buffer, 0, buffer.Length);
+
+            string readText = File.ReadAllText(fileName);
+
+            SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(
+                readText,
+                new CSharpParseOptions(),
+                encoding: encoding,
+                path: fileName
+                );
+
+            OptimizationLevel optimization = OptimizationLevel.Release;
+            if (System.Diagnostics.Debugger.IsAttached)
+                optimization = OptimizationLevel.Debug;
+
+            compilation = CSharpCompilation.Create(
                 Path.GetFileNameWithoutExtension(assemblyFileNameToCreate),
-                new[] { encoded },
+                new[] { syntaxTree },
                 referencedAssemblies,
-                new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary)); ;
-            }
-            else
-            {
-                sourceName = Path.GetFileNameWithoutExtension(assemblyFileNameToCreate) + ".cs";
-                SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(
-                    code,
-                    new CSharpParseOptions(),
-                    path: sourceName);
+                new CSharpCompilationOptions(optimizationLevel: optimization,
+                                            outputKind: OutputKind.DynamicallyLinkedLibrary,
+                                            metadataImportOptions: MetadataImportOptions.All
+                                            )
+                );
 
-                CSharpSyntaxNode syntaxRootNode = syntaxTree.GetRoot() as CSharpSyntaxNode;
-                var encoded = CSharpSyntaxTree.Create(syntaxRootNode, null, sourceName, System.Text.Encoding.UTF8);
-                compilation = CSharpCompilation.Create(
-                    Path.GetFileNameWithoutExtension(assemblyFileNameToCreate),
-                    new[] { encoded },
-                    referencedAssemblies,
-                    new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
-            }
             return compilation;
         }
 


### PR DESCRIPTION
Resolves #8956

As I've looked into how to make this work, I have also been doing a general cleanup of the script compiler code. Removing references to compiling VB script, making sure settings were right on the compiler and recreating Visual Studio's method for debugging in VS Code so we ca have proper breakpoints working.

I've also updated the launch.json and task.json to hopefully speed up and improve the general compiling of apsim so it's closer to what we are used to. Please keep on eye on this in case there is a problem.