### PR TITLE
Ensure Gtk has adequate time to display descriptions correctly.

### DIFF
--- a/APSIM.Documentation/Models/Types/DocSubDailyInterpolation.cs
+++ b/APSIM.Documentation/Models/Types/DocSubDailyInterpolation.cs
@@ -30,8 +30,8 @@ namespace APSIM.Documentation.Models.Types
 
             if (Response != null)
             {
-                section.Add(new Paragraph($"{model.Name} is the {sub.agregationMethod.ToString().ToLower()} of sub-daily values from a {Response.GetType().Name}."));
-                section.Add(new Paragraph($"Each of the interpolated {InterpolationMethod.OutputValueType}s are then passed into the following Response and the {sub.agregationMethod} taken to give daily {sub.Name}"));
+                section.Add(new Paragraph($"{model.Name} is the {sub.aggregationMethod.ToString().ToLower()} of sub-daily values from a {Response.GetType().Name}."));
+                section.Add(new Paragraph($"Each of the interpolated {InterpolationMethod.OutputValueType}s are then passed into the following Response and the {sub.aggregationMethod} taken to give daily {sub.Name}"));
                 section.Add(AutoDocumentation.DocumentModel(Response));
                 section.Add(AutoDocumentation.DocumentModel(InterpolationMethod as IModel));
             }

--- a/APSIM.Documentation/Models/Types/DocSubDailyInterpolation.cs
+++ b/APSIM.Documentation/Models/Types/DocSubDailyInterpolation.cs
@@ -30,8 +30,8 @@ namespace APSIM.Documentation.Models.Types
 
             if (Response != null)
             {
-                section.Add(new Paragraph($"{model.Name} is the {sub.aggregationMethod.ToString().ToLower()} of sub-daily values from a {Response.GetType().Name}."));
-                section.Add(new Paragraph($"Each of the interpolated {InterpolationMethod.OutputValueType}s are then passed into the following Response and the {sub.aggregationMethod} taken to give daily {sub.Name}"));
+                section.Add(new Paragraph($"{model.Name} is the {sub.agregationMethod.ToString().ToLower()} of sub-daily values from a {Response.GetType().Name}."));
+                section.Add(new Paragraph($"Each of the interpolated {InterpolationMethod.OutputValueType}s are then passed into the following Response and the {sub.agregationMethod} taken to give daily {sub.Name}"));
                 section.Add(AutoDocumentation.DocumentModel(Response));
                 section.Add(AutoDocumentation.DocumentModel(InterpolationMethod as IModel));
             }

--- a/ApsimNG/Views/ExplorerView.cs
+++ b/ApsimNG/Views/ExplorerView.cs
@@ -111,7 +111,8 @@ namespace UserInterface.Views
                     rightHandView.PackStart(descriptionView.MainWidget, false, false, 0);
                     // Let Gtk catch up with things; otherwise too much space
                     // is allocated to the new description view. Is there a better way?
-                    while (Gtk.Application.EventsPending())
+
+                    while (!descriptionView.SizeIsAllocated)
                         Gtk.Application.RunIteration();
                 }
                 descriptionView.Text = description;

--- a/ApsimNG/Views/MarkdownView.cs
+++ b/ApsimNG/Views/MarkdownView.cs
@@ -42,6 +42,7 @@ namespace UserInterface.Views
         private MarkdownFindView findView;
         private AccelGroup accelerators = new AccelGroup();
         private Menu popupMenu = new Menu();
+        private bool sizeAllocated = false;
 
         /// <summary>Table of font sizes for ASCII characters. Set on attach and reset on attach whenver font has changed.</summary>
         private static readonly int[] fontCharSizes = new int[128];
@@ -115,6 +116,7 @@ namespace UserInterface.Views
             textView.WidgetEventAfter += OnWidgetEventAfter;
             CreateStyles(textView);
             mainWidget.ShowAll();
+            mainWidget.SizeAllocated += OnSizeAllocated;
             mainWidget.Destroyed += OnDestroyed;
             mainWidget.Realized += OnRealized;
             textView.FocusInEvent += OnGainFocus;
@@ -187,6 +189,18 @@ namespace UserInterface.Views
         }
 
         /// <summary>
+        /// Received when the size of the main widget has been allocated.
+        /// For now we care only whether the initial allocation has occurred.
+        /// </summary>
+        /// <param name="o"></param>
+        /// <param name="args"></param>
+        private void OnSizeAllocated(object o, SizeAllocatedArgs args)
+        {
+            sizeAllocated = true;
+            MainWidget.SizeAllocated -= OnSizeAllocated;
+        }
+
+        /// <summary>
         /// Trap keypress events - show the text search dialog on ctrl + f.
         /// </summary>
         /// <param name="sender">Sender widget.</param>
@@ -241,6 +255,14 @@ namespace UserInterface.Views
         {
             get { return textView.Visible; }
             set { textView.Visible = value; }
+        }
+
+        /// <summary>
+        /// Returns true if Gtk is done allocating a size for our main widget
+        /// </summary>
+        public bool SizeIsAllocated
+        {
+            get { return sizeAllocated; }
         }
 
         /// <summary>Gets or sets the markdown text.</summary>
