### PR TITLE
Removes the string [bot] from the author string

### DIFF
--- a/.github/workflows/run-model-validations.yml
+++ b/.github/workflows/run-model-validations.yml
@@ -151,6 +151,9 @@ jobs:
           echo "Commit SHA: ${{ github.event.pull_request.head.sha }}"
           commitsha=${{ github.event.pull_request.head.sha }}
           author=${{ github.actor }}
+          if [[ "$author" == *"[bot]"* ]]; then
+            author="${author//"[bot]"/}"
+          fi
           # This is used to make a PR specific pool to avoid multiple PRs issues on Azure.
           azure_pool="${DOCKER_METADATA_OUTPUT_VERSION:3}-${commitsha:0:6}"
           echo "azure pool: ${azure_pool}"

--- a/.github/workflows/run-model-validations.yml
+++ b/.github/workflows/run-model-validations.yml
@@ -152,7 +152,7 @@ jobs:
           commitsha=${{ github.event.pull_request.head.sha }}
           author=${{ github.actor }}
           if [[ "$author" == *"[bot]"* ]]; then
-            author="${author//"[bot]"/}"
+            author="${author%"[bot]"}"
           fi
           # This is used to make a PR specific pool to avoid multiple PRs issues on Azure.
           azure_pool="${DOCKER_METADATA_OUTPUT_VERSION:3}-${commitsha:0:6}"


### PR DESCRIPTION
resolves #10523

Rather than url encode unsafe characters, this simply removes the [bot] suffix from the author string to prevent postats call failure in the model validation github workflow.

As mentioned in the linked issue, this prevented security and package updates fixes from completing.