### PR TITLE
Return an empty array rather than null if Zones are not yet initialised.

### DIFF
--- a/Models/Core/VariableProperty.cs
+++ b/Models/Core/VariableProperty.cs
@@ -359,7 +359,7 @@ namespace Models.Core
                     obj = ProcessPropertyOfArrayElement();
                 else
                     obj = this.property.GetValue(this.Object, null);
-                if (lowerArraySpecifier != 0 || upperArraySpecifier != 0)
+                if (obj != null && (lowerArraySpecifier != 0 || upperArraySpecifier != 0))
                 {
                     if (obj is IList array)
                     {

--- a/Models/PMF/Organs/Root.cs
+++ b/Models/PMF/Organs/Root.cs
@@ -351,7 +351,7 @@ namespace Models.PMF.Organs
             get
             {
                 if (Zones == null || Zones.Count == 0)
-                    return new double[0];
+                    return Array.Empty<double>();
                 double[] uptake = (double[])Zones[0].WaterUptake;
                 for (int i = 1; i != Zones.Count; i++)
                     uptake = MathUtilities.Add(uptake, Zones[i].WaterUptake);
@@ -379,7 +379,7 @@ namespace Models.PMF.Organs
             get
             {
                 if (Zones == null || Zones.Count == 0)
-                    return new double[0];
+                    return Array.Empty<double>();
                 if (Zones.Count > 1)
                     throw new Exception(this.Name + " Can't report layered Nuptake for multiple zones as they may not have the same size or number of layers");
                 double[] uptake = new double[Zones[0].Physical.Thickness.Length];

--- a/Models/PMF/Organs/Root.cs
+++ b/Models/PMF/Organs/Root.cs
@@ -351,7 +351,7 @@ namespace Models.PMF.Organs
             get
             {
                 if (Zones == null || Zones.Count == 0)
-                    return null;
+                    return new double[0];
                 double[] uptake = (double[])Zones[0].WaterUptake;
                 for (int i = 1; i != Zones.Count; i++)
                     uptake = MathUtilities.Add(uptake, Zones[i].WaterUptake);
@@ -379,7 +379,7 @@ namespace Models.PMF.Organs
             get
             {
                 if (Zones == null || Zones.Count == 0)
-                    return null;
+                    return new double[0];
                 if (Zones.Count > 1)
                     throw new Exception(this.Name + " Can't report layered Nuptake for multiple zones as they may not have the same size or number of layers");
                 double[] uptake = new double[Zones[0].Physical.Thickness.Length];


### PR DESCRIPTION
Resolves #9836 