### PR TITLE
A few more tidy ups

### DIFF
--- a/Prototypes/WheatSimpleLeaf/SimpleLeafImplementation/.ipynb_checkpoints/TempCleanup-checkpoint.ipynb
+++ b/Prototypes/WheatSimpleLeaf/SimpleLeafImplementation/.ipynb_checkpoints/TempCleanup-checkpoint.ipynb
@@ -1,0 +1,179 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import datetime\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import xml.etree.ElementTree as ET\n",
+    "import xmltodict, json\n",
+    "import ast\n",
+    "import numbers\n",
+    "import shlex # package to construct the git command to subprocess format\n",
+    "import subprocess \n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def findModel(Parent,PathElements):\n",
+    "    for pe in PathElements:\n",
+    "        Parent = findNextChild(Parent,pe)\n",
+    "    return Parent\n",
+    "\n",
+    "def findNextChild(Parent,ChildName):\n",
+    "    if len(Parent['Children']) >0:\n",
+    "        for child in range(len(Parent['Children'])):\n",
+    "            if Parent['Children'][child]['Name'] == ChildName:\n",
+    "                return Parent['Children'][child]\n",
+    "    else:\n",
+    "        return Parent[ChildName]\n",
+    "   \n",
+    "def replaceModel(Parent,modelPath,New):\n",
+    "    PathElements = modelPath.split('.')\n",
+    "    try:\n",
+    "        test = findModel(Parent,PathElements[:-1])[PathElements[-1]]\n",
+    "        findModel(Parent,PathElements[:-1])[PathElements[-1]] = New\n",
+    "    except:\n",
+    "        try:\n",
+    "            pos = 0\n",
+    "            for kid in findModel(Parent,PathElements[:-1])['Children']:\n",
+    "                if kid['Name'] == PathElements[-1]:\n",
+    "                    findModel(Parent,PathElements[:-1])['Children'][pos] = New\n",
+    "                    break\n",
+    "                pos +=1\n",
+    "        except:   \n",
+    "            print('Could not find parent node of model to over write for ' + modelPath)\n",
+    "            raise"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CompletedProcess(args=['git', '--git-dir=C:/GitHubRepos/ApsimX/.git', '--work-tree=C:/GitHubRepos/ApsimX', 'checkout', 'upstream/master', 'C:/GitHubRepos/ApsimX/Tests/Validation/Wheat/Wheat.apsimx'], returncode=0)"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "command= \"git --git-dir=C:/GitHubRepos/ApsimX/.git --work-tree=C:/GitHubRepos/ApsimX checkout upstream/master C:/GitHubRepos/ApsimX/Tests/Validation/Wheat/Wheat.apsimx\" \n",
+    "#command= \"git --git-dir=C:/GitHubRepos/ApsimX/.git --work-tree=C:/GitHubRepos/ApsimX checkout C:/GitHubRepos/ApsimX/Models/Resources/Wheat.json\" \n",
+    "comm=shlex.split(command) # This will convert the command into list format\n",
+    "subprocess.run(comm, shell=True) # Run the git command"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "## Read wheat test file into json object\n",
+    "with open('C:\\GitHubRepos\\ApsimX\\Tests\\Validation\\Wheat\\Wheat.apsimx','r') as WheatTestsJSON:\n",
+    "    WheatTests = json.load(WheatTestsJSON)\n",
+    "    WheatTestsJSON.close()\n",
+    "    ## read prototype wheat file into json object\n",
+    "with open('C:\\GitHubRepos\\ApsimX\\Prototypes\\WheatSimpleLeaf\\WheatFewer.apsimx','r') as WheatPrototypeJSON:\n",
+    "    WheatPrototype = json.load(WheatPrototypeJSON)\n",
+    "    WheatPrototypeJSON.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#Copy prototype wheat model out of replacements and put it in replacements in test file\n",
+    "Replacements =  findModel(WheatPrototype,['Replacements'])\n",
+    "replaceModel(WheatTests,'Replacements',Replacements)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with open('C:\\GitHubRepos\\ApsimX\\Tests\\Validation\\Wheat\\Wheat.apsimx','w') as WheatTestsJSON:\n",
+    "    json.dump(WheatTests ,WheatTestsJSON,indent=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "replacements = pd.read_excel('C:\\GitHubRepos\\ApsimX\\Prototypes\\WheatSimpleLeaf\\SimpleLeafImplementation\\VariableRenames.xlsx',index_col=0).to_dict()['SimpleLeaf']\n",
+    "with open(r'C:\\GitHubRepos\\ApsimX\\Tests\\Validation\\Wheat\\Wheat.apsimx', 'r') as file: \n",
+    "    data = file.read() \n",
+    "    for v in replacements.keys():\n",
+    "        data = data.replace(v, replacements[v]) \n",
+    "        \n",
+    "# Opening our text file in write only \n",
+    "# mode to write the replaced content \n",
+    "with open(r'C:\\GitHubRepos\\ApsimX\\Tests\\Validation\\Wheat\\Wheat.apsimx', 'w') as file: \n",
+    "  \n",
+    "    # Writing the replaced data in our \n",
+    "    # text file \n",
+    "    file.write(data) "
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "formats": "ipynb,py:light"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
working on #7623 

Removed filters from two of the top level validation graphs.

Made all file pointers in wheat.apsim full paths (%root%\\Tests\\Validation\\Wheat\\) so wheat.apsimx can be duplicated in another location (for testing the simple leaf model) but still finds all the necessary files to run.

