### PR TITLE
9367 ISO Date fix

### DIFF
--- a/APSIM.Shared/Utilities/DateUtilities.cs
+++ b/APSIM.Shared/Utilities/DateUtilities.cs
@@ -85,7 +85,7 @@ namespace APSIM.Shared.Utilities
             rxYearShort = new Regex(@"^\d\d$"),
             rxDateNoSymbol = new Regex(@"^\d\d\w\w\w$|^\w\w\w\d\d$"),
             rxDateAllNums = new Regex(@"^\d\d?-\d\d?-(\d{4}|\d{2})$|^\d\d?-\d\d?$"),
-            rxISO = new Regex(@"^\d\d\d\d-\d\d-\d\d$|^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d$"),
+            rxISO = new Regex(@"^\d\d\d\d-\d?\d-\d?\d$|^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d$"),
             rxDateAndTime = new Regex(@"^(\d+)/(\d+)/(\d+)\s\d+:\d+:\d+\s*\w*$");
 
         /// <summary>

--- a/Tests/UnitTests/UtilityTests/DataUtilitiesTests.cs
+++ b/Tests/UnitTests/UtilityTests/DataUtilitiesTests.cs
@@ -29,8 +29,14 @@ namespace UnitTests.UtilityTests
             //ISO - test ISO format sperately
             string isoTest1 = $"2000-01-01T00:00:00";
             string isoTest2 = $"2000-01-01";
+            string isoTest3 = $"2000-1-01";
+            string isoTest4 = $"2000-01-1";
+            string isoTest5 = $"2000-1-1";
             Assert.That(DateUtilities.GetDate(isoTest1), Is.EqualTo(DateTime.Parse(isoTest1, null, DateTimeStyles.RoundtripKind)));
             Assert.That(DateUtilities.GetDate(isoTest2), Is.EqualTo(DateTime.Parse(isoTest2, null, DateTimeStyles.RoundtripKind)));
+            Assert.That(DateUtilities.GetDate(isoTest3), Is.EqualTo(DateTime.Parse(isoTest2, null, DateTimeStyles.RoundtripKind)));
+            Assert.That(DateUtilities.GetDate(isoTest4), Is.EqualTo(DateTime.Parse(isoTest2, null, DateTimeStyles.RoundtripKind)));
+            Assert.That(DateUtilities.GetDate(isoTest5), Is.EqualTo(DateTime.Parse(isoTest2, null, DateTimeStyles.RoundtripKind)));
 
             //check dates are trimmed
             string trimTest = $" 2000-01-01 ";


### PR DESCRIPTION
Resolves #9367 

The regex used for detecting an ISO date was not flexible enough to see it when 2000-1-1 zeros were missing from the month and day. Fixed that and added unit tests for that edge case.