### PR TITLE
9059 Graph with String axis fixed

### DIFF
--- a/ApsimNG/Views/GraphView.cs
+++ b/ApsimNG/Views/GraphView.cs
@@ -1690,10 +1690,12 @@ namespace UserInterface.Views
                             while (enumerator.MoveNext())
                             {
                                 int axisIndex = axis.Labels.IndexOf(enumerator.Current.ToString());
-                                if (axisIndex == -1)
+                                if (axisIndex == -1) {
                                     axis.Labels.Add(enumerator.Current.ToString());
-
-                                values.Add(index);
+                                    axisIndex = axis.Labels.Count - 1;
+                                }
+                                
+                                values.Add(axisIndex);
                                 index += 1;
                             }
                         }


### PR DESCRIPTION
Resolves #9059 

I put the wrong index into the string array when fixing a bug here a few weeks ago, that has been fixed. I also found an existing bug with a string not being found that I solved as well.