### PR TITLE
10471 Locator finds model with brackets

### DIFF
--- a/APSIM.Core/Locate/Locator.cs
+++ b/APSIM.Core/Locate/Locator.cs
@@ -499,7 +499,7 @@ internal class Locator
 
             modelInfo = model.GetChildren().FirstOrDefault(m => m.Name.Equals(name, compareType));
 
-            //If matching by name did not wor, try matching by type
+            //If matching by name did not work, try matching by type
             if (modelInfo == null)
                 modelInfo = model.GetChildren().FirstOrDefault(m => m.GetType().Name.Equals(name, compareType));
         }

--- a/APSIM.Core/Locate/Locator.cs
+++ b/APSIM.Core/Locate/Locator.cs
@@ -175,13 +175,30 @@ internal class Locator
         composite.AddInstance(relativeTo.Model);
         for (int j = 0; j < namePathBits.Length; j++)
         {
+            object objectInfo = null;
+            List<object> argumentsList = new List<object>();
+
             // look for an array specifier e.g. sw[2]
-            //need to do this first as the [ ] will screw up matching to a property
+            //need to do this first as the [ ] will screw up matching to a property if its an array
             string arraySpecifier = null;
             if (!onlyModelChildren && namePathBits[j].Contains("["))
+            {
+                string[] copyOfNamePathBits = namePathBits.Clone() as string[];
                 arraySpecifier = StringUtilities.SplitOffBracketedValue(ref namePathBits[j], '[', ']');
 
-            object objectInfo = GetInternalObjectInfo(relativeToObject, namePathBits[j], composite, namePathBits.Length-j-1, ignoreCase, throwOnError, onlyModelChildren, out List<object> argumentsList);
+                objectInfo = GetInternalObjectInfo(relativeToObject, namePathBits[j], composite, namePathBits.Length - j - 1, ignoreCase, throwOnError, onlyModelChildren, out argumentsList);
+
+                //we found and stripped [] for an array, but then didnt find the object, prehaps the object had [] in the name but wasn't an array, so let's check again
+                if (objectInfo == null)
+                {
+                    argumentsList = new List<object>();
+                    objectInfo = GetInternalObjectInfo(relativeToObject, copyOfNamePathBits[j], composite, copyOfNamePathBits.Length - j - 1, ignoreCase, throwOnError, onlyModelChildren, out argumentsList);
+                }
+            }
+            else
+            {
+                objectInfo = GetInternalObjectInfo(relativeToObject, namePathBits[j], composite, namePathBits.Length - j - 1, ignoreCase, throwOnError, onlyModelChildren, out argumentsList);
+            }
 
             //Depending on the type we found, handle it
             bool propertiesOnly = (flags & LocatorFlags.PropertiesOnly) == LocatorFlags.PropertiesOnly;

--- a/Tests/UnitTests/APSIM.Core/LocatorTests.cs
+++ b/Tests/UnitTests/APSIM.Core/LocatorTests.cs
@@ -928,7 +928,7 @@ namespace APSIM.Core.Tests
         }
         
         /// <summary>
-        /// Test to make sure the type of an object can be passed to find a child, even if the child has a different name to it's type.
+        /// Test to make sure the type of an object can be found even if it has square brackets in it's name
         /// </summary>
         [Test]
         public void GetChildModelThatHasSquareBracketsInName()

--- a/Tests/UnitTests/APSIM.Core/LocatorTests.cs
+++ b/Tests/UnitTests/APSIM.Core/LocatorTests.cs
@@ -926,5 +926,19 @@ namespace APSIM.Core.Tests
                 if (names.Contains(prop.Name) == false)
                     Assert.Fail($"{prop.Name} is not tested by an individual unit test.");
         }
+        
+        /// <summary>
+        /// Test to make sure the type of an object can be passed to find a child, even if the child has a different name to it's type.
+        /// </summary>
+        [Test]
+        public void GetChildModelThatHasSquareBracketsInName()
+        {
+            Simulations sims = MakeTestSimulation();
+            IStructure loc = sims.Node;
+            loc.Set("[Simulation].ModelF.Name", "ModelFWith[1]");
+
+            //Should find ModelF even though it's not called ModelF
+            Assert.That(loc.Get("[Simulation].ModelFWith[1]"), Is.Not.Null);
+        }
     }
 }


### PR DESCRIPTION
Resolves #10471 

Split from #10438 so the locator changes aren't with the Oats validation changes.

Locator will now check if the text with [], matches a model name after failing to find an array property with that name.