### PR TITLE
9052 ExcelInput Multiline

### DIFF
--- a/ApsimNG/Views/PropertyView.cs
+++ b/ApsimNG/Views/PropertyView.cs
@@ -340,7 +340,6 @@ namespace UserInterface.Views
                     component = dropDown.MainWidget;
                     break;
                 case PropertyType.File:
-                case PropertyType.Files:
                 case PropertyType.Directory:
                     //case PropertyType.Directories:
                     // Add an Entry and a Button inside a VBox.
@@ -353,8 +352,6 @@ namespace UserInterface.Views
                     fileChooserButton.Name = property.ID.ToString();
                     if (property.DisplayMethod == PropertyType.File)
                         fileChooserButton.Clicked += (o, _) => ChooseFile(o as Widget, false, false);
-                    else if (property.DisplayMethod == PropertyType.Files)
-                        fileChooserButton.Clicked += (o, _) => ChooseFile(o as Widget, true, false);
                     else if (property.DisplayMethod == PropertyType.Directory)
                         fileChooserButton.Clicked += (o, _) => ChooseFile(o as Widget, false, true);
 
@@ -362,6 +359,32 @@ namespace UserInterface.Views
                     container.PackStart(fileNameInput, true, true, 0);
                     container.PackStart(fileChooserButton, false, false, 0);
                     component = container;
+                    break;
+                case PropertyType.Files:
+                    string filenamesText = property.Value?.ToString();
+                    filenamesText = filenamesText.Replace(',', '\n');
+                    if (!filenamesText.EndsWith('\n'))
+                        filenamesText += '\n';
+
+                    TextView filenamesEditor = new TextView();
+                    filenamesEditor.SizeAllocated += OnTextViewSizeAllocated;
+                    filenamesEditor.WrapMode = WrapMode.Word;
+                    filenamesEditor.Buffer.Text = filenamesText ?? "";
+                    originalEntryText[property.ID] = filenamesText;
+                    filenamesEditor.Name = property.ID.ToString();
+                    filenamesEditor.FocusOutEvent += UpdateText;
+
+                    Frame filenamesOutline = new Frame();
+                    filenamesOutline.Add(filenamesEditor);
+
+                    Button filesChooserButton = new Button("...");
+                    filesChooserButton.Clicked += (o, _) => ChooseFile(o as Widget, true, false);
+
+                    Box filenamesContainer = new HBox();
+                    filenamesContainer.PackStart(filenamesOutline, true, true, 0);
+                    filenamesContainer.PackStart(filesChooserButton, false, false, 0);
+                    component = filenamesContainer;
+
                     break;
                 case PropertyType.Colour:
                     ColourDropDownView colourChooser = new ColourDropDownView(this);
@@ -490,7 +513,7 @@ namespace UserInterface.Views
                 bool doUpdate = false;
                 if (e is KeyPressEventArgs) 
                 {
-                    if ((e as KeyPressEventArgs).Event.Key == Gdk.Key.Return)
+                    if (!(sender is TextView) && (e as KeyPressEventArgs).Event.Key == Gdk.Key.Return)
                         doUpdate = true;
                 }
                 else 
@@ -530,6 +553,36 @@ namespace UserInterface.Views
             {
                 ShowError(err);
             }
+        }
+
+        /// <summary>
+        /// Called when a multiline filenames has been modified.
+        /// </summary>
+        /// <param name="sender">The entry which has been modified.</param>
+        /// <param name="e">Event data.</param>
+        [GLib.ConnectBefore]
+        private void UpdateFilenamesText(object sender, EventArgs e)
+        {
+           /* try
+            {
+                Widget widget = sender as Widget;
+                if (widget != null)
+                {
+                    StoreScrollerPosition();
+                    Guid id = Guid.Parse(widget.Name);
+                    string text = editor.Buffer.Text;
+                    if (originalEntryText.ContainsKey(id) && !string.Equals(originalEntryText[id], text, StringComparison.CurrentCulture))
+                    {
+                        var args = new PropertyChangedEventArgs(id, text);
+                        originalEntryText[id] = text;
+                        PropertyChanged?.Invoke(this, args);
+                    }
+                }                
+            }
+            catch (Exception err)
+            {
+                ShowError(err);
+            }*/
         }
 
         /// <summary>

--- a/ApsimNG/Views/PropertyView.cs
+++ b/ApsimNG/Views/PropertyView.cs
@@ -362,7 +362,8 @@ namespace UserInterface.Views
                     break;
                 case PropertyType.Files:
                     string filenamesText = property.Value?.ToString();
-                    filenamesText = filenamesText.Replace(", ", "\n");
+                    filenamesText = filenamesText.Replace(",", "\n");
+                    filenamesText = filenamesText.Replace("\n ", "\n");
                     if (!filenamesText.EndsWith('\n'))
                         filenamesText += '\n';
 
@@ -572,7 +573,7 @@ namespace UserInterface.Views
                     StoreScrollerPosition();
                     Guid id = Guid.Parse(widget.Name);
                     string text = (widget as TextView).Buffer.Text;
-
+                    text = text.Replace(",", "\n"); //do this again incase someone entered filenames with , instead of newlines
                     text = text.Replace("\n", ", ");
                     if (text.EndsWith(", "))
                         text = text.Remove(text.Length-2, 2);

--- a/ApsimNG/Views/PropertyView.cs
+++ b/ApsimNG/Views/PropertyView.cs
@@ -362,7 +362,7 @@ namespace UserInterface.Views
                     break;
                 case PropertyType.Files:
                     string filenamesText = property.Value?.ToString();
