### PR TITLE
Add protection for when soils come in with no name

### DIFF
--- a/ApsimNG/Presenters/SoilDownloadPresenter.cs
+++ b/ApsimNG/Presenters/SoilDownloadPresenter.cs
@@ -188,9 +188,12 @@ namespace UserInterface.Presenters
                         string fullName = await GetPlacenameFromLatLongAsync();
 
                         //remove the address at start of the name "This business is closed, Dalby"
-                        if (fullName.Contains(','))
-                            fullName = fullName.Substring(fullName.IndexOf(',') + 2);
-                        placeNameEditBox.Text = fullName;
+                        if (fullName != null)
+                        {
+                            if (fullName.Contains(','))
+                                fullName = fullName.Substring(fullName.IndexOf(',') + 2);
+                            placeNameEditBox.Text = fullName;
+                        }
 
                         // Use this to monitor task progress
                         Progress<ProgressReportModel> progress = new Progress<ProgressReportModel>();


### PR DESCRIPTION
resolves #8864

## Bug
Soils were being downloaded that did not contain a name. The names were being modified and if missing, caused a object reference exception.

## Fix
Put protection around the offending code.