### PR TITLE
Ensure detached and removed biomass are zeroed

### DIFF
--- a/Models/AgPasture/PastureSpecies.cs
+++ b/Models/AgPasture/PastureSpecies.cs
@@ -287,9 +287,6 @@ namespace Models.AgPasture
                 root.Dead.DetachBiomass(RootWt, RootN);
             }
 
-            // set flag to zero all transfer variables 'tomorrow'
-            hasJustEnded = true;
-
             // reset state variables
             Leaf.SetBiomassState(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
             Stem.SetBiomassState(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
@@ -989,9 +986,6 @@ namespace Models.AgPasture
 
         /// <summary>Flag whether this species is alive (actively growing).</summary>
         private bool isAlive = false;
-
-        /// <summary>Flag whether this species has been ended today or yesterday (to clean up variables).</summary>
-        private bool hasJustEnded = false;
 
         /// <summary>Number of layers in the soil.</summary>
         private int nLayers;
@@ -2660,10 +2654,7 @@ namespace Models.AgPasture
         [EventSubscribe("DoDailyInitialisation")]
         private void OnDoDailyInitialisation(object sender, EventArgs e)
         {
-            if (isAlive || hasJustEnded)
-            {
-                ClearDailyTransferredAmounts();
-            }
+            ClearDailyTransferredAmounts();
         }
 
         /// <summary>Reset the transfer amounts in the plant and all organs.</summary>
@@ -2711,11 +2702,6 @@ namespace Models.AgPasture
             foreach (PastureBelowGroundOrgan root in roots)
             {
                 root.ClearDailyTransferredAmounts();
-            }
-
-            if (hasJustEnded)
-            {
-                hasJustEnded = false;
             }
         }
 

--- a/Models/PMF/Organs/GenericOrgan.cs
+++ b/Models/PMF/Organs/GenericOrgan.cs
@@ -147,6 +147,11 @@ namespace Models.PMF.Organs
         /// <summary>The dry matter potentially being allocated</summary>
         public BiomassPoolType potentialDMAllocation { get; set; }
 
+        /// <summary>
+        /// Flag whether leaf has just been terminated (crop ended), for clean up
+        /// </summary>
+        bool hasJustBeenTerminated;
+
         /// <summary>Constructor</summary>
         public GenericOrgan()
         {
@@ -487,7 +492,15 @@ namespace Models.PMF.Organs
         protected void OnDoDailyInitialisation(object sender, EventArgs e)
         {
             if (parentPlant.IsAlive)
+            {
                 ClearBiomassFlows();
+            }
+
+            if (hasJustBeenTerminated)
+            {
+                ClearBiomassFlows();
+                hasJustBeenTerminated = false;
+            }
         }
 
         /// <summary>Called when crop is ending</summary>
@@ -500,6 +513,7 @@ namespace Models.PMF.Organs
             {
                 Clear();
                 ClearBiomassFlows();
+                hasJustBeenTerminated = false;
                 Live.StructuralWt = InitialWt.Structural.Value();
                 Live.MetabolicWt = InitialWt.Metabolic.Value();
                 Live.StorageWt = InitialWt.Storage.Value();
@@ -561,6 +575,7 @@ namespace Models.PMF.Organs
                 surfaceOrganicMatter.Add(Wt * 10, N * 10, 0, parentPlant.PlantType, Name);
             }
 
+            hasJustBeenTerminated = true;
             Clear();
         }
 

--- a/Models/PMF/Organs/GenericOrgan.cs
+++ b/Models/PMF/Organs/GenericOrgan.cs
@@ -147,11 +147,6 @@ namespace Models.PMF.Organs
         /// <summary>The dry matter potentially being allocated</summary>
         public BiomassPoolType potentialDMAllocation { get; set; }
 
-        /// <summary>
-        /// Flag whether leaf has just been terminated (crop ended), for clean up
-        /// </summary>
-        bool hasJustBeenTerminated;
-
         /// <summary>Constructor</summary>
         public GenericOrgan()
         {
@@ -491,16 +486,7 @@ namespace Models.PMF.Organs
         [EventSubscribe("DoDailyInitialisation")]
         protected void OnDoDailyInitialisation(object sender, EventArgs e)
         {
-            if (parentPlant.IsAlive)
-            {
-                ClearBiomassFlows();
-            }
-
-            if (hasJustBeenTerminated)
-            {
-                ClearBiomassFlows();
-                hasJustBeenTerminated = false;
-            }
+            ClearBiomassFlows();
         }
 
         /// <summary>Called when crop is ending</summary>
@@ -513,7 +499,6 @@ namespace Models.PMF.Organs
             {
                 Clear();
                 ClearBiomassFlows();
-                hasJustBeenTerminated = false;
                 Live.StructuralWt = InitialWt.Structural.Value();
                 Live.MetabolicWt = InitialWt.Metabolic.Value();
                 Live.StorageWt = InitialWt.Storage.Value();
@@ -575,7 +560,6 @@ namespace Models.PMF.Organs
                 surfaceOrganicMatter.Add(Wt * 10, N * 10, 0, parentPlant.PlantType, Name);
             }
 
-            hasJustBeenTerminated = true;
             Clear();
         }
 

--- a/Models/PMF/Organs/HIReproductiveOrgan.cs
+++ b/Models/PMF/Organs/HIReproductiveOrgan.cs
@@ -144,7 +144,15 @@ namespace Models.PMF.Organs
         protected void OnDoDailyInitialisation(object sender, EventArgs e)
         {
             if (parentPlant.IsAlive)
+            {
                 ClearBiomassFlows();
+            }
+
+            if (hasJustBeenTerminated)
+            {
+                ClearBiomassFlows();
+                hasJustBeenTerminated = false;
+            }
         }
 
         /// <summary>Called when [simulation commencing].</summary>
@@ -175,6 +183,7 @@ namespace Models.PMF.Organs
             {
                 Clear();
                 ClearBiomassFlows();
+                hasJustBeenTerminated = false;
             }
         }
 
