### PR TITLE
9727 Apsim Importer can handling missing soultes/initialwater

### DIFF
--- a/Models/Core/Apsim710File/Importer.cs
+++ b/Models/Core/Apsim710File/Importer.cs
@@ -335,6 +335,7 @@ namespace Models.Core.Apsim710File
                     this.AddCompNode(destParent, "CERESSoilTemperature", "Temperature");
                     AddNutrients(compNode, ref destParent);
                     AddSwimNutrientData(compNode, ref destParent);
+                    AddInitialWater(compNode, ref destParent);
                 }
                 else if (compNode.Name.ToLower() == "soilwater")
                 {
@@ -342,10 +343,7 @@ namespace Models.Core.Apsim710File
                     this.soilWaterExists = newNode != null;
                     this.AddCompNode(destParent, "CERESSoilTemperature", "Temperature");
                     AddNutrients(compNode, ref destParent);
-                }
-                else if (compNode.Name == "InitialWater")
-                {
-                    newNode = CopyNode(compNode, destParent, "InitialWater");
+                    AddInitialWater(compNode, ref destParent);
                 }
                 else if (compNode.Name == "SoilOrganicMatter")
                 {
@@ -450,36 +448,90 @@ namespace Models.Core.Apsim710File
             XmlNode newUREANode = this.AddCompNode(destParent, "Solute", "Urea");
 
             XmlNode srcNode = XmlUtilities.FindByType(compNode.ParentNode, "Sample");
+
+            XmlNode thicknessSrc = srcNode;
+            if (thicknessSrc == null)
+                thicknessSrc = XmlUtilities.FindByType(compNode.ParentNode, "Water");
+
+            XmlNode arrayNode;
+            XmlNode childNode;
+
+            // find soil layers and values for NO3
+            arrayNode = XmlUtilities.Find(thicknessSrc, "Thickness");
+            this.CopyNodeAndValueArray(arrayNode, newNO3Node, "Thickness", "Thickness");
+
+            // find soil layers and values for NH4
+            arrayNode = XmlUtilities.Find(thicknessSrc, "Thickness");
+            this.CopyNodeAndValueArray(arrayNode, newNH4Node, "Thickness", "Thickness");
+
+            // find soil layers for UREA
+            arrayNode = XmlUtilities.Find(thicknessSrc, "Thickness");
+            this.CopyNodeAndValueArray(arrayNode, newUREANode, "Thickness", "Thickness");
+
+            InitNodeValueArray(newUREANode, "InitialValues", arrayNode.ChildNodes.Count, 0.0);
+            childNode = newUREANode.AppendChild(newUREANode.OwnerDocument.CreateElement("InitialValuesUnits"));
+            if (childNode != null)
+                childNode.InnerText = "1";  // ensure kg/ha units
+
+            //if source for solutes exists, copy values
             if (srcNode != null)
             {
-                XmlNode arrayNode;
-
                 // values are ppm
-                // find soil layers and values for NO3
-                arrayNode = XmlUtilities.Find(srcNode, "Thickness");
-                this.CopyNodeAndValueArray(arrayNode, newNO3Node, "Thickness", "Thickness");
                 arrayNode = XmlUtilities.Find(srcNode, "NO3");
                 this.CopyNodeAndValueArray(arrayNode, newNO3Node, "NO3", "InitialValues");
 
-                // find soil layers and values for NH4
-                srcNode = XmlUtilities.FindByType(compNode.ParentNode, "Sample");
-                arrayNode = XmlUtilities.Find(srcNode, "Thickness");
-                this.CopyNodeAndValueArray(arrayNode, newNH4Node, "Thickness", "Thickness");
                 arrayNode = XmlUtilities.Find(srcNode, "NH4");
                 this.CopyNodeAndValueArray(arrayNode, newNH4Node, "NH4", "InitialValues");
 
-                // find soil layers for UREA
-                srcNode = XmlUtilities.FindByType(compNode.ParentNode, "Sample");
-                arrayNode = XmlUtilities.Find(srcNode, "Thickness");
-                this.CopyNodeAndValueArray(arrayNode, newUREANode, "Thickness", "Thickness");
-
-                // initialise the UREA with some default values
-                InitNodeValueArray(newUREANode, "InitialValues", arrayNode.ChildNodes.Count, 0.0);
-                XmlNode childNode = newUREANode.AppendChild(newUREANode.OwnerDocument.CreateElement("InitialValuesUnits"));
+            }
+            else //if it doesn't, initialise with 0 like classic defaults to
+            {
+                // initialise with some default values
+                InitNodeValueArray(newNO3Node, "InitialValues", arrayNode.ChildNodes.Count, 0.0);
+                childNode = newNO3Node.AppendChild(newNO3Node.OwnerDocument.CreateElement("InitialValuesUnits"));
                 if (childNode != null)
-                {
                     childNode.InnerText = "1";  // ensure kg/ha units
-                }
+
+                InitNodeValueArray(newNH4Node, "InitialValues", arrayNode.ChildNodes.Count, 0.0);
+                childNode = newNH4Node.AppendChild(newNH4Node.OwnerDocument.CreateElement("InitialValuesUnits"));
+                if (childNode != null)
+                    childNode.InnerText = "1";  // ensure kg/ha units
+
+            }
+        }
+
+        /// <summary>
+        /// Add the InitialWater component
+        /// </summary>
+        /// <param name="compNode">The source component node in the .apsim file</param>
+        /// <param name="destParent">The parent of the new component in the .apsimx file</param>
+        private void AddInitialWater(XmlNode compNode, ref XmlNode destParent)
+        {
+            XmlNode newInitialWaterNode = this.AddCompNode(destParent, "InitialWater", "InitialWater");
+            XmlNode srcNode = XmlUtilities.FindByType(compNode.ParentNode, "InitialWater");
+
+            XmlNode thicknessSrc = srcNode;
+            if (thicknessSrc == null)
+                thicknessSrc = XmlUtilities.FindByType(compNode.ParentNode, "Water");
+
+            // find soil layers and values for NO3
+            XmlNode arrayNode = XmlUtilities.Find(thicknessSrc, "Thickness");
+            this.CopyNodeAndValueArray(arrayNode, newInitialWaterNode, "Thickness", "Thickness");
+
+            //if source for solutes exists, copy values
+            if (srcNode != null)
+            {
+                XmlUtilities.SetValue(newInitialWaterNode, "FractionFull", XmlUtilities.Value(srcNode, "FractionFull"));
+                XmlUtilities.SetValue(newInitialWaterNode, "DepthWetSoil", XmlUtilities.Value(srcNode, "DepthWetSoil"));
+                XmlUtilities.SetValue(newInitialWaterNode, "PercentMethod", XmlUtilities.Value(srcNode, "PercentMethod"));
+                XmlUtilities.SetValue(newInitialWaterNode, "RelativeTo", XmlUtilities.Value(srcNode, "RelativeTo"));
+            }
+            else //if it doesn't, initialise with 0 like classic defaults to
+            {
+                XmlUtilities.SetValue(newInitialWaterNode, "FractionFull", "1");
+                XmlUtilities.SetValue(newInitialWaterNode, "DepthWetSoil", "NaN");
+                XmlUtilities.SetValue(newInitialWaterNode, "PercentMethod", "EvenlyDistributed");
+                XmlUtilities.SetValue(newInitialWaterNode, "RelativeTo", "ll15");
             }
         }
 

