### PR TITLE
Do not treat namespace declarations as members.

### DIFF
--- a/APSIM.Core/ApsimFile/ManagerConverter.cs
+++ b/APSIM.Core/ApsimFile/ManagerConverter.cs
@@ -213,6 +213,7 @@ internal class ManagerConverter
             if (match.Groups["TypeName"].Value != string.Empty &&
                 match.Groups["TypeName"].Value != "as" &&
                 match.Groups["TypeName"].Value != "return" &&
+                match.Groups["TypeName"].Value != "namespace" &&
                 match.Groups["InstanceName"].Value != string.Empty &&
                 match.Groups["InstanceName"].Value != "get" &&
                 match.Groups["InstanceName"].Value != "set" &&


### PR DESCRIPTION
Resolves #10208 

It looks like this keyword was missed when getting member declarations. In the future it might be useful to just have a set of keywords and compare instance names and type names against that.