### PR TITLE
Use correct namespace for JsonIgnore

### DIFF
--- a/APSIM.Shared/Graphing/Arc.cs
+++ b/APSIM.Shared/Graphing/Arc.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System;
 using System.Drawing;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace APSIM.Shared.Graphing
 {

--- a/Models/CLEM/Activities/OtherAnimalsActivityBuy.cs
+++ b/Models/CLEM/Activities/OtherAnimalsActivityBuy.cs
@@ -9,7 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace Models.CLEM.Activities

--- a/Models/CLEM/Activities/OtherAnimalsActivitySell.cs
+++ b/Models/CLEM/Activities/OtherAnimalsActivitySell.cs
@@ -10,7 +10,7 @@ using System.ComponentModel.DataAnnotations;
 using Models.CLEM.Groupings;
 using Models.CLEM.Resources;
 using Microsoft.VisualBasic.FileIO;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 using Models.LifeCycle;
 using Models.PMF.Organs;
 using Microsoft.CodeAnalysis.CSharp;

--- a/Models/CLEM/Groupings/OtherAnimalsFeedGroup.cs
+++ b/Models/CLEM/Groupings/OtherAnimalsFeedGroup.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Models.CLEM.Resources;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 using Models.CLEM.Interfaces;
 using System.ComponentModel.DataAnnotations;
 

--- a/Models/CLEM/Resources/OtherAnimals.cs
+++ b/Models/CLEM/Resources/OtherAnimals.cs
@@ -5,7 +5,7 @@ using Models.PMF.Organs;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace Models.CLEM.Resources
 {

--- a/Models/CLEM/Resources/OtherAnimalsTypeCohort.cs
+++ b/Models/CLEM/Resources/OtherAnimalsTypeCohort.cs
@@ -7,7 +7,7 @@ using Models.Core.Attributes;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace Models.CLEM.Resources
 {

--- a/Models/PMF/SimplePlantModels/ScrumCropInstance.cs
+++ b/Models/PMF/SimplePlantModels/ScrumCropInstance.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 using Models.Core;
 using Models.Climate;
 using Models.Functions;

--- a/Models/Sensor/Spectral.cs
+++ b/Models/Sensor/Spectral.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 using APSIM.Numerics;
 using Mapsui.Extensions;
 using Models.Core;


### PR DESCRIPTION
Resolves #10087

Some units were using System.Text.Json.Serialization rather than Newtonsoft.Json as the namespace for JsonIgnore.