### PR TITLE
Operations no longer sets private properties.

### DIFF
--- a/Models/Core/VariableComposite.cs
+++ b/Models/Core/VariableComposite.cs
@@ -189,7 +189,7 @@ namespace Models.Core
         /// <summary>
         /// Returns true if the variable is writable
         /// </summary>
-        public override bool Writable { get { return Variables.All(v => v.Writable); } }
+        public override bool Writable { get { return Variables.Last().Writable; } }
 
         /// <summary>
         /// Return an attribute

--- a/Models/Core/VariableComposite.cs
+++ b/Models/Core/VariableComposite.cs
@@ -189,7 +189,7 @@ namespace Models.Core
         /// <summary>
         /// Returns true if the variable is writable
         /// </summary>
-        public override bool Writable { get { return true; } }
+        public override bool Writable { get { return Variables.All(v => v.Writable); } }
 
         /// <summary>
         /// Return an attribute

--- a/Models/Core/VariableProperty.cs
+++ b/Models/Core/VariableProperty.cs
@@ -592,7 +592,7 @@ namespace Models.Core
         /// <summary>
         /// Returns true if the variable is writable
         /// </summary>
-        public override bool Writable { get { return property.CanRead && property.CanWrite; } }
+        public override bool Writable { get { return property.CanRead && property.CanWrite && property.GetSetMethod() != null; } }
 
         /// <summary>
         /// Gets the display format for this property e.g. 'N3'. Can return null if not present.

--- a/Models/Management/Operations.cs
+++ b/Models/Management/Operations.cs
@@ -257,7 +257,11 @@ namespace Models
                         string variableName = st;
                         string value = StringUtilities.SplitOffAfterDelimiter(ref variableName, "=").Trim();
                         variableName = variableName.Trim();
-                        this.FindByPath(variableName).Value = value;
+                        var ivariable = this.FindByPath(variableName);
+                        if (ivariable.Writable)
+                            ivariable.Value = value;
+                        else
+                            throw new Exception($"{variableName} is not writable to by Operations.");
                     }
                     else if (st.Trim() != string.Empty)
                     {


### PR DESCRIPTION
Resolves #10027

Initially I tried to make it so that VariablesProperties could only be written to if the setter was public, but this messed Links up pretty badly. property.GetSetMethod() is null for non-public setters (CanWrite && GetSetMethod() == null implies the existence of a non-public setter). This doesn't address other ways a user might get around visibility (cultivars and config files are two possibilities).