--- a/Models/Core/Apsim710File/Importer.cs
+++ b/Models/Core/Apsim710File/Importer.cs
@@ -518,19 +518,55 @@ namespace Models.Core.Apsim710File
             XmlNode arrayNode = XmlUtilities.Find(thicknessSrc, "Thickness");
             this.CopyNodeAndValueArray(arrayNode, newInitialWaterNode, "Thickness", "Thickness");
 
-            //if source for solutes exists, copy values
             if (srcNode != null)
             {
-                XmlUtilities.SetValue(newInitialWaterNode, "FractionFull", XmlUtilities.Value(srcNode, "FractionFull"));
-                XmlUtilities.SetValue(newInitialWaterNode, "DepthWetSoil", XmlUtilities.Value(srcNode, "DepthWetSoil"));
-                XmlUtilities.SetValue(newInitialWaterNode, "PercentMethod", XmlUtilities.Value(srcNode, "PercentMethod"));
-                XmlUtilities.SetValue(newInitialWaterNode, "RelativeTo", XmlUtilities.Value(srcNode, "RelativeTo"));
+                arrayNode = XmlUtilities.Find(srcNode, "FractionFull");
+                if (arrayNode != null)
+                    XmlUtilities.SetValue(newInitialWaterNode, "FractionFull", XmlUtilities.Value(srcNode, "FractionFull"));
+                else
+                    XmlUtilities.SetValue(newInitialWaterNode, "FractionFull", "1");
             }
