### PR TITLE
9480 Link Physical for WIERDO gui

### DIFF
--- a/Models/Soils/MultiPoreWater/WEIRDO.cs
+++ b/Models/Soils/MultiPoreWater/WEIRDO.cs
@@ -142,7 +142,10 @@ namespace Models.Soils
         {
             get
             {
-                return APSoilUtilities.CalcPAWC(soilPhysical.Thickness, soilPhysical.LL15, soilPhysical.DUL, null);
+                IPhysical physical = soilPhysical;
+                if (physical == null) //So that the GUI can find physical when calling this
+                    physical = FindAncestor<Soil>()?.FindDescendant<IPhysical>() ?? FindInScope<IPhysical>();
+                return APSoilUtilities.CalcPAWC(physical.Thickness, physical.LL15, physical.DUL, null);
             }
         }
 
@@ -165,7 +168,15 @@ namespace Models.Soils
         [Units("mm")]
         [Display(Format = "N0", ShowTotal = true)]
         [JsonIgnore]
-        public double[] PAWCmm { get { return MathUtilities.Multiply(PAWC, soilPhysical.Thickness); } }
+        public double[] PAWCmm { 
+            get 
+            { 
+                IPhysical physical = soilPhysical;
+                if (physical == null) //So that the GUI can find physical when calling this
+                    physical = FindAncestor<Soil>()?.FindDescendant<IPhysical>() ?? FindInScope<IPhysical>();
+                return MathUtilities.Multiply(PAWC, physical.Thickness); 
+            } 
+        }
 
         /// <summary>Plant available water SW-LL15 (mm/mm).</summary>
         [Units("mm/mm")]


### PR DESCRIPTION
Resolves #9480

The gui has to call the PAWC and PAWCmm properties in weirdo, but these won't work if the model isn't linked. Following the same structure as the Water model (which also has this problem), if the model isn't linked it will find the Physical model it needs when the gui asks for it.