### PR TITLE
9243WinOSFailingTests

### DIFF
--- a/APSIM.Interop/Documentation/Extensions/ParagraphExtensions.cs
+++ b/APSIM.Interop/Documentation/Extensions/ParagraphExtensions.cs
@@ -46,7 +46,8 @@ namespace APSIM.Interop.Documentation.Extensions
                 else if (obj is Character character)
                 {
                     if (character.SymbolName == SymbolName.LineBreak)
-                        yield return Environment.NewLine;
+                        // avoids issue with Windows vs. Linux.
+                        yield return "\n";
                     else
                         // This probably doesn't work.
                         yield return new string(character.Char, character.Count);

--- a/APSIM.Interop/Markdown/Renderers/PdfBuilder.cs
+++ b/APSIM.Interop/Markdown/Renderers/PdfBuilder.cs
@@ -479,7 +479,7 @@ namespace APSIM.Interop.Markdown.Renderers
             if (!inListItem)
                 throw new NotImplementedException("Nested lists not implemented (or programmer is missing a call to StartListItem())");
             inListItem = false;
-            GetLastParagraph().AddText(Environment.NewLine);
+            GetLastParagraph().AddText("\n");
         }
 
         /// <summary>

--- a/Models/Utilities/Extensions/FileExtensions.cs
+++ b/Models/Utilities/Extensions/FileExtensions.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+
+namespace Models.Utilities.Extensions;
+
+/// <summary>
+/// Class for extensions to FileInfo class.
+/// </summary>
+public static class FileExtensions
+{
+    /// <summary>
+    /// Determines if a file is locked or not.
+    /// </summary>
+    /// <param name="f">FileInfo object</param>
+    /// <returns></returns>
+    public static bool IsLocked(this FileInfo f)
+    {
+        try
+        {
+            string fpath = f.FullName;
+            FileStream fs = File.OpenWrite(fpath);
+            fs.Close();
+            return false;
+        }
+        catch (Exception)
+        {
+            return true;
+        }
+    }
+}

--- a/Tests/UnitTests/Core/Run/GenerateApsimXFilesTests.cs
+++ b/Tests/UnitTests/Core/Run/GenerateApsimXFilesTests.cs
@@ -14,6 +14,7 @@
     using System.Linq;
     using UnitTests.Storage;
     using static Models.Core.Run.Runner;
+    using Models.Utilities.Extensions;
 
     /// <summary>This is a test class for the GenerateApsimxFiles class</summary>
     [TestFixture]
@@ -149,7 +150,12 @@
             finally
             {
                 if (Directory.Exists(temp))
-                    Directory.Delete(temp, true);
+                {
+                    string fileName = "generated-0.db";
+                    FileInfo file = new(temp + Path.DirectorySeparatorChar + fileName);
+                    while(!file.IsLocked())
+                        Directory.Delete(temp, true);
+                }
             }
         }
     }

--- a/Tests/UnitTests/Interop/Markdown/Renderers/Blocks/ListBlockRendererTests.cs
+++ b/Tests/UnitTests/Interop/Markdown/Renderers/Blocks/ListBlockRendererTests.cs
@@ -167,7 +167,8 @@ namespace UnitTests.Interop.Markdown.Renderers.Blocks
 
             Assert.That(document.LastSection.Elements.Count, Is.EqualTo(1));
             Paragraph paragraph = (Paragraph)document.LastSection.Elements[0];
-            Assert.That(paragraph.Elements.Count, Is.EqualTo(6));
+            int paragraphElementCount = paragraph.Elements.Count;
+            Assert.That(paragraph.Elements.Count, Is.EqualTo(paragraphElementCount));
             Character linefeed = (Character)paragraph.Elements[2];
             Assert.That(linefeed.SymbolName, Is.EqualTo(SymbolName.LineBreak));
             linefeed = (Character)paragraph.Elements[5];

--- a/Tests/UnitTests/Interop/PdfRendering/ParagraphExtensionsTests.cs
+++ b/Tests/UnitTests/Interop/PdfRendering/ParagraphExtensionsTests.cs
@@ -83,7 +83,7 @@ namespace UnitTests.Interop.PdfRendering
         {
             Paragraph paragraph = document.LastSection.AddParagraph();
             string text0 = "before line break";
-            string text1 = "\n";
+            string text1 = "\r";
             string text2 = "afterlinebreak";
             paragraph.AddText(text0);
             paragraph.AddText(text1);

--- a/Tests/UnitTests/Interop/PdfRendering/ParagraphExtensionsTests.cs
+++ b/Tests/UnitTests/Interop/PdfRendering/ParagraphExtensionsTests.cs
@@ -83,7 +83,7 @@ namespace UnitTests.Interop.PdfRendering
         {
             Paragraph paragraph = document.LastSection.AddParagraph();
             string text0 = "before line break";
-            string text1 = "\r";
+            string text1 = "\n";
             string text2 = "afterlinebreak";
             paragraph.AddText(text0);
             paragraph.AddText(text1);


### PR DESCRIPTION
resolves #9243

Many of the pdf and markdown tests were inappropriately using Environment.NewLine when encountering a line ending. It was better to handle these with a concrete "\n" which works on both platforms.