-            else //if it doesn't, initialise with 0 like classic defaults to
+            else
             {
                 XmlUtilities.SetValue(newInitialWaterNode, "FractionFull", "1");
+            }
+
+            if (srcNode != null)
+            {
+                arrayNode = XmlUtilities.Find(srcNode, "DepthWetSoil");
+                if (arrayNode != null)
+                    XmlUtilities.SetValue(newInitialWaterNode, "DepthWetSoil", XmlUtilities.Value(srcNode, "DepthWetSoil"));
+                else
+                    XmlUtilities.SetValue(newInitialWaterNode, "DepthWetSoil", "NaN");
+            }
+            else
+            {
                 XmlUtilities.SetValue(newInitialWaterNode, "DepthWetSoil", "NaN");
+            }
+
+            if (srcNode != null)
+            {
+                arrayNode = XmlUtilities.Find(srcNode, "PercentMethod");
+                if (arrayNode != null)
+                    XmlUtilities.SetValue(newInitialWaterNode, "PercentMethod", XmlUtilities.Value(srcNode, "PercentMethod"));
+                else
+                    XmlUtilities.SetValue(newInitialWaterNode, "PercentMethod", "EvenlyDistributed");
+            }
+            else
+            {
                 XmlUtilities.SetValue(newInitialWaterNode, "PercentMethod", "EvenlyDistributed");
+            }
+
+            if (srcNode != null)
+            {
+                arrayNode = XmlUtilities.Find(srcNode, "RelativeTo");
+                if (arrayNode != null)
+                    XmlUtilities.SetValue(newInitialWaterNode, "RelativeTo", XmlUtilities.Value(srcNode, "RelativeTo"));
+                else
+                    XmlUtilities.SetValue(newInitialWaterNode, "RelativeTo", "ll15");
+            }
+            else
+            {
                 XmlUtilities.SetValue(newInitialWaterNode, "RelativeTo", "ll15");
             }
         }

--- a/Tests/UnitTests/Core/ApsimFile/ConverterTests.cs
+++ b/Tests/UnitTests/Core/ApsimFile/ConverterTests.cs
@@ -1,9 +1,6 @@
 ﻿using APSIM.Shared.Utilities;
 using Models.Core;
-using Models.Core.Apsim710File;
 using Models.Core.ApsimFile;
-using Models.Soils;
-using Models.WaterModel;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using System;
@@ -474,26 +471,6 @@ namespace UnitTests.Core.ApsimFile
             Assert.That(actual, Is.EqualTo(expected));
 
             Assert.Pass();
