### PR TITLE
9116 ASRIS xml format finds soil node

### DIFF
--- a/Tests/UnitTests/Core/ApsimFile/ConverterTests.cs
+++ b/Tests/UnitTests/Core/ApsimFile/ConverterTests.cs
@@ -449,7 +449,7 @@ namespace UnitTests.Core.ApsimFile
         {
           string xml = ReflectionUtilities.GetResourceAsString("UnitTests.Core.ApsimFile.Soil.apsim");
           ConverterReturnType result = Converter.DoConvert(xml, Converter.LatestVersion);
-          Assert.That(JsonUtilities.ChildWithName(result.Root, "SoilTemperature"), Is.Not.Null);
+          Assert.That(JsonUtilities.ChildWithName(result.Root, "Temperature"), Is.Not.Null);
           Assert.That(JsonUtilities.ChildWithName(result.Root, "Nutrient"), Is.Not.Null);
         }
     }


### PR DESCRIPTION
Resolves #9116 

When you download an ASRIS file, the node sits under a parent, and then when using Models.exe --upgrade, it can't find the soil to upgrade it correctly. This fixes that.

It also changes the name of the CERESSoilTemperature node that is added to just be "Temperature" to match our other code.