### PR TITLE
9258 Commands system Filepath for value

### DIFF
--- a/Models/Core/ConfigFile/ConfigFile.cs
+++ b/Models/Core/ConfigFile/ConfigFile.cs
@@ -76,9 +76,16 @@ namespace Models.Core.ConfigFile
                 Match firstSplitResult = rxOverrideTargetNode.Match(commandSplits[0]);
                 if (firstSplitResult.Success)
                 {
+                    string property = commandSplits[0];
+                    string value = commandSplits[1];
+                    //check if second part is a filename or value (ends in ; and file exists)
+                    //if so, read contents of that file in as the value
+                    string potentialFilepath = configFileDirectory + "\\" + value.Substring(0, value.Length-1);
+                    if (value.EndsWith(';') && File.Exists(potentialFilepath)) 
+                        value = File.ReadAllText(potentialFilepath);
+
                     // TODO: Needs fixing to make sure overrides with encoded spaces (@) are handled correctly.
-                    //string[] singleLineCommandArray = { string.Join<string>(' ', commandSplits) };
-                    string[] singleLineCommandArray = { string.Join('=', commandSplits) };
+                    string[] singleLineCommandArray = { property + "=" + value };
                     var overrides = Overrides.ParseStrings(singleLineCommandArray);
                     tempSim = (Simulations)ApplyOverridesToApsimxFile(overrides, tempSim);
                 }

--- a/Models/Core/ConfigFile/ConfigFile.cs
+++ b/Models/Core/ConfigFile/ConfigFile.cs
@@ -307,7 +307,7 @@ namespace Models.Core.ConfigFile
             }
             catch (Exception e)
             {
-                string message = e.Message + " : " + instruction.NodeForAction + " and " + instruction.NodeToModify + " " + instruction.keyword;
+                string message = e.Message + " : " + instruction.keyword + " " +  instruction.NodeToModify + " " + instruction.NodeForAction;
                 throw new Exception(message);
             }
         }

--- a/Models/Core/ConfigFile/ConfigFile.cs
+++ b/Models/Core/ConfigFile/ConfigFile.cs
@@ -307,7 +307,8 @@ namespace Models.Core.ConfigFile
             }
             catch (Exception e)
             {
-                throw new Exception(e.Message);
+                string message = e.Message + " : " + instruction.NodeForAction + " and " + instruction.NodeToModify + " " + instruction.keyword;
+                throw new Exception(message);
             }
         }
 

--- a/Models/Core/ConfigFile/ConfigFile.cs
+++ b/Models/Core/ConfigFile/ConfigFile.cs
@@ -87,7 +87,7 @@ namespace Models.Core.ConfigFile
 
                     //check if second part is a filename or value (ends in ; and file exists)
                     //if so, read contents of that file in as the value
-                    string potentialFilepath = configFileDirectory + "\\" + value.Substring(0, value.Length-1);
+                    string potentialFilepath = configFileDirectory + "/" + value.Substring(0, value.Length-1);
                     if (value.Trim().EndsWith(';') && File.Exists(potentialFilepath)) 
                         value = File.ReadAllText(potentialFilepath);
 

--- a/Models/Core/ConfigFile/ConfigFile.cs
+++ b/Models/Core/ConfigFile/ConfigFile.cs
@@ -77,11 +77,18 @@ namespace Models.Core.ConfigFile
                 if (firstSplitResult.Success)
                 {
                     string property = commandSplits[0];
-                    string value = commandSplits[1];
+                    string value = "";
+                    for(int i = 1; i < commandSplits.Count; i++)
+                    {
+                        value += commandSplits[i];
+                        if (i < commandSplits.Count-1)
+                            value += "=";
+                    }
+
                     //check if second part is a filename or value (ends in ; and file exists)
                     //if so, read contents of that file in as the value
                     string potentialFilepath = configFileDirectory + "\\" + value.Substring(0, value.Length-1);
-                    if (value.EndsWith(';') && File.Exists(potentialFilepath)) 
+                    if (value.Trim().EndsWith(';') && File.Exists(potentialFilepath)) 
                         value = File.ReadAllText(potentialFilepath);
 
                     // TODO: Needs fixing to make sure overrides with encoded spaces (@) are handled correctly.

--- a/Tests/UnitTests/CommandLineArgsTests.cs
+++ b/Tests/UnitTests/CommandLineArgsTests.cs
@@ -1068,6 +1068,28 @@ run";
 
         }
 
+        [Test]
+        public void TestReadingInputValueFromFile()
+        {
+            Simulations file = Utilities.GetRunnableSim();
+
+            string inputFile = "input.txt";
+            string newName = "New Name";
+            File.WriteAllText(Path.Combine(Path.GetTempPath(), inputFile), newName);
+
+            string outputFile = "test.apsimx";
+
+            string configFile = Path.GetTempPath() + "config.txt";
+            File.WriteAllText(configFile, "[Simulation].Name=input.txt;\nsave " + outputFile);
+
+            Utilities.RunModels(file, $"--apply {configFile}");
+
+            // Reload simulation from file text. Needed to see changes made.
+            string text = File.ReadAllText(Path.GetTempPath() + outputFile);
+            Simulations result = FileFormat.ReadFromString<Simulations>(text, e => throw e, false).NewModel as Simulations;
+
+            Assert.That(result.FindInScope<Simulation>().Name, Is.EqualTo(newName));
+        }
 
     }
 }

--- a/Tests/UnitTests/CommandLineArgsTests.cs
+++ b/Tests/UnitTests/CommandLineArgsTests.cs
@@ -1073,19 +1073,21 @@ run";
         {
             Simulations file = Utilities.GetRunnableSim();
 
-            string inputFile = "input.txt";
+            string tempPath = Path.GetTempPath();
+            
+            string inputFile = tempPath + "input.txt";
             string newName = "New Name";
-            File.WriteAllText(Path.Combine(Path.GetTempPath(), inputFile), newName);
+            File.WriteAllText(inputFile, newName);
 
             string outputFile = "test.apsimx";
 
-            string configFile = Path.GetTempPath() + "config.txt";
+            string configFile = tempPath + "config.txt";
             File.WriteAllText(configFile, "[Simulation].Name=input.txt;\nsave " + outputFile);
 
             Utilities.RunModels(file, $"--apply {configFile}");
 
             // Reload simulation from file text. Needed to see changes made.
-            string text = File.ReadAllText(Path.GetTempPath() + outputFile);
+            string text = File.ReadAllText(tempPath + outputFile);
             Simulations result = FileFormat.ReadFromString<Simulations>(text, e => throw e, false).NewModel as Simulations;
 
             Assert.That(result.FindInScope<Simulation>().Name, Is.EqualTo(newName));


### PR DESCRIPTION
Resolves #9258

To provide a filepath instead of a value in the commands txt, you can set the value like so:

```
[Simulation].Name=mytextfile.txt;
```

It will look for a semi-colon at the end (like when you do a replace action with a node from another file) and if a file with that name exists. If both are true, instead of using the text in that line, the text from the file is read in instead and entered as the value.

This lets you provide multi-line string inputs and larger values from a separate file instead of having to get it all into the commands.txt

A unit test was also created for this behaviour.