@@ -855,6 +877,7 @@ namespace UserInterface.Views
                 textView.VisibilityNotifyEvent -= OnVisibilityNotify;
                 textView.MotionNotifyEvent -= OnMotionNotify;
                 textView.WidgetEventAfter -= OnWidgetEventAfter;
+                mainWidget.SizeAllocated -= OnSizeAllocated;
                 mainWidget.Destroyed -= OnDestroyed;
                 mainWidget.Realized -= OnRealized;
                 textView.FocusInEvent -= OnGainFocus;

--- a/Models/Functions/SubDailyInterpolation.cs
+++ b/Models/Functions/SubDailyInterpolation.cs
@@ -34,10 +34,10 @@ namespace Models.Functions
 
         /// <summary>Method used to aggregate sub daily values</summary>
         [Description("Method used to aggregate sub daily temperature function")]
-        public AggregationMethod aggregationMethod { get; set; }
+        public AgregationMethod agregationMethod { get; set; }
 
-        /// <summary>Method used to agregate sub daily values</summary>
-        public enum AggregationMethod
+        /// <summary>Method used to aggregate sub daily values</summary>
+        public enum AgregationMethod
         {
             /// <summary>Return average of sub daily values</summary>
             Average,
@@ -59,9 +59,9 @@ namespace Models.Functions
         {
             if (SubDailyResponse != null)
             {
-                if (aggregationMethod == AggregationMethod.Average)
+                if (agregationMethod == AgregationMethod.Average)
                     return SubDailyResponse.Average();
-                if (aggregationMethod == AggregationMethod.Sum)
+                if (agregationMethod == AgregationMethod.Sum)
                     return SubDailyResponse.Sum();
                 else
                     throw new Exception("invalid aggregation method selected in " + this.Name + "temperature interpolation");

--- a/Models/Functions/SubDailyInterpolation.cs
+++ b/Models/Functions/SubDailyInterpolation.cs
@@ -14,7 +14,7 @@ namespace Models.Functions
     /// </summary>
 
     [Serializable]
-    [Description("Uses the specified InterpolationMethod to determine sub daily values then calcualtes a value for the Response at each of these time steps and returns either the sum or average depending on the AgrevationMethod selected")]
+    [Description("Uses the specified InterpolationMethod to determine sub daily values then calculates a value for the Response at each of these time steps and returns either the sum or average depending on the AggregationMethod selected")]
     [ViewName("UserInterface.Views.PropertyView")]
     [PresenterName("UserInterface.Presenters.PropertyPresenter")]
     public class SubDailyInterpolation : Model, IFunction
@@ -32,12 +32,12 @@ namespace Models.Functions
         [Link(Type = LinkType.Child, ByName = true)]
         private IIndexedFunction Response = null;
 
-        /// <summary>Method used to agreagate sub daily values</summary>
-        [Description("Method used to agregate sub daily temperature function")]
-        public AgregationMethod agregationMethod { get; set; }
+        /// <summary>Method used to aggreagate sub daily values</summary>
+        [Description("Method used to aggregate sub daily temperature function")]
+        public AggregationMethod aggregationMethod { get; set; }
 
         /// <summary>Method used to agreagate sub daily values</summary>
-        public enum AgregationMethod
+        public enum AggregationMethod
         {
             /// <summary>Return average of sub daily values</summary>
             Average,
@@ -59,9 +59,9 @@ namespace Models.Functions
         {
             if (SubDailyResponse != null)
             {
-                if (agregationMethod == AgregationMethod.Average)
+                if (aggregationMethod == AggregationMethod.Average)
                     return SubDailyResponse.Average();
-                if (agregationMethod == AgregationMethod.Sum)
+                if (aggregationMethod == AggregationMethod.Sum)
                     return SubDailyResponse.Sum();
                 else
                     throw new Exception("invalid agregation method selected in " + this.Name + "temperature interpolation");

--- a/Models/Functions/SubDailyInterpolation.cs
+++ b/Models/Functions/SubDailyInterpolation.cs
@@ -32,11 +32,11 @@ namespace Models.Functions
         [Link(Type = LinkType.Child, ByName = true)]
         private IIndexedFunction Response = null;
 
-        /// <summary>Method used to aggreagate sub daily values</summary>
+        /// <summary>Method used to aggregate sub daily values</summary>
         [Description("Method used to aggregate sub daily temperature function")]
         public AggregationMethod aggregationMethod { get; set; }
 
-        /// <summary>Method used to agreagate sub daily values</summary>
+        /// <summary>Method used to agregate sub daily values</summary>
         public enum AggregationMethod
         {
             /// <summary>Return average of sub daily values</summary>
@@ -64,7 +64,7 @@ namespace Models.Functions
                 if (aggregationMethod == AggregationMethod.Sum)
                     return SubDailyResponse.Sum();
                 else
-                    throw new Exception("invalid agregation method selected in " + this.Name + "temperature interpolation");
+                    throw new Exception("invalid aggregation method selected in " + this.Name + "temperature interpolation");
             }
             else
                 return 0.0;


### PR DESCRIPTION
Resolves #10360.

The problem was not with Dropdown widgets, but rather with excess space being used by the description above. There was already an attempt in ExplorerView.cs to deal with this, but because some layout in a Gtk TextView occurs using "idle" handlers rather than "event" handlers, that earlier fix did not always work. 