### PR TITLE
Fix how to contribute link from the contribute menu page

### DIFF
--- a/Docs/content/Contribute/_index.md
+++ b/Docs/content/Contribute/_index.md
@@ -7,4 +7,4 @@ weight: 20
 * [Compile](/contribute/compile)
 * [Modify the website](/contribute/modifywebsite/changewebsite)
 * [Move model into release](/contribute/movemodeltorelease)
-* [How to contribute](/contribute/howtocontribute)
+* [How to contribute](/contribute/howtocontribute/howtocontribute)


### PR DESCRIPTION
resolves #9451 

Fixes the Contribute menu link to how to contribute page.
Thanks for spotting this @BrianCollinss 