### PR TITLE
Split column name at '.' characters before searching for "Today" or "…

### DIFF
--- a/Gtk.Sheet/Data/PagedDataProvider.cs
+++ b/Gtk.Sheet/Data/PagedDataProvider.cs
@@ -352,7 +352,7 @@ namespace Gtk.Sheet
             rawColumnNames.RemoveAll(name => unwantedColumns.Contains(name));
 
             // Determine columns that always appear at start of grid: Date, SimulationName, Zone
-            var priorityColumns = rawColumnNames.Where(name => name.Contains("Date") || name.Contains("Today"))
+            var priorityColumns = rawColumnNames.Where(name => name.Split('.').Contains("Date") || name.Split('.').Contains("Today"))
                                                 .Concat(new string[] { "SimulationName" })
                                                 .Concat(rawColumnNames.Where(name => name == "Zone"));
 


### PR DESCRIPTION
…Date".

Resolves #10164. Should still allow Clock.Today or Clock.Today.Date to match as a "priority" column, but not DatePalm or SowingDate.