### PR TITLE
Improve behaviour of DropDownView when dealing with long lists of items.

### DIFF
--- a/APSIM.Shared/Utilities/SQLite.cs
+++ b/APSIM.Shared/Utilities/SQLite.cs
@@ -176,7 +176,7 @@ namespace APSIM.Shared.Utilities
                     }
                 }
                 reader.Close();
-                reader.DisposeAsync();
+                reader.Dispose();
             }
             return table;
         }

--- a/APSIM.Shared/Utilities/SQLite.cs
+++ b/APSIM.Shared/Utilities/SQLite.cs
@@ -176,7 +176,7 @@ namespace APSIM.Shared.Utilities
                     }
                 }
                 reader.Close();
-                reader.Dispose();
+                reader.DisposeAsync();
             }
             return table;
         }

--- a/ApsimNG/Views/DropDownView.cs
+++ b/ApsimNG/Views/DropDownView.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Gtk;
+﻿using Gtk;
+using System;
 
 namespace UserInterface.Views
 {
@@ -70,6 +70,8 @@ namespace UserInterface.Views
             combobox1.Model = comboModel;
             combobox1.PackStart(comboRender, false);
             combobox1.AddAttribute(comboRender, "text", 0);
+            comboRender.FixedHeightFromFont = 1;
+            combobox1.PoppedUp += OnCombobox1PoppedUp;
             combobox1.Changed += OnSelectionChanged;
             mainWidget.Destroyed += _mainWidget_Destroyed;
         }
@@ -84,6 +86,7 @@ namespace UserInterface.Views
             try
             {
                 combobox1.Changed -= OnSelectionChanged;
+                combobox1.PoppedUp -= OnCombobox1PoppedUp;
                 comboModel.Dispose();
                 comboRender.Dispose();
                 mainWidget.Destroyed -= _mainWidget_Destroyed;
@@ -236,6 +239,35 @@ namespace UserInterface.Views
             {
                 ShowError(err);
             }
+        }
+
+        /// <summary>
+        /// The first time a GtkComboBox is popped up, it can be rather slow to
+        /// appear if the number of items is "large". This handler detects the initial
+        /// popup and displays a wait cursor. The ShowWaitCursor routine also runs
+        /// the GLib/Gtk iterator loop, handling all waiting events before returning.
+        /// This gives the widget an opportunity to get itself set up before we return
+        /// to the normal cursor.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnCombobox1PoppedUp(object sender, EventArgs e)
+        {
+            if (comboModel.IterNChildren() > 20)
+            {
+                ViewBase view = Owner;
+                while (view != null)
+                {
+                    if (view is MainView mainView)
+                    {
+                        mainView.ShowWaitCursor(true);
+                        mainView.ShowWaitCursor(false);
+                        break;
+                    }
+                    view = view.Owner;
+                }
+            }
+            combobox1.PoppedUp -= OnCombobox1PoppedUp;
         }
 
         /// <summary>

--- a/Tests/UnitTests/Storage/DataStoreReaderTests.cs
+++ b/Tests/UnitTests/Storage/DataStoreReaderTests.cs
@@ -17,17 +17,6 @@
         private IDatabaseConnection database;
         //private string sqliteFileName;
 
-        /// <summary>Find and return the file name of SQLite runtime .dll</summary>
-        public static string FindSqlite3DLL()
-        {
-            string directory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            string[] files = Directory.GetFiles(directory, "sqlite3.dll");
-            if (files.Length == 1)
-                return files[0];
-
-            throw new Exception("Cannot find sqlite3 dll directory");
-        }
-
         /// <summary>Initialisation code for all unit tests in this class</summary>
         [SetUp]
         public void Initialise()


### PR DESCRIPTION
Resolves #10378 

The initial display is still rather slow when there are many items, but a wait cursor assures the user something is happening.
All items are listed and the scrollbar displays correctly.