### PR TITLE
Update .gitignore and fix Wheat documentation link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ Prototypes/Lentil/.ipynb_checkpoints
 Prototypes/Lentil/Data
 Prototypes/WheatSimpleLeaf/.ipynb_checkpoints
 Tests/Validation/Wheat/SimpleLeafImplementation/.ipynb_checkpoints
+.env


### PR DESCRIPTION
resolves #9688

- add .env files to .gitignore to prevent sensitive information from being tracked
- update the Wheat documentation link for accuracy.