### PR TITLE
Link citations to references in documentation

### DIFF
--- a/APSIM.Documentation/WebDocs.cs
+++ b/APSIM.Documentation/WebDocs.cs
@@ -362,7 +362,7 @@ namespace APSIM.Documentation
                     if (citation != null)
                     {
                         citations.Add(citation);
-                        output = output.Replace(value, citation.InTextCite);
+                        output = output.Replace(value, $"[{citation.InTextCite}](#references)");
                     }
                 }
             }

--- a/Tests/UnitTests/Documentation/DocumentTests.cs
+++ b/Tests/UnitTests/Documentation/DocumentTests.cs
@@ -6,6 +6,7 @@ using Models.Core.ApsimFile;
 using System.Collections.Generic;
 using NUnit.Framework;
 using System.IO;
+using APSIM.Documentation;
 
 namespace UnitTests.Documentation
 {
@@ -68,6 +69,18 @@ namespace UnitTests.Documentation
                     Assert.That(textA, Is.EqualTo(textE), message: errorMessage);
                 }
             }
+        }
+
+        /// <summary>
+        /// Test that the citation processor replaces citations with links to references section.
+        /// </summary>
+        [Test]
+        public void TestProcessCitationsReplacesCitationWithLink()
+        {
+            string text = "This is a citation [brown_plant_2014] and some more text.";
+            string expected = "This is a citation [Brown et al., 2014](#references) and some more text.";
+            WebDocs.ProcessCitations(text, out string actual);
+            Assert.That(actual, Is.EqualTo(expected));
         }
     }
 }


### PR DESCRIPTION
resolves #9804

Update citation processing to modify citation text from just a citation to a citation that is a link to the references section in the documentation. Add a test to verify this functionality.