-        }
-
-        [Test]
-        public void TestInitialEmptySolutesInitialisesSolutes()
-        {
-          List<Exception> importExceptions = new();
-          string xml = ReflectionUtilities.GetResourceAsString("UnitTests.Core.ApsimFile.SoilMissingSolutesAndInitialWater.apsim");
-          var importer = new Importer();
-          Simulations simulations = importer.CreateSimulationsFromXml(xml, e => { importExceptions.Add(e); });
-
-          foreach(Solute solute in simulations.FindAllDescendants<Solute>())
-          {
-            Assert.That(solute.Thickness, Is.Not.Null);
-            Assert.That(MathUtilities.Sum(solute.kgha).Equals(0));
-          }
-
-          foreach(WaterBalance water in simulations.FindAllDescendants<WaterBalance>())
-          {
-            Assert.That(water.Thickness, Is.Not.Null);
-          }
         }
     }
 }

--- a/Tests/UnitTests/Core/ApsimFile/ConverterTests.cs
+++ b/Tests/UnitTests/Core/ApsimFile/ConverterTests.cs
@@ -1,6 +1,9 @@
 ﻿using APSIM.Shared.Utilities;
 using Models.Core;
+using Models.Core.Apsim710File;
 using Models.Core.ApsimFile;
+using Models.Soils;
+using Models.WaterModel;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using System;
@@ -471,6 +474,26 @@ namespace UnitTests.Core.ApsimFile
             Assert.That(actual, Is.EqualTo(expected));
 
             Assert.Pass();
+        }
+
+        [Test]
+        public void TestInitialEmptySolutesInitialisesSolutes()
+        {
+          List<Exception> importExceptions = new();
+          string xml = ReflectionUtilities.GetResourceAsString("UnitTests.Core.ApsimFile.SoilMissingSolutesAndInitialWater.apsim");
+          var importer = new Importer();
+          Simulations simulations = importer.CreateSimulationsFromXml(xml, e => { importExceptions.Add(e); });
+
+          foreach(Solute solute in simulations.FindAllDescendants<Solute>())
+          {
+            Assert.That(solute.Thickness, Is.Not.Null);
+            Assert.That(MathUtilities.Sum(solute.kgha).Equals(0));
+          }
+
+          foreach(WaterBalance water in simulations.FindAllDescendants<WaterBalance>())
+          {
+            Assert.That(water.Thickness, Is.Not.Null);
+          }
         }
     }
 }

