### PR TITLE
Add more decimal places to the display of XF

### DIFF
--- a/Models/Soils/SoilCrop.cs
+++ b/Models/Soils/SoilCrop.cs
@@ -52,7 +52,7 @@ namespace Models.Soils
         /// <summary>The exploration factor</summary>
         [Summary]
         [Units("0-1")]
-        [Display(Format = "N1")]
+        [Display(Format = "N3")]
         public double[] XF { get; set; }
 
         /// <summary>The metadata for crop lower limit</summary>


### PR DESCRIPTION
resolves #9880 

Only showing 1 decimal place is making evaluating soil libraries difficult. Changed this to 3 places.

@rcichota 