### PR TITLE
Error in Digestibility of Harvestable DM

### DIFF
--- a/Models/AgPasture/PastureSpecies.cs
+++ b/Models/AgPasture/PastureSpecies.cs
@@ -2269,9 +2269,9 @@ namespace Models.AgPasture
                 {
                     Wt = Leaf.DMTotalHarvestable + Stem.DMTotalHarvestable + Stolon.DMTotalHarvestable,
                     N = Leaf.NTotalHarvestable + Stem.NTotalHarvestable + Stolon.NTotalHarvestable,
-                    Digestibility = MathUtilities.Divide(Leaf.StandingDigestibility * Leaf.NTotalHarvestable +
-                                                         Stem.StandingDigestibility * Stem.NTotalHarvestable +
-                                                         Stolon.StandingDigestibility * Stolon.NTotalHarvestable,
+                    Digestibility = MathUtilities.Divide(Leaf.StandingDigestibility * Leaf.DMTotalHarvestable +
+                                                         Stem.StandingDigestibility * Stem.DMTotalHarvestable +
+                                                         Stolon.StandingDigestibility * Stolon.DMTotalHarvestable,
                                                          Leaf.DMTotalHarvestable + Stem.DMTotalHarvestable +
                                                          Stolon.DMTotalHarvestable, 0.0)
                 };


### PR DESCRIPTION
Working on #10418 

Changed the code to reflect changes in the Harvestable Digestibility of dry matter.

Revised code:
  ```
  public AGPBiomass Harvestable
        {
            get
            {
                return new AGPBiomass()
                {
                    Wt = Leaf.DMTotalHarvestable + Stem.DMTotalHarvestable + Stolon.DMTotalHarvestable,
                    N = Leaf.NTotalHarvestable + Stem.NTotalHarvestable + Stolon.NTotalHarvestable,
                    Digestibility = MathUtilities.Divide(Leaf.StandingDigestibility * Leaf.DMTotalHarvestable +
                                                         Stem.StandingDigestibility * Stem.DMTotalHarvestable +
                                                         Stolon.StandingDigestibility * Stolon.DMTotalHarvestable,
                                                         Leaf.DMTotalHarvestable + Stem.DMTotalHarvestable +
                                                         Stolon.DMTotalHarvestable, 0.0)
                };
            }
        }
```