### PR TITLE
10215 Remove from node tree instead of old structure code

### DIFF
--- a/Models/Core/Structure.cs
+++ b/Models/Core/Structure.cs
@@ -186,7 +186,11 @@ namespace Models.Core.ApsimFile
         public static bool Delete(IModel model)
         {
             Apsim.ClearCaches(model);
-            return model.Parent.Children.Remove(model as Model);
+
+            Node parentNode = (model.Parent as Model).Node;
+            parentNode.RemoveChild(model as Model);
+
+            return true;
         }
 
         /// <summary>Replace one model with another.</summary>


### PR DESCRIPTION
Resolves #10215

Turns out it was the delete node code not removing the child from the parent because it was still calling the old delete code instead of the new node deleting code.