--- a/Tests/UnitTests/Core/ApsimFile/SoilMissingSolutesAndInitialWater.apsim
+++ b/Tests/UnitTests/Core/ApsimFile/SoilMissingSolutesAndInitialWater.apsim
@@ -1,0 +1,285 @@
+<folder version="37" creator="Apsim 7.10-r4220" name="Soils">
+  <Soil>
+    <RecordNumber>0</RecordNumber>
+    <Latitude>-27.18</Latitude>
+    <Longitude>151.26</Longitude>
+    <YearOfSampling>0</YearOfSampling>
+    <Water>
+      <Thickness>
+        <double>100</double>
+        <double>150</double>
+        <double>250</double>
+        <double>250</double>
+        <double>250</double>
+        <double>250</double>
+        <double>250</double>
+      </Thickness>
+      <BD>
+        <double>1.011</double>
+        <double>1.071</double>
+        <double>1.094</double>
+        <double>1.159</double>
+        <double>1.173</double>
+        <double>1.163</double>
+        <double>1.187</double>
+      </BD>
+      <AirDry>
+        <double>0.13</double>
+        <double>0.199</double>
+        <double>0.28</double>
+        <double>0.28</double>
+        <double>0.28</double>
+        <double>0.28</double>
+        <double>0.28</double>
+      </AirDry>
+      <LL15>
+        <double>0.261</double>
+        <double>0.248</double>
+        <double>0.28</double>
+        <double>0.28</double>
+        <double>0.28</double>
+        <double>0.28</double>
+        <double>0.28</double>
+      </LL15>
+      <DUL>
+        <double>0.521</double>
+        <double>0.497</double>
+        <double>0.488</double>
+        <double>0.48</double>
+        <double>0.472</double>
+        <double>0.457</double>
+        <double>0.452</double>
+      </DUL>
+      <SAT>
+        <double>0.589</double>
+        <double>0.566</double>
+        <double>0.557</double>
+        <double>0.533</double>
+        <double>0.527</double>
+        <double>0.531</double>
+        <double>0.522</double>
+      </SAT>
+      <BDMetadata>
+        <string>Field measured and checked for sensibility</string>
+        <string>Field measured and checked for sensibility</string>
+        <string>Field measured and checked for sensibility</string>
+        <string>Field measured and checked for sensibility</string>
+        <string>Field measured and checked for sensibility</string>
+        <string>Field measured and checked for sensibility</string>
+        <string>Field measured and checked for sensibility</string>
+      </BDMetadata>
+      <AirDryMetadata>
+        <string>Estimated based on local knowledge</string>
+        <string>Estimated based on local knowledge</string>
+        <string>Estimated based on local knowledge</string>
+        <string>Estimated based on local knowledge</string>
+        <string>Estimated based on local knowledge</string>
+        <string>Estimated based on local knowledge</string>
+        <string>Estimated based on local knowledge</string>
+      </AirDryMetadata>
+      <LL15Metadata>
+        <string>Estimated based on local knowledge</string>
+        <string>Estimated based on local knowledge</string>
+        <string>Estimated based on local knowledge</string>
+        <string>Estimated based on local knowledge</string>
+        <string>Estimated based on local knowledge</string>
+        <string>Estimated based on local knowledge</string>
+        <string>Estimated based on local knowledge</string>
+      </LL15Metadata>
+      <DULMetadata>
+        <string>Estimated based on local knowledge</string>
+        <string>Estimated based on local knowledge</string>
+        <string>Estimated based on local knowledge</string>
+        <string>Estimated based on local knowledge</string>
+        <string>Estimated based on local knowledge</string>
+        <string>Estimated based on local knowledge</string>
+        <string>Estimated based on local knowledge</string>
+      </DULMetadata>
+      <SATMetadata>
+        <string>Calculated from measured, estimated or calculated BD</string>
+        <string>Calculated from measured, estimated or calculated BD</string>
+        <string>Calculated from measured, estimated or calculated BD</string>
+        <string>Calculated from measured, estimated or calculated BD</string>
+        <string>Calculated from measured, estimated or calculated BD</string>
+        <string>Calculated from measured, estimated or calculated BD</string>
+        <string>Calculated from measured, estimated or calculated BD</string>
+      </SATMetadata>
+      <SoilCrop name="Wheat">
+        <Thickness>
+          <double>100</double>
+          <double>150</double>
+          <double>250</double>
+          <double>250</double>
+          <double>250</double>
+          <double>250</double>
+          <double>250</double>
+        </Thickness>
+        <LL>
+          <double>0.261</double>
+          <double>0.248</double>
+          <double>0.28</double>
+          <double>0.306</double>
+          <double>0.36</double>
+          <double>0.392</double>
+          <double>0.446</double>
+        </LL>
+        <KL>
+          <double>0.06</double>
+          <double>0.06</double>
+          <double>0.06</double>
+          <double>0.04</double>
+          <double>0.04</double>
+          <double>0.02</double>
+          <double>0.01</double>
+        </KL>
+        <XF>
+          <double>1</double>
+          <double>1</double>
+          <double>1</double>
+          <double>1</double>
+          <double>1</double>
+          <double>1</double>
+          <double>1</double>
+        </XF>
+      </SoilCrop>
+    </Water>
+    <SoilWater>
+      <SummerCona>3</SummerCona>
+      <SummerU>4</SummerU>
+      <SummerDate>1-Nov</SummerDate>
+      <WinterCona>3</WinterCona>
+      <WinterU>4</WinterU>
+      <WinterDate>1-Apr</WinterDate>
+      <DiffusConst>40</DiffusConst>
+      <DiffusSlope>16</DiffusSlope>
+      <Salb>0.1</Salb>
+      <CN2Bare>65</CN2Bare>
+      <CNRed>20</CNRed>
+      <CNCov>0.8</CNCov>
+      <Slope>NaN</Slope>
+      <DischargeWidth>NaN</DischargeWidth>
+      <CatchmentArea>NaN</CatchmentArea>
+      <MaxPond>NaN</MaxPond>
+      <Thickness>
+        <double>100</double>
+        <double>150</double>
+        <double>250</double>
+        <double>250</double>
+        <double>250</double>
+        <double>250</double>
+        <double>250</double>
+      </Thickness>
+      <SWCON>
+        <double>0.3</double>
+        <double>0.3</double>
+        <double>0.3</double>
+        <double>0.3</double>
+        <double>0.3</double>
+        <double>0.3</double>
+        <double>0.3</double>
+      </SWCON>
+    </SoilWater>
+    <SoilOrganicMatter>
+      <RootCN>70</RootCN>
+      <RootWt>5250</RootWt>
+      <SoilCN>17.2</SoilCN>
+      <EnrACoeff>7.4</EnrACoeff>
+      <EnrBCoeff>0.2</EnrBCoeff>
+      <Thickness>
+        <double>100</double>
+        <double>150</double>
+        <double>250</double>
+        <double>250</double>
+        <double>250</double>
+        <double>250</double>
+        <double>250</double>
+      </Thickness>
+      <OC>
+        <double>4.4</double>
+        <double>0.55</double>
+        <double>0.543</double>
+        <double>0.37</double>
+        <double>0.267</double>
+        <double>0.268</double>
+        <double>0.218</double>
+      </OC>
+      <OCMetadata>
+        <string>Measured</string>
+        <string>Measured</string>
+        <string>Measured</string>
+        <string>Measured</string>
+        <string>Measured</string>
+        <string>Measured</string>
+        <string>Measured</string>
+      </OCMetadata>
+      <FBiom>
+        <double>0.04</double>
+        <double>0.02</double>
+        <double>0.02</double>
+        <double>0.02</double>
+        <double>0.01</double>
+        <double>0.01</double>
+        <double>0.01</double>
+      </FBiom>
+      <FInert>
+        <double>0.4</double>
+        <double>0.6</double>
+        <double>0.8</double>
+        <double>1</double>
+        <double>1</double>
+        <double>1</double>
+        <double>1</double>
+      </FInert>
+      <OCUnits>Total</OCUnits>
+    </SoilOrganicMatter>
+    <Analysis>
+      <Thickness>
+        <double>100</double>
+        <double>150</double>
+        <double>250</double>
+        <double>250</double>
+        <double>250</double>
+        <double>250</double>
+        <double>250</double>
+      </Thickness>
+      <Texture>
+        <string />
+        <string />
+        <string />
+        <string />
+        <string />
+        <string />
+        <string />
+      </Texture>
+      <MunsellColour>
+        <string />
+        <string />
+        <string />
+        <string />
+        <string />
+        <string />
+        <string />
+      </MunsellColour>
+      <PH>
+        <double>8</double>
+        <double>8</double>
+        <double>8</double>
+        <double>8</double>
+        <double>8</double>
+        <double>8</double>
+        <double>8</double>
+      </PH>
+      <PHMetadata>
+        <string>Measured</string>
+        <string>Measured</string>
+        <string>Measured</string>
+        <string>Measured</string>
+        <string>Measured</string>
+        <string>Measured</string>
+        <string>Measured</string>
+      </PHMetadata>
+      <PHUnits>Water</PHUnits>
+      <BoronUnits>HotWater</BoronUnits>
+    </Analysis>
+  </Soil>
+</folder>

