### PR TITLE
fix: make sheets allow full table view via horizontal scrollbar

### DIFF
--- a/Gtk.Sheet/Sheet.cs
+++ b/Gtk.Sheet/Sheet.cs
@@ -163,6 +163,11 @@ namespace Gtk.Sheet
         /// <summary>The number of rows to paint in the grid. If zero, then the data provider will determine the number of rows in the grid.</summary>
         public int RowCount { get; private set; } = 0;
 
+        public int ColumnCount 
+        {
+            get => ColumnWidths.Length;
+        }
+
         /// <summary>A collection of column indexes that are currently visible or partially visible.</summary>        
         public IEnumerable<int> VisibleColumnIndexes {  get { return DetermineVisibleColumnIndexes(fullyVisible: false);  } }
 

--- a/Gtk.Sheet/Sheet.cs
+++ b/Gtk.Sheet/Sheet.cs
@@ -163,10 +163,8 @@ namespace Gtk.Sheet
         /// <summary>The number of rows to paint in the grid. If zero, then the data provider will determine the number of rows in the grid.</summary>
         public int RowCount { get; private set; } = 0;
 
-        public int ColumnCount 
-        {
-            get => ColumnWidths.Length;
-        }
+        public int ColumnCount {get; private set; } = 0;
+
 
         /// <summary>A collection of column indexes that are currently visible or partially visible.</summary>        
         public IEnumerable<int> VisibleColumnIndexes {  get { return DetermineVisibleColumnIndexes(fullyVisible: false);  } }
@@ -200,6 +198,8 @@ namespace Gtk.Sheet
                 }                
 
                 RowCount = DataProvider.RowCount + NumberFrozenRows;
+                ColumnCount = DataProvider.ColumnCount;
+
                 if (blankRowAtBottom)
                     RowCount++;
             }
@@ -244,7 +244,8 @@ namespace Gtk.Sheet
 
         public void Refresh()
         {
-            RowCount = DataProvider.RowCount + NumberFrozenRows;
+            ColumnCount = DataProvider.ColumnCount;
+            RowCount = DataProvider.RowCount + NumberFrozenRows;    
                 if (blankRowAtBottom)
                     RowCount++;
             RedrawNeeded?.Invoke(this, new EventArgs());

--- a/Gtk.Sheet/SheetScrollBars.cs
+++ b/Gtk.Sheet/SheetScrollBars.cs
@@ -56,7 +56,7 @@ namespace Gtk.Sheet
         /// <param name="e">The event arguments.</param>
         private void OnSheetInitialised(object sender, EventArgs e)
         {
-            SetScrollbarAdjustments(sheet.MaximumNumberHiddenColumns, sheet.MaximumNumberHiddenRows);
+            SetScrollbarAdjustments(sheet.ColumnCount, sheet.MaximumNumberHiddenRows);
         }
 
         /// <summary>A scroll bars to the sheet widget.</summary>
@@ -86,7 +86,7 @@ namespace Gtk.Sheet
 
         public void SetScrollbarAdjustments(int columns, int rows)
         {
-            horizontalScrollbar.Adjustment.Upper = columns + 1;
+            horizontalScrollbar.Adjustment.Upper = columns;
             horizontalScrollbar.Adjustment.Lower = 0;
             verticalScrollbar.Adjustment.Upper = rows + 2;
             verticalScrollbar.Adjustment.Lower = 0;


### PR DESCRIPTION
resolves #9509

# Notes

- this fixes an issue where the report table was not able to be fully seen because the horizontal scrollbar would not allow navigation to the end of the table.
- Note that if your column is too large for the scale of the program it will still be truncated as only whole columns can be viewed with GTK