### PR TITLE
9355 Add EndCrop functionality to OilPalm

### DIFF
--- a/Models/PMF/OilPalm/OilPalm.cs
+++ b/Models/PMF/OilPalm/OilPalm.cs
@@ -153,14 +153,6 @@ namespace Models.PMF.OilPalm
             Clear();
         }
 
-        /// <summary>Clears this instance.</summary>
-        private void Clear()
-        {
-            SowingData = new SowingParameters();
-            plant_status = "out";
-            CropInGround = false;
-        }
-
         /// <summary>The plant_status</summary>
         [JsonIgnore]
         public string plant_status = "out";
@@ -719,6 +711,15 @@ namespace Models.PMF.OilPalm
         [EventSubscribe("Commencing")]
         private void OnSimulationCommencing(object sender, EventArgs e)
         {
+            Clear();
+        }
+
+        /// <summary>Clears this instance.</summary>
+        private void Clear()
+        {
+            plant_status = "out";
+            CropInGround = false;
+
             //zero public properties
             CumulativeFrondNumber = 0;
             CumulativeBunchNumber = 0;

--- a/Models/PMF/OilPalm/OilPalm.cs
+++ b/Models/PMF/OilPalm/OilPalm.cs
@@ -129,9 +129,37 @@ namespace Models.PMF.OilPalm
 
         /// <summary>Returns true if the crop is ready for harvesting</summary>
         public bool IsReadyForHarvesting { get { return false; } }
+        
+        /// <summary>Occurs when a plant is ended via EndCrop.</summary>
+        public event EventHandler PlantEnding;
 
-        /// <summary>End the crop</summary>
-        public void EndCrop() { }
+        /// <summary>The summary</summary>
+        [Link]
+        private ISummary summary = null;
+
+        /// <summary>End the crop.</summary>
+        public void EndCrop()
+        {
+            if (IsAlive == false)
+                throw new Exception("EndCrop method called when no crop is planted.  Either your planting rule is not working or your end crop is happening at the wrong time");
+            summary.WriteMessage(this, "Crop ending", MessageType.Information);
+
+            // Undo cultivar changes.
+            cultivarDefinition.Unapply();
+            // Invoke a plant ending event.
+            if (PlantEnding != null)
+                PlantEnding.Invoke(this, new EventArgs());
+
+            Clear();
+        }
+
+        /// <summary>Clears this instance.</summary>
+        private void Clear()
+        {
+            SowingData = new SowingParameters();
+            plant_status = "out";
+            CropInGround = false;
+        }
 
         /// <summary>The plant_status</summary>
         [JsonIgnore]


### PR DESCRIPTION
Resolves #9355

Using the EndCrop functionality in Plant.cs, I adapted a version to work with the OilPalm model so that the crop can be ended in a way similar to other crops.

I then tested it using the OilPalm example to plant, endcrop and then a few years later, sow a new OilPalm to check that it functioned correctly and reset with a new crop on the 2nd sowing.

It seems to work for me, but definitely needs checking over in case I missed something important.