### PR TITLE
9154 Silence DeepCloner Warnings

### DIFF
--- a/DeepCloner.Core/DeepCloner.Core.csproj
+++ b/DeepCloner.Core/DeepCloner.Core.csproj
@@ -12,6 +12,8 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>CS8600,CS8601,CS8602,CS8603,CS8604,CS8618</NoWarn>
   </PropertyGroup>
   
   <PropertyGroup>


### PR DESCRIPTION
Resolves #9154

After having a go at resolving the warnings, it's not really worth it. All of them are just complaints that a variable may be null when passed or used, and changing one causes a cascade of changes across the program.

So I've just silenced them for now so it doesn't bloat out our build messages. I also turned on "Treat Warnings as Errors" to make DeepCloner consistent with the rest of the apsim projects.