### PR TITLE
Arithmetic overflow exception workaround for drag/drop of models

### DIFF
--- a/ApsimNG/Views/TreeView.cs
+++ b/ApsimNG/Views/TreeView.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Timers;
@@ -968,7 +969,7 @@ namespace UserInterface.Views
         {
             try
             {
-                byte[] data = e.SelectionData.Data;
+                var data = e.SelectionData.Data;
                 Int64 value = BitConverter.ToInt64(data, 0);
                 if (value != 0)
                 {
@@ -978,7 +979,9 @@ namespace UserInterface.Views
             }
             catch (Exception err)
             {
-                ShowError(err);
+                if (err.Message.Contains("Arithmetic operation resulted in an overflow."))
+                    ShowError(new Exception("Unable to add new model. Try adding the model again."));
+                else ShowError(err);
             }
         }
 


### PR DESCRIPTION
resolves #9075

# Notes

- Note: Does not solve the issue but instructs user on what to do when this error occurs.
- There's a lot going on here and will require some refactoring in the future to resolve correctly. Right now, it's not worth the time spent to correct.
- I'm not a fan of the manual memory management going on in the whole drag and drop process and I think it should be done in a more simple and robust manner.