### PR TITLE
Add PET a and r into I canopy

### DIFF
--- a/Models/AgPasture/PastureSpecies.cs
+++ b/Models/AgPasture/PastureSpecies.cs
@@ -170,6 +170,17 @@ namespace Models.AgPasture
             set { myWaterDemand = value; }
         }
 
+        /// <summary>The pe tr</summary>
+        [Units("mm")]
+        [JsonIgnore]
+        public double PETr { get; set; }
+
+        /// <summary>The pe ta</summary>
+        [JsonIgnore]
+        [Units("mm")]
+        public double PETa { get; set; }
+
+
         /// <summary>Light profile, energy available for each canopy layer (W/m^2).</summary>
         private CanopyEnergyBalanceInterceptionlayerType[] myLightProfile;
 

--- a/Models/G_Range/G_Range.cs
+++ b/Models/G_Range/G_Range.cs
@@ -164,6 +164,17 @@ namespace Models
         [JsonIgnore]
         public double PotentialEP { get; set; }
 
+        /// <summary>The pe tr</summary>
+        [Units("mm")]
+        [JsonIgnore]
+        public double PETr { get; set; }
+
+        /// <summary>The pe ta</summary>
+        [JsonIgnore]
+        [Units("mm")]
+        public double PETa { get; set; }
+
+
         /// <summary>Sets the actual water demand.</summary>
         [JsonIgnore]
         [Units("mm")]

--- a/Models/Interfaces/ICanopy.cs
+++ b/Models/Interfaces/ICanopy.cs
@@ -43,6 +43,12 @@ namespace Models.Interfaces
         /// <summary>Sets the potential evapotranspiration.</summary>
         double PotentialEP { get; set; }
 
+        /// <summary>The pe tr</summary>
+        public double PETr { get; set; }
+
+        /// <summary>The pe ta</summary>
+        public double PETa { get; set; }
+
         /// <summary>Sets the actual water demand.</summary>
         double WaterDemand { get; set; }
 

--- a/Models/MicroClimate/MicroClimateZone.cs
+++ b/Models/MicroClimate/MicroClimateZone.cs
@@ -517,6 +517,8 @@ namespace Models
                         totalPotentialEp += Canopies[j].PET[i];
                         totalInterception += Canopies[j].interception[i];
                     }
+                    Canopies[j].Canopy.PETa = totalPETa;
+                    Canopies[j].Canopy.PETr = totalPETr;
                     Canopies[j].Canopy.PotentialEP = totalPotentialEp;
                     Canopies[j].Canopy.WaterDemand = totalPotentialEp;
                     Canopies[j].Canopy.LightProfile = lightProfile;

--- a/Models/PMF/BiomassArbitration/EnergyBalance.cs
+++ b/Models/PMF/BiomassArbitration/EnergyBalance.cs
@@ -143,6 +143,16 @@ namespace Models.PMF
             }
         }
 
+        /// <summary>The pe tr</summary>
+        [Units("mm")]
+        [JsonIgnore]
+        public double PETr { get; set; }
+
+        /// <summary>The pe ta</summary>
+        [JsonIgnore]
+        [Units("mm")]
+        public double PETa { get; set; }
+
         /// <summary>Sets the actual water demand.</summary>
         [Units("mm")]
         [JsonIgnore]

--- a/Models/PMF/OilPalm/OilPalm.cs
+++ b/Models/PMF/OilPalm/OilPalm.cs
@@ -101,6 +101,18 @@ namespace Models.PMF.OilPalm
         [Units("mm")]
         public double PotentialEP { get; set; }
 
+        /// <summary>The pe tr</summary>
+        [Units("mm")]
+        [JsonIgnore]
+        public double PETr { get; set; }
+
+        /// <summary>The pe ta</summary>
+        [JsonIgnore]
+        [Units("mm")]
+        public double PETa { get; set; }
+
+
+
         /// <summary>Sets the actual water demand.</summary>
         [JsonIgnore]
         [Units("mm")]

--- a/Models/PMF/Organs/Leaf.cs
+++ b/Models/PMF/Organs/Leaf.cs
@@ -205,6 +205,16 @@ namespace Models.PMF.Organs
             set { _PotentialEP = value; }
         }
 
+        /// <summary>The pe tr</summary>
+        [Units("mm")]
+        [JsonIgnore]
+        public double PETr { get; set; }
+
+        /// <summary>The pe ta</summary>
+        [JsonIgnore]
+        [Units("mm")]
+        public double PETa { get; set; }
+
         /// <summary>Sets the actual water demand.</summary>
         [Units("mm")]
         public double WaterDemand { get; set; }

--- a/Models/PMF/Organs/PerennialLeaf.cs
+++ b/Models/PMF/Organs/PerennialLeaf.cs
@@ -177,6 +177,17 @@ namespace Models.PMF.Organs
             set { _PotentialEP = value; }
         }
 
