### PR TITLE
Fixes missing harvest of 2nd crop in mixed cropping (CLEM)

### DIFF
--- a/Models/CLEM/Activities/CLEMActivityBase.cs
+++ b/Models/CLEM/Activities/CLEMActivityBase.cs
@@ -853,7 +853,7 @@ namespace Models.CLEM.Activities
                                 }
                             }
 
-                            errorMessage = $"Insufficient resources for [a={this.NameWithParent}] with [Report error and stop] selected when resource shortfall occurs";
+                            errorMessage = $"Insufficient resources [r={string.Join(", ", shortfallsToTransmute.Select(a => (a.Resource as CLEMModel).NameWithParent))}] for [a={this.NameWithParent}] with [Report error and stop] selected when resource shortfall occurs";
                             Warnings.CheckAndWrite(errorMessage, Summary, this, MessageType.Error);
                             throw new ApsimXException(this, errorMessage);
                         case OnPartialResourcesAvailableActionTypes.SkipActivity:

--- a/Models/CLEM/Activities/CLEMActivityBase.cs
+++ b/Models/CLEM/Activities/CLEMActivityBase.cs
@@ -568,7 +568,9 @@ namespace Models.CLEM.Activities
                         // get all companion models except filter groups
                         foreach (IActivityCompanionModel companionChild in FindAllChildren<IActivityCompanionModel>().Where(a => identifier != "" ? (a.Identifier ?? "") == identifier : true))
                         {
-                            (companionChild as CLEMActivityBase).Status = ActivityStatus.Ignored; 
+                            if (companionChild is CLEMActivityBase cChild)
+                                cChild.Status = ActivityStatus.Ignored;
+                            companionChild.PrepareForTimestep();
                         }
                     }
 
@@ -589,7 +591,8 @@ namespace Models.CLEM.Activities
                                 var unitsProvided = ValueForCompanionModel(companionChild);
                                 if (MathUtilities.IsPositive(unitsProvided))
                                 {
-                                    (companionChild as CLEMActivityBase).Status = ActivityStatus.Success;
+                                    if (companionChild is CLEMActivityBase cChild)
+                                        cChild.Status = ActivityStatus.Success;
                                     foreach (ResourceRequest request in companionChild.RequestResourcesForTimestep(unitsProvided))
                                     {
                                         if(request.ActivityModel is null)

--- a/Models/CLEM/Activities/CropActivityManageProduct.cs
+++ b/Models/CLEM/Activities/CropActivityManageProduct.cs
@@ -157,7 +157,7 @@ namespace Models.CLEM.Activities
         /// Flag for determining if this crop is currently being managed in cropping system e.g. rotation
         /// </summary>
         [JsonIgnore]
-        public bool CurrentlyManaged { get; set; }
+        public bool CurrentlyManaged { get; set; } = true;
 
         /// <summary>
         /// Constructor
@@ -214,7 +214,6 @@ namespace Models.CLEM.Activities
                 // set manager of graze food store if linked
                 (LinkedResourceItem as GrazeFoodStoreType).Manager = Parent as IPastureManager;
                 addReason = "Growth";
-
             }
 
             // look up tree until we find a parent to allow nested crop products for rotate vs mixed cropping/products
@@ -511,7 +510,6 @@ namespace Models.CLEM.Activities
                 var tagsShort = shortfalls.Where(a => a.CompanionModelDetails.identifier == "").FirstOrDefault();
                 if (tagsShort != null)
                     amountToSkip = Convert.ToInt32(amountToDo * (1 - tagsShort.Available / tagsShort.Required));
-
                 this.Status = ActivityStatus.Partial;
             }
 
@@ -528,7 +526,6 @@ namespace Models.CLEM.Activities
 
                 limiter.AddWeightCarried(AmountHarvested);
             }
-
         }
 
         /// <inheritdoc/>

