### PR TITLE
Update package references for MessagePack in required projects

### DIFF
--- a/APSIM.Server/ZMQ+msgpack/APSIM.ZMQServer.csproj
+++ b/APSIM.Server/ZMQ+msgpack/APSIM.ZMQServer.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>  
 
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="2.5.108" />
+    <PackageReference Include="MessagePack" Version="2.5.187" />
     <PackageReference Include="NetMQ" Version="4.0.1.12" />
     <ProjectReference Include="../../Models/Models.csproj" />
     <ProjectReference Include="../../APSIM.Shared/APSIM.Shared.csproj" />

--- a/Models/Models.csproj
+++ b/Models/Models.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="NetMQ" Version="4.0.1.12" />
-    <PackageReference Include="MessagePack" Version="2.5.108" />
+    <PackageReference Include="MessagePack" Version="2.5.187" />
     <ProjectReference Include="..\APSIM.Shared\APSIM.Shared.csproj" />
     <PackageReference Include="System.Windows.Extensions" Version="6.0.0.0" />
     <PackageReference Include="ExcelDataReader.DataSet" Version="3.6.0" />


### PR DESCRIPTION
resolves #9387
resolves #9384

A missing package update was not allowing APSIM to build. This fixes the error that prevented building.