### PR TITLE
9864 Simulation names don't conflict under replacements

### DIFF
--- a/APSIM.Documentation/Models/Types/DocSimulations.cs
+++ b/APSIM.Documentation/Models/Types/DocSimulations.cs
@@ -159,7 +159,7 @@ namespace APSIM.Documentation.Models.Types
                 { 
                     tags.Add(new Section(child.Name, DocumentTutorial(child as Simulation)));
                 } 
-                else if(child is Memo || child is Graph || !Folder.IsModelReplacementsFolder(child))
+                else if(child is Memo || child is Graph || (child is Folder && !Folder.IsModelReplacementsFolder(child)))
                 {
                     tags.AddRange(AutoDocumentation.DocumentModel(child));
                 }

--- a/APSIM.Documentation/Models/Types/DocSimulations.cs
+++ b/APSIM.Documentation/Models/Types/DocSimulations.cs
@@ -118,7 +118,7 @@ namespace APSIM.Documentation.Models.Types
             //Then just document the folders that aren't replacements
             foreach (IModel child in m.FindAllChildren<Folder>())
             {
-                if(child.Name != "Replacements")
+                if(!Folder.IsModelReplacementsFolder(child))
                     tags.AddRange(AutoDocumentation.DocumentModel(child));
             }
 
@@ -159,7 +159,7 @@ namespace APSIM.Documentation.Models.Types
                 { 
                     tags.Add(new Section(child.Name, DocumentTutorial(child as Simulation)));
                 } 
-                else if(child is Memo || child is Graph || (child is Folder && child.Name != "Replacements"))
+                else if(child is Memo || child is Graph || !Folder.IsModelReplacementsFolder(child))
                 {
                     tags.AddRange(AutoDocumentation.DocumentModel(child));
                 }

