### PR TITLE
10258 Weather Filename Slash Fix

### DIFF
--- a/Models/Climate/Weather.cs
+++ b/Models/Climate/Weather.cs
@@ -154,11 +154,20 @@ namespace Models.Climate
         }
 
         /// <summary>
+        /// Filename for the weather file.
+        /// </summary>
+        private string fileName;
+
+        /// <summary>
         /// Gets or sets the file name. Should be relative filename where possible.
         /// </summary>
         [Summary]
         [Description("Weather file name")]
-        public string FileName { get; set; }
+        public string FileName
+        {
+            get { return fileName; }
+            set { fileName = value.Replace("\\", "/"); }
+        }
 
         /// <summary>
         /// Gets or sets the full file name (with path). The user interface uses this.


### PR DESCRIPTION
Resolves #10258

Filenames should really not be stored with windows \ in the filepaths, as it just tend to break things when moving cross platform. This just adds a replace function on the property so that all \ are replaced with / in the weather filename.