### PR TITLE
Protect against NaNs in SWIM when using Log10 functions.

### DIFF
--- a/Models/Soils/SWIM/Swim.cs
+++ b/Models/Soils/SWIM/Swim.cs
@@ -2638,6 +2638,14 @@ namespace Models.Soils
             hklg = Math.Log10(HP.SimpleK(node, tpsi, physical.SAT, physical.KS));
             temp = Math.Log10(HP.SimpleK(node, tpsi + dpsi, physical.SAT, physical.KS));
             hklgd = (temp - hklg) / Math.Log10((tpsi + dpsi) / tpsi);
+
+            // The above Log10 functions will produce NaNs when '(tpsi + dpsi) / tpsi' is negative.
+            // Check for this and set the values to zero if NaNs were produced.
+            if (double.IsNaN(thd))
+            {
+                thd = 0;
+                hklgd = 0;
+            }
         }
 
         private double CalcTheta(int node, double suction)


### PR DESCRIPTION
Resolves #9716