### PR TITLE
Updated parameters for CNI and CNIII

### DIFF
--- a/Models/Soils/WaterModel/Runoff.cs
+++ b/Models/Soils/WaterModel/Runoff.cs
@@ -122,12 +122,12 @@ namespace Models.WaterModel
                 cnpd = MathUtilities.Bound(cnpd, 0.0, 1.0);
 
                 // curve no. for dry soil (antecedant) moisture
-                // Original parameters are modified according to Ajmal et al. (2023; https://doi.org/10.1016/j.jhydrol.2022.129049)
+                // Original parameters are modified according to Mishra et al. (2008; 10.1007/s11269-007-9233-5)
                 // Original: double cn1 = MathUtilities.Divide(cn2New, (2.334 - 0.01334 * cn2New), 0.0);
                 double cn1 = MathUtilities.Divide(cn2New, (2.2754 - 0.012754 * cn2New), 0.0);
 
                 // curve no. for wet soil (antecedant) moisture
-                // Original parameters are modified according to Ajmal et al. (2023; https://doi.org/10.1016/j.jhydrol.2022.129049)
+                // Original parameters are modified according to Mishra et al. (2008; 10.1007/s11269-007-9233-5)
                 // Original: double cn3 = MathUtilities.Divide(cn2New, (0.4036 + 0.005964 * cn2New), 0.0);
                 double cn3 = MathUtilities.Divide(cn2New, (0.430 + 0.0057 * cn2New), 0.0);
 

--- a/Models/Soils/WaterModel/Runoff.cs
+++ b/Models/Soils/WaterModel/Runoff.cs
@@ -122,10 +122,14 @@ namespace Models.WaterModel
                 cnpd = MathUtilities.Bound(cnpd, 0.0, 1.0);
 
                 // curve no. for dry soil (antecedant) moisture
-                double cn1 = MathUtilities.Divide(cn2New, (2.334 - 0.01334 * cn2New), 0.0);
+                // Original parameters are modified according to Ajmal et al. (2023; https://doi.org/10.1016/j.jhydrol.2022.129049)
+                // Original: double cn1 = MathUtilities.Divide(cn2New, (2.334 - 0.01334 * cn2New), 0.0);
+                double cn1 = MathUtilities.Divide(cn2New, (2.2754 - 0.012754 * cn2New), 0.0);
 
                 // curve no. for wet soil (antecedant) moisture
-                double cn3 = MathUtilities.Divide(cn2New, (0.4036 + 0.005964 * cn2New), 0.0);
+                // Original parameters are modified according to Ajmal et al. (2023; https://doi.org/10.1016/j.jhydrol.2022.129049)
+                // Original: double cn3 = MathUtilities.Divide(cn2New, (0.4036 + 0.005964 * cn2New), 0.0);
+                double cn3 = MathUtilities.Divide(cn2New, (0.430 + 0.0057 * cn2New), 0.0);
 
                 // scs curve number
                 double cn = cn1 + (cn3 - cn1) * cnpd;


### PR DESCRIPTION
Working on #9722 

Based on comparison made by [Mishra et al. (2008)](https://doi.org/10.1007/s11269-007-9233-5).

"For accuracy in runoff prediction using the popular SCS-CN method, correct estimation of AMC-dependent CN-values is necessary. The analysis of the available four and proposed formulae for CN-conversion finds the Sobhani and Hawkins formulae to perform the best in CNI - and CNIII -conversions, respectively, when compared with the NEH-4 table values as target values. However, their application to field data yields the proposed new formulae to perform the best, and the Neitsch formulae the poorest. The Hawkins formula ranks next to the proposed one. As the proposed formulae perform next to the Hawkins formulae in
numerical comparison utilizing target NEH-4 CN-values and best on field data, the former are recommended for field use for enhanced accuracy reasons."

![image](https://github.com/user-attachments/assets/3acd4cfa-8348-4000-9eb0-811bae35072d)
![image](https://github.com/user-attachments/assets/91bdcb93-3b73-4cd3-b709-03d372f668d7)