@@ -191,6 +200,7 @@ namespace Models.PMF.Organs
                 SurfaceOrganicMatter.Add(Wt * 10, N * 10, 0, parentPlant.PlantType, Name);
             }
 
+            hasJustBeenTerminated = true;
             Clear();
         }
 
@@ -310,6 +320,11 @@ namespace Models.PMF.Organs
             Removed.Clear();
 
         }
+
+        /// <summary>
+        /// Flag whether leaf has just been terminated (crop ended), for clean up
+        /// </summary>
+        bool hasJustBeenTerminated;
 
         /// <summary>Clears the transferring biomass amounts.</summary>
         private void ClearBiomassFlows()

--- a/Models/PMF/Organs/HIReproductiveOrgan.cs
+++ b/Models/PMF/Organs/HIReproductiveOrgan.cs
@@ -143,16 +143,7 @@ namespace Models.PMF.Organs
         [EventSubscribe("DoDailyInitialisation")]
         protected void OnDoDailyInitialisation(object sender, EventArgs e)
         {
-            if (parentPlant.IsAlive)
-            {
-                ClearBiomassFlows();
-            }
-
-            if (hasJustBeenTerminated)
-            {
-                ClearBiomassFlows();
-                hasJustBeenTerminated = false;
-            }
+            ClearBiomassFlows();
         }
 
         /// <summary>Called when [simulation commencing].</summary>
@@ -183,7 +174,6 @@ namespace Models.PMF.Organs
             {
                 Clear();
                 ClearBiomassFlows();
-                hasJustBeenTerminated = false;
             }
         }
 
@@ -200,7 +190,6 @@ namespace Models.PMF.Organs
                 SurfaceOrganicMatter.Add(Wt * 10, N * 10, 0, parentPlant.PlantType, Name);
             }
 
-            hasJustBeenTerminated = true;
             Clear();
         }
 
@@ -320,11 +309,6 @@ namespace Models.PMF.Organs
             Removed.Clear();
 
         }
-
-        /// <summary>
-        /// Flag whether leaf has just been terminated (crop ended), for clean up
-        /// </summary>
-        bool hasJustBeenTerminated;
 
         /// <summary>Clears the transferring biomass amounts.</summary>
         private void ClearBiomassFlows()

--- a/Models/PMF/Organs/Leaf.cs
+++ b/Models/PMF/Organs/Leaf.cs
@@ -349,11 +349,6 @@ namespace Models.PMF.Organs
         private Biomass liveBiomass = new Biomass();
         private Biomass deadBiomass = new Biomass();
 
-        /// <summary>
-        /// Flag whether leaf has just been terminated (crop ended), for clean up
-        /// </summary>
-        bool hasJustBeenTerminated;
-
         #endregion
 
         #region States
@@ -1815,7 +1810,6 @@ namespace Models.PMF.Organs
                 if (data.MaxCover <= 0.0)
                     throw new Exception("MaxCover must exceed zero in a Sow event.");
                 MaxCover = data.MaxCover;
-                hasJustBeenTerminated = false;
             }
         }
 
@@ -1886,7 +1880,6 @@ namespace Models.PMF.Organs
 
             Reset();
             CohortsAtInitialisation = 0;
