### PR TITLE
Fix CN reduction for tillage

### DIFF
--- a/Models/Soils/WaterModel/CNReductionForTillage.cs
+++ b/Models/Soils/WaterModel/CNReductionForTillage.cs
@@ -63,8 +63,14 @@ namespace Models.WaterModel
             {
                 // Tillage Reduction is biggest (tillageCnRed value) straight after Tillage 
                 // and gets smaller and becomes 0 when reaches tillageCnCumWater.
-                double tillage_fract = Math.Min(1, MathUtilities.Divide(cumWaterSinceTillage, tillageCnCumWater, 0.0));
-                double tillage_reduction = tillageCnRed * tillage_fract;
+
+                // We want the opposite fraction (hence, 1 - x). 
+                // If cumWaterSinceTillage = 0, tillage_reduction = tillageCnRed.
+                // If cumWaterSinceTillage = 0.3 x tillageCnCumWater, tillage_reduction = 0.7 x tillageCnRed.
+                // If cumWaterSinceTillage >= tillageCnCumWater, tillage_reduction = 0 (there won't be a continued reduction).
+
+                double tillage_fract = 1 - Math.Min(1, MathUtilities.Divide(cumWaterSinceTillage, tillageCnCumWater, 0.0));
+                double tillage_reduction = tillage_fract * tillageCnRed;
                 return tillage_reduction;
             }
             else

--- a/Models/Soils/WaterModel/CNReductionForTillage.cs
+++ b/Models/Soils/WaterModel/CNReductionForTillage.cs
@@ -20,9 +20,9 @@ namespace Models.WaterModel
     {
         // --- Links -------------------------------------------------------------------------
 
-        /// <summary>Link to the weather component.</summary>
+        /// <summary>The water movement model.</summary>
         [Link]
-        private IWeather weather = null;
+        private WaterBalance soil = null;
 
         // --- Privates ----------------------------------------------------------------------
 
@@ -37,36 +37,38 @@ namespace Models.WaterModel
         /// <summary>The amount to reduce curve number by the day after tillage (0-100).</summary>
         public double tillageCnRed { get; set; }
 
+        private RunoffModel runoffModel;
+
         // --- Outputs -----------------------------------------------------------------------
 
         /// <summary>Returns the value to subtract from curve number due to tillage.</summary>
         public double Value(int arrayIndex = -1)
         {
+            IModel parent = this.Parent;
+
+            if (parent is RunoffModel)
+            {
+                runoffModel = parent as RunoffModel;
+
+                cumWaterSinceTillage = runoffModel.CumWaterSinceTillage;
+                tillageCnCumWater = runoffModel.TillageCnCumWater;
+                tillageCnRed = runoffModel.TillageCnRed;
+            }
+            else
+            {
+                throw new Exception("Parent model of CNReductionForTillage must be RunoffModel.");
+            }
+
             if (tillageCnCumWater > 0.0)
             {
                 // Tillage Reduction is biggest (tillageCnRed value) straight after Tillage 
                 // and gets smaller and becomes 0 when reaches tillageCnCumWater.
-                double tillage_fract = MathUtilities.Divide(cumWaterSinceTillage, tillageCnCumWater, 0.0);
+                double tillage_fract = Math.Min(1, MathUtilities.Divide(cumWaterSinceTillage, tillageCnCumWater, 0.0));
                 double tillage_reduction = tillageCnRed * tillage_fract;
                 return tillage_reduction;
             }
             else
                 return 0;
-        }
-
-        // --- Event handlers ----------------------------------------------------------------
-
-        /// <summary>
-        /// Called when a tillage event has occurred.
-        /// </summary>
-        /// <param name="sender">The sender of the event.</param>
-        /// <param name="tillageType">The type of tillage performed.</param>
-        [EventSubscribe("TillageCompleted")]
-        private void OnTillageCompleted(object sender, Soils.TillageType tillageType)
-        {
-            tillageCnCumWater = tillageType.cn_rain;
-            tillageCnRed = tillageType.cn_red;
-            cumWaterSinceTillage = 0;
         }
 
         /// <summary>
@@ -87,7 +89,7 @@ namespace Models.WaterModel
             }
 
             if (tillageCnCumWater > 0)
