### PR TITLE
9593 Documentation View Fixes

### DIFF
--- a/APSIM.Shared/Documentation/CodeDocumentation.cs
+++ b/APSIM.Shared/Documentation/CodeDocumentation.cs
@@ -132,14 +132,15 @@ namespace APSIM.Shared.Documentation
 
             if (typeLetter == 'P' || typeLetter == 'F' || typeLetter == 'E')
             {
+                string cacheName = fullName+tagName;
                 string description = "";
-                if (modelDescriptionCache.TryGetValue(fullName, out description))
+                if (modelDescriptionCache.TryGetValue(cacheName, out description))
                     return description;
 
                 description = GetDocumentationElement(document, fullName, tagName, typeLetter);
                 if (!string.IsNullOrEmpty(description))
                 {
-                    modelDescriptionCache.Add(fullName, description);
+                    modelDescriptionCache.Add(cacheName, description);
                     return description;
                 }
             }
@@ -150,14 +151,15 @@ namespace APSIM.Shared.Documentation
                 args = args.Replace("+", ".");
                 string name = $"{fullName}({args})";
 
+                string cacheName = name+tagName;
                 string description = "";
-                if (modelDescriptionCache.TryGetValue(name, out description))
+                if (modelDescriptionCache.TryGetValue(cacheName, out description))
                     return description;
 
                 description = GetDocumentationElement(document, name, tagName, typeLetter);
                 if (!string.IsNullOrEmpty(description))
                 {
-                    modelDescriptionCache.Add(name, description);
+                    modelDescriptionCache.Add(cacheName, description);
                     return description;
                 }
             }

--- a/APSIM.Shared/Documentation/CodeDocumentation.cs
+++ b/APSIM.Shared/Documentation/CodeDocumentation.cs
@@ -20,6 +20,8 @@ namespace APSIM.Shared.Documentation
 
         private static Dictionary<Assembly, XmlDocument> documentCache = new Dictionary<Assembly, XmlDocument>();
 
+        private static Dictionary<string, string> modelDescriptionCache = new Dictionary<string, string>();
+
         /// <summary>
         /// Get the summary of a type removing CRLF.
         /// </summary>
@@ -85,42 +87,85 @@ namespace APSIM.Shared.Documentation
         {
             XmlDocument document = LoadDocument(member.DeclaringType.Assembly);
             
-            string result = "";
+            //make a list of types to check
+            Type type = member.ReflectedType.BaseType;
             List<Type> types = new List<Type>();
-            types.Add(member.ReflectedType);
-
-            while (types.Count > 0 && string.IsNullOrEmpty(result))
+            while(type != null)
             {
-                Type type = types.Last();
-                types.Remove(type);
+                types.Add(type);
+                type = type.BaseType;
+            }
+            types.Add(member.ReflectedType);
+            //Then reverse the list to do this type first, then work upwards from model for preformance
+            types.Reverse();
 
-                if (type.BaseType != null)
-                    types.Add(type.BaseType);
-
-                foreach (Type t in type.GetInterfaces())
-                    types.Add(t);                
-
-                string fullName = type.FullName + "." + member.Name;
-
-                if (member is PropertyInfo)
-                    result = GetDocumentationElement(document, fullName, tagName, 'P');
-                else if (member is FieldInfo)
-                    result = GetDocumentationElement(document, fullName, tagName, 'F');
-                else if (member is EventInfo)
-                    result = GetDocumentationElement(document, fullName, tagName, 'E');
-                else if (member is MethodInfo method)
-                {
-                    string args = string.Join(",", method.GetParameters().Select(p => p.ParameterType.FullName));
-                    args = args.Replace("+", ".");
-                    result = GetDocumentationElement(document, $"{fullName}({args})", tagName, 'M');
-                }
-                else
-                {
-                    throw new ArgumentException($"Unknown argument type {member.GetType().Name}");
-                }
+            foreach(Type t in types)
+            {
+                string result = GetCustomTagDetails(member, tagName, document, t);
+                if (!string.IsNullOrEmpty(result))
+                    return result;
             }
 
-            return result;
+            return "";
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="member">The member.</param>
+        /// <param name="tagName">The name of the xml element in the documentation to be reaed. E.g. "summary".</param>
+        /// <param name="document"></param>
+        /// <param name="type"></param>
+        public static string GetCustomTagDetails(MemberInfo member, string tagName, XmlDocument document, Type type)
+        {
+            string fullName = type.FullName + "." + member.Name;
+
+            char typeLetter = ' ';
+            if (member is PropertyInfo)
+                typeLetter = 'P';
+            else if (member is FieldInfo)
+                typeLetter = 'F';
+            else if (member is EventInfo)
+                typeLetter = 'E';
+            else if (member is MethodInfo method)
+                typeLetter = 'M';
+
+            if (typeLetter == 'P' || typeLetter == 'F' || typeLetter == 'E')
+            {
+                string description = "";
+                if (modelDescriptionCache.TryGetValue(fullName, out description))
+                    return description;
+
+                description = GetDocumentationElement(document, fullName, tagName, typeLetter);
+                if (!string.IsNullOrEmpty(description))
+                {
+                    modelDescriptionCache.Add(fullName, description);
+                    return description;
+                }
+            }
+            else if (typeLetter == 'M')
+            {
+                MethodInfo method = member as MethodInfo;
+                string args = string.Join(",", method.GetParameters().Select(p => p.ParameterType.FullName));
+                args = args.Replace("+", ".");
+                string name = $"{fullName}({args})";
+
+                string description = "";
+                if (modelDescriptionCache.TryGetValue(name, out description))
+                    return description;
+
+                description = GetDocumentationElement(document, name, tagName, typeLetter);
+                if (!string.IsNullOrEmpty(description))
+                {
+                    modelDescriptionCache.Add(name, description);
+                    return description;
+                }
+            }
+            else
+            {
+                throw new ArgumentException($"Unknown argument type {member.GetType().Name}");
+            }
+            return "";
         }
 
         /// <summary>

--- a/APSIM.Shared/Utilities/DataTableUtilities.cs
+++ b/APSIM.Shared/Utilities/DataTableUtilities.cs
@@ -990,7 +990,7 @@ public static DataTable ReadDataTable(string filePath, char delimiter = ' ', int
                 for (int i = 0; i < table.Columns.Count; i++)
                 {
                     int padding = columnWidths[i] - row[i]?.ToString()?.Length ?? 0;
-                    result.Append(row[i]);
+                    result.Append(row[i].ToString().Replace("\n", " ").Replace("\r", "").Trim());
                     result.Append(new string(' ', padding));
                     result.Append("|");
                 }


### PR DESCRIPTION
Resolves #9593
Resolves #9594

The fixes to get the Documentation View working again made it a little slow, so this improves the experience a bit. A cache is now used for method/variable lookup so it only needs to go loading the xml once, and the page load is split into 4 steps so it load gradually instead of waiting for everything and loading all at once.

Also fixed a bug in the datatable to markdown code that was causing newlines to break tables in the view.