### PR TITLE
9458 Change Accumulator update event

### DIFF
--- a/Models/Functions/AccumulateByNumericPhase.cs
+++ b/Models/Functions/AccumulateByNumericPhase.cs
@@ -66,8 +66,8 @@ namespace Models.Functions
         /// <summary>Called by Plant.cs when phenology routines are complete.</summary>
         /// <param name="sender">Plant.cs</param>
         /// <param name="e">Event arguments</param>
-        [EventSubscribe("PostPhenology")]
-        private void PostPhenology(object sender, EventArgs e)
+        [EventSubscribe("DoUpdate")]
+        private void DoUpdate(object sender, EventArgs e)
         {
             if (ChildFunctions == null)
                 ChildFunctions = FindAllChildren<IFunction>().ToList();

--- a/Models/Functions/AccumulateFunction.cs
+++ b/Models/Functions/AccumulateFunction.cs
@@ -80,8 +80,8 @@ namespace Models.Functions
         /// <summary>Called by Plant.cs when phenology routines are complete.</summary>
         /// <param name="sender">Plant.cs</param>
         /// <param name="e">Event arguments</param>
-        [EventSubscribe("PostPhenology")]
-        private void PostPhenology(object sender, EventArgs e)
+        [EventSubscribe("DoUpdate")]
+        private void DoUpdate(object sender, EventArgs e)
         {
             if (ChildFunctions == null)
                 ChildFunctions = FindAllChildren<IFunction>().ToList();


### PR DESCRIPTION
Working on #9458

At the moment the Accumulator function updates in the PostPhenology event which is part-way through the day, this leads to inconsistent results compared to "sum of" in reports as sometimes the value being accumulated is modified after that event.

This is a test of changing it to the DoUpdate event nearer to the end of the day to see what effect it has on stats.