### PR TITLE
9352 Graph Size options

### DIFF
--- a/ApsimNG/Utility/Configuration.cs
+++ b/ApsimNG/Utility/Configuration.cs
@@ -2,6 +2,9 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
+using System.Linq;
+using APSIM.Shared.Documentation.Extensions;
+using APSIM.Shared.Utilities;
 using Models.Core;
 
 namespace Utility
@@ -87,6 +90,10 @@ namespace Utility
         [Input("Enable graph debugging output")]
         [Tooltip("Outputs messages in the status bar if data is missing, is outside axis bounds or is NaN. Useful for debugging Observed/Predicted graphs.")]
         public bool EnableGraphDebuggingMessages { get; set; } = false;
+
+        [Input("Graph Size")]
+        [Tooltip("The picture resolution of graph when copied to the clipboard. Width by Height.")]
+        public string GraphSize { get; set; } = "800x600";
 
         /// <summary>Return the name of the summary file JPG.</summary>
         public string SummaryPngFileName
@@ -186,6 +193,28 @@ namespace Utility
         public ApsimFileMetadata GetMruFile(string fileName)
         {
             return MruList.Find(f => f.FileName == fileName);
+        }
+
+        public (int, int) GetGraphSize()
+        {
+            try 
+            {
+                string input = GraphSize.Trim();
+                string[] parts = input.Split("x", StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length == 1)
+                    parts = input.Split(",", StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length == 1)
+                    parts = input.Split("/", StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length == 1)
+                    parts = input.Split(" ", StringSplitOptions.RemoveEmptyEntries);
+                int width = int.Parse(parts[0]);
+                int height = int.Parse(parts[1]);
+                return (width, height);
+            }
+            catch
+            {
+                return (800, 600);
+            }
         }
 
         /// <summary>Add a filename to the list.</summary>

--- a/ApsimNG/Utility/SettingsDialog.cs
+++ b/ApsimNG/Utility/SettingsDialog.cs
@@ -104,6 +104,8 @@ namespace UserInterface.Views
             {
                 if (property.PropertyType == typeof(bool))
                     displayType = PropertyType.Checkbox;
+                else if (property.PropertyType == typeof(string))
+                    displayType = PropertyType.SingleLineText;
                 else if (ReflectionUtilities.IsNumericType(property.PropertyType))
                     displayType = PropertyType.Numeric;
                 else

--- a/ApsimNG/Views/GraphView.cs
+++ b/ApsimNG/Views/GraphView.cs
@@ -1363,7 +1363,10 @@ namespace UserInterface.Views
         public void ExportToClipboard()
         {
             string fileName = Path.ChangeExtension(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()), ".png");
-            PngExporter.Export(plot1.Model, fileName, 800, 600, new Cairo.SolidPattern(new Cairo.Color(BackColor.R / 255.0, BackColor.G / 255.0, BackColor.B / 255.0, 1), false));
+            (int, int) size = Configuration.Settings.GetGraphSize();
+            int width = size.Item1;
+            int height = size.Item2;
+            PngExporter.Export(plot1.Model, fileName, width, height, new Cairo.SolidPattern(new Cairo.Color(BackColor.R / 255.0, BackColor.G / 255.0, BackColor.B / 255.0, 1), false));
             Clipboard cb = MainWidget.GetClipboard(Gdk.Selection.Clipboard);
             cb.Image = new Gdk.Pixbuf(fileName);
         }


### PR DESCRIPTION
Resolves #9352

Adds a graph size option into the settings menu (settings are in the top bar on the first screen in apsimng). This then defines how big the graph should be when copied out of apsim.

Considered a few options for this, but this is the easiest way to make it completely customizable for whatever size and formatting users want in their graph, and still making it consistent every time they copy a graph. It will still default to 800x600 currently, but that can now be changed.