--- a/Tests/UnitTests/ImporterTests.cs
+++ b/Tests/UnitTests/ImporterTests.cs
@@ -423,22 +423,22 @@ namespace UnitTests
         }
 
         [Test]
-        public void TestInitialEmptySolutesInitialisesSolutes()
+        public void TestImporterCreatesSolutesAndWaterBalancesIfMissing()
         {
-          string xml = ReflectionUtilities.GetResourceAsString("UnitTests.Core.ApsimFile.SoilMissingSolutesAndInitialWater.apsim");
-          var importer = new Importer();
-          Simulations simulations = importer.CreateSimulationsFromXml(xml, e => Assert.Fail());
+            string xml = ReflectionUtilities.GetResourceAsString("UnitTests.Core.ApsimFile.SoilMissingSolutesAndInitialWater.apsim");
+            var importer = new Importer();
+            Simulations simulations = importer.CreateSimulationsFromXml(xml, e => Assert.Fail());
 
-          foreach(Solute solute in simulations.FindAllDescendants<Solute>())
-          {
-            Assert.That(solute.Thickness, Is.Not.Null);
-            Assert.That(MathUtilities.Sum(solute.kgha).Equals(0));
-          }
+            foreach(Solute solute in simulations.FindAllDescendants<Solute>())
+            {
+                Assert.That(solute.Thickness, Is.Not.Null);
+                Assert.That(MathUtilities.Sum(solute.kgha).Equals(0));
+            }
 
-          foreach(WaterBalance water in simulations.FindAllDescendants<WaterBalance>())
-          {
-            Assert.That(water.Thickness, Is.Not.Null);
-          }
+            foreach(WaterBalance water in simulations.FindAllDescendants<WaterBalance>())
+            {
+                Assert.That(water.Thickness, Is.Not.Null);
+            }
         }
     }
 }

