### PR TITLE
Put protection in for when there is only one row in the DataStore when setting column widths

### DIFF
--- a/Gtk.Sheet/Sheet.cs
+++ b/Gtk.Sheet/Sheet.cs
@@ -564,20 +564,11 @@ namespace Gtk.Sheet
             if (autoCalculateColumnWidths && DataProvider != null)
             {
                 int visibleRows = FullyVisibleRowIndexes.Count() + NumberHiddenRows;
-                if (visibleRows >= DataProvider.RowCount)
-                {
-                    // Prevents visibleRows from going to zero when there is only one data row.
-                    if (DataProvider.RowCount > 1)
-                    {
-                        visibleRows = DataProvider.RowCount - 1;
-                    }
-                }
-
                 ColumnWidths = new int[DataProvider.ColumnCount];
                 for (int columnIndex = 0; columnIndex < DataProvider.ColumnCount; columnIndex++)
                 {
                     int columnWidth = GetWidthOfCell(cr, columnIndex, 0);
-                    for (int rowIndex = NumberHiddenRows; rowIndex <= visibleRows; rowIndex++)
+                    for (int rowIndex = NumberHiddenRows; rowIndex < visibleRows; rowIndex++)
                         columnWidth = Math.Max(columnWidth, GetWidthOfCell(cr, columnIndex, rowIndex));
 
                     ColumnWidths[columnIndex] = columnWidth + ColumnPadding * 2;

--- a/Gtk.Sheet/Sheet.cs
+++ b/Gtk.Sheet/Sheet.cs
@@ -565,7 +565,13 @@ namespace Gtk.Sheet
             {
                 int visibleRows = FullyVisibleRowIndexes.Count() + NumberHiddenRows;
                 if (visibleRows >= DataProvider.RowCount)
-                    visibleRows = DataProvider.RowCount - 1;
+                {
+                    // Prevents visibleRows from going to zero when there is only one data row.
+                    if (DataProvider.RowCount > 1)
+                    {
+                        visibleRows = DataProvider.RowCount - 1;
+                    }
+                }
 
                 ColumnWidths = new int[DataProvider.ColumnCount];
                 for (int columnIndex = 0; columnIndex < DataProvider.ColumnCount; columnIndex++)


### PR DESCRIPTION
resolves #9267

# Cause of bug
 
When setting the column widths in Sheet, if there was a single data row, the data rows columns were not included in the process of determining column width.

This meant that if you had a fairly short column header like 'Es' data would be hidden, if the data was longer than the header.

# Fix

I made sure that when there is a single data row, that it always gets included for column width setting.