### PR TITLE
Make each validation run use its own Azure batch pool

### DIFF
--- a/.github/workflows/run-model-validations.yml
+++ b/.github/workflows/run-model-validations.yml
@@ -120,9 +120,11 @@ jobs:
         # Tell POStats2 to open and get ready to accept data
         echo "Opening POStats2 to accept data..."
         echo "Commit SHA: ${{ github.event.pull_request.head.sha }}"
-        # NOTE: Enable once the workflow is ready for production.
         commitsha=${{ github.event.pull_request.head.sha }}
         author=${{ github.actor }}
+        # This is used to make a PR specific pool to avoid multiple PRs issues on Azure.
+        azure_pool="${DOCKER_METADATA_OUTPUT_VERSION:3}-${commitsha:0:6}"
+        echo "azure pool: ${azure_pool}"
         echo "author variable: ${author}"
         # substrings the variable so we get the number only after the 'pr-' part.
         echo "PR Number: ${DOCKER_METADATA_OUTPUT_VERSION:3}"
@@ -132,7 +134,7 @@ jobs:
         response=$(curl "https://postats2.apsim.info/api/open?pullrequestnumber=${DOCKER_METADATA_OUTPUT_VERSION:3}&commitid=${commitsha}&author=${author}&count=${jobcount}") # count needs to be a proper number later
         echo "POStats2 open response: ${response}"
         echo "Start creating payload..."
-        dotnet ./bin/Release/net8.0/APSIM.Workflow.dll --payload-directory "${PAYLOAD_FOLDER_PATH}" -g "$author" -t $DOCKER_METADATA_OUTPUT_VERSION --commit-sha "$commitsha" --pr-number ${DOCKER_METADATA_OUTPUT_VERSION:3} -v
+        dotnet ./bin/Release/net8.0/APSIM.Workflow.dll --payload-directory "${PAYLOAD_FOLDER_PATH}" -g "$author" -t $DOCKER_METADATA_OUTPUT_VERSION --commit-sha "$commitsha" --pr-number ${DOCKER_METADATA_OUTPUT_VERSION:3} --azure-pool ${azure_pool} -v
 
     - name: Print workflow submit success summary markdown
       if: success()

--- a/APSIM.Workflow/Options.cs
+++ b/APSIM.Workflow/Options.cs
@@ -61,5 +61,9 @@ public class Options
     [Option("sim-count", Required = false, HelpText = "The number of simulations/validation locations available.")]
     public string SimulationCount { get; set; } = "";
 
+    /// <summary> Azure pool to use for the workflow. </summary>
+    [Option("azure-pool", Required = false, HelpText = "The Azure pool to use for the workflow.")]
+    public string AzurePool { get; set; } = "workflo-pool";
+
 }
     

--- a/APSIM.Workflow/WorkFloFileUtilities.cs
+++ b/APSIM.Workflow/WorkFloFileUtilities.cs
@@ -35,6 +35,7 @@ public static class WorkFloFileUtilities
             ];
             string workFloFileContents = $"""
             name: workflo_apsim_validation_pr_{options.PullRequestNumber}
+            pool: {options.AzurePool}
             inputfiles:
             - .env
             - workflow.yml


### PR DESCRIPTION
working on #10436

This PR includes changes to help resolve validation run issues outlined in #10436.

In addition to this PR, another one is required in another repository to enable this to work as intended.