### PR TITLE
Fix Water RelativeTo Bug for Soils in an Experiment

### DIFF
--- a/Models/Soils/Water.cs
+++ b/Models/Soils/Water.cs
@@ -264,7 +264,7 @@ namespace Models.Soils
                         if (RelativeTo != "LL15")
                         {
                             //Get layer indices that have a XF as 0.
-                            var plantCrop = FindInScope<SoilCrop>(RelativeTo + "Soil");
+                            var plantCrop = GetCropSoil();
 
                             double[] initialValuesMMMinusEmptyXFLayers = MathUtilities.Multiply(plantCrop.XF, InitialValuesMM);
                             double[] relativeToLLMMMinusEmptyXFLayers = MathUtilities.Multiply(plantCrop.XF, RelativeToLLMM);
@@ -359,7 +359,7 @@ namespace Models.Soils
                     values = Physical.LL15;
                 else
                 {
-                    var plantCrop = FindAncestor<Soil>().FindDescendant<SoilCrop>(RelativeTo + "Soil");
+                    var plantCrop = GetCropSoil();
                     if (plantCrop == null)
                     {
                         RelativeTo = "LL15";
@@ -383,10 +383,7 @@ namespace Models.Soils
             {
                 if (RelativeTo != "LL15")
                 {
-                    var physical = FindSibling<Physical>();
-                    if (physical == null)
-                        physical = FindInScope<Physical>();
-                    var plantCrop = physical.FindChild<SoilCrop>(RelativeTo + "Soil");
+                    SoilCrop plantCrop = GetCropSoil();
                     if (plantCrop != null)
                         return SoilUtilities.MapConcentration(plantCrop.XF, Physical.Thickness, Thickness, plantCrop.XF.Last());
                 }
@@ -732,6 +729,15 @@ namespace Models.Soils
                     return false;
             }
             return true;
+        }
+
+        private SoilCrop GetCropSoil()
+        {
+            var physical = FindSibling<Physical>();
+            if (physical == null)
+                physical = FindInScope<Physical>();
+            var plantCrop = physical.FindChild<SoilCrop>(RelativeTo + "Soil");
+            return plantCrop;
         }
     }
 }

--- a/Models/Soils/Water.cs
+++ b/Models/Soils/Water.cs
@@ -731,12 +731,20 @@ namespace Models.Soils
             return true;
         }
 
+        /// <summary>
+        /// Attempts to get an appropriate SoilCrop.
+        /// </summary>
+        /// <exception cref="Exception"></exception>
         private SoilCrop GetCropSoil()
         {
             var physical = FindSibling<Physical>();
             if (physical == null)
                 physical = FindInScope<Physical>();
+                if (physical == null)
+                    throw new Exception($"Unable to locate a Physical node when updating {this.Name}.");
             var plantCrop = physical.FindChild<SoilCrop>(RelativeTo + "Soil");
+            if (plantCrop == null)
+                throw new Exception($"Unable to locate an appropriate SoilCrop with the name of {RelativeTo + "Soil"} under {physical.Name}.");
             return plantCrop;
         }
     }

--- a/Models/Soils/Water.cs
+++ b/Models/Soils/Water.cs
@@ -383,7 +383,10 @@ namespace Models.Soils
             {
                 if (RelativeTo != "LL15")
                 {
-                    var plantCrop = FindInScope<SoilCrop>(RelativeTo + "Soil");
+                    var physical = FindSibling<Physical>();
+                    if (physical == null)
+                        physical = FindInScope<Physical>();
+                    var plantCrop = physical.FindChild<SoilCrop>(RelativeTo + "Soil");
                     if (plantCrop != null)
                         return SoilUtilities.MapConcentration(plantCrop.XF, Physical.Thickness, Thickness, plantCrop.XF.Last());
                 }


### PR DESCRIPTION
resolves #8993

# Notes
- When calculations for various water properties is taking place water would search for a physical model located within a Simulation model. This is ok for water models that are descendants of a Simulation but not for ones that descendants of Experiments/Factors.
- A method has been created to find CropSoils appropriately.