### PR TITLE
stop unit test workflow from running on user's forks.

### DIFF
--- a/.github/workflows/run-apsimx-unit-tests.yml
+++ b/.github/workflows/run-apsimx-unit-tests.yml
@@ -12,6 +12,7 @@ jobs:
   build-and-test:
     name: build-and-test
     # Run all subsequent steps on the specified operating systems.
+    if: github.repository_owner == 'APSIMInitiative'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
resolves #10427

This PR resolves the issue where the unit test GitHub workflow runs when shouldn't on a user's fork.