### PR TITLE
9363 Converter for IntialWater storing "CropSoil" instead of "Crop

### DIFF
--- a/Models/Core/ApsimFile/Converter.cs
+++ b/Models/Core/ApsimFile/Converter.cs
@@ -24,7 +24,7 @@ namespace Models.Core.ApsimFile
     public class Converter
     {
         /// <summary>Gets the latest .apsimx file format version.</summary>
-        public static int LatestVersion { get { return 181; } }
+        public static int LatestVersion { get { return 182; } }
 
         /// <summary>Converts a .apsimx string to the latest version.</summary>
         /// <param name="st">XML or JSON string to convert.</param>
@@ -5778,6 +5778,29 @@ namespace Models.Core.ApsimFile
         {
             foreach (JObject leafCohortParametersObject in JsonUtilities.ChildrenRecursively(root, "Models.PMF.Organs.Leaf+LeafCohortParameters"))
                 leafCohortParametersObject["$type"] = leafCohortParametersObject["$type"].ToString().Replace("Models.PMF.Organs.Leaf+LeafCohortParameters", "Models.PMF.Organs.LeafCohortParameters");
+        }
+
+        /// <summary>
+        /// Renames Models.PMF.Organs.Leaf+LeafCohortParameters to Models.PMF.Organs.LeafCohortParameters.
+        /// LeafCohortParameters class was moved from the Leaf.cs to LeafCohortParameters.cs.
+        /// </summary>
+        /// <param name="root"></param>
+        /// <param name="fileName"></param>
+        private static void UpgradeToVersion182(JObject root, string fileName)
+        {
+            foreach (JToken water in JsonUtilities.ChildrenRecursively(root, "Water"))
+            {
+                JToken relTo = water.SelectToken("RelativeTo");
+                if (relTo != null)
+                {
+                    string cropsoil = water["RelativeTo"].ToString();
+                    if (cropsoil.EndsWith("Soil"))
+                    {
+                        cropsoil = cropsoil.Substring(0, cropsoil.Length-4);
+                        water["RelativeTo"] = cropsoil;
+                    }
+                }
+            }
         }
     }
     

