### PR TITLE
Make the workflow yml include the pool name

### DIFF
--- a/APSIM.Workflow/WorkFloFileUtilities.cs
+++ b/APSIM.Workflow/WorkFloFileUtilities.cs
@@ -51,7 +51,7 @@ public static class WorkFloFileUtilities
                   args: '"$Path" --verbose'
               finally:
                 - uses: apsiminitiative/postats2-collector:latest
-                  args: upload {currentBuildNumber} {options.CommitSHA} {options.GitHubAuthorID} {brisbaneDatetimeNow.ToString(timeFormat)} ""$Path""
+                  args: upload {currentBuildNumber} {options.CommitSHA} {options.GitHubAuthorID} {brisbaneDatetimeNow.ToString(timeFormat)} {options.AzurePool} ""$Path""
             """;
             File.WriteAllText(Path.Combine(options.DirectoryPath, workFloFileName), workFloFileContents);
             Console.WriteLine($"Workflow.yml contents:\n{workFloFileContents}");


### PR DESCRIPTION
working on #10437

This simply makes the workflow.yml file include the pool name so the po stats collector knows which Azure batch pool to close when the validation run is complete.