### PR TITLE
Display model type in DocumentationPresenter and GenericPresenter views

### DIFF
--- a/ApsimNG/Presenters/DocumentationPresenter.cs
+++ b/ApsimNG/Presenters/DocumentationPresenter.cs
@@ -44,25 +44,27 @@ namespace UserInterface.Presenters
             try
             {
                 //Default text while loading
+                string classInfo = "Model type: " + model.GetType().Name + $"{Environment.NewLine}";
+
                 markdownSummaryAndRemarks = DocumentSummaryAndRemarks(model);
-                view.Text = markdownSummaryAndRemarks.ToString().Replace("<", @"\<");
+                view.Text = classInfo + markdownSummaryAndRemarks.ToString().Replace("<", @"\<");
 
                 //Desynced loading of reflection details (this can take a few seconds, so we desync it from the GUI so it's not laggy)
                 markdownDependencies = await Task.Run(() => DocumentModelDependencies(model));
                 markdownSummaryAndRemarks = markdownSummaryAndRemarks.Append(markdownDependencies);
-                view.Text = markdownSummaryAndRemarks.ToString().Replace("<", @"\<");
+                view.Text = classInfo + markdownSummaryAndRemarks.ToString().Replace("<", @"\<");
 
                 markdownMethods= await Task.Run(() => DocumentModelMethods(model));
                 markdownSummaryAndRemarks = markdownSummaryAndRemarks.Append(markdownMethods);
-                view.Text = markdownSummaryAndRemarks.ToString().Replace("<", @"\<");
+                view.Text = classInfo + markdownSummaryAndRemarks.ToString().Replace("<", @"\<");
 
                 markdownEvents= await Task.Run(() => DocumentModelEvents(model));
                 markdownSummaryAndRemarks = markdownSummaryAndRemarks.Append(markdownEvents);
-                view.Text = markdownSummaryAndRemarks.ToString().Replace("<", @"\<");
+                view.Text = classInfo + markdownSummaryAndRemarks.ToString().Replace("<", @"\<");
 
                 markdownOutputs= await Task.Run(() => DocumentModelOutputs(model));
                 markdownSummaryAndRemarks = markdownSummaryAndRemarks.Append(markdownOutputs);
-                view.Text = markdownSummaryAndRemarks.ToString().Replace("<", @"\<");
+                view.Text = classInfo + markdownSummaryAndRemarks.ToString().Replace("<", @"\<");
 
             }
             catch(Exception e)

--- a/ApsimNG/Presenters/GenericPresenter.cs
+++ b/ApsimNG/Presenters/GenericPresenter.cs
@@ -2,6 +2,7 @@
 using UserInterface.Views;
 using APSIM.Documentation;
 using APSIM.Documentation.Models;
+using System;
 
 namespace UserInterface.Presenters
 {
@@ -36,8 +37,8 @@ namespace UserInterface.Presenters
             this.model = model as Model;
             this.genericView = view as IMarkdownView;
             this.explorerPresenter = explorerPresenter;
-
-            this.genericView.Text = WebDocs.ConvertToMarkdown(AutoDocumentation.Document(this.model), "");
+            this.genericView.Text = "Model type: " + this.model.GetType().Name + $"{Environment.NewLine}";
+            this.genericView.Text += WebDocs.ConvertToMarkdown(AutoDocumentation.Document(this.model), "");
         }
 
         /// <summary>


### PR DESCRIPTION
resolves #9697

Add a line at the top of the view to show the simple model type, enhancing clarity for users.

@par456 what do you think about this?