--- a/Models/CLEM/Activities/LabourActivityTask.cs
+++ b/Models/CLEM/Activities/LabourActivityTask.cs
@@ -4,6 +4,7 @@ using Models.CLEM.Interfaces;
 using System;
 using System.Collections.Generic;
 using Models.Core.Attributes;
+using System.Linq;
 
 namespace Models.CLEM.Activities
 {
@@ -20,19 +21,14 @@ namespace Models.CLEM.Activities
     [Version(1, 0, 1, "")]
     public class LabourActivityTask : CLEMActivityBase, IHandlesActivityCompanionModels
     {
+        private double amountToSkip = 0;
+
         /// <summary>
         /// Constructor
         /// </summary>
         public LabourActivityTask()
         {
             this.SetDefaults();
-        }
-
-        /// <inheritdoc/>
-        public override List<ResourceRequest> RequestResourcesForTimestep(double argument = 0)
-        {
-            List<ResourceRequest> resourcesNeeded = null;
-            return resourcesNeeded;
         }
 
         /// <inheritdoc/>
@@ -51,6 +47,50 @@ namespace Models.CLEM.Activities
                     return new LabelsForCompanionModels();
             }
         }
+
+        /// <inheritdoc/>
+        public override List<ResourceRequest> RequestResourcesForTimestep(double argument = 0)
+        {
+            amountToSkip = 0;
+
+            // provide updated measure for companion models
+            foreach (var valueToSupply in valuesForCompanionModels)
+            {
+                switch (valueToSupply.Key.unit)
+                {
+                    case "fixed":
+                        valuesForCompanionModels[valueToSupply.Key] = 1;
+                        break;
+                    default:
+                        throw new NotImplementedException(UnknownUnitsErrorText(this, valueToSupply.Key));
+                }
+            }
+            return null;
+        }
+
+
+        /// <inheritdoc/>
+        protected override void AdjustResourcesForTimestep()
+        {
+            IEnumerable<ResourceRequest> shortfalls = MinimumShortfallProportion();
+            if (shortfalls.Any())
+            {
+                // find shortfall by identifiers as these may have different influence on outcome
+                var tagsShort = shortfalls.Where(a => a.CompanionModelDetails.identifier == "").FirstOrDefault();
+                //if (tagsShort != null)
+                amountToSkip = (1 - tagsShort.Available / tagsShort.Required);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void PerformTasksForTimestep(double argument = 0)
+        {
+            if (ResourceRequestList.Any())
+            {
+                SetStatusSuccessOrPartial(amountToSkip > 0);
+            }
+        }
+
 
     }
 }

--- a/Models/CLEM/Activities/PastureActivityManage.cs
+++ b/Models/CLEM/Activities/PastureActivityManage.cs
@@ -244,7 +244,7 @@ namespace Models.CLEM.Activities
                     ResourceType = typeof(Land),
                     ResourceTypeName = LandTypeNameToUse.Split('.').Last(),
                     ActivityModel = this,
-                    Category = TransactionCategory,
+                    Category = UseAreaAvailable? "Assign unallocated": TransactionCategory,
                     FilterDetails = null
                 }
             };

--- a/Models/CLEM/Activities/ResourceActivityProcess.cs
+++ b/Models/CLEM/Activities/ResourceActivityProcess.cs
@@ -96,6 +96,7 @@ namespace Models.CLEM.Activities
         public override List<ResourceRequest> RequestResourcesForTimestep(double argument = 0)
         {
             List<ResourceRequest> resourcesNeeded = new List<ResourceRequest>();
+            resourceRequest = null;
 
             amountToSkip = 0;
             amountToDo = resourceTypeProcessModel.Amount;

--- a/Models/CLEM/Activities/RuminantActivityMove.cs
+++ b/Models/CLEM/Activities/RuminantActivityMove.cs
@@ -21,6 +21,7 @@ namespace Models.CLEM.Activities
     [ValidParent(ParentType = typeof(ActivitiesHolder))]
     [ValidParent(ParentType = typeof(ActivityFolder))]
     [Description("Define the location (pastures) of specified individuals (move) and assign location at the start of the simulation")]
+    [Version(1, 0, 3, "Includes ability to select timing of activity within the time-step")]
     [Version(1, 0, 2, "Now allows multiple RuminantFilterGroups to identify individuals to be moved")]
     [Version(1, 0, 1, "")]
     [HelpUri(@"Content/Features/Activities/Ruminant/RuminantMove.htm")]

--- a/Models/CLEM/Common.cs
+++ b/Models/CLEM/Common.cs
@@ -965,6 +965,25 @@ namespace Models.CLEM
     }
 
     /// <summary>
+    /// Activity timing within time-step
+    /// </summary>
+    public enum WithinTimeStepTimingStyle
+    {
+        /// <summary>
+        /// Early in ythe time-step before related activities
+        /// </summary>
+        Early,
+        /// <summary>
+        /// Perform at GetResourcesRequired with other competing activities
+        /// </summary>
+        Normal,
+        /// <summary>
+        /// Late in the time-step after related activites
+        /// </summary>
+        Late
+    }
+
+    /// <summary>
     /// A list of labels used for communication between an activity and companion models
     /// </summary>
     [Serializable]

--- a/Models/CLEM/Groupings/RuminantFeedGroup.cs
+++ b/Models/CLEM/Groupings/RuminantFeedGroup.cs
@@ -157,7 +157,7 @@ namespace Models.CLEM.Groupings
                 ResourceTypeName = feedActivityParent.FeedTypeName,
                 ActivityModel = Parent as CLEMActivityBase,
                 Category = (Parent as CLEMActivityBase).TransactionCategory,
-                RelatesToResource = feedActivityParent.PredictedHerdNameToDisplay,
+                RelatesToResource = Name, //feedActivityParent.PredictedHerdNameToDisplay,
                 AdditionalDetails = foodPacket
             };
 

--- a/Models/CLEM/Resources/LandType.cs
+++ b/Models/CLEM/Resources/LandType.cs
@@ -166,12 +166,12 @@ namespace Models.CLEM.Resources
 
                 ReportTransaction(TransactionType.Gain, amountAdded, activity, relatesToResource, category, this);
 
-                if (category != "Initialise")
+                if (category != "Starting value")
                 {
                     UpdateLandAllocatedList(activity, amountAdded, true);
                     // adjust activity using all remaining land as well.
                     if (ActivityRequestingRemainingLand != null && ActivityRequestingRemainingLand != activity)
-                        UpdateLandAllocatedList(ActivityRequestingRemainingLand, amountAdded, true);
+                        UpdateLandAllocatedList(ActivityRequestingRemainingLand, amountAdded, false);
                 }
             }
         }
@@ -203,12 +203,13 @@ namespace Models.CLEM.Resources
 
             request.Provided = amountRemoved;
 
-            ReportTransaction(TransactionType.Loss, amountRemoved, request.ActivityModel, request.RelatesToResource, request.Category, this);
+            if (request.Category != "Assign unallocated")
+                ReportTransaction(TransactionType.Loss, amountRemoved, request.ActivityModel, request.RelatesToResource, request.Category, this);
 
             UpdateLandAllocatedList(request.ActivityModel, amountRemoved, false);
             // adjust activity using all remaining land as well.
             if (ActivityRequestingRemainingLand != null && ActivityRequestingRemainingLand != request.ActivityModel)
-                UpdateLandAllocatedList(ActivityRequestingRemainingLand, amountRemoved, false);
+                UpdateLandAllocatedList(ActivityRequestingRemainingLand, amountRemoved, true);
         }
 
         /// <summary>


### PR DESCRIPTION
Resolves #9456
This fixes a missing harvest of a mixed/intercrop 2nd crop while labour allocation was ok
It also addresses an issue where an activity requested land after another activity was assigned all unallocated land.