### PR TITLE
Graph/Series debugging messages will not show unless the setting is enabled in the main presenter

### DIFF
--- a/ApsimNG/Presenters/GraphPresenter.cs
+++ b/ApsimNG/Presenters/GraphPresenter.cs
@@ -1,20 +1,23 @@
-﻿namespace UserInterface.Presenters
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using System.Linq;
+using APSIM.Shared.Documentation.Extensions;
+using APSIM.Shared.Graphing;
+using APSIM.Shared.Utilities;
+using UserInterface.EventArguments;
+using Models;
+using Models.Core;
+using Models.Storage;
+using UserInterface.Views;
+using UserInterface.Interfaces;
+using Configuration = Utility.Configuration;
+
+namespace UserInterface.Presenters
 {
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Data;
-    using System.IO;
-    using System.Linq;
-    using APSIM.Shared.Documentation.Extensions;
-    using APSIM.Shared.Graphing;
-    using APSIM.Shared.Utilities;
-    using EventArguments;
-    using Interfaces;
-    using Models;
-    using Models.Core;
-    using Models.Storage;
-    using Views;
+
 
     /// <summary>
     /// A presenter for a graph.
@@ -127,7 +130,7 @@
                 storage = graph.FindInScope<IDataStore>();
             if (graph != null && graph.Series != null)
             {
-                if (definitions.Count() == 0)
+                if (definitions.Count() == 0 && Configuration.Settings.EnableGraphDebuggingMessages)
                     explorerPresenter.MainPresenter.ShowMessage($"{this.graph.Name}: No data matches the properties and filters set for this graph", Simulation.MessageType.Warning, false);
 
                 foreach (SeriesDefinition definition in definitions)
@@ -230,7 +233,7 @@
                                 pointsInsideAxis += 1;
                         }
                     }
-                    if (xNaNCount == valuesX.Count || yNaNCount == valuesY.Count || bothNaNCount == valuesX.Count)
+                    if (Configuration.Settings.EnableGraphDebuggingMessages && xNaNCount == valuesX.Count || yNaNCount == valuesY.Count || bothNaNCount == valuesX.Count)
                     {
                         explorerPresenter.MainPresenter.ShowMessage($"{seriesName}: NaN Values found in points. These may be empty cells in the datastore.", Simulation.MessageType.Information, false);
                         if (xNaNCount > 0)
@@ -242,11 +245,11 @@
                     }
                 }
 
-                if (pointsOutsideAxis > 0 && pointsInsideAxis == 0)
+                if (pointsOutsideAxis > 0 && pointsInsideAxis == 0 && Configuration.Settings.EnableGraphDebuggingMessages)
                 {
                     explorerPresenter.MainPresenter.ShowMessage($"{this.graph.Name}: No points are visible with current axis values.", Simulation.MessageType.Warning, false);
                 }
-                else if (pointsOutsideAxis > 0)
+                else if (pointsOutsideAxis > 0 && Configuration.Settings.EnableGraphDebuggingMessages)
                 {
                     explorerPresenter.MainPresenter.ShowMessage($"{this.graph.Name}: {pointsOutsideAxis} points are outside of the provided graph axis. Adjust the minimums and maximums for the axis, or clear them to have them autocalculate and show everything.", Simulation.MessageType.Warning, false);
                 }

--- a/ApsimNG/Presenters/SeriesPresenter.cs
+++ b/ApsimNG/Presenters/SeriesPresenter.cs
@@ -13,6 +13,7 @@ using UserInterface.Commands;
 using Models.Storage;
 using APSIM.Shared.Graphing;
 using Series = Models.Series;
+using Configuration = Utility.Configuration;
 
 namespace UserInterface.Presenters
 {
@@ -431,7 +432,7 @@ namespace UserInterface.Presenters
             {
                 this.SetModelProperty("TableName", this.seriesView.DataSource.SelectedValue);
                 List<string> warnings = PopulateFieldNames();
-                if (warnings != null && warnings.Count > 0)
+                if (warnings != null && warnings.Count > 0 && Configuration.Settings.EnableGraphDebuggingMessages)
                 {
                     explorerPresenter.MainPresenter.ClearStatusPanel();
                     explorerPresenter.MainPresenter.ShowMessage(warnings, Simulation.MessageType.Warning);
@@ -555,7 +556,7 @@ namespace UserInterface.Presenters
             // Populate filter textbox.
             this.seriesView.Filter.Text = series.Filter;
 
-            if (warnings != null && warnings.Count > 0)
+            if (warnings != null && warnings.Count > 0 && Configuration.Settings.EnableGraphDebuggingMessages)
                 explorerPresenter.MainPresenter.ShowMessage(warnings, Simulation.MessageType.Warning);
         }
 

--- a/ApsimNG/Utility/Configuration.cs
+++ b/ApsimNG/Utility/Configuration.cs
@@ -68,7 +68,7 @@ namespace Utility
         [Tooltip("Should the file be automatically saved to disk before running simulations?")]
         public bool AutoSave { get; set; } = true;
 
-        /// <summary>Iff true, the GUI will not play a sound when simulations finish running.</summary>
+        /// <summary>If true, the GUI will not play a sound when simulations finish running.</summary>
         [Input("Mute all sound effects")]
         public bool Muted { get; set; } = true;
 
@@ -81,6 +81,10 @@ namespace Utility
         [Input("Use faster file closing algorithm")]
         [Tooltip("This will mostly eliminate the pause when closing a file, but it may cause apsim to fail to prompt to save the file in some cases.")]
         public bool UseFastFileClose { get; set; }
+
+        [Input("Enable graph debugging output")]
+        [Tooltip("Outputs messages in the status bar if data is missing, is outside axis bounds or is NaN. Useful for debugging Observed/Predicted graphs.")]
+        public bool EnableGraphDebuggingMessages { get; set; } = false;
 
         /// <summary>Return the name of the summary file JPG.</summary>
         public string SummaryPngFileName


### PR DESCRIPTION
resolves #8599

# Notes
- Users can now enable/disable graph and series debugging messages.
- The messages are great for model builders but not so great for other users. So having the choice to enable and disable should help.