### PR TITLE
9298 Add protection to GridPresenter

### DIFF
--- a/ApsimNG/Presenters/GridPresenter.cs
+++ b/ApsimNG/Presenters/GridPresenter.cs
@@ -433,8 +433,12 @@ namespace UserInterface.Presenters
         /// <param name="changedModel">The model with changes</param>
         private void OnModelChanged(object changedModel)
         {
-            dataProvider = ModelToSheetDataProvider.ToSheetDataProvider(changedModel as IModel);
-            Refresh();
+            IModel changed = changedModel as IModel;
+            if (changed != null)
+            {
+                dataProvider = ModelToSheetDataProvider.ToSheetDataProvider(changedModel as IModel);
+                Refresh();
+            }
         }
 
         /// <summary>Save the contents of the grid to the model.</summary>


### PR DESCRIPTION
Resolves #9298

CroptimizR property changes don't need to update the grid as it passes back a non-IModel. So this just adds some protection to the grid presenter so it doesn't try and update the grid with a type it can't handle.