### PR TITLE
CLEM ensure milking activity happens during the milking event

### DIFF
--- a/Models/CLEM/Activities/RuminantActivityMilking.cs
+++ b/Models/CLEM/Activities/RuminantActivityMilking.cs
@@ -70,6 +70,14 @@ namespace Models.CLEM.Activities
             }
         }
 
+        /// <summary>
+        /// Constructor for milking activity
+        /// </summary>
+        public RuminantActivityMilking()
+        {
+            AllocationStyle = ResourceAllocationStyle.Manual;
+        }
+
         /// <summary>An event handler to allow us to initialise ourselves.</summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
@@ -93,6 +101,13 @@ namespace Models.CLEM.Activities
             foreach (RuminantFemale item in this.CurrentHerd(true).OfType<RuminantFemale>().Where(a => a.IsLactating))
                 // set these females to state milking performed so they switch to the non-suckling milk production curves.
                 item.MilkingPerformed = true;
+        }
+
+        /// <inheritdoc/>
+        [EventSubscribe("CLEMAnimalMilking")]
+        protected override void OnGetResourcesPerformActivity(object sender, EventArgs e)
+        {
+            ManageActivityResourcesAndTasks();
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Resolves #10517

Set Milking activity to manual and fire during the CLEMMilking event to ensure timing with suckling is correct