-                    filenamesText = filenamesText.Replace(',', '\n');
+                    filenamesText = filenamesText.Replace(", ", "\n");
                     if (!filenamesText.EndsWith('\n'))
                         filenamesText += '\n';
 
@@ -372,12 +372,13 @@ namespace UserInterface.Views
                     filenamesEditor.Buffer.Text = filenamesText ?? "";
                     originalEntryText[property.ID] = filenamesText;
                     filenamesEditor.Name = property.ID.ToString();
-                    filenamesEditor.FocusOutEvent += UpdateText;
+                    filenamesEditor.FocusOutEvent += UpdateFilenamesText;
 
                     Frame filenamesOutline = new Frame();
                     filenamesOutline.Add(filenamesEditor);
 
                     Button filesChooserButton = new Button("...");
+                    filesChooserButton.Name = property.ID.ToString();
                     filesChooserButton.Clicked += (o, _) => ChooseFile(o as Widget, true, false);
 
                     Box filenamesContainer = new HBox();
@@ -563,14 +564,19 @@ namespace UserInterface.Views
         [GLib.ConnectBefore]
         private void UpdateFilenamesText(object sender, EventArgs e)
         {
-           /* try
+            try
             {
                 Widget widget = sender as Widget;
                 if (widget != null)
                 {
                     StoreScrollerPosition();
                     Guid id = Guid.Parse(widget.Name);
-                    string text = editor.Buffer.Text;
+                    string text = (widget as TextView).Buffer.Text;
+
+                    text = text.Replace("\n", ", ");
+                    if (text.EndsWith(", "))
+                        text = text.Remove(text.Length-2, 2);
+
                     if (originalEntryText.ContainsKey(id) && !string.Equals(originalEntryText[id], text, StringComparison.CurrentCulture))
                     {
                         var args = new PropertyChangedEventArgs(id, text);
@@ -582,7 +588,7 @@ namespace UserInterface.Views
             catch (Exception err)
             {
                 ShowError(err);
-            }*/
+            }
         }
 
         /// <summary>

--- a/Models/PostSimulationTools/ExcelInput.cs
+++ b/Models/PostSimulationTools/ExcelInput.cs
@@ -36,7 +36,7 @@ namespace Models.PostSimulationTools
         /// Gets or sets the file name to read from.
         /// </summary>
         [Description("EXCEL file names")]
-        [Tooltip("Can contain more than one file name, separated by commas.")]
+        [Tooltip("Can contain more than one file name, each on a new line")]
         [Display(Type = DisplayType.FileNames)]
         public string[] FileNames
         {

--- a/Models/PostSimulationTools/ExcelInput.cs
+++ b/Models/PostSimulationTools/ExcelInput.cs
@@ -75,7 +75,14 @@ namespace Models.PostSimulationTools
                 if (value == null)
                     sheetNames = Array.Empty<string>();
                 else
-                    sheetNames = value;
+                {
+                    List<string> filtered = new List<string>();
+                    foreach(string line in value) {
+                        if (line != null && line.Length > 0)
+                            filtered.Add(line);
+                    }
+                    sheetNames = filtered.ToArray();
+                }
             }
         }
 

--- a/Models/PostSimulationTools/ExcelInput.cs
+++ b/Models/PostSimulationTools/ExcelInput.cs
@@ -63,6 +63,7 @@ namespace Models.PostSimulationTools
         /// Gets or sets the list of EXCEL sheet names to read from.
         /// </summary>
         [Description("EXCEL sheet names (csv)")]
+        [Display(Type = DisplayType.MultiLineText)]
         public string[] SheetNames
         {
             get

--- a/Models/PostSimulationTools/ExcelInput.cs
+++ b/Models/PostSimulationTools/ExcelInput.cs
@@ -46,11 +46,17 @@ namespace Models.PostSimulationTools
             }
             set
             {
+                //remove any null or blank filenames that could be passed in
+                List<string> filtered = new List<string>();
+                foreach(string line in value)
+                        if (line != null && line.Length > 0)
+                            filtered.Add(line);
+
                 Simulations simulations = FindAncestor<Simulations>();
                 if (simulations != null && simulations.FileName != null && value != null)
-                    this.filenames = value.Select(v => PathUtilities.GetRelativePath(v, simulations.FileName)).ToArray();
+                    this.filenames = filtered.Select(v => PathUtilities.GetRelativePath(v, simulations.FileName)).ToArray();
                 else
-                    this.filenames = value;
+                    this.filenames = filtered.ToArray();
             }
         }
 
@@ -76,11 +82,12 @@ namespace Models.PostSimulationTools
                     sheetNames = Array.Empty<string>();
                 else
                 {
+                    //remove any null or blank sheet names that could be passed in
                     List<string> filtered = new List<string>();
-                    foreach(string line in value) {
+                    foreach(string line in value)
                         if (line != null && line.Length > 0)
                             filtered.Add(line);
-                    }
+
                     sheetNames = filtered.ToArray();
                 }
             }


### PR DESCRIPTION
Resolves #9052

Makes the input fields on the ExcelInput model into multi-line text boxes. Much easier to read now than one big long list in something like the Wheat validation.

I tried to avoid changing the model as much as possible here and do it all through GUI changes, as the underlying structure was already suitable for this, it just needed to be displayed better.

Might be worth pulling and testing as a GUI change though before it's merged.