### PR TITLE
fix: add property to menu description args in checkpoint menu to show the 'show in graph?' option

### DIFF
--- a/ApsimNG/Presenters/CheckpointsPresenter.cs
+++ b/ApsimNG/Presenters/CheckpointsPresenter.cs
@@ -57,7 +57,8 @@
             popupMenu = new MenuDescriptionArgs()
             {
                 Name = "Show on graphs?",
-                ResourceNameForImage = "empty"
+                ResourceNameForImage = "empty",
+                Enabled = true,
             };
             popupMenu.OnClick += OnCheckpointTicked;
             checkpointList.ContextMenu = new MenuView();


### PR DESCRIPTION
resolves #9790

Checkpoint presenter just needed to initialise the menu description args (context menu options) with an enabled option set to true to make it appear like it used to.