-            hasJustBeenTerminated = true;
         }
 
         /// <summary>Called when crop is being cut.</summary>
@@ -1914,20 +1907,9 @@ namespace Models.PMF.Organs
         [EventSubscribe("DoDailyInitialisation")]
         protected void OnDoDailyInitialisation(object sender, EventArgs e)
         {
-            if (parentPlant.IsAlive)
-            {
-                ClearBiomassFlows();
-                foreach (LeafCohort leaf in Leaves)
-                    leaf.DoDailyCleanup();
-            }
-
-            if (hasJustBeenTerminated)
-            {
-                ClearBiomassFlows();
-                hasJustBeenTerminated = false;
-                foreach (LeafCohort leaf in Leaves)
-                    leaf.DoDailyCleanup();
-            }
+            ClearBiomassFlows();
+            foreach (LeafCohort leaf in Leaves)
+                leaf.DoDailyCleanup();
         }
 
         /// <summary>Called when [phase changed].</summary>

--- a/Models/PMF/Organs/Leaf.cs
+++ b/Models/PMF/Organs/Leaf.cs
@@ -348,6 +348,12 @@ namespace Models.PMF.Organs
         private bool needToRecalculateLiveDead = true;
         private Biomass liveBiomass = new Biomass();
         private Biomass deadBiomass = new Biomass();
+
+        /// <summary>
+        /// Flag whether leaf has just been terminated (crop ended), for clean up
+        /// </summary>
+        bool hasJustBeenTerminated;
+
         #endregion
 
         #region States
@@ -1809,6 +1815,7 @@ namespace Models.PMF.Organs
                 if (data.MaxCover <= 0.0)
                     throw new Exception("MaxCover must exceed zero in a Sow event.");
                 MaxCover = data.MaxCover;
+                hasJustBeenTerminated = false;
             }
         }
 
@@ -1879,6 +1886,7 @@ namespace Models.PMF.Organs
 
             Reset();
             CohortsAtInitialisation = 0;
+            hasJustBeenTerminated = true;
         }
 
         /// <summary>Called when crop is being cut.</summary>
@@ -1909,6 +1917,14 @@ namespace Models.PMF.Organs
             if (parentPlant.IsAlive)
             {
                 ClearBiomassFlows();
+                foreach (LeafCohort leaf in Leaves)
+                    leaf.DoDailyCleanup();
+            }
+
+            if (hasJustBeenTerminated)
+            {
+                ClearBiomassFlows();
+                hasJustBeenTerminated = false;
                 foreach (LeafCohort leaf in Leaves)
                     leaf.DoDailyCleanup();
             }

--- a/Models/PMF/Organs/Nodule.cs
+++ b/Models/PMF/Organs/Nodule.cs
@@ -260,6 +260,11 @@ namespace Models.PMF.Organs
         /// <summary>The dry matter potentially being allocated</summary>
         public BiomassPoolType potentialDMAllocation { get; set; }
 
+        /// <summary>
+        /// Flag whether nodule has just been terminated (crop ended), for clean up
+        /// </summary>
+        bool hasJustBeenTerminated;
+
         /// <summary>Constructor</summary>
         public Nodule()
         {
@@ -494,7 +499,15 @@ namespace Models.PMF.Organs
         protected void OnDoDailyInitialisation(object sender, EventArgs e)
         {
             if (parentPlant.IsAlive)
+            {
                 ClearBiomassFlows();
+            }
+
+            if (hasJustBeenTerminated)
+            {
+                ClearBiomassFlows();
+                hasJustBeenTerminated = false;
+            }
         }
 
         /// <summary>Called when crop is ending</summary>
@@ -507,6 +520,7 @@ namespace Models.PMF.Organs
             {
                 Clear();
                 ClearBiomassFlows();
+                hasJustBeenTerminated = false;
                 Live.StructuralWt = initialWtFunction.Value();
                 Live.StorageWt = 0.0;
                 Live.StructuralN = Live.StructuralWt * minimumNConc.Value();
@@ -578,6 +592,7 @@ namespace Models.PMF.Organs
                 surfaceOrganicMatter.Add(Wt * 10, N * 10, 0, parentPlant.PlantType, Name);
             }
 
+            hasJustBeenTerminated = true;
             Clear();
         }
 

--- a/Models/PMF/Organs/Nodule.cs
+++ b/Models/PMF/Organs/Nodule.cs
@@ -260,11 +260,6 @@ namespace Models.PMF.Organs
         /// <summary>The dry matter potentially being allocated</summary>
         public BiomassPoolType potentialDMAllocation { get; set; }
 