--- a/ApsimNG/Classes/PropertyPresenterHelpers.cs
+++ b/ApsimNG/Classes/PropertyPresenterHelpers.cs
@@ -20,8 +20,7 @@ namespace UserInterface.Classes
         /// <returns>A list of cultivars.</returns>
         public static string[] GetCultivarNames(IPlant crop)
         {
-            Simulations simulations = (crop as IModel).FindAncestor<Simulations>();
-            Folder replacements = simulations.FindChild<Folder>("Replacements");
+            Folder replacements = Folder.FindReplacementsFolder(crop);
 
             if (replacements == null)
                 return crop.CultivarNames;
@@ -139,8 +138,7 @@ namespace UserInterface.Classes
         {
             if (lifeCycle.LifeCyclePhaseNames.Length == 0)
             {
-                Simulations simulations = (lifeCycle as IModel).FindAncestor<Simulations>();
-                Folder replacements = simulations.FindChild<Folder>("Replacements");
+                Folder replacements = Folder.FindReplacementsFolder(lifeCycle);
                 if (replacements != null)
                 {
                     LifeCycle replacementLifeCycle = replacements.FindChild((lifeCycle as IModel).Name) as LifeCycle;

--- a/ApsimNG/EventArguments/NeedContextItemsArgs.cs
+++ b/ApsimNG/EventArguments/NeedContextItemsArgs.cs
@@ -268,7 +268,7 @@
                 catch (Exception) { }
             }
             
-            if (o == null && relativeTo.Parent is Folder && relativeTo.Parent.Name == "Replacements")
+            if (o == null && Folder.IsModelReplacementsFolder(relativeTo.Parent))
             {
                 // Model 'relativeTo' could be under replacements. Look for the first simulation and try that.
                 IModel simulation = relativeTo.Parent.Parent.FindInScope<Simulation>();
@@ -355,7 +355,7 @@
                 // If we're under replacements we won't be able to find some simulation-
                 // related nodes such as weather/soil/etc. In this scenario, we should
                 // search through all models, not just those in scope.
-                if (node == null && relativeTo.FindAncestor<Folder>("Replacements") != null)
+                if (node == null && Folder.IsUnderReplacementsFolder(relativeTo) != null)
                 {
                     node = relativeTo.FindAncestor<Simulations>().FindAllDescendants().FirstOrDefault(child => child.Name == modelName);
 

--- a/ApsimNG/Presenters/AddModelPresenter.cs
+++ b/ApsimNG/Presenters/AddModelPresenter.cs
@@ -186,7 +186,10 @@
                         else
                         {
                             child.ResourceName = selectedModelType.ResourceString;
-                            bool isUnderReplacements = model.Name == "Replacements";
+                            bool isUnderReplacements = false;
+                            if (Folder.IsModelReplacementsFolder(model))
+                                isUnderReplacements = true;
+
                             // Make all children that area about to be added from resource hidden and readonly.
                             bool isHidden = !isUnderReplacements;
                             foreach (Model descendant in child.FindAllDescendants())

--- a/Models/Core/ApsimFile/Structure.cs
+++ b/Models/Core/ApsimFile/Structure.cs
@@ -36,8 +36,8 @@ namespace Models.Core.ApsimFile
             }
             else throw new ArgumentException($"A {modelToAdd.GetType().Name} cannot be added to a {parent.GetType().Name}.");
 
-            if (modelToAdd is Folder && modelToAdd.Name.CompareTo("Replacements") == 0 && !(parent is Simulations))
-                throw new ArgumentException($"A Replacements can only be added to the top Simulations Node");
+            //Do error checking on model if it's a Replacements folder
+            Folder.IsModelReplacementsFolder(modelToAdd);
 
             modelToAdd.OnCreated();
 

--- a/Models/Core/Folder.cs
+++ b/Models/Core/Folder.cs
@@ -17,5 +17,54 @@ namespace Models.Core
         /// Whether this folder should show up in documentation or not.
         /// </remarks>
         public bool ShowInDocs { get; set; }
+
+        /// <summary>Returns true if this folder is a child of the root Simulations model, and has the name Replacements.</summary>
+        public static bool IsModelReplacementsFolder(IModel model)
+        {
+            if (model == null)
+                return false;
+
+            if (model.Name == "Replacements")
+            {
+                if (model is Folder)
+                {
+                    if (model.Parent is Simulations)
+                        return true;
+                    else
+                        throw new ArgumentException($"Replacements can only be added to the top Simulations Node");
+                }
+                else
+                {
+                    throw new ArgumentException($"Replacements must be a Folder");
+                }
+            }
+            return false;
+        }
+
+        /// <summary>Returns true if this folder is a child of the root Simulations model, and has the name Replacements.</summary>
+        public static Folder FindReplacementsFolder(IModel model)
+        {
+            //If this model is the root model, use it
+            IModel root = model;
+            if (model.Parent != null)
+                //Otherwise look for the simulations model
+                root = model.FindAncestor<Simulations>();
+            
+            Folder replacements = root.FindChild<Folder>("Replacements");
+            if (IsModelReplacementsFolder(replacements))
+                return replacements;
+            else
+                return null;
+        }
+
+        /// <summary>Returns true if this folder is a child of the root Simulations model, and has the name Replacements.</summary>
+        public static Folder IsUnderReplacementsFolder(IModel model)
+        {
+            Folder replacements = model.FindAncestor<Folder>("Replacements");
+            if (IsModelReplacementsFolder(replacements))
+                return replacements;
+            else
+                return null;
+        }
     }
 }

--- a/Models/Core/Resource.cs
+++ b/Models/Core/Resource.cs
@@ -51,7 +51,7 @@ namespace Models.Core
             {
                 modelFromResource.Enabled = enabled;
 
-                bool isUnderReplacements = model.FindAncestor<Folder>("Replacements") != null;
+                bool isUnderReplacements = Folder.IsUnderReplacementsFolder(model) != null;
 
                 // Get children that need to be added from the resource model
                 IEnumerable<IModel> childrenToAdd = modelFromResource.Children.Where(mc =>

--- a/Models/Core/Run/SimulationDescription.cs
+++ b/Models/Core/Run/SimulationDescription.cs
@@ -228,7 +228,7 @@ namespace Models.Core.Run
         {
             if (topLevelModel != null)
             {
-                IModel replacements = topLevelModel.FindChild<Folder>("Replacements");
+                IModel replacements = Folder.FindReplacementsFolder(topLevelModel);
                 if (replacements != null && replacements.Enabled)
                 {
                     foreach (IModel replacement in replacements.Children.Where(m => m.Enabled))

--- a/Models/Core/Run/SimulationGroup.cs
+++ b/Models/Core/Run/SimulationGroup.cs
@@ -157,6 +157,9 @@ namespace Models.Core.Run
 
             IEnumerable<ISimulationDescriptionGenerator> allSims = rootModel.FindAllDescendants<ISimulationDescriptionGenerator>();
 
+            //remove any sims there are under replacements
+            allSims = allSims.Where(s => Folder.IsUnderReplacementsFolder((s as IModel)) == null);
+
             List<string> dupes = new List<string>();
             foreach (var simType in allSims.GroupBy(s => s.GetType()))
             {

--- a/Models/Core/Run/SimulationGroup.cs
+++ b/Models/Core/Run/SimulationGroup.cs
@@ -330,7 +330,7 @@ namespace Models.Core.Run
                     if (SimulationNameIsMatched(description.Name))
                         yield return description;
             }
-            else if (relativeTo is Folder || relativeTo is Simulations)
+            else if ((relativeTo is Folder && !Folder.IsModelReplacementsFolder(relativeTo)) || relativeTo is Simulations)
             {
                 // Get a list of all models we're going to run.
                 foreach (var child in relativeTo.Children)

--- a/Models/Management/BiomassRemovalEvents.cs
+++ b/Models/Management/BiomassRemovalEvents.cs
@@ -202,8 +202,7 @@ namespace Models.Management
             List<IOrgan> organs = PlantToRemoveFrom.FindAllDescendants<IOrgan>().ToList();
             if (organs.Count == 0)
             {
-                Simulations sims = PlantToRemoveFrom.FindAncestor<Simulations>();
-                Folder replacements = sims.FindChild<Folder>("Replacements");
+                Folder replacements = Folder.FindReplacementsFolder(PlantToRemoveFrom);
                 if (replacements != null)
                 {
                     Plant plant = replacements.FindChild<Plant>(PlantToRemoveFrom.Name);

--- a/Models/Optimisation/CroptimizR.cs
+++ b/Models/Optimisation/CroptimizR.cs
@@ -268,8 +268,8 @@ namespace Models.Optimisation
             sims.Children.AddRange(Children.Select(c => Apsim.Clone(c)));
             sims.Children.RemoveAll(c => c is IDataStore);
 
-            IModel replacements = this.FindInScope<Folder>("Replacements");
-            if (replacements != null && !sims.Children.Any(c => c is Folder && c.Name == "Replacements"))
+            IModel replacements = Folder.FindReplacementsFolder(this);
+            if (replacements != null && !sims.Children.Any(c => Folder.IsModelReplacementsFolder(c)))
                 sims.Children.Add(Apsim.Clone(replacements));
 
             // Search for IDataStore, not DataStore - to allow for StorageViaSockets.

--- a/Tests/UnitTests/Documentation/DocumentTests.cs
+++ b/Tests/UnitTests/Documentation/DocumentTests.cs
@@ -41,16 +41,16 @@ namespace UnitTests.Documentation
                 string savedJSON = ReflectionUtilities.GetResourceAsString("UnitTests.Documentation.TestFiles."+file+".json");
                 List<ITag> expectedTags = APSIM.Documentation.TestUtilities.GetTags(savedJSON);
 
-                MatchTagStructure(expectedTags, actualTags);
+                MatchTagStructure(expectedTags, actualTags, file);
             }
         }
 
         ///<summary>
         /// Recursive function that walks the tree of ITags to see if they match.
         ///</summary>
-        public void MatchTagStructure(List<ITag> expectedTags, List<ITag> actualTags)
+        public void MatchTagStructure(List<ITag> expectedTags, List<ITag> actualTags, string modelName)
         {
-            string errorMessage = "Documentation structure has been changed for a model. If this was expected use the Upgrade Resource Files button to update the test files and commit them.";
+            string errorMessage = $"Documentation structure has been changed for the {modelName} model. If this was expected use the Upgrade Resource Files button to update the test files and commit them.";
             Assert.That(actualTags.Count, Is.EqualTo(expectedTags.Count), message: errorMessage);
 
             for (int i = 0; i < expectedTags.Count; i++) {
@@ -60,7 +60,7 @@ namespace UnitTests.Documentation
                 if (expected.GetType() == typeof(Section))
                 {
                     Assert.That((actual as Section).Title, Is.EqualTo((expected as Section).Title), message: errorMessage);
-                    MatchTagStructure((expected as Section).Children, (actual as Section).Children);
+                    MatchTagStructure((expected as Section).Children, (actual as Section).Children, modelName);
                 }
                 else if (expected.GetType() == typeof(Paragraph))
                 {


### PR DESCRIPTION
Resolves #9864 

Rather than just solving this problem by putting yet another replacements check in where it was required, I did a small refactor instead.

I've added three functions under Folder that do the checking if a model is a folder that can be a Replacements, so that all the error checking and constraints we have on replacements is done in one place. 

New functions are:
- IsModelReplacementsFolder
- FindReplacementsFolder
- IsUnderReplacementsFolder

These are the 3 use cases in apsim for either checking if a folder is replacements, or to find the replacements folder, so now all references to replacements have to go through these functions. Not sure if this is the best place for it, I could see this in Structure instead, but that class is already quite large, and Replacements are just special folders, so we can discuss that.

At least with this, all the requirements for how we determine if a folder is Replacements is now in one class, instead of being spread across a bunch of files. In the future when we refactor this, it should be much easier now.