### PR TITLE
Fix protein expression calculation in wheat models

### DIFF
--- a/Models/Resources/Barley.json
+++ b/Models/Resources/Barley.json
@@ -2618,7 +2618,7 @@
             },
             {
               "$type": "Models.Functions.ExpressionFunction, Models",
-              "Expression": "([Grain].Live.N + [Grain].Dead.N)/([Grain].Live.Wt + [Grain].Dead.Wt) * 100 * 5.71",
+              "Expression": "divide(([Grain].Live.N + [Grain].Dead.N),([Grain].Live.Wt + [Grain].Dead.Wt)) * 100 * 5.71",
               "Name": "Protein",
               "Children": [],
               "IncludeInDocumentation": false,


### PR DESCRIPTION
resolves #9794 

Update the expression for Barley model protein calculation to use a divide function for greater protection against divide by zero issues