### PR TITLE
9495 InitialiseModel now controls Manager scripts being compiled at init

### DIFF
--- a/APSIM.Documentation/WebDocs.cs
+++ b/APSIM.Documentation/WebDocs.cs
@@ -83,7 +83,7 @@ namespace APSIM.Documentation
             else
                 throw new Exception($"Provided name \"{name}\", does not match any validation folders or tutorial files.");
 
-            Simulations sims = FileFormat.ReadFromFile<Simulations>(path, e => throw e, false).NewModel as Simulations;
+            Simulations sims = FileFormat.ReadFromFile<Simulations>(path, e => throw e, false, compileManagerScripts: false).NewModel as Simulations;
             return GenerateWeb(sims);
         }
 

--- a/APSIM.Documentation/WebDocs.cs
+++ b/APSIM.Documentation/WebDocs.cs
@@ -83,7 +83,7 @@ namespace APSIM.Documentation
             else
                 throw new Exception($"Provided name \"{name}\", does not match any validation folders or tutorial files.");
 
-            Simulations sims = FileFormat.ReadFromFile<Simulations>(path, e => throw e, true).NewModel as Simulations;
+            Simulations sims = FileFormat.ReadFromFile<Simulations>(path, e => throw e, false).NewModel as Simulations;
             return GenerateWeb(sims);
         }
 

--- a/Models/Core/ApsimFile/FileFormat.cs
+++ b/Models/Core/ApsimFile/FileFormat.cs
@@ -116,9 +116,9 @@ namespace Models.Core.ApsimFile
 
             // Call created in all models.
             if (initInBackground)
-                Task.Run(() => InitialiseModel(newModel, errorHandler));
+                Task.Run(() => InitialiseModel(newModel, errorHandler, true));
             else
-                InitialiseModel(newModel, errorHandler);
+                InitialiseModel(newModel, errorHandler, false);
 
             converter.NewModel = newModel;
 
@@ -130,7 +130,8 @@ namespace Models.Core.ApsimFile
         /// </summary>
         /// <param name="newModel"></param>
         /// <param name="errorHandler"></param>
-        public static void InitialiseModel(IModel newModel, Action<Exception> errorHandler)
+        /// <param name="compileManagers"></param>
+        public static void InitialiseModel(IModel newModel, Action<Exception> errorHandler, bool compileManagers = true)
         {
             List<Simulation> simulationList = newModel.FindAllDescendants<Simulation>().ToList();
             foreach (Simulation simulation in simulationList)
@@ -142,6 +143,10 @@ namespace Models.Core.ApsimFile
                     try
                     {
                         model.OnCreated();
+
+                        if (compileManagers)
+                            if (model is Manager manager)
+                                manager.RebuildScriptModel();
                     }
                     catch (Exception err)
                     {

--- a/Models/Core/ApsimFile/FileFormat.cs
+++ b/Models/Core/ApsimFile/FileFormat.cs
@@ -55,7 +55,8 @@ namespace Models.Core.ApsimFile
         /// <param name="fileName">Name of the file.</param>
         /// <param name="errorHandler">Action to be taken when an error occurs.</param>
         /// <param name="initInBackground">Iff set to true, the models' OnCreated() method calls will occur in a background thread.</param>
-        public static ConverterReturnType ReadFromFile<T>(string fileName, Action<Exception> errorHandler, bool initInBackground) where T : IModel
+        /// <param name="compileManagerScripts">If set to true, manager scripts will be compiled as it is loaded. Defaults to true</param>
+        public static ConverterReturnType ReadFromFile<T>(string fileName, Action<Exception> errorHandler, bool initInBackground, bool compileManagerScripts = true) where T : IModel
         {
             try
             {
@@ -63,7 +64,7 @@ namespace Models.Core.ApsimFile
                     throw new Exception("Cannot read file: " + fileName + ". File does not exist.");
 
                 string contents = File.ReadAllText(fileName);
-                var converter = ReadFromString<T>(contents, errorHandler, initInBackground, fileName);
+                var converter = ReadFromString<T>(contents, errorHandler, initInBackground, fileName, compileManagerScripts: compileManagerScripts);
                 var newModel = converter.NewModel;
 
                 if (newModel is Simulations)
@@ -84,7 +85,8 @@ namespace Models.Core.ApsimFile
         /// <param name="errorHandler">Action to be taken when an error occurs.</param>
         /// <param name="initInBackground">Iff set to true, the models' OnCreated() method calls will occur in a background thread.</param>
         /// <param name="fileName">The optional filename where the string came from. This is required by the converter, when it needs to modify the .db file.</param>
-        public static ConverterReturnType ReadFromString<T>(string st, Action<Exception> errorHandler, bool initInBackground, string fileName = null) where T : IModel
+        /// <param name="compileManagerScripts">If set to true, manager scripts will be compiled as it is loaded. Defaults to true</param>
+        public static ConverterReturnType ReadFromString<T>(string st, Action<Exception> errorHandler, bool initInBackground, string fileName = null, bool compileManagerScripts = true) where T : IModel
         {
             // Run the converter.
             var converter = Converter.DoConvert(st, -1, fileName);
@@ -116,9 +118,9 @@ namespace Models.Core.ApsimFile
 
             // Call created in all models.
             if (initInBackground)
-                Task.Run(() => InitialiseModel(newModel, errorHandler, true));
+                Task.Run(() => InitialiseModel(newModel, errorHandler, compileManagerScripts));
             else
-                InitialiseModel(newModel, errorHandler, false);
+                InitialiseModel(newModel, errorHandler, compileManagerScripts);
 
             converter.NewModel = newModel;
 

--- a/Models/Core/Run/SimulationGroup.cs
+++ b/Models/Core/Run/SimulationGroup.cs
@@ -259,6 +259,11 @@ namespace Models.Core.Run
                             throw new Exception($"Duplicate soils found in zone: {zone.FullPath}");
                     }
 
+                    //check if a manager scripts needs compiling
+                    foreach (Manager manager in relativeTo.FindAllDescendants<Manager>().ToList())
+                        if (!manager.SuccessfullyCompiledLast)
+                            manager.RebuildScriptModel();
+
                     // Publish BeginRun event.
                     var e = new Events(rootModel);
                     e.Publish("BeginRun", new object[] { this, new EventArgs() });

--- a/Models/Management/Manager.cs
+++ b/Models/Management/Manager.cs
@@ -137,7 +137,6 @@ namespace Models
         public override void OnCreated()
         {
             base.OnCreated();
-            RebuildScriptModel(true);
         }
 
         /// <summary>
@@ -151,7 +150,7 @@ namespace Models
             if (Enabled && ScriptModel != null)
             {
                 // throw an exception to stop simulations from running with an old binary
-                if (ScriptModel != null && SuccessfullyCompiledLast == false)
+                if (SuccessfullyCompiledLast == false)
                     throw new Exception("Errors found in manager model " + Name);
                 GetParametersFromScriptModel();
                 SetParametersInScriptModel();

--- a/Models/Management/Manager.cs
+++ b/Models/Management/Manager.cs
@@ -122,7 +122,7 @@ namespace Models
         /// Prevents an old binary brom being used if the last compile had errors
         /// </summary>
         [JsonIgnore]
-        private bool SuccessfullyCompiledLast { get; set; } = false;
+        public bool SuccessfullyCompiledLast { get; private set; } = false;
 
         /// <summary>
         /// Stores errors that were generated the last time the script was compiled.

--- a/Tests/UnitTests/Manager/ManagerTests.cs
+++ b/Tests/UnitTests/Manager/ManagerTests.cs
@@ -442,12 +442,14 @@ namespace UnitTests.ManagerTests
             //shouldn't throw, but shouldn't load any script
             testManager = createManager(true, false, false, false);
             Assert.DoesNotThrow(() => testManager.OnCreated());
+            Assert.DoesNotThrow(() => testManager.RebuildScriptModel());
             Assert.DoesNotThrow(() => testManager.GetParametersFromScriptModel());
             Assert.That(testManager.Parameters.Count, Is.EqualTo(0));
 
             //should compile the script
             testManager = createManager(true, false, true, false);
             Assert.DoesNotThrow(() => testManager.OnCreated());
+            Assert.DoesNotThrow(() => testManager.RebuildScriptModel());
             Assert.DoesNotThrow(() => testManager.GetParametersFromScriptModel());
             Assert.That(testManager.Parameters.Count, Is.EqualTo(1));
         }
@@ -477,7 +479,7 @@ namespace UnitTests.ManagerTests
             testManager = createManager(true, false, false, false);
             testManager.OnCreated();
             Assert.DoesNotThrow(() => testManager.RebuildScriptModel());
-            Assert.That(testManager.Parameters.Count, Is.EqualTo(0));
+            Assert.That(testManager.Parameters, Is.Null);
 
             //should not compile if code is empty
             testManager = createManager(true, false, false, false);
@@ -489,8 +491,6 @@ namespace UnitTests.ManagerTests
             //should throw error if broken code
             testManager = createManager(true, false, true, false);
             Assert.Throws<Exception>(() => testManager.Code = testManager.Code.Replace("{", ""));
-            Assert.Throws<Exception>(() => testManager.OnCreated());
-            Assert.Throws<Exception>(() => testManager.RebuildScriptModel());
             Assert.That(testManager.Parameters, Is.Null);
         }
 
@@ -634,8 +634,6 @@ namespace UnitTests.ManagerTests
         {
             Manager testManager = createManager(true, true, true, true);
             Assert.Throws<Exception>(() => testManager.Code = "public class Script : Model {}");
-            Assert.Throws<Exception>(() => testManager.OnCreated());
-            Assert.Throws<Exception>(() => testManager.RebuildScriptModel());
             Assert.That(testManager.Errors.Split('\n').Length, Is.EqualTo(3));
         }
 
@@ -690,6 +688,20 @@ namespace UnitTests.ManagerTests
             string code = testManager.Code;
             testManager.Reformat();
             Assert.That(testManager.Code, Is.EqualTo(code));
+        }
+
+        /// <summary>
+        /// Specific test for SuccessfullyCompiledLast
+        /// Check that it is false before compiling, true after
+        /// </summary>
+        [Test]
+        public void SuccessfullyCompiledLastTests()
+        {
+            Manager testManager = createManager(true, true, false, false);
+            Assert.That(testManager.SuccessfullyCompiledLast, Is.False);
+
+            testManager = createManager(true, true, true, true);
+            Assert.That(testManager.SuccessfullyCompiledLast, Is.True);
         }
 
         /// <summary>


### PR DESCRIPTION
Working on #9495

Manager scripts are now only compiled at initialisation if it is being loaded in a background thread. This makes them pre-load in the gui, but not preload for documentation or commandline uses. If you run the sim and it hasn't been preloaded, it will then compile it before running (there is a check for that in manager already).