### PR TITLE
9908 Refactor MenuDescriptionArgs to solve popup bug

### DIFF
--- a/ApsimNG/Interfaces/MenuDescriptionArgs.cs
+++ b/ApsimNG/Interfaces/MenuDescriptionArgs.cs
@@ -1,18 +1,7 @@
-﻿namespace UserInterface.Interfaces
+﻿using System;
+
+namespace UserInterface.Interfaces
 {
-    using System;
-    using System.Collections.Generic;
-
-    /// <summary>
-    /// The interface for a menu
-    /// </summary>
-    public interface IMenuView
-    {
-        /// <summary>Populate the main menu tool strip.</summary>
-        /// <param name="menuDescriptions">Descriptions for each item.</param>
-        void Populate(List<MenuDescriptionArgs> menuDescriptions);
-    }
-
     /// <summary>A class for holding info about a collection of menu items.</summary>
     public class MenuDescriptionArgs
     {
@@ -43,7 +32,21 @@
         /// <summary>For toolstrips, is this menu item aligned to right side of bar?</summary>
         public bool RightAligned;
 
-        /// <summary> Has a separator preceding it. </summary>
+        /// <summary>Has a separator preceding it. </summary>
         public bool FollowsSeparator;
+
+        /// <summary>MenuDescriptionArgs Constructor</summary>
+        public MenuDescriptionArgs() {
+            Name = "";
+            ToolTip = "";
+            ResourceNameForImage = "empty";
+            OnClick = null;
+            ShowCheckbox = false;
+            Checked = false;
+            ShortcutKey = "";
+            Enabled = true;
+            RightAligned = false;
+            FollowsSeparator = false;
+        }
     }
 }

--- a/ApsimNG/Views/MenuView.cs
+++ b/ApsimNG/Views/MenuView.cs
@@ -1,17 +1,17 @@
-﻿namespace UserInterface.Views
-{
-    using Extensions;
-    using Gtk;
-    using Interfaces;
-    using System;
-    using System.Collections.Generic;
-    using System.Reflection;
-    using Utility;
+﻿using UserInterface.Extensions;
+using Gtk;
+using UserInterface.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Utility;
 
+namespace UserInterface.Views
+{
     /// <summary>
     /// Encapsulates a menu
     /// </summary>
-    public class MenuView : IMenuView
+    public class MenuView
     {
         private Menu menu = new Menu();
 


### PR DESCRIPTION
Resolves #9908

Eric found the problem and solved it in #9910 but the file where the fix was needed a refactor to get rid of stuff that wasn't needed. This included an interface IMenuView which was only used by one class, splitting MenuDescriptionArgs class into its own file and giving it a constructor to set its properties to default starting values instead of null.