### PR TITLE
Don't clear pools until after the connection is closed.

### DIFF
--- a/APSIM.Shared/Utilities/SQLite.cs
+++ b/APSIM.Shared/Utilities/SQLite.cs
@@ -95,11 +95,11 @@ namespace APSIM.Shared.Utilities
         {
             if (_open)
             {
-                SqliteConnection.ClearAllPools();
                 _connection?.Close();
                 _connection?.Dispose();
                 _connection = null;
                 _open = false;
+                SqliteConnection.ClearAllPools();
             }
         }
 
@@ -122,72 +122,62 @@ namespace APSIM.Shared.Utilities
         public System.Data.DataTable ExecuteQuery(string query)
         {
             DataTable table = new DataTable();
-            SqliteCommand cmd = new SqliteCommand(query, _connection);
-            SqliteDataReader reader = cmd.ExecuteReader();
-            if (reader.HasRows)
+            using (SqliteCommand cmd = new SqliteCommand(query, _connection))
             {
-                // "Load" would be really simple to use here, but because SQLite doesn't support
-                // true DATE fields, it doesn't handle returned dates well.
-                //
-                // The approach taken here is to examine the "type" of each column as it was
-                // defined when the SQLite table was created, and create a DataColumn of a
-                // compatible type. We then read the returned data row by row and add the values
-                // to the resulting DataTable. Note that DataTables have stricter expectations
-                // about "type" than does SQLite, and errors may occur if the data values do not
-                // match the expected type. This may occur when column names were used
-                // inconsistently across multiple simulations or across multiple files of
-                // obeserved data imported from Excel.
-                // We could possibly just treat all DataColumns as being of type "Object", but it's
-                // probably better to let any dataype inconsistencies raise exceptions so that they
-                // can be identified and corrected.
-                // table.Load(reader);
-
-                //get the number of returned columns
-                int columnCount = reader.FieldCount;
-
-                Type[] colTypes = new Type[columnCount];
-                // Add datatable columns of appropriate type
-                for (int i = 0; i < columnCount; i++)
+                using (SqliteDataReader reader = cmd.ExecuteReader())
                 {
-                    colTypes[i] = GetTypeFromSQLiteType(reader.GetDataTypeName(i));
-                    table.Columns.Add(reader.GetName(i), colTypes[i]);
-                }
-
-                // Add the data rows
-                object[] values = new object[columnCount];
-                while (reader.Read())
-                {
-                    DataRow row = table.NewRow();
-                    reader.GetValues(values);
-
-                    for (int i = 0; i < values.Length; i++)
+                    if (reader.HasRows)
                     {
-                        // This test is needed to handle some odd things that can happen
-                        // when values are imported from multiple Excel files and column
-                        // data types cannot be determined by the importer.
-                        if (colTypes[i] != typeof(string) && (values[i] is string) && String.IsNullOrEmpty(values[i] as string))
-                            row[i] = DBNull.Value;
-                        else
-                            row[i] = values[i];
+                        // "Load" would be really simple to use here, but because SQLite doesn't support
+                        // true DATE fields, it doesn't handle returned dates well.
+                        //
+                        // The approach taken here is to examine the "type" of each column as it was
+                        // defined when the SQLite table was created, and create a DataColumn of a
+                        // compatible type. We then read the returned data row by row and add the values
+                        // to the resulting DataTable. Note that DataTables have stricter expectations
+                        // about "type" than does SQLite, and errors may occur if the data values do not
+                        // match the expected type. This may occur when column names were used
+                        // inconsistently across multiple simulations or across multiple files of
+                        // obeserved data imported from Excel.
+                        // We could possibly just treat all DataColumns as being of type "Object", but it's
+                        // probably better to let any dataype inconsistencies raise exceptions so that they
+                        // can be identified and corrected.
+                        // table.Load(reader);
 
+                        //get the number of returned columns
+                        int columnCount = reader.FieldCount;
+
+                        Type[] colTypes = new Type[columnCount];
+                        // Add datatable columns of appropriate type
+                        for (int i = 0; i < columnCount; i++)
+                        {
+                            colTypes[i] = GetTypeFromSQLiteType(reader.GetDataTypeName(i));
+                            table.Columns.Add(reader.GetName(i), colTypes[i]);
+                        }
+
+                        // Add the data rows
+                        object[] values = new object[columnCount];
+                        while (reader.Read())
+                        {
+                            DataRow row = table.NewRow();
+                            reader.GetValues(values);
+
+                            for (int i = 0; i < values.Length; i++)
+                            {
+                                // This test is needed to handle some odd things that can happen
+                                // when values are imported from multiple Excel files and column
+                                // data types cannot be determined by the importer.
+                                if (colTypes[i] != typeof(string) && (values[i] is string) && String.IsNullOrEmpty(values[i] as string))
+                                    row[i] = DBNull.Value;
+                                else
+                                    row[i] = values[i];
+
+                            }
+                            table.Rows.Add(row);
+                        }
                     }
-                    table.Rows.Add(row);
                 }
             }
-
-            try
-            {
-                reader.Close();
-                reader.DisposeAsync();
-
-                cmd.DisposeAsync();
-            }
-            catch
-            {
-                Console.WriteLine("SQLite failed to dispse correctly.");
-            }
-            
-
             return table;
         }
         


### PR DESCRIPTION
Working on #10396 

The call to "ClearAllPools" is there to help ensure that a "closed" connection doesn't still hold the database file open and prevent us from deleting or renaming it, but it was probably in the wrong place. 