-        /// <summary>
-        /// Flag whether nodule has just been terminated (crop ended), for clean up
-        /// </summary>
-        bool hasJustBeenTerminated;
-
         /// <summary>Constructor</summary>
         public Nodule()
         {
@@ -498,16 +493,7 @@ namespace Models.PMF.Organs
         [EventSubscribe("DoDailyInitialisation")]
         protected void OnDoDailyInitialisation(object sender, EventArgs e)
         {
-            if (parentPlant.IsAlive)
-            {
-                ClearBiomassFlows();
-            }
-
-            if (hasJustBeenTerminated)
-            {
-                ClearBiomassFlows();
-                hasJustBeenTerminated = false;
-            }
+            ClearBiomassFlows();
         }
 
         /// <summary>Called when crop is ending</summary>
@@ -520,7 +506,6 @@ namespace Models.PMF.Organs
             {
                 Clear();
                 ClearBiomassFlows();
-                hasJustBeenTerminated = false;
                 Live.StructuralWt = initialWtFunction.Value();
                 Live.StorageWt = 0.0;
                 Live.StructuralN = Live.StructuralWt * minimumNConc.Value();
@@ -592,7 +577,6 @@ namespace Models.PMF.Organs
                 surfaceOrganicMatter.Add(Wt * 10, N * 10, 0, parentPlant.PlantType, Name);
             }
 
-            hasJustBeenTerminated = true;
             Clear();
         }
 

--- a/Models/PMF/Organs/PerennialLeaf.cs
+++ b/Models/PMF/Organs/PerennialLeaf.cs
@@ -29,7 +29,7 @@ namespace Models.PMF.Organs
         /// The plant
         /// </summary>
         [Link]
-        private Plant plant = null;
+        private Plant parentPlant = null;
 
         /// <summary>Carbon concentration</summary>
         /// [Units("-")]
@@ -90,6 +90,11 @@ namespace Models.PMF.Organs
         /// <summary>Gets the DM amount detached (sent to soil/surface organic matter) (g/m2)</summary>
         [JsonIgnore]
         public Biomass Detached { get; set; }
+
+        /// <summary>
+        /// Flag whether leaf has just been terminated (crop ended), for clean up
+        /// </summary>
+        bool hasJustBeenTerminated;
 
         #region Canopy interface
 
@@ -392,8 +397,16 @@ namespace Models.PMF.Organs
                     if (Structure != null)
                         Structure.LeafTipsAppeared = 1.0;
 
-            if (plant.IsAlive)
+            if (parentPlant.IsAlive)
+            {
                 ClearBiomassFlows();
+            }
+
+            if (hasJustBeenTerminated)
+            {
+                ClearBiomassFlows();
+                hasJustBeenTerminated = false;
+            }
         }
         #endregion
 
@@ -586,6 +599,7 @@ namespace Models.PMF.Organs
         protected void OnPlantSowing(object sender, SowingParameters data)
         {
             Clear();
+            hasJustBeenTerminated = false;
         }
 
         /// <summary>Kill a fraction of the green leaf</summary>
@@ -669,6 +683,7 @@ namespace Models.PMF.Organs
                 SurfaceOrganicMatter.Add(Wt * 10, N * 10, 0, Plant.PlantType, Name);
             }
 
+            hasJustBeenTerminated = true;
             Clear();
         }
 

--- a/Models/PMF/Organs/PerennialLeaf.cs
+++ b/Models/PMF/Organs/PerennialLeaf.cs
@@ -25,12 +25,6 @@ namespace Models.PMF.Organs
         [Link]
         public IWeather MetData = null;
 
-        /// <summary>
-        /// The plant
-        /// </summary>
-        [Link]
-        private Plant parentPlant = null;
-
         /// <summary>Carbon concentration</summary>
         /// [Units("-")]
         [Link(Type = LinkType.Child, ByName = true)]

--- a/Models/PMF/Organs/PerennialLeaf.cs
+++ b/Models/PMF/Organs/PerennialLeaf.cs
@@ -91,11 +91,6 @@ namespace Models.PMF.Organs
         [JsonIgnore]
         public Biomass Detached { get; set; }
 
-        /// <summary>
-        /// Flag whether leaf has just been terminated (crop ended), for clean up
-        /// </summary>
-        bool hasJustBeenTerminated;
-
         #region Canopy interface
 
         /// <summary>Gets the canopy. Should return null if no canopy present.</summary>
@@ -397,16 +392,7 @@ namespace Models.PMF.Organs
                     if (Structure != null)
                         Structure.LeafTipsAppeared = 1.0;
 
