### PR TITLE
9775 Phenology Phase returns null when not alive

### DIFF
--- a/Models/PMF/Phenology/Phases/BlankPhase.cs
+++ b/Models/PMF/Phenology/Phases/BlankPhase.cs
@@ -1,0 +1,31 @@
+﻿using Models.Core;
+
+namespace Models.PMF.Phen
+{
+    /// <summary>
+    /// A phase that represents no phase. Used when a plant has not been sown yet.
+    /// </summary>
+    public class BlankPhase : Model, IPhase
+    {
+        /// <summary></summary>
+        public string Start { get {return "";} }
+
+        /// <summary></summary>
+        public string End { get {return "";} }
+
+        /// <summary></summary>
+        public bool IsEmerged { get {return false;} }
+
+        /// <summary></summary>
+        public double FractionComplete { get { return 0; } }
+
+        /// <summary></summary>
+        public bool DoTimeStep(ref double propOfDayToUse) { return false; }
+
+        /// <summary>Resets the phase.</summary>
+        public void ResetPhase() {}
+    }
+}
+
+
+

--- a/Models/PMF/Phenology/Phenology.cs
+++ b/Models/PMF/Phenology/Phenology.cs
@@ -180,8 +180,10 @@ namespace Models.PMF.Phen
         {
             get
             {
-                if (phases == null || currentPhaseIndex >= phases.Count || !plant.IsAlive)
+                if (phases == null || currentPhaseIndex >= phases.Count)
                     return null;
+                else if (!plant.IsAlive)
+                    return new BlankPhase() {Name=""};
                 else
                     return phases[currentPhaseIndex];
             }

--- a/Models/PMF/Phenology/Phenology.cs
+++ b/Models/PMF/Phenology/Phenology.cs
@@ -122,7 +122,15 @@ namespace Models.PMF.Phen
 
         /// <summary>The emerged</summary>
         [JsonIgnore]
-        public bool Emerged { get { return CurrentPhase.IsEmerged; } }
+        public bool Emerged { 
+            get 
+            { 
+                if (CurrentPhase != null)
+                    return CurrentPhase.IsEmerged; 
+                else
+                    return false;
+            } 
+        }
 
         /// <summary>A one based stage number.</summary>
         [JsonIgnore]
@@ -147,7 +155,7 @@ namespace Models.PMF.Phen
         {
             get
             {
-                if (OnStartDayOf(CurrentPhase.Start))
+                if (CurrentPhase != null && OnStartDayOf(CurrentPhase.Start))
                     return CurrentPhase.Start;
                 else
                     return "";
@@ -159,7 +167,10 @@ namespace Models.PMF.Phen
         {
             get
             {
-                return CurrentPhase.FractionComplete;
+                if (CurrentPhase != null)
+                    return CurrentPhase.FractionComplete;
+                else
+                    return 0;
             }
         }
 
@@ -169,7 +180,7 @@ namespace Models.PMF.Phen
         {
             get
             {
-                if (phases == null || currentPhaseIndex >= phases.Count)
+                if (phases == null || currentPhaseIndex >= phases.Count || !plant.IsAlive)
                     return null;
                 else
                     return phases[currentPhaseIndex];

--- a/Models/PMF/Phenology/Scales/ZadokPMF.cs
+++ b/Models/PMF/Phenology/Scales/ZadokPMF.cs
@@ -52,32 +52,33 @@ namespace Models.PMF.Phen
             get
             {
                 double fracInCurrent = Phenology.FractionInCurrentPhase;
-                double zadok_stage = 0.0;
-                if (Phenology.InPhase("Germinating"))
-                    zadok_stage = 5.0f * fracInCurrent;
-                else if (Phenology.InPhase("Emerging"))
-                    zadok_stage = 5.0f + 5 * fracInCurrent;
-                else if ((Phenology.InPhase("Vegetative") && fracInCurrent <= 0.9)
-                    || (!Phenology.InPhase("ReadyForHarvesting") && Phenology.Stage < 4.3))
+                if (Phenology.InPhase(""))
                 {
-                    if (Structure.BranchNumber <= 0.0)
-                        zadok_stage = 10.0f + Structure.LeafTipsAppeared;
-                    else
-                        zadok_stage = 20.0f + Structure.BranchNumber;
+                    return 0;
+                }
+                else if (Phenology.InPhase("Germinating"))
+                {
+                    return 5.0f * fracInCurrent;
+                }
+                else if (Phenology.InPhase("Emerging"))
+                {
+                    return 5.0f + 5 * fracInCurrent;
+                }
+                else if ((Phenology.InPhase("Vegetative") && fracInCurrent <= 0.9) || (!Phenology.InPhase("ReadyForHarvesting") && Phenology.Stage < 4.3))
+                {
                     // Try using Yield Prophet approach where Zadok stage during vegetative phase is based on leaf number only
-                    zadok_stage = 10.0f + Structure.LeafTipsAppeared;
-
+                    return 10.0f + Structure.LeafTipsAppeared;
                 }
                 else if (!Phenology.InPhase("ReadyForHarvesting"))
                 {
                     double[] zadok_code_y = { 30.0, 33, 39.0, 65.0, 71.0, 87.0, 90.0 };
                     double[] zadok_code_x = { 4.3, 4.9, 5.0, 6.0, 7.0, 8.0, 9.0 };
-                    bool DidInterpolate;
-                    zadok_stage = MathUtilities.LinearInterpReal(Phenology.Stage,
-                                                               zadok_code_x, zadok_code_y,
-                                                               out DidInterpolate);
+                    return MathUtilities.LinearInterpReal(Phenology.Stage, zadok_code_x, zadok_code_y, out bool DidInterpolate);
                 }
-                return zadok_stage;
+                else
+                {
+                    return 0;
+                }
             }
         }
     }


### PR DESCRIPTION
Resolves #9775

Rather than the approach Hamish used in #9781 to add a new phenology phase, ~~I've simply adjusted Phenology to return 'null' when the linked plant to it is not alive. It already returned null when phases weren't set or when the phase index was too big, so this shouldn't have too many knock on effects.~~

Then when other functions like getting the name, or emergence are called, they return sensible results if the phase is null.

Will test in validation and see what happens.