### PR TITLE
Manager read only bug fix

### DIFF
--- a/ApsimNG/Interfaces/IEditorView.cs
+++ b/ApsimNG/Interfaces/IEditorView.cs
@@ -148,7 +148,14 @@ namespace UserInterface.Interfaces
         /// <summary>Gets or sets the widget visibility.</summary>
         bool Visible { get; set; }
 
-        /// <summary>Status of horizontal scrollbars' visibility.</summary>
-        bool IsVerticalScrollBarVisible();
+        /// <summary>
+        /// Hide the TextEditor
+        /// </summary>
+        public void Hide();
+
+        /// <summary>
+        /// Show the Text Editor
+        /// </summary>
+        public void Show();
     }
 }

--- a/ApsimNG/Interfaces/IEditorView.cs
+++ b/ApsimNG/Interfaces/IEditorView.cs
@@ -147,5 +147,8 @@ namespace UserInterface.Interfaces
 
         /// <summary>Gets or sets the widget visibility.</summary>
         bool Visible { get; set; }
+
+        /// <summary>Status of horizontal scrollbars' visibility.</summary>
+        bool IsVerticalScrollBarVisible();
     }
 }

--- a/ApsimNG/Views/EditorView.cs
+++ b/ApsimNG/Views/EditorView.cs
@@ -11,6 +11,8 @@ using UserInterface.Intellisense;
 using UserInterface.Interfaces;
 using Utility;
 using FontDescription = Pango.FontDescription;
+using APSIM.Shared.Documentation.Extensions;
+using System.Collections;
 
 namespace UserInterface.Views
 {
@@ -909,6 +911,20 @@ namespace UserInterface.Views
                 }
             };
             return null;
+        }
+
+        /// <summary>
+        /// Is vertical scroll bar visible?
+        /// </summary>
+        /// <returns></returns>
+        public bool IsVerticalScrollBarVisible()
+        {
+            if (scroller.AllChildren.Count() > 1)
+            {
+                // First Child is Vertical scrollbar.
+                return ((scroller.AllChildren as ArrayList)[1] as Scrollbar).ChildVisible;
+            }
+            return false;
         }
 
         /// <summary>

--- a/ApsimNG/Views/EditorView.cs
+++ b/ApsimNG/Views/EditorView.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -11,8 +10,6 @@ using UserInterface.Intellisense;
 using UserInterface.Interfaces;
 using Utility;
 using FontDescription = Pango.FontDescription;
-using APSIM.Shared.Documentation.Extensions;
-using System.Collections;
 
 namespace UserInterface.Views
 {
@@ -343,6 +340,8 @@ namespace UserInterface.Views
             
             textEditor = new SourceView();
             textEditor.DragDataReceived += TextEditorDragDataReceived;
+            textEditor.AutoIndent = true;
+            textEditor.InsertSpacesInsteadOfTabs = true;
             searchSettings = new SearchSettings();
             searchContext = new SearchContext(textEditor.Buffer, searchSettings);
 
@@ -695,7 +694,6 @@ namespace UserInterface.Views
         {
             try
             {
-                //textEditor.Document.ReadOnly = false;
                 textEditor.GrabFocus();
             }
             catch (Exception err)
@@ -914,17 +912,19 @@ namespace UserInterface.Views
         }
 
         /// <summary>
-        /// Is vertical scroll bar visible?
+        /// Hide the Text Editor
         /// </summary>
-        /// <returns></returns>
-        public bool IsVerticalScrollBarVisible()
+        public void Hide()
         {
-            if (scroller.AllChildren.Count() > 1)
-            {
-                // First Child is Vertical scrollbar.
-                return ((scroller.AllChildren as ArrayList)[1] as Scrollbar).ChildVisible;
-            }
-            return false;
+            textEditor.Visible = false;
+        }
+
+        /// <summary>
+        /// Show the Text Editor
+        /// </summary>
+        public void Show()
+        {
+            textEditor.Visible = true;
         }
 
         /// <summary>

--- a/ApsimNG/Views/ManagerView.cs
+++ b/ApsimNG/Views/ManagerView.cs
@@ -79,7 +79,7 @@ namespace UserInterface.Views
             }
 
             //default value for no cursor
-            if (cursor.ScrollH.Valid == false)
+            if (cursor.ScrollV.Valid == false)
             {
                 cursor = scriptEditor.Location;
                 notebook.Drawn -= OnDrawn;
@@ -88,7 +88,7 @@ namespace UserInterface.Views
 
             if (this.TabIndex == TAB_SCRIPT)
             {
-                if (cursor.ScrollH.Upper == scriptEditor.Location.ScrollH.Upper)
+                if (cursor.ScrollV.Upper == scriptEditor.Location.ScrollV.Upper)
                 {
                     scriptEditor.Location = cursor;
                     notebook.Drawn -= OnDrawn;

--- a/ApsimNG/Views/ManagerView.cs
+++ b/ApsimNG/Views/ManagerView.cs
@@ -70,10 +70,15 @@ namespace UserInterface.Views
             //This is required because the text is loaded in over time from a buffer, so big files
             //can take a while to completely load in. If we set the scrollbar too early, it scrolls
             //to the wrong position as more text is loaded.
+            //Checking if a vertical scrollbar makes it so long scripts are checked but short ones get made read only much quicker.
+            //There was an issues where short scripts would be stuck in read-only, if something like this was not checked.
             if (cursor == null)
                 cursor = CursorLocation;
 
-            if (drawCount < 40 && !(scriptEditor.Location.ScrollV.Upper == cursor.ScrollV.Upper && scriptEditor.Location.ScrollH.Upper == cursor.ScrollH.Upper))
+            if (drawCount < 40 && 
+                !(scriptEditor.Location.ScrollV.Upper == cursor.ScrollV.Upper && scriptEditor.Location.ScrollH.Upper == cursor.ScrollH.Upper) &&
+                scriptEditor.IsVerticalScrollBarVisible()
+                )
             {
                 drawCount += 1;
             } 
@@ -82,7 +87,9 @@ namespace UserInterface.Views
                 scriptEditor.ReadOnly = false;
                 notebook.Drawn -= OnDrawn;
                 if (cursor != null && this.TabIndex == TAB_SCRIPT)
+                {
                     scriptEditor.Location = cursor;
+                }
             }
         }
 


### PR DESCRIPTION
resolves #9278

This was a read-only issue.

This checks for a vertical scrollbar in the managers editor (meaning the script is quite long) and makes it do buffer checks before making text writable.
If however a manager's editor does not have a vertical scrollbar it will skip buffer checks and make the text writable.