+        /// <summary>The pe tr</summary>
+        [Units("mm")]
+        [JsonIgnore]
+        public double PETr { get; set; }
+
+        /// <summary>The pe ta</summary>
+        [JsonIgnore]
+        [Units("mm")]
+        public double PETa { get; set; }
+
+
         /// <summary>Sets the actual water demand.</summary>
         [Units("mm")]
         public double WaterDemand { get; set; }

--- a/Models/PMF/Organs/SimpleLeaf.cs
+++ b/Models/PMF/Organs/SimpleLeaf.cs
@@ -337,6 +337,17 @@ namespace Models.PMF.Organs
         [Units("mm")]
         public double PotentialEP { get; set; }
 
+        /// <summary>The pe tr</summary>
+        [Units("mm")]
+        [JsonIgnore]
+        public double PETr { get; set; }
+
+        /// <summary>The pe ta</summary>
+        [JsonIgnore]
+        [Units("mm")]
+        public double PETa { get; set; }
+
+
         /// <summary>Sets the actual water demand.</summary>
         [Units("mm")]
         public double WaterDemand { get; set; }

--- a/Models/PMF/Organs/SorghumLeaf.cs
+++ b/Models/PMF/Organs/SorghumLeaf.cs
@@ -137,6 +137,7 @@ namespace Models.PMF.Organs
         private IFunction FrostSenescence = null;
 
         private double potentialEP = 0;
+
         private bool leafInitialised = false;
         private double nDeadLeaves;
         private double dltDeadLeaves;
@@ -297,6 +298,17 @@ namespace Models.PMF.Organs
                 MicroClimatePresent = true;
             }
         }
+
+        /// <summary>The pe tr</summary>
+        [Units("mm")]
+        [JsonIgnore]
+        public double PETr { get; set; }
+
+        /// <summary>The pe ta</summary>
+        [JsonIgnore]
+        [Units("mm")]
+        public double PETa { get; set; }
+
 
         /// <summary>Sets the light profile. Set by MICROCLIMATE.</summary>
         public CanopyEnergyBalanceInterceptionlayerType[] LightProfile { get; set; }

--- a/Models/PMF/SimpleTree/SimpleTree.cs
+++ b/Models/PMF/SimpleTree/SimpleTree.cs
@@ -59,6 +59,17 @@ namespace Models.PMF
         [JsonIgnore]
         public double PotentialEP { get; set; }
 
+        /// <summary>The pe tr</summary>
+        [Units("mm")]
+        [JsonIgnore]
+        public double PETr { get; set; }
+
+        /// <summary>The pe ta</summary>
+        [JsonIgnore]
+        [Units("mm")]
+        public double PETa { get; set; }
+
+
         /// <summary>Sets the actual water demand.</summary>
         [JsonIgnore]
         [Units("mm")]

--- a/Models/Pasture/pasture.cs
+++ b/Models/Pasture/pasture.cs
@@ -457,6 +457,17 @@ namespace Models.GrazPlan
             set { myWaterDemand = value; }
         }
 
+        /// <summary>The pe tr</summary>
+        [Units("mm")]
+        [JsonIgnore]
+        public double PETr { get; set; }
+
+        /// <summary>The pe ta</summary>
+        [JsonIgnore]
+        [Units("mm")]
+        public double PETa { get; set; }
+
+
         /// <summary>Light profile, energy available for each canopy layer (W/m^2).</summary>
         private CanopyEnergyBalanceInterceptionlayerType[] myLightProfile;
 

--- a/Models/Sugarcane/Sugarcane.cs
+++ b/Models/Sugarcane/Sugarcane.cs
@@ -424,6 +424,17 @@ namespace Models
         [JsonIgnore]
         public double PotentialEP { get; set; } //sv- just a place holder I think. This is eop not ep.
 
+        /// <summary>The pe tr</summary>
+        [Units("mm")]
+        [JsonIgnore]
+        public double PETr { get; set; }
+
+        /// <summary>The pe ta</summary>
+        [JsonIgnore]
+        [Units("mm")]
+        public double PETa { get; set; }
+
+
         /// <summary>Sets the actual water demand.</summary>
         [Units("mm")]
         public double WaterDemand { get; set; }

--- a/Models/Surface/SurfOrganicMatterType.cs
+++ b/Models/Surface/SurfOrganicMatterType.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Text.Json.Serialization;
+using Models.Core;
 using Models.Interfaces;
 
 namespace Models.Surface
@@ -123,6 +125,17 @@ namespace Models.Surface
 
         /// <summary>Sets the potential evapotranspiration.</summary>
         public double PotentialEP { get; set; }
+
+        /// <summary>The pe tr</summary>
+        [Units("mm")]
+        [JsonIgnore]
+        public double PETr { get; set; }
+
+        /// <summary>The pe ta</summary>
+        [JsonIgnore]
+        [Units("mm")]
+        public double PETa { get; set; }
+
 
         /// <summary>Sets the actual water demand.</summary>
         public double WaterDemand { get; set; }


### PR DESCRIPTION
working on #10221

@hol353 @par456 @hut104 @ric394 adding these ET components to I canopy is the only way to report them given the current structure of microclimate.  Arguably they do not really need reporting but I have found it essential to review these components as part of the model sensibility checking for STRUM.