-                cumWaterSinceTillage += weather.Rain;
+                cumWaterSinceTillage += soil.PotentialRunoff;
         }
     }
 }

--- a/Models/Soils/WaterModel/CNReductionForTillage.cs
+++ b/Models/Soils/WaterModel/CNReductionForTillage.cs
@@ -15,7 +15,7 @@ namespace Models.WaterModel
     /// and erosion.Aust.J.Soil Res. 34: 91-102.
     /// </summary>
     [Serializable]
-    [ValidParent(typeof(WaterBalance))]
+    [ValidParent(typeof(RunoffModel))]
     public class CNReductionForTillage : Model, IFunction
     {
         // --- Links -------------------------------------------------------------------------
@@ -45,19 +45,11 @@ namespace Models.WaterModel
         public double Value(int arrayIndex = -1)
         {
             IModel parent = this.Parent;
+            runoffModel = parent as RunoffModel;
 
-            if (parent is RunoffModel)
-            {
-                runoffModel = parent as RunoffModel;
-
-                cumWaterSinceTillage = runoffModel.CumWaterSinceTillage;
-                tillageCnCumWater = runoffModel.TillageCnCumWater;
-                tillageCnRed = runoffModel.TillageCnRed;
-            }
-            else
-            {
-                throw new Exception("Parent model of CNReductionForTillage must be RunoffModel.");
-            }
+            cumWaterSinceTillage = runoffModel.CumWaterSinceTillage;
+            tillageCnCumWater = runoffModel.TillageCnCumWater;
+            tillageCnRed = runoffModel.TillageCnRed;
 
             if (tillageCnCumWater > 0.0)
             {

--- a/Models/Soils/WaterModel/Runoff.cs
+++ b/Models/Soils/WaterModel/Runoff.cs
@@ -94,17 +94,6 @@ namespace Models.WaterModel
             {
                 double cn2New = soil.CN2Bare - cnReductionForCover.Value(arrayIndex) - cnReductionForTillage.Value(arrayIndex);
 
-                // Tillage reduction on cn
-                if (TillageCnCumWater > 0.0)
-                {
-                    // We minus 1 because we want the opposite fraction. 
-                    // Tillage Reduction is biggest (CnRed value) straight after Tillage and gets smaller and becomes 0 when reaches CumWater.
-                    // unlike the Cover Reduction, where the reduction starts out smallest (0) and gets bigger and becomes (CnRed value) when you hit CnCover.
-                    var tillageFract = MathUtilities.Divide(CumWaterSinceTillage, TillageCnCumWater, 0.0) - 1.0;
-                    var tillageReduction = TillageCnRed * tillageFract;
-                    cn2New = cn2New + tillageReduction;
-                }
-
                 // Cut off response to cover at high covers
                 cn2New = MathUtilities.Bound(cn2New, 0.0, 100.0);
 


### PR DESCRIPTION
Resolves #9724

Ready to merge. I removed the code from `RunoffModel` and tried to complete `CNReductionForTillage` in a way that does not need an extra event (`TillageCompleted`) to be published. If the event is implemented, these parameters can be removed from `RunoffModel` and moved to `CNReductionForTillage`. 

```
        /// <summary>Cumulative rainfall below which tillage reduces CN (mm).</summary>
        public double TillageCnCumWater { get; set; }
        /// <summary>Reduction in CN due to tillage()</summary>
        public double TillageCnRed { get; set; }
        /// <summary>Running total of cumulative rainfall since last tillage event. Used for tillage CN reduction (mm).</summary>
        public double CumWaterSinceTillage { get; set; }
```

In one example I used, this did not change results. The reason could be that `CNReductionForTillage` was never doing anything and all the reduction was done inside the `RunoffModel`. Now, at least the order and logic of things are correct. 