### PR TITLE
Add ability to ignore commented lines in composite factors specifications

### DIFF
--- a/Models/Factorial/CompositeFactor.cs
+++ b/Models/Factorial/CompositeFactor.cs
@@ -127,7 +127,7 @@ namespace Models.Factorial
         /// <param name="allValues">The list of values to add to.</param>
         private void ParseSpecification(string specification, List<string> allPaths, List<object> allValues)
         {
-            if (string.IsNullOrEmpty(specification))
+            if (string.IsNullOrEmpty(specification) || specification.StartsWith("//"))
                 return;
 
             string path = specification;

--- a/Tests/UnitTests/Factorial/ExperimentTests.cs
+++ b/Tests/UnitTests/Factorial/ExperimentTests.cs
@@ -960,7 +960,7 @@ namespace UnitTests.Factorial
 
         }
 
-                /// <summary>Ensure a property set overrides work.</summary>
+        /// <summary>Ensure a property set overrides work.</summary>
         [Test]
         public void EnsureCommentingPropertyWorks()
         {
@@ -1004,7 +1004,6 @@ namespace UnitTests.Factorial
             Assert.That(sims.Count, Is.EqualTo(1));
 
             Assert.That(sims[0].Descriptors.Find(d => d.Name == "Experiment").Value, Is.EqualTo("Exp1"));
-            // Assert.That(sims[0].Descriptors.Find(d => d.Name == "MaxT").Value, Is.EqualTo("20"));
             var weather = sims[0].ToSimulation().Children[0] as MockWeather;
             Assert.That(weather.MaxT, Is.EqualTo(20));
         }

--- a/Tests/UnitTests/Factorial/ExperimentTests.cs
+++ b/Tests/UnitTests/Factorial/ExperimentTests.cs
@@ -960,5 +960,54 @@ namespace UnitTests.Factorial
 
         }
 
+                /// <summary>Ensure a property set overrides work.</summary>
+        [Test]
+        public void EnsureCommentingPropertyWorks()
+        {
+            var experiment = new Experiment()
+            {
+                Name = "Exp1",
+                Children = new List<IModel>()
+                {
+                    new Simulation()
+                    {
+                        Name = "BaseSimulation",
+                        Children = new List<IModel>()
+                        {
+                            new MockWeather()
+                            {
+                                Name = "Weather",
+                                MaxT = 1,
+                                StartDate = DateTime.MinValue
+                            },
+                        }
+                    },
+                    new Factors()
+                    {
+                        Children = new List<IModel>()
+                        {
+                            new CompositeFactor()
+                            {
+                                Name = "MaxT",
+                                Specifications = new List<string>(){
+                                    "//[Weather].MaxT = 10",
+                                    "[Weather].MaxT = 20"
+                                }
+                            },
+                        }
+                    }
+                }
+            };
+            experiment.ParentAllDescendants();
+
+            var sims = experiment.GenerateSimulationDescriptions();
+            Assert.That(sims.Count, Is.EqualTo(1));
+
+            Assert.That(sims[0].Descriptors.Find(d => d.Name == "Experiment").Value, Is.EqualTo("Exp1"));
+            // Assert.That(sims[0].Descriptors.Find(d => d.Name == "MaxT").Value, Is.EqualTo("20"));
+            var weather = sims[0].ToSimulation().Children[0] as MockWeather;
+            Assert.That(weather.MaxT, Is.EqualTo(20));
+        }
+
     }
 }


### PR DESCRIPTION
resolves #9805 

Implement functionality to ignore lines that start with "//" in composite factor specifications, enhancing the parsing logic.