### PR TITLE
Whether double-clicking opens a new tab or new instance made user-set…

### DIFF
--- a/ApsimNG/Utility/Configuration.cs
+++ b/ApsimNG/Utility/Configuration.cs
@@ -78,6 +78,14 @@ namespace Utility
         public bool Muted { get; set; } = true;
 
         /// <summary>
+        /// If true, clicking on an .apsimx file in Explorer will open that file in a new tab of the
+        /// current ApsimNG instance rather than staring a new instance of the GUI.
+        /// </summary>
+        [Input("Open files in new tabs")]
+        [Tooltip("Should double-clicking an .apsimx file open it in a new tab rather than a new instance of the user interface? (Requires restart)")]
+        public bool UseExistingInstance { get; set; } = true;
+
+        /// <summary>
         /// In theory, if there are any commands in the command history,
         /// then the file has been modified. In practice, there may be
         /// some faulty presenters which make changes to the model without


### PR DESCRIPTION
…table.

Also explicitly release the Mutex when the hosting instance of the application is closed.

Working on #10269 

I have not been able to replicate the original Issue, although explicit release of the mutex should help prevent possible AbandonedMutex exceptions.

