### PR TITLE
Remove duplicate instruction to return biomass

### DIFF
--- a/Models/AgPasture/PastureSpecies.cs
+++ b/Models/AgPasture/PastureSpecies.cs
@@ -273,7 +273,6 @@ namespace Models.AgPasture
             detachedShootN += AboveGroundN;
 
             // return all above ground parts to surface OM
-            AddDetachedShootToSurfaceOM(detachedShootDM, detachedShootN);
             AddDetachedShootToSurfaceOM(AboveGroundWt, AboveGroundN);
 
             // incorporate all root mass to soil fresh organic matter


### PR DESCRIPTION
Resolves #9921
The extra line seems to have been left behind when implementing the outputs for detached biomass. The duplication only happens on EndCrop. I believe this is something that is seldom used, luckily...