### PR TITLE
10318 Remove global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-    "sdk": {
-      "version": "8.0.12",
-      "rollForward": "latestFeature"
-    }
-}


### PR DESCRIPTION
Resolves #10318

This was pinning apsim to a specific version of .net, removed to fix.