### PR TITLE
10232 Don't try to parse empty cells in array

### DIFF
--- a/Models/Logging/InitialConditionsTable.cs
+++ b/Models/Logging/InitialConditionsTable.cs
@@ -64,7 +64,15 @@ namespace Models.Logging
                             DataTableUtilities.AddColumn(vectorsTable, columnName, MathUtilities.StringsToDoubles(value));
                         else
                         {
-                            value = value.Select(x => double.Parse(x).ToString(condition.DisplayFormat)).ToArray();
+                            List<string> convertedArray = new List<string>();
+                            foreach (string val in value)
+                            {
+                                if (string.IsNullOrEmpty(val))
+                                    convertedArray.Add("");
+                                else
+                                    convertedArray.Add(double.Parse(val).ToString(condition.DisplayFormat));
+                            }
+                            value = convertedArray.ToArray();
                             DataTableUtilities.AddColumn(vectorsTable, columnName, value);
                         }
                     }


### PR DESCRIPTION
Resolves #10232

Not sure why this suddenly appeared, I wonder if the big refactor merged last week fixed an unknown bug that was stopping this.

Anyway, simple fix to just check if a string[] array index was empty before trying to convert it to a double, and avoiding that.