### PR TITLE
9248 Fixes Pathing in weather view, adds relative path alongside full path

### DIFF
--- a/APSIM.Shared/Utilities/PathUtilities.cs
+++ b/APSIM.Shared/Utilities/PathUtilities.cs
@@ -124,14 +124,22 @@
                 path = path.Replace(relativeDirectory + Path.DirectorySeparatorChar, "");  // the relative path should not have a preceding \
             }
 
-            // Convert slashes.
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT ||
-                Environment.OSVersion.Platform == PlatformID.Win32Windows)
-                path = path.Replace("/", @"\");
-            else
-                path = path.Replace(@"\", "/");
+            return ConvertSlashes(path);
+        }
 
-            return path;
+        /// <summary>
+        /// Creates a relative path from the given path and uses %root% replacement if path is under the %root%/Examples folder.
+        /// </summary>
+        /// <param name="path">The path to make relative</param>
+        /// <param name="relativePath">The relative path to use</param>
+        /// <returns>The relative path</returns>
+        public static string GetRelativePathAndRootExamples(string path, string relativePath)
+        {
+            string examplesPath = GetAbsolutePath("%root%/Examples/", null);
+            if (path.Contains(examplesPath))
+                return ConvertSlashes("%root%/Examples/" + path.Remove(path.IndexOf(examplesPath), examplesPath.Length));
+            else
+                return GetRelativePath(path, relativePath);
         }
 
         /// <summary>

--- a/ApsimNG/Presenters/MetDataPresenter.cs
+++ b/ApsimNG/Presenters/MetDataPresenter.cs
@@ -204,7 +204,6 @@ namespace UserInterface.Presenters
             this.graphMetData = new DataTable();
             if (filename != null)
             {
-                this.weatherDataView.Filename = PathUtilities.GetAbsolutePath(filename, this.explorerPresenter.ApsimXFile.FileName);
                 try
                 {
                     if (ExcelUtilities.IsExcelFile(filename))
@@ -270,8 +269,14 @@ namespace UserInterface.Presenters
                 }
             }
 
-            // this.weatherDataView.Filename = PathUtilities.GetRelativePath(filename, this.explorerPresenter.ApsimXFile.FileName);
-            this.weatherDataView.Filename = PathUtilities.GetAbsolutePath(filename, this.explorerPresenter.ApsimXFile.FileName);
+            string fullFilePath = PathUtilities.GetAbsolutePath(filename, this.explorerPresenter.ApsimXFile.FileName);
+            string relativeFilePath = fullFilePath;
+            Simulations simulations = weatherData.FindAncestor<Simulations>();
+            if (simulations != null)
+                relativeFilePath = PathUtilities.GetRelativePathAndRootExamples(filename, simulations.FileName);
+
+            this.weatherDataView.Filename = fullFilePath;
+            this.weatherDataView.FilenameRelative = relativeFilePath;
             this.weatherDataView.ConstantsFileName = weatherData.ConstantsFile;
             this.weatherDataView.ExcelWorkSheetName = sheetName;
         }