-            if (parentPlant.IsAlive)
-            {
-                ClearBiomassFlows();
-            }
-
-            if (hasJustBeenTerminated)
-            {
-                ClearBiomassFlows();
-                hasJustBeenTerminated = false;
-            }
+            ClearBiomassFlows();
         }
         #endregion
 
@@ -599,7 +585,6 @@ namespace Models.PMF.Organs
         protected void OnPlantSowing(object sender, SowingParameters data)
         {
             Clear();
-            hasJustBeenTerminated = false;
         }
 
         /// <summary>Kill a fraction of the green leaf</summary>
@@ -683,7 +668,6 @@ namespace Models.PMF.Organs
                 SurfaceOrganicMatter.Add(Wt * 10, N * 10, 0, Plant.PlantType, Name);
             }
 
-            hasJustBeenTerminated = true;
             Clear();
         }
 

--- a/Models/PMF/Organs/ReproductiveOrgan.cs
+++ b/Models/PMF/Organs/ReproductiveOrgan.cs
@@ -214,6 +214,11 @@ namespace Models.PMF.Organs
             }
         }
 
+        /// <summary>
+        /// Flag whether organ has just been terminated (crop ended), for clean up
+        /// </summary>
+        bool hasJustBeenTerminated;
+
         /// <summary>Initializes a new instance of the <see cref="ReproductiveOrgan"/> class.</summary>
         public ReproductiveOrgan()
         {
@@ -241,6 +246,7 @@ namespace Models.PMF.Organs
             {
                 Clear();
                 ClearBiomassFlows();
+                hasJustBeenTerminated = false;
             }
         }
 
@@ -251,7 +257,15 @@ namespace Models.PMF.Organs
         protected void OnDoDailyInitialisation(object sender, EventArgs e)
         {
             if (parentPlant.IsAlive)
+            {
                 ClearBiomassFlows();
+            }
+
+            if (hasJustBeenTerminated)
+            {
+                ClearBiomassFlows();
+                hasJustBeenTerminated = false;
+            }
         }
 
         /// <summary>Called when crop is being cut.</summary>
@@ -281,6 +295,7 @@ namespace Models.PMF.Organs
                 SurfaceOrganicMatter.Add(Wt * 10, N * 10, 0, parentPlant.PlantType, Name);
             }
 
+            hasJustBeenTerminated = true;
             Clear();
         }
         /// <summary>Calculate and return the dry matter demand (g/m2)</summary>

--- a/Models/PMF/Organs/ReproductiveOrgan.cs
+++ b/Models/PMF/Organs/ReproductiveOrgan.cs
@@ -214,11 +214,6 @@ namespace Models.PMF.Organs
             }
         }
 
-        /// <summary>
-        /// Flag whether organ has just been terminated (crop ended), for clean up
-        /// </summary>
-        bool hasJustBeenTerminated;
-
         /// <summary>Initializes a new instance of the <see cref="ReproductiveOrgan"/> class.</summary>
         public ReproductiveOrgan()
         {
@@ -246,7 +241,6 @@ namespace Models.PMF.Organs
             {
                 Clear();
                 ClearBiomassFlows();
-                hasJustBeenTerminated = false;
             }
         }
 
@@ -256,16 +250,7 @@ namespace Models.PMF.Organs
         [EventSubscribe("DoDailyInitialisation")]
         protected void OnDoDailyInitialisation(object sender, EventArgs e)
         {
-            if (parentPlant.IsAlive)
-            {
-                ClearBiomassFlows();
-            }
-
-            if (hasJustBeenTerminated)
-            {
-                ClearBiomassFlows();
-                hasJustBeenTerminated = false;
-            }
+            ClearBiomassFlows();
         }
 
         /// <summary>Called when crop is being cut.</summary>
@@ -295,7 +280,6 @@ namespace Models.PMF.Organs
                 SurfaceOrganicMatter.Add(Wt * 10, N * 10, 0, parentPlant.PlantType, Name);
             }
 
-            hasJustBeenTerminated = true;
             Clear();
         }
         /// <summary>Calculate and return the dry matter demand (g/m2)</summary>

--- a/Models/PMF/Organs/Root.cs
+++ b/Models/PMF/Organs/Root.cs
@@ -182,9 +182,6 @@ namespace Models.PMF.Organs
         /// <summary>The N supply for reallocation</summary>
         private double nReallocationSupply = 0.0;
 