--- a/Tests/UnitTests/ImporterTests.cs
+++ b/Tests/UnitTests/ImporterTests.cs
@@ -1,22 +1,24 @@
-﻿namespace UnitTests
-{
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using APSIM.Shared.Utilities;
-    using Models;
-    using Models.Core;
-    using Models.Core.Apsim710File;
-    using Models.Interfaces;
-    using Models.PMF;
-    using Models.Soils;
-    using Models.Soils.Nutrients;
-    using Models.Soils.SoilTemp;
-    using Models.Storage;
-    using Models.Surface;
-    using NUnit.Framework;
-    using UserInterface.Presenters;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using APSIM.Shared.Documentation.Extensions;
+using APSIM.Shared.Utilities;
+using Models;
+using Models.Core;
+using Models.Core.Apsim710File;
+using Models.Interfaces;
+using Models.PMF;
+using Models.Soils;
+using Models.Soils.Nutrients;
+using Models.Soils.SoilTemp;
+using Models.Storage;
+using Models.Surface;
+using Models.WaterModel;
+using NUnit.Framework;
+using UserInterface.Presenters;
 
+namespace UnitTests
+{
     /// <summary>This is a test class for the .apsim file importer.</summary>
     [TestFixture]
     public class ImporterTests
@@ -122,37 +124,35 @@
             var importer = new Importer();
             Simulations sims = importer.CreateSimulationsFromXml(oldXml, e => Assert.Fail());
 
-            Soil s = sims.Children[0].Children[0] as Soil;
-            Assert.That(s.Name, Is.EqualTo("Soil"));
+            Soil soil = sims.FindDescendant<Soil>();
+            Assert.That(soil.Name, Is.EqualTo("Soil"));
 
-            Water initWater = s.Children[0] as Water;
+            Water initWater = soil.FindChild<Water>();
             Assert.That(initWater.FractionFull, Is.EqualTo(0.5).Within(0.000000001));
             Assert.That(initWater.FilledFromTop, Is.True);
 
-            Physical w = s.Children[1] as Physical;
-            Assert.That(w.Thickness, Is.EqualTo(new double[] { 150, 150, 300, 300 }));
-            Assert.That(w.BD, Is.EqualTo(new double[] { 1.02, 1.03, 1.02, 1.02 }));
-            Assert.That(w.LL15, Is.EqualTo(new double[] { 0.29, 0.29, 0.29, 0.29 }));
+            Physical physical = soil.FindChild<Physical>();
+            Assert.That(physical.Thickness, Is.EqualTo(new double[] { 150, 150, 300, 300 }));
+            Assert.That(physical.BD, Is.EqualTo(new double[] { 1.02, 1.03, 1.02, 1.02 }));
+            Assert.That(physical.LL15, Is.EqualTo(new double[] { 0.29, 0.29, 0.29, 0.29 }));
 
-            ISoilWater sw = s.Children[2] as ISoilWater;
+            ISoilWater sw = soil.FindChild<ISoilWater>();
             Assert.That(sw.Thickness, Is.EqualTo(new double[] { 150, 150, 300, 300 }));
 
-            Assert.That(s.Children[8] is Nutrient, Is.True);
-            Assert.That(s.Children[9] is SoilTemperature, Is.True);
-            Assert.That(s.Children[3] is Solute, Is.True);
-            Assert.That(s.Children[4] is Solute, Is.True);
-            Assert.That(s.Children[5] is Solute, Is.True);
-            Organic som = s.Children[6] as Organic;
+            Assert.That(soil.FindChild<Nutrient>(), Is.Not.Null);
+            Assert.That(soil.FindChild<SoilTemperature>(), Is.Not.Null);
+            Assert.That(soil.FindAllChildren<Solute>().Count().Equals(3));
+            Organic som = soil.FindChild<Organic>();
             Assert.That(som.Thickness, Is.EqualTo(new double[] { 150, 150, 300, 300 }));
             Assert.That(som.Carbon, Is.EqualTo(new double[] { 1.04, 0.89, 0.89, 0.89 }));
             Assert.That(som.FBiom, Is.EqualTo(new double[] { 0.025, 0.02, 0.015, 0.01 }));
 
-            Chemical a = s.Children[7] as Chemical;
+            Chemical a = soil.FindChild<Chemical>();
             Assert.That(a.Thickness, Is.EqualTo(new double[] { 150, 150, 300, 300 }));
             Assert.That(a.EC, Is.EqualTo(new double[] { 0.2, 0.25, 0.31, 0.40 }));
             Assert.That(a.PH, Is.EqualTo(new double[] { 8.4, 8.8, 9.0, 9.2 }));
 
-            SoilCrop crop = s.Children[1].Children[0] as SoilCrop;
+            SoilCrop crop = physical.FindChild<SoilCrop>();
             Assert.That(crop.LL, Is.EqualTo(new double[] { 0.29, 0.29, 0.32, 0.38 }));
             Assert.That(crop.KL, Is.EqualTo(new double[] { 0.1, 0.1, 0.08, 0.06 }));
             Assert.That(crop.XF, Is.EqualTo(new double[] { 1, 1, 1, 1 }));
@@ -420,6 +420,25 @@
             Memo memo = sims.Children[0].Children[0] as Memo;
             Assert.That(memo, Is.Not.Null);
             Assert.That(memo.Text, Is.EqualTo("hello there"), "Failed to import memo message from .apsim file");
+        }
+
+        [Test]
+        public void TestInitialEmptySolutesInitialisesSolutes()
+        {
+          string xml = ReflectionUtilities.GetResourceAsString("UnitTests.Core.ApsimFile.SoilMissingSolutesAndInitialWater.apsim");
+          var importer = new Importer();
+          Simulations simulations = importer.CreateSimulationsFromXml(xml, e => Assert.Fail());
+
+          foreach(Solute solute in simulations.FindAllDescendants<Solute>())
+          {
+            Assert.That(solute.Thickness, Is.Not.Null);
+            Assert.That(MathUtilities.Sum(solute.kgha).Equals(0));
+          }
+
+          foreach(WaterBalance water in simulations.FindAllDescendants<WaterBalance>())
+          {
+            Assert.That(water.Thickness, Is.Not.Null);
+          }
         }
     }
 }


### PR DESCRIPTION
Resolves #9727 

Refactored the importer solutes code to handle if solutes is missing and give the new solutes the default values and layer structure from Water.

Also added default value of 100% full for initialwater if that node is missing from the apsim file. All defaults are based on what Apsim 7.10 uses as defaults for components when added new.