--- a/Models/Resources/AGPBrowntop.json
+++ b/Models/Resources/AGPBrowntop.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/AGPCocksfoot.json
+++ b/Models/Resources/AGPCocksfoot.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/AGPKikuyu.json
+++ b/Models/Resources/AGPKikuyu.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/AGPLucerne.json
+++ b/Models/Resources/AGPLucerne.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/AGPPaspalum.json
+++ b/Models/Resources/AGPPaspalum.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/AGPPhalaris.json
+++ b/Models/Resources/AGPPhalaris.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/AGPRedClover.json
+++ b/Models/Resources/AGPRedClover.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/AGPRhodes.json
+++ b/Models/Resources/AGPRhodes.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/AGPRyegrass.json
+++ b/Models/Resources/AGPRyegrass.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/AGPTallFescue.json
+++ b/Models/Resources/AGPTallFescue.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/AGPWhiteClover.json
+++ b/Models/Resources/AGPWhiteClover.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Barley.json
+++ b/Models/Resources/Barley.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Canola.json
+++ b/Models/Resources/Canola.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Chickpea.json
+++ b/Models/Resources/Chickpea.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Chicory.json
+++ b/Models/Resources/Chicory.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Eucalyptus.json
+++ b/Models/Resources/Eucalyptus.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Fertiliser.json
+++ b/Models/Resources/Fertiliser.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/FodderBeet.json
+++ b/Models/Resources/FodderBeet.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Gliricidia.json
+++ b/Models/Resources/Gliricidia.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Grapevine.json
+++ b/Models/Resources/Grapevine.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Angus.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Angus.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Beef Shorthorn.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Beef Shorthorn.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Brahman.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Brahman.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/British x Brahman.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/British x Brahman.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/British x Charolais.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/British x Charolais.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/British x Friesian.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/British x Friesian.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/British x Holstein.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/British x Holstein.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Charolais x Friesian.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Charolais x Friesian.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Charolais x Holstein.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Charolais x Holstein.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Charolais.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Charolais.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Chianina.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Chianina.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Hereford.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Hereford.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Limousin.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Limousin.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Simmental.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Simmental.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/South Devon.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/South Devon.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Ujimqin Cattle.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Ujimqin Cattle.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Ujimqin x Angus (1st cross).json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Ujimqin x Angus (1st cross).json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Ujimqin x Angus (2nd cross).json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Ujimqin x Angus (2nd cross).json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Ujimqin x Charolais (1st cross).json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Ujimqin x Charolais (1st cross).json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Ujimqin x Charolais (2nd cross).json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Beef/Ujimqin x Charolais (2nd cross).json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Ayrshire.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Ayrshire.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Brown Swiss.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Brown Swiss.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Dairy Shorthorn.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Dairy Shorthorn.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Friesian.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Friesian.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Guernsey.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Guernsey.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Holstein.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Holstein.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Jersey.json
+++ b/Models/Resources/GrazPlan/Genotypes/Cattle/Dairy/Jersey.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Goats/Ujimqin Goats.json
+++ b/Models/Resources/GrazPlan/Genotypes/Goats/Ujimqin Goats.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Crossbreds/Border Leicester x Merino.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Crossbreds/Border Leicester x Merino.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Crossbreds/Dorset x Merino.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Crossbreds/Dorset x Merino.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Crossbreds/Mongolian x Merino.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Crossbreds/Mongolian x Merino.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Blackface x Whiteface.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Blackface x Whiteface.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Border Leicester.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Border Leicester.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Cheviot.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Cheviot.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Columbia.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Columbia.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Dorset.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Dorset.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Finnsheep.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Finnsheep.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Hampshire.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Hampshire.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Polypay.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Polypay.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Rambouillet.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Rambouillet.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Ryeland.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Ryeland.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Southdown (US).json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Southdown (US).json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Southdown.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Southdown.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Suffolk (US).json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Suffolk (US).json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Suffolk.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Suffolk.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Texel.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Texel.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Ujimqin Sheep.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Meat breeds/Ujimqin Sheep.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Corriedale.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Corriedale.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Delaine-Merino.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Delaine-Merino.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Large Merino.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Large Merino.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Medium Merino.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Medium Merino.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Polwarth.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Polwarth.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Romney.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Romney.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Small Merino.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Small Merino.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Targhee.json
+++ b/Models/Resources/GrazPlan/Genotypes/Sheep/Wool breeds/Targhee.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "ApsimVersion": "0.0.0.0",
   "Name": "Simulations",
   "Children": [

--- a/Models/Resources/Maize.json
+++ b/Models/Resources/Maize.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/MicroClimate.json
+++ b/Models/Resources/MicroClimate.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Mungbean.json
+++ b/Models/Resources/Mungbean.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Nutrient.json
+++ b/Models/Resources/Nutrient.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Oats.json
+++ b/Models/Resources/Oats.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/OilPalm.json
+++ b/Models/Resources/OilPalm.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Peanut.json
+++ b/Models/Resources/Peanut.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Pinus.json
+++ b/Models/Resources/Pinus.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/PlantainForage.json
+++ b/Models/Resources/PlantainForage.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Potato.json
+++ b/Models/Resources/Potato.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/RedClover.json
+++ b/Models/Resources/RedClover.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/SCRUM.json
+++ b/Models/Resources/SCRUM.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Slurp.json
+++ b/Models/Resources/Slurp.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Sorghum.json
+++ b/Models/Resources/Sorghum.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Soybean.json
+++ b/Models/Resources/Soybean.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Sugarcane.json
+++ b/Models/Resources/Sugarcane.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/SurfaceOrganicMatter.json
+++ b/Models/Resources/SurfaceOrganicMatter.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/WaterBalance.json
+++ b/Models/Resources/WaterBalance.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/Wheat.json
+++ b/Models/Resources/Wheat.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Models/Resources/WhiteClover.json
+++ b/Models/Resources/WhiteClover.json
@@ -1,7 +1,7 @@
 {
   "$type": "Models.Core.Simulations, Models",
   "ExplorerWidth": 0,
-  "Version": 181,
+  "Version": 182,
   "Name": "Simulations",
   "Children": [
     {

--- a/Tests/UnitTests/Core/ApsimFile/FileFormatTests.cs
+++ b/Tests/UnitTests/Core/ApsimFile/FileFormatTests.cs
@@ -11,6 +11,7 @@
     using System.IO;
     using System.Reflection;
     using System.Linq;
+    using APSIM.Shared.Extensions.Collections;
 
     /// <summary>
     /// Test the writer's load/save .apsimx capability 
@@ -133,6 +134,22 @@
 
             int result = Models.Program.Main(new[] { fileName });
             Assert.That(result, Is.EqualTo(1));
+        }
+
+        /// <summary>Test that the example files can be loaded and saved without error.</summary>
+        [Test]
+        public void LoadAndSaveExamples()
+        {
+            bool allFilesHaveRootReference = true;
+            string binDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            string exampleFileDirectory = Path.GetFullPath(Path.Combine(binDirectory, "..", "..", "..", "Examples"));
+            IEnumerable<string> exampleFileNames = Directory.GetFiles(exampleFileDirectory, "*.apsimx", SearchOption.AllDirectories);
+            foreach (string exampleFile in exampleFileNames)
+            {
+                Simulations sim = FileFormat.ReadFromFile<Simulations>(exampleFile, e => throw new Exception(), false).NewModel as Simulations;
+                FileFormat.WriteToString(sim);
+            }
+            Assert.That(allFilesHaveRootReference, Is.True);
         }
     }
 }

--- a/Tests/UnitTests/Weather/WeatherTests.cs
+++ b/Tests/UnitTests/Weather/WeatherTests.cs
@@ -197,7 +197,7 @@ namespace UnitTests.Weather
             bool allFilesHaveRootReference = true;
             string binDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             string exampleFileDirectory = Path.GetFullPath(Path.Combine(binDirectory, "..", "..", "..", "Examples"));
-            IEnumerable<string> exampleFileNames = Directory.GetFiles(exampleFileDirectory, "*.apsimx");
+            IEnumerable<string> exampleFileNames = Directory.GetFiles(exampleFileDirectory, "*.apsimx", SearchOption.AllDirectories);
             foreach (string exampleFile in exampleFileNames)
             {
                 Simulations sim = FileFormat.ReadFromFile<Simulations>(exampleFile, e => throw new Exception(), false).NewModel as Simulations;


### PR DESCRIPTION
Resolves #9363

A couple of the examples would crash when saving, meaning they couldn't be run through the GUI. This has a converter to fix the bug, and a new unit test to check that the examples can be saved without an error.