-        /// <summary>Flag whether root has just been terminated (crop ended), for clean up</summary>
-        bool hasJustBeenTerminated;
-
         /// <summary>Constructor</summary>
         public Root()
         {
@@ -1056,16 +1053,7 @@ namespace Models.PMF.Organs
         [EventSubscribe("DoDailyInitialisation")]
         private void OnDoDailyInitialisation(object sender, EventArgs e)
         {
-            if (parentPlant.IsAlive)
-            {
-                ClearBiomassFlows();
-            }
-
-            if (hasJustBeenTerminated)
-            {
-                ClearBiomassFlows();
-                hasJustBeenTerminated = false;
-            }
+            ClearBiomassFlows();
         }
 
         /// <summary>Called when crop is sown</summary>
@@ -1074,7 +1062,6 @@ namespace Models.PMF.Organs
         [EventSubscribe("PlantSowing")]
         private void OnPlantSowing(object sender, SowingParameters data)
         {
-            hasJustBeenTerminated = false;
             if (data.Plant == parentPlant)
             {
                 //sorghum calcs
@@ -1132,7 +1119,6 @@ namespace Models.PMF.Organs
             if (Wt > 0.0)
                 RemoveBiomass(liveToResidue: 1.0);
 
-            hasJustBeenTerminated = true;
             Clear();
         }
 

--- a/Models/PMF/Organs/Root.cs
+++ b/Models/PMF/Organs/Root.cs
@@ -182,6 +182,9 @@ namespace Models.PMF.Organs
         /// <summary>The N supply for reallocation</summary>
         private double nReallocationSupply = 0.0;
 
+        /// <summary>Flag whether root has just been terminated (crop ended), for clean up</summary>
+        bool hasJustBeenTerminated;
+
         /// <summary>Constructor</summary>
         public Root()
         {
@@ -1053,7 +1056,16 @@ namespace Models.PMF.Organs
         [EventSubscribe("DoDailyInitialisation")]
         private void OnDoDailyInitialisation(object sender, EventArgs e)
         {
-            ClearBiomassFlows();
+            if (parentPlant.IsAlive)
+            {
+                ClearBiomassFlows();
+            }
+
+            if (hasJustBeenTerminated)
+            {
+                ClearBiomassFlows();
+                hasJustBeenTerminated = false;
+            }
         }
 
         /// <summary>Called when crop is sown</summary>
@@ -1062,6 +1074,7 @@ namespace Models.PMF.Organs
         [EventSubscribe("PlantSowing")]
         private void OnPlantSowing(object sender, SowingParameters data)
         {
+            hasJustBeenTerminated = false;
             if (data.Plant == parentPlant)
             {
                 //sorghum calcs
@@ -1119,6 +1132,7 @@ namespace Models.PMF.Organs
             if (Wt > 0.0)
                 RemoveBiomass(liveToResidue: 1.0);
 
+            hasJustBeenTerminated = true;
             Clear();
         }
 

--- a/Models/PMF/Organs/Root.cs
+++ b/Models/PMF/Organs/Root.cs
@@ -482,6 +482,10 @@ namespace Models.PMF.Organs
             }
         }
 
+        /// <summary>Gets or sets the maximum nconc.</summary>
+        [Units("g/g")]
+        public double MaxNConc { get { return maximumNConc.Value(); } }
+
         /// <summary>Gets or sets the minimum nconc.</summary>
         [Units("g/g")]
         public double MinNConc { get { return minimumNConc.Value(); } }
@@ -901,7 +905,7 @@ namespace Models.PMF.Organs
                     Soil soil = zone.FindInScope<Soil>();
                     if (soil == null)
                         throw new Exception("Cannot find soil in zone: " + zone.Name);
-                    ZoneState newZone = new ZoneState(parentPlant, this, soil, ZoneRootDepths[i], ZoneInitialDM[i], parentPlant.Population, maximumNConc.Value(),
+                    ZoneState newZone = new ZoneState(parentPlant, this, soil, ZoneRootDepths[i], ZoneInitialDM[i], parentPlant.Population, MaxNConc,
                                                       rootFrontVelocity, maximumRootDepth, remobilisationCost);
                     Zones.Add(newZone);
                 }
@@ -1027,7 +1031,7 @@ namespace Models.PMF.Organs
             Soil soil = this.FindInScope<Soil>();
             if (soil == null)
                 throw new Exception("Cannot find soil");
-            PlantZone = new ZoneState(parentPlant, this, soil, 0, InitialWt, parentPlant.Population, maximumNConc.Value(),
+            PlantZone = new ZoneState(parentPlant, this, soil, 0, InitialWt, parentPlant.Population, MaxNConc,
                                       rootFrontVelocity, maximumRootDepth, remobilisationCost);
 
             SoilCrop = soil.FindDescendant<SoilCrop>(parentPlant.Name + "Soil");
@@ -1065,7 +1069,7 @@ namespace Models.PMF.Organs
             if (data.Plant == parentPlant)
             {
                 //sorghum calcs
-                PlantZone.Initialise(parentPlant.SowingData.Depth, InitialWt, parentPlant.Population, maximumNConc.Value());
+                PlantZone.Initialise(parentPlant.SowingData.Depth, InitialWt, parentPlant.Population, MaxNConc);
                 InitialiseZones();
 
                 needToRecalculateLiveDead = true;

--- a/Models/PMF/Organs/SimpleLeaf.cs
+++ b/Models/PMF/Organs/SimpleLeaf.cs
@@ -43,7 +43,7 @@ namespace Models.PMF.Organs
         /// The plant
         /// </summary>
         [Link]
-        private Plant plant = null;
+        private Plant parentPlant = null;
 
         /// <summary>Link to summary instance.</summary>
         [Link]
@@ -249,9 +249,14 @@ namespace Models.PMF.Organs
         private Biomass startLive = null;
 
         /// <summary>
-        /// Is leaf initialised?
+        /// Flag whether leaf is initialised
         /// </summary>
         private bool leafInitialised = false;
+
+        /// <summary>
+        /// Flag whether leaf has just been terminated (crop ended), for clean up
+        /// </summary>
+        bool hasJustBeenTerminated;
 
         /// <summary>
         /// Constructor.
@@ -557,7 +562,7 @@ namespace Models.PMF.Organs
         {
             get
             {
-                return plant.PlantType;
+                return parentPlant.PlantType;
             }
         }
 
@@ -604,7 +609,7 @@ namespace Models.PMF.Organs
         {
             get
             {
-                if (plant.IsAlive)
+                if (parentPlant.IsAlive)
                 {
                     double greenCover = 0.0;
                     if (cover == null)
@@ -693,8 +698,6 @@ namespace Models.PMF.Organs
                 return totalRadn;
             }
         }
-
-
 
         /// <summary>
         /// Daily maximum stomatal conductance.
@@ -792,7 +795,7 @@ namespace Models.PMF.Organs
         private void OnDoPotentialPlantGrowth(object sender, EventArgs e)
         {
             // save current state
-            if (plant.IsEmerged)
+            if (parentPlant.IsEmerged)
                 startLive = ReflectionUtilities.Clone(Live) as Biomass;
             if (leafInitialised)
             {
@@ -905,8 +908,16 @@ namespace Models.PMF.Organs
         [EventSubscribe("DoDailyInitialisation")]
         protected void OnDoDailyInitialisation(object sender, EventArgs e)
         {
-            if (plant.IsAlive)
+            if (parentPlant.IsAlive)
+            {
                 ClearBiomassFlows();
+            }
+
+            if (hasJustBeenTerminated)
+            {
+                ClearBiomassFlows();
+                hasJustBeenTerminated  = false;
+            }
         }
 
         /// <summary>
@@ -917,10 +928,11 @@ namespace Models.PMF.Organs
         [EventSubscribe("PlantSowing")]
         protected void OnPlantSowing(object sender, SowingParameters data)
         {
-            if (data.Plant == plant)
+            if (data.Plant == parentPlant)
             {
                 Clear();
                 ClearBiomassFlows();
+                hasJustBeenTerminated = false;
                 Live.StructuralWt = initialWt.Value();
                 Live.StorageWt = 0.0;
                 Live.StructuralN = Live.StructuralWt * minimumNConc.Value();
@@ -936,7 +948,7 @@ namespace Models.PMF.Organs
         [EventSubscribe("DoActualPlantGrowth")]
         protected void OnDoActualPlantGrowth(object sender, EventArgs e)
         {
-            if (plant.IsAlive)
+            if (parentPlant.IsAlive)
             {
                 // Do senescence
                 double senescedFrac = senescenceRate.Value();
@@ -956,7 +968,7 @@ namespace Models.PMF.Organs
                 if (detaching.Wt > 0.0)
                 {
                     Detached.Add(detaching);
-                    surfaceOrganicMatter.Add(detaching.Wt * 10, detaching.N * 10, 0, plant.PlantType, Name);
+                    surfaceOrganicMatter.Add(detaching.Wt * 10, detaching.N * 10, 0, parentPlant.PlantType, Name);
                 }
 
                 // Do maintenance respiration
@@ -981,9 +993,10 @@ namespace Models.PMF.Organs
             {
                 Detached.Add(Live);
                 Detached.Add(Dead);
-                surfaceOrganicMatter.Add(Wt * 10, N * 10, 0, plant.PlantType, Name);
+                surfaceOrganicMatter.Add(Wt * 10, N * 10, 0, parentPlant.PlantType, Name);
             }
 
+            hasJustBeenTerminated = true;
             Clear();
         }
 

--- a/Models/PMF/Organs/SimpleLeaf.cs
+++ b/Models/PMF/Organs/SimpleLeaf.cs
@@ -254,11 +254,6 @@ namespace Models.PMF.Organs
         private bool leafInitialised = false;
 
         /// <summary>
-        /// Flag whether leaf has just been terminated (crop ended), for clean up
-        /// </summary>
-        bool hasJustBeenTerminated;
-
-        /// <summary>
         /// Constructor.
         /// </summary>
         public SimpleLeaf()
@@ -908,16 +903,7 @@ namespace Models.PMF.Organs
         [EventSubscribe("DoDailyInitialisation")]
         protected void OnDoDailyInitialisation(object sender, EventArgs e)
         {
-            if (parentPlant.IsAlive)
-            {
-                ClearBiomassFlows();
-            }
-
-            if (hasJustBeenTerminated)
-            {
-                ClearBiomassFlows();
-                hasJustBeenTerminated  = false;
-            }
+            ClearBiomassFlows();
         }
 
         /// <summary>
@@ -932,7 +918,6 @@ namespace Models.PMF.Organs
             {
                 Clear();
                 ClearBiomassFlows();
-                hasJustBeenTerminated = false;
                 Live.StructuralWt = initialWt.Value();
                 Live.StorageWt = 0.0;
                 Live.StructuralN = Live.StructuralWt * minimumNConc.Value();
@@ -996,7 +981,6 @@ namespace Models.PMF.Organs
                 surfaceOrganicMatter.Add(Wt * 10, N * 10, 0, parentPlant.PlantType, Name);
             }
 
-            hasJustBeenTerminated = true;
             Clear();
         }
 

--- a/Models/PMF/Organs/SorghumLeaf.cs
+++ b/Models/PMF/Organs/SorghumLeaf.cs
@@ -142,11 +142,6 @@ namespace Models.PMF.Organs
         /// <summary>Tolerance for biomass comparisons</summary>
         protected double biomassToleranceValue = 0.0000000001;
 
-        /// <summary>
-        /// Flag whether leaf has just been terminated (crop ended), for clean up
-        /// </summary>
-        bool hasJustBeenTerminated;
-
         /// <summary>Constructor</summary>
         public SorghumLeaf()
         {
@@ -1159,19 +1154,7 @@ namespace Models.PMF.Organs
         [EventSubscribe("DoDailyInitialisation")]
         private void OnDoDailyInitialisation(object sender, EventArgs e)
         {
-            if (parentPlant.IsAlive)
-            {
-                if (parentPlant.IsAlive)
-                {
-                    ClearBiomassFlows();
-                }
-
-                if (hasJustBeenTerminated)
-                {
-                    ClearBiomassFlows();
-                    hasJustBeenTerminated = false;
-                }
-            }
+            ClearBiomassFlows();
         }
 
         /// <summary>Called when [phase changed].</summary>
@@ -1223,16 +1206,6 @@ namespace Models.PMF.Organs
             leafIndex = organNames.IndexOf(Name);
 
             ClearBiomassFlows();
-            hasJustBeenTerminated = false;
-        }
-
-        /// <summary>Called when crop is ending</summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
-        [EventSubscribe("PlantEnding")]
-        private void OnPlantEnding(object sender, EventArgs e)
-        {
-            hasJustBeenTerminated = true;
         }
 
         /// <summary>Event from sequencer telling us to do our potential growth.</summary>

--- a/Models/PMF/Plant.cs
+++ b/Models/PMF/Plant.cs
@@ -382,6 +382,7 @@ namespace Models.PMF
 
             // Undo cultivar changes.
             cultivarDefinition.Unapply();
+
             // Invoke a plant ending event.
             if (PlantEnding != null)
                 PlantEnding.Invoke(this, new EventArgs());


### PR DESCRIPTION
Resolves #9809 
Organs have two Biomass component (Detached and Removed) to record daily values of biomass that are detached (going back to residue or FOM) or removed (harvested, taken off field). These were not being zeroed at the end of crop and thus making difficult to record these variables to track biomass fluxes.
I added a variable (hasJustBeenEnded) that is set to true on CropEnding and then used to zero the two Biomass components (OnDoDailyInitialisation). 