### PR TITLE
CLEM add switch to allow pasture and food store to be cleared on data import

### DIFF
--- a/Models/CLEM/Activities/CropActivityManageProduct.cs
+++ b/Models/CLEM/Activities/CropActivityManageProduct.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Xml.Serialization;
 using APSIM.Shared.Utilities;
 using APSIM.Numerics;
+using Models.GrazPlan;
 
 namespace Models.CLEM.Activities
 {
@@ -68,6 +69,12 @@ namespace Models.CLEM.Activities
         [Core.Display(Type = DisplayType.DropDown, Values = "GetResourcesAvailableByName", ValuesArgs = new object[] { new Type[] { typeof(AnimalFoodStore), typeof(GrazeFoodStore), typeof(HumanFoodStore), typeof(ProductStore) } })]
         [Required]
         public string StoreItemName { get; set; }
+
+        /// <summary>
+        /// Style used to addd new product to the store
+        /// </summary>
+        [Description("Add new product style")]
+        public AddNewCropProductStyle AddProductStyle { get; set; } = AddNewCropProductStyle.Add;
 
         /// <summary>
         /// Proportion of the crop harvest that is available
@@ -392,7 +399,6 @@ namespace Models.CLEM.Activities
             {
                 Status = ActivityStatus.NotNeeded;
                 ManageActivityResourcesAndTasks();
-                //PerformTasksForTimestep();
             }
         }
 
@@ -535,11 +541,23 @@ namespace Models.CLEM.Activities
             Status = ActivityStatus.NoTask;
             if (CurrentlyManaged)
             {
-                if (this.TimingOK) // && NextHarvest != null)
+                if (this.TimingOK)
                 {
                     Status = ActivityStatus.NotNeeded;
                     if (MathUtilities.IsPositive(AmountHarvested))
                     {
+                        if (AddProductStyle == AddNewCropProductStyle.Replace)
+                        {
+                            // remove current store ready to be replaced by new product
+                            LinkedResourceItem.Remove(new ResourceRequest()
+                            {
+                                ActivityModel = this,
+                                AdditionalDetails = this,
+                                Category = "StoreCleared",
+                                Required = 0,
+                                AllowTransmutation = false
+                            });
+                        }
                         AmountAvailableForHarvest = AmountHarvested;
 
                         double percentN = 0;
@@ -650,5 +668,20 @@ namespace Models.CLEM.Activities
         }
 
         #endregion
+    }
+
+    /// <summary>
+    /// Style to use for adding new product from input files
+    /// </summary>
+    public enum AddNewCropProductStyle
+    {
+        /// <summary>
+        /// Add to the current store
+        /// </summary>
+        Add,
+        /// <summary>
+        /// Replace current store with new value
+        /// </summary>
+        Replace
     }
 }

--- a/Models/CLEM/Activities/PastureActivityCutAndCarry.cs
+++ b/Models/CLEM/Activities/PastureActivityCutAndCarry.cs
@@ -244,7 +244,7 @@ namespace Models.CLEM.Activities
                 };
 
                 foodstore.Add(packet, this, null, TransactionCategory);
-                limiter.AddWeightCarried(amountToDo - amountToSkip);
+                limiter?.AddWeightCarried(amountToDo - amountToSkip);
                 SetStatusSuccessOrPartial(amountToSkip > 0);
             }
         }


### PR DESCRIPTION
Resolves #10022 
Adds new enum as property to allow user to select Add, Replace when reading in crop product data from input file.
Amount removed/destroyed is reported in ledger as "StoreCleared" transaction for complete accounting.