### PR TITLE
Added exception when graph is under simulation 

### DIFF
--- a/Models/Graph/GraphPage.cs
+++ b/Models/Graph/GraphPage.cs
@@ -75,8 +75,7 @@ namespace Models
             // Find a parent that heads the scope that we're going to graph
             
             IModel simulation = model.FindAncestor<Simulation>();
-            
-            if (simulation.Parent is Experiment)
+            if (simulation != null && simulation.Parent is Experiment)
                 throw new Exception("Graph scope is incorrect if placed under a Simulation in an Experiment. It should be a child of the Experiment instead.");
            
             


### PR DESCRIPTION
Resolves #10078 

Throws an exception when Graph node is a child of Simulation in an experiment.