### PR TITLE
10318 Add option for dotnet version to install in workflow

### DIFF
--- a/.github/workflows/run-model-validations.yml
+++ b/.github/workflows/run-model-validations.yml
@@ -26,7 +26,9 @@ jobs:
 
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
-    
+      with:
+        dotnet-version: '8.0.x'
+
     - name: Get PR number from GitHub API
       id: fetch_pr_number
       run: |


### PR DESCRIPTION
Resolves #10318

I removed the global.json, but the workflow needs a version to install. Provided it with the generic "get latest 8.0" version so it knows what to install.