@@ -351,7 +356,7 @@ namespace UserInterface.Presenters
         private void WriteSummary(DataTable table)
         {
             StringBuilder summary = new StringBuilder();
-            summary.AppendLine("File name : " + this.weatherData.FileName);
+            summary.AppendLine("File name : " + Path.GetFileName(this.weatherData.FileName));
             if (!string.IsNullOrEmpty(this.weatherData.ExcelWorkSheetName))
             {
                 summary.AppendLine("Sheet Name: " + this.weatherData.ExcelWorkSheetName.ToString());

--- a/ApsimNG/Resources/Glade/TabbedMetDataView.glade
+++ b/ApsimNG/Resources/Glade/TabbedMetDataView.glade
@@ -41,20 +41,95 @@
           </packing>
         </child>
         <child>
-          <object class="GtkLabel" id="labelFileName">
+          <object class="GtkBox" id="vbox2">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <property name="margin-start">10</property>
-            <property name="margin-end">5</property>
-            <property name="margin-top">5</property>
-            <property name="margin-bottom">5</property>
-            <property name="label" translatable="yes">File name</property>
-            <property name="xalign">0</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel" id="label13">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-start">10</property>
+                <property name="margin-end">5</property>
+                <property name="margin-top">5</property>
+                <property name="margin-bottom">5</property>
+                <property name="label" translatable="yes">Relative Path:</property>
+                <property name="xalign">1</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label14">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-start">10</property>
+                <property name="margin-end">5</property>
+                <property name="margin-top">5</property>
+                <property name="margin-bottom">5</property>
+                <property name="label" translatable="yes">Full Path:</property>
+                <property name="xalign">1</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="vbox3">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel" id="labelFileNameRelative">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-start">10</property>
+                <property name="margin-end">5</property>
+                <property name="margin-top">5</property>
+                <property name="margin-bottom">5</property>
+                <property name="label" translatable="yes">File name</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="labelFileName">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-start">10</property>
+                <property name="margin-end">5</property>
+                <property name="margin-top">5</property>
+                <property name="margin-bottom">5</property>
+                <property name="label" translatable="yes">File name</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/ApsimNG/Views/TabbedMetDataView.cs
+++ b/ApsimNG/Views/TabbedMetDataView.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data;
 using UserInterface.Interfaces;
 using Gtk;
-using UserInterface.Presenters;
+using System.IO;
+using APSIM.Shared.Utilities;
 
 // This is the view used by the WeatherFile component
 namespace UserInterface.Views
@@ -46,6 +46,7 @@ namespace UserInterface.Views
         public event BrowseDelegate ConstantsFileSelected;
 
         private Label labelFileName = null;
+        private Label labelFileNameRelative = null;
         private Box vbox1 = null;
         private Notebook notebook1 = null;
         private TextView textview1 = null;
@@ -72,6 +73,7 @@ namespace UserInterface.Views
         {
             Builder builder = BuilderFromResource("ApsimNG.Resources.Glade.TabbedMetDataView.glade");
             labelFileName = (Label)builder.GetObject("labelFileName");
+            labelFileNameRelative = (Label)builder.GetObject("labelFileNameRelative");
             vbox1 = (Box)builder.GetObject("vbox1");
             notebook1 = (Notebook)builder.GetObject("notebook1");
             textview1 = (TextView)builder.GetObject("textview1");
@@ -145,6 +147,22 @@ namespace UserInterface.Views
         {
             get { return labelFileName.Text; }
             set { labelFileName.Text = value; }
+        }
+
+        /// <summary>Gets or sets the filename.</summary>
+        /// <value>The filename.</value>
+        public string FilenameRelative
+        {
+            set { 
+                if (value.StartsWith("%root%"))
+                    labelFileNameRelative.Text = value;
+                else if (value.CompareTo(PathUtilities.GetAbsolutePath(value, null)) == 0)
+                    labelFileNameRelative.Text = value;
+                else if (value.StartsWith('/') || value.StartsWith('\\'))
+                    labelFileNameRelative.Text = "." + value;
+                else
+                    labelFileNameRelative.Text = "./" + value;
+            }
         }
 
         /// <summary>Gets or sets the filename.</summary>
@@ -481,6 +499,9 @@ namespace UserInterface.Views
 
         /// <summary>Gets or sets the filename.</summary>
         string Filename { get; set; }
+
+        /// <summary>Gets or sets the filename.</summary>
+        string FilenameRelative { set; }
 
         /// <summary>Gets or sets the filename.</summary>
         string ConstantsFileName { get; set; }

--- a/Models/Climate/Weather.cs
+++ b/Models/Climate/Weather.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Data;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 
 namespace Models.Climate
 {
@@ -184,9 +183,21 @@ namespace Models.Climate
             {
                 Simulations simulations = FindAncestor<Simulations>();
                 if (simulations != null)
-                    this.FileName = PathUtilities.GetRelativePath(value, simulations.FileName);
+                    this.FileName = PathUtilities.GetRelativePathAndRootExamples(value, simulations.FileName);
                 else
                     this.FileName = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the stored file name. The user interface uses this. Use FullFileName to set.
+        /// </summary>
+        [JsonIgnore]
+        public string RelativeFileName
+        {
+            get
+            {
+                return FileName;
             }
         }
 


### PR DESCRIPTION
Resolves #9248
Resolves #7120

This just tidies up the weather presenter/view so that users can see the filename, relative path and full path for the weather file they have selected. It also appends %root% to the start of the weather path if the simulation is using an example weather file, which previously saved an absolute path.

This should help with making sure the weather files are linked correctly when moving between people/computers, and gives a better idea to the user about why the path might be wrong and where the file should be.

Closing the 9248 as this addresses adding %root% to example weather files, and closing 7120 because we did move to a relative path system for this if the file is alongside/under the simulation, and this PR just helps illustrate that.