### PR TITLE
Give WaterView grid only the space it needs.

### DIFF
--- a/ApsimNG/Resources/Glade/WaterView.glade
+++ b/ApsimNG/Resources/Glade/WaterView.glade
@@ -16,7 +16,7 @@
         </child>
       </object>
       <packing>
-        <property name="expand">True</property>
+        <property name="expand">False</property>
         <property name="fill">True</property>
         <property name="position">0</property>
       </packing>


### PR DESCRIPTION
Resolves #9195, but only in a minimalist way.