### PR TITLE
Quick fix to prevent Manager completion crash.

### DIFF
--- a/ApsimNG/Classes/CustomScriptCompletionProposal.cs
+++ b/ApsimNG/Classes/CustomScriptCompletionProposal.cs
@@ -42,18 +42,15 @@ namespace UserInterface.Intellisense
             }
         }
 
+        private static readonly Pixbuf functionPixbuf = new(typeof(CustomScriptCompletionProposal).Assembly, "ApsimNG.Resources.Function.png", 16, 16);
+        private static readonly Pixbuf propertyPixbuf = new(typeof(CustomScriptCompletionProposal).Assembly, "ApsimNG.Resources.Property.png", 16, 16);
+
         /// <summary>
         /// Gets the GdkPixbuf for the icon of proposal.
         /// </summary>
         public Pixbuf Icon
         {
-            get
-            {
-                // tbi
-                Pixbuf functionPixbuf = new Pixbuf(null, "ApsimNG.Resources.Function.png", 16, 16);
-                Pixbuf propertyPixbuf = new Pixbuf(null, "ApsimNG.Resources.Property.png", 16, 16);
-                return isProperty ? propertyPixbuf : functionPixbuf;
-            }
+            get => isProperty ? propertyPixbuf : functionPixbuf;
         }
 
         /// <summary>


### PR DESCRIPTION
Resolves #9631 

This prevents manager completions from crashing the UI. The completion images still fail to properly display (as they did before) but I don't think that is an APSIM issue.

I favor making the assembly reference explicit here rather than relying on the behavior of null as first argument even though this wouldn't get inlined.