### PR TITLE
10469 Check model children types if searching by name fails

### DIFF
--- a/APSIM.Core/Locate/Locator.cs
+++ b/APSIM.Core/Locate/Locator.cs
@@ -481,6 +481,10 @@ internal class Locator
                 compareType = StringComparison.OrdinalIgnoreCase;
 
             modelInfo = model.GetChildren().FirstOrDefault(m => m.Name.Equals(name, compareType));
+
+            //If matching by name did not wor, try matching by type
+            if (modelInfo == null)
+                modelInfo = model.GetChildren().FirstOrDefault(m => m.GetType().Name.Equals(name, compareType));
         }
 
         if (methodInfo != null) //if we found a method, return it

--- a/Tests/UnitTests/APSIM.Core/LocatorTests.cs
+++ b/Tests/UnitTests/APSIM.Core/LocatorTests.cs
@@ -470,7 +470,7 @@ namespace APSIM.Core.Tests
 
             //check that the child still exists as well
             Model cnrfChild = null;
-            foreach(Model child in nutrient.Children)
+            foreach (Model child in nutrient.Children)
                 if (child.Name == "CNRF")
                     cnrfChild = child;
             if (cnrfChild == null)
@@ -835,7 +835,7 @@ namespace APSIM.Core.Tests
 
             //Empty path should give back no bits or error
             inputs.Add("");
-            results.Add(new string[] {});
+            results.Add(new string[] { });
 
             //a single space path should give an error
             inputs.Add(" ");
@@ -925,6 +925,20 @@ namespace APSIM.Core.Tests
             foreach (PropertyInfo prop in properties)
                 if (names.Contains(prop.Name) == false)
                     Assert.Fail($"{prop.Name} is not tested by an individual unit test.");
+        }
+
+        /// <summary>
+        /// Test to make sure the type of an object can be passed to find a child, even if the child has a different name to it's type.
+        /// </summary>
+        [Test]
+        public void GetChildModelByTypeInsteadOfName()
+        {
+            Simulations sims = MakeTestSimulation();
+            IStructure loc = sims.Node;
+            loc.Set("[Simulation].ModelF.Name", "NotModelF");
+
+            //Should find ModelF even though it's not called ModelF
+            Assert.That(loc.Get("[Simulation].ModelF"), Is.Not.Null);
         }
     }
 }


### PR DESCRIPTION
Resolves #10469

Bug was found in #10466 where the Physical node had been renamed and a function in Nutrient couldn't find it anymore.

This solves the bug in the locator and adds a unit test for that condition.