### PR TITLE
9187 Unsquash Rotation Manager Presenter

### DIFF
--- a/ApsimNG/Views/BubbleChartView.cs
+++ b/ApsimNG/Views/BubbleChartView.cs
@@ -96,7 +96,7 @@ namespace UserInterface.Views
             objectBox = (Gtk.Box)builder.GetObject("object_box");
             Box instructionsBox = (Gtk.Box)builder.GetObject("instructions_box");
 
-            graphView = new DirectedGraphView(this);
+            graphView = new DirectedGraphView(this, horizontalSplitterPosition);
             chartBox.Add(graphView.MainWidget);
             graphView.AddArc += OnAddArcEnd;
 

--- a/ApsimNG/Views/DirectedGraphView.cs
+++ b/ApsimNG/Views/DirectedGraphView.cs
@@ -107,9 +107,11 @@ namespace UserInterface.Views
         /// <summary>
         /// Initializes a new instance of the <see cref="DirectedGraphView" /> class.
         /// </summary>
-        public DirectedGraphView(ViewBase owner = null) : base(owner)
+        public DirectedGraphView(ViewBase owner = null, int width=800) : base(owner)
         {
             drawable = new DrawingArea();
+            drawable.WidthRequest = width;
+
             drawable.AddEvents(
             (int)Gdk.EventMask.PointerMotionMask
             | (int)Gdk.EventMask.ButtonPressMask
@@ -125,7 +127,8 @@ namespace UserInterface.Views
             ScrolledWindow scroller = new ScrolledWindow()
             {
                 HscrollbarPolicy = PolicyType.Always,
-                VscrollbarPolicy = PolicyType.Always
+                VscrollbarPolicy = PolicyType.Always,
+                WidthRequest = width
             };
 
 


### PR DESCRIPTION
Resolves #9187

Not sure why GTK has suddenly stopped respecting the size of the drawing area in the paned window (maybe has to do with #9149 changing to the newer Paned object instead of HPaned and VPaned).

This change just gives the drawing area a default size so that it doesn't get squished.