### PR TITLE
9493 Restore code to generate old docs files

### DIFF
--- a/APSIM.Documentation/WebDocs.cs
+++ b/APSIM.Documentation/WebDocs.cs
@@ -83,7 +83,7 @@ namespace APSIM.Documentation
             else
                 throw new Exception($"Provided name \"{name}\", does not match any validation folders or tutorial files.");
 
-            Simulations sims = FileFormat.ReadFromFile<Simulations>(path, e => throw e, false).NewModel as Simulations;
+            Simulations sims = FileFormat.ReadFromFile<Simulations>(path, e => throw e, true).NewModel as Simulations;
             return GenerateWeb(sims);
         }
 


### PR DESCRIPTION
Resolves #9493

Need to keep the code for generating the old docs files until we are ready to put the new server live, otherwise the netlify site breaks.