### PR TITLE
Treat NU1902 and NU1903 as warnings rather than errors.

### DIFF
--- a/APSIM.Cli/APSIM.Cli.csproj
+++ b/APSIM.Cli/APSIM.Cli.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks>net6.0</TargetFrameworks>
     <BaseOutputPath>../bin</BaseOutputPath>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	<WarningsNotAsErrors>NU1902;NU1903</WarningsNotAsErrors>
     <AssemblyName>apsim</AssemblyName>
     <SelfContained>false</SelfContained>
   </PropertyGroup>

--- a/APSIM.Documentation/APSIM.Documentation.csproj
+++ b/APSIM.Documentation/APSIM.Documentation.csproj
@@ -5,7 +5,8 @@
     <TargetFrameworks>net6.0</TargetFrameworks>
     <BaseOutputPath>../bin</BaseOutputPath>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+	<WarningsNotAsErrors>NU1902;NU1903</WarningsNotAsErrors>
+	<GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SelfContained>false</SelfContained>
   </PropertyGroup>
 

--- a/APSIM.Interop/APSIM.Interop.csproj
+++ b/APSIM.Interop/APSIM.Interop.csproj
@@ -4,7 +4,8 @@
     <TargetFrameworks>net6.0</TargetFrameworks>
     <BaseOutputPath>../bin</BaseOutputPath>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <SelfContained>false</SelfContained>
+	<WarningsNotAsErrors>NU1902;NU1903</WarningsNotAsErrors>
+	<SelfContained>false</SelfContained>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/APSIM.Shared/APSIM.Shared.csproj
+++ b/APSIM.Shared/APSIM.Shared.csproj
@@ -8,7 +8,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <SelfContained>false</SelfContained>
+	<WarningsNotAsErrors>NU1902;NU1903</WarningsNotAsErrors>
+	<SelfContained>false</SelfContained>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/ApsimNG/ApsimNG.csproj
+++ b/ApsimNG/ApsimNG.csproj
@@ -11,7 +11,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>CS1591,CS1572</NoWarn>
+	<WarningsNotAsErrors>NU1902;NU1903</WarningsNotAsErrors>
+	<NoWarn>CS1591,CS1572</NoWarn>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <SelfContained>false</SelfContained>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>

--- a/Gtk.Sheet/Gtk.Sheet.csproj
+++ b/Gtk.Sheet/Gtk.Sheet.csproj
@@ -6,7 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>CS1591,CS1572</NoWarn>
+	<WarningsNotAsErrors>NU1902;NU1903</WarningsNotAsErrors>
+	<NoWarn>CS1591,CS1572</NoWarn>
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/Models/Models.csproj
+++ b/Models/Models.csproj
@@ -13,7 +13,8 @@
 	  <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <SelfContained>false</SelfContained>
+	<WarningsNotAsErrors>NU1902;NU1903</WarningsNotAsErrors>
+	<SelfContained>false</SelfContained>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/Tests/UnitTests/UnitTests.csproj
+++ b/Tests/UnitTests/UnitTests.csproj
@@ -8,7 +8,8 @@
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <NoWarn>CS1591,CS1572,CS1573,CS0067</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <IsPublishable>false</IsPublishable>
+	<WarningsNotAsErrors>NU1902;NU1903</WarningsNotAsErrors>
+	<IsPublishable>false</IsPublishable>
     <SelfContained>false</SelfContained>
   </PropertyGroup>
 


### PR DESCRIPTION
Resolves #9478 

Doesn't fully resolve the underlying issues, but gives warnings rather than errors, allowing developers to update Visual Studio and still continue being able to build APSIM. Eliminating the warnings can be treated as a new separate issue (or issues).