### PR TITLE
Ensure CLEM.Transmutation.PacketSize provided is greater than 0

### DIFF
--- a/Models/CLEM/Extras/Transmutation.cs
+++ b/Models/CLEM/Extras/Transmutation.cs
@@ -37,7 +37,7 @@ namespace Models.CLEM
         /// Amount of resource in shortfall per transmutation packet
         /// </summary>
         [Description("Transmutation packet size (amount of A)")]
-        [Required, GreaterThanEqualValue(0)]
+        [Required, GreaterThanValue(0)]
         public double TransmutationPacketSize { get; set; }
 
         /// <summary>
@@ -71,13 +71,11 @@ namespace Models.CLEM
         /// <returns></returns>
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            var results = new List<ValidationResult>();
-            if (!this.FindAllChildren<ITransmute>().Where(a => (a as IModel).Enabled).Any()) //   Apsim.Children (this, typeof(TransmutationCost)).Count() == 0)
+            if (!this.FindAllChildren<ITransmute>().Where(a => (a as IModel).Enabled).Any())
             {
                 string[] memberNames = new string[] { "Transmutes" };
-                results.Add(new ValidationResult("No transmute components provided under this transmutation", memberNames));
+                yield return new ValidationResult("No transmute components provided under this transmutation", memberNames);
             }
-            return results;
         }
         #endregion
 

--- a/Models/CLEM/ZoneCLEM.cs
+++ b/Models/CLEM/ZoneCLEM.cs
@@ -286,6 +286,10 @@ namespace Models.CLEM
             IModel simulation = model.FindAncestor<Simulation>();
             var summary = simulation.FindDescendant<Summary>();
 
+            // force summary to write messages
+            // if not included the messages table isn't propogated to exit model on errors detected.
+            summary.WriteMessagesToDataStore();
+
             // get all validations
             ReportErrors(model, summary.GetMessages(simulation.Name)?.Where(a => a.Severity == MessageType.Error && a.Text.StartsWith("Invalid parameter ")));
 
@@ -314,7 +318,6 @@ namespace Models.CLEM
                 throw new ApsimXException(model, $"{messages.Count()} error{(messages.Count() == 1 ? "" : "s")} occured during start up.{Environment.NewLine}See CLEM component [{model.GetType().Name}] Messages tab for details{Environment.NewLine}", innerException);
             }
         }
-
 
         /// <summary>
         /// Internal method to iterate through all children in CLEM and report any parameter setting errors


### PR DESCRIPTION
Update validation rule and call Summary.WriteMessagesToDataStore() to ensure database is up to date before checking for validation errors.
Resolves #9644
