### PR TITLE
Ensure unit tests close the database and fix multithreading issues.

### DIFF
--- a/APSIM.Shared/APSIM.Shared.csproj
+++ b/APSIM.Shared/APSIM.Shared.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Mapsui.Nts" Version="4.1.7" />
     <PackageReference Include="Mapsui.Rendering.Skia" Version="4.1.7" />
     <PackageReference Include="Mapsui.Tiling" Version="4.1.7" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SkiaSharp" Version="2.88.8" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />

--- a/APSIM.Shared/Utilities/SQLite.cs
+++ b/APSIM.Shared/Utilities/SQLite.cs
@@ -1,6 +1,7 @@
 using Microsoft.Data.Sqlite;
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Data;
 using System.Globalization;
 using System.Linq;
@@ -13,11 +14,6 @@ namespace APSIM.Shared.Utilities
     [Serializable]
     public class SQLite : IDatabaseConnection
     {
-        /// <summary>
-        /// Connection of SQLite database
-        /// </summary>
-        [NonSerialized]
-        private SqliteConnection _connection;
         /// <summary>Indicates whether or not the database is open</summary>
         [NonSerialized]
         private bool _open;
@@ -36,7 +32,21 @@ namespace APSIM.Shared.Utilities
         public bool IsInMemory { get; private set; } = false;
 
         /// <summary>A lock object to prevent multiple threads from starting a transaction at the same time</summary>
+        [NonSerialized]
         private readonly object transactionLock = new object();
+
+        /// <summary>
+        /// String for establishing a connection
+        /// </summary>
+        private string connectionString;
+
+        /// <summary>
+        /// A dictionary of connections, using Threads as the key. This allows
+        /// us to use a different connection for each thread, as SqliteConnection
+        /// is not thread-safe.
+        /// </summary>
+        [NonSerialized]
+        private ConcurrentDictionary<Thread, SqliteConnection> connectionPool = new ConcurrentDictionary<Thread, SqliteConnection>();
 
         /// <summary>Begin a transaction. Any code between begin and end needs to be in a try-finally so that the lock
         /// is unlocked if there is an exception thrown.</summary>
@@ -70,24 +80,40 @@ namespace APSIM.Shared.Utilities
             }
         }
 
-        /// <summary>Opens or creates SQLite database with the specified path</summary>
+        /// <summary>Builds a connection string for an SQLite database 
+        /// with the specified path. The connection is not actually
+        /// opened unti GetConnection is called.</summary>
         /// <param name="path">Path to SQLite database</param>
         /// <param name="readOnly">if set to <c>true</c> [read only].</param>
         public void OpenDatabase(string path, bool readOnly)
         {
-            SqliteConnectionStringBuilder builder = new SqliteConnectionStringBuilder
+            IsInMemory = path.ToLower().Contains(":memory:");
+            SqliteConnectionStringBuilder builder;
+            // In-memory databases are treated a bit diffently, since we need to
+            // ensure that connections for mulitiple threads are all accessing
+            // the same database. Hence the shared cache and explicit, unique, datasource name
+            if (IsInMemory)
             {
-                DataSource = path,
-                Mode = readOnly ? SqliteOpenMode.ReadOnly : SqliteOpenMode.ReadWriteCreate,
-                DefaultTimeout = 40000
-            };
-            _connection = new SqliteConnection(builder.ToString());
-            _connection.Open();
-
-            _open = true;
+                builder = new SqliteConnectionStringBuilder
+                {
+                    DataSource = Guid.NewGuid().ToString(),
+                    Mode = SqliteOpenMode.Memory,
+                    Cache = SqliteCacheMode.Shared,
+                    DefaultTimeout = 1000
+                };
+            }
+            else
+            {
+                builder = new SqliteConnectionStringBuilder
+                {
+                    DataSource = path,
+                    Mode = readOnly ? SqliteOpenMode.ReadOnly : SqliteOpenMode.ReadWriteCreate,
+                    DefaultTimeout = 40000
+                };
+            }
+            connectionString = builder.ToString();
             dbPath = path;
             IsReadOnly = readOnly;
-            IsInMemory = path.ToLower().Contains(":memory:");
         }
 
         /// <summary>Closes the SQLite database</summary>
@@ -95,29 +121,26 @@ namespace APSIM.Shared.Utilities
         {
             if (_open)
             {
-                if (_connection != null)
+                SqliteConnection connection;
+                foreach (Thread thread in connectionPool.Keys)
                 {
-                    try
+                    if (connectionPool.Remove(thread, out connection))
                     {
-                        _connection?.Close();
-                        SqliteConnection.ClearPool(_connection);
-                        _connection?.Dispose();
+                        connection.Close();
+                        SqliteConnection.ClearPool(connection);
+                        connection.Dispose();
                     }
-                    catch
-                    {
-                        Console.WriteLine("SQLite failed to close correctly when closing database.");
-                    }
-                    _connection = null;
                 }
                 _open = false;
             }
         }
 
+
         /// <summary>Executes a query that returns no results</summary>
         /// <param name="query">SQL query to execute</param>
         public void ExecuteNonQuery(string query)
         {
-            using (SqliteCommand command = new SqliteCommand(query, _connection))
+            using (SqliteCommand command = new SqliteCommand(query, GetConnection()))
             {
                 command.ExecuteNonQuery();
             }
@@ -132,72 +155,62 @@ namespace APSIM.Shared.Utilities
         public System.Data.DataTable ExecuteQuery(string query)
         {
             DataTable table = new DataTable();
-            SqliteCommand cmd = new SqliteCommand(query, _connection);
-            SqliteDataReader reader = cmd.ExecuteReader();
-            if (reader.HasRows)
+            using (SqliteCommand cmd = new SqliteCommand(query, GetConnection()))
             {
-                // "Load" would be really simple to use here, but because SQLite doesn't support
-                // true DATE fields, it doesn't handle returned dates well.
-                //
-                // The approach taken here is to examine the "type" of each column as it was
-                // defined when the SQLite table was created, and create a DataColumn of a
-                // compatible type. We then read the returned data row by row and add the values
-                // to the resulting DataTable. Note that DataTables have stricter expectations
-                // about "type" than does SQLite, and errors may occur if the data values do not
-                // match the expected type. This may occur when column names were used
-                // inconsistently across multiple simulations or across multiple files of
-                // obeserved data imported from Excel.
-                // We could possibly just treat all DataColumns as being of type "Object", but it's
-                // probably better to let any dataype inconsistencies raise exceptions so that they
-                // can be identified and corrected.
-                // table.Load(reader);
-
-                //get the number of returned columns
-                int columnCount = reader.FieldCount;
-
-                Type[] colTypes = new Type[columnCount];
-                // Add datatable columns of appropriate type
-                for (int i = 0; i < columnCount; i++)
+                using (SqliteDataReader reader = cmd.ExecuteReader())
                 {
-                    colTypes[i] = GetTypeFromSQLiteType(reader.GetDataTypeName(i));
-                    table.Columns.Add(reader.GetName(i), colTypes[i]);
-                }
-
-                // Add the data rows
-                object[] values = new object[columnCount];
-                while (reader.Read())
-                {
-                    DataRow row = table.NewRow();
-                    reader.GetValues(values);
-
-                    for (int i = 0; i < values.Length; i++)
+                    if (reader.HasRows)
                     {
-                        // This test is needed to handle some odd things that can happen
-                        // when values are imported from multiple Excel files and column
-                        // data types cannot be determined by the importer.
-                        if (colTypes[i] != typeof(string) && (values[i] is string) && String.IsNullOrEmpty(values[i] as string))
-                            row[i] = DBNull.Value;
-                        else
-                            row[i] = values[i];
+                        // "Load" would be really simple to use here, but because SQLite doesn't support
+                        // true DATE fields, it doesn't handle returned dates well.
+                        //
+                        // The approach taken here is to examine the "type" of each column as it was
+                        // defined when the SQLite table was created, and create a DataColumn of a
+                        // compatible type. We then read the returned data row by row and add the values
+                        // to the resulting DataTable. Note that DataTables have stricter expectations
+                        // about "type" than does SQLite, and errors may occur if the data values do not
+                        // match the expected type. This may occur when column names were used
+                        // inconsistently across multiple simulations or across multiple files of
+                        // obeserved data imported from Excel.
+                        // We could possibly just treat all DataColumns as being of type "Object", but it's
+                        // probably better to let any dataype inconsistencies raise exceptions so that they
+                        // can be identified and corrected.
+                        // table.Load(reader);
 
+                        //get the number of returned columns
+                        int columnCount = reader.FieldCount;
+
+                        Type[] colTypes = new Type[columnCount];
+                        // Add datatable columns of appropriate type
+                        for (int i = 0; i < columnCount; i++)
+                        {
+                            colTypes[i] = GetTypeFromSQLiteType(reader.GetDataTypeName(i));
+                            table.Columns.Add(reader.GetName(i), colTypes[i]);
+                        }
+
+                        // Add the data rows
+                        object[] values = new object[columnCount];
+                        while (reader.Read())
+                        {
+                            DataRow row = table.NewRow();
+                            reader.GetValues(values);
+
+                            for (int i = 0; i < values.Length; i++)
+                            {
+                                // This test is needed to handle some odd things that can happen
+                                // when values are imported from multiple Excel files and column
+                                // data types cannot be determined by the importer.
+                                if (colTypes[i] != typeof(string) && (values[i] is string) && String.IsNullOrEmpty(values[i] as string))
+                                    row[i] = DBNull.Value;
+                                else
+                                    row[i] = values[i];
+
+                            }
+                            table.Rows.Add(row);
+                        }
                     }
-                    table.Rows.Add(row);
                 }
             }
-
-            try
-            {
-                reader.Close();
-                reader.DisposeAsync();
-
-                cmd.DisposeAsync();
-            }
-            catch
-            {
-                Console.WriteLine("SQLite failed to dispose correctly.");
-            }
-            
-
             return table;
         }
         
@@ -210,7 +223,7 @@ namespace APSIM.Shared.Utilities
         /// <returns></returns>
         public int ExecuteQueryReturnInt(string query, int columnNumber)
         {
-            using (SqliteCommand cmd = new SqliteCommand(query, _connection))
+            using (SqliteCommand cmd = new SqliteCommand(query, GetConnection()))
             {
                 using (SqliteDataReader reader = cmd.ExecuteReader(CommandBehavior.SingleRow))
                 {
@@ -267,7 +280,7 @@ namespace APSIM.Shared.Utilities
         {
             List<string> colNames = new List<string>();
             string sql = $"select * from [{tableName}] LIMIT 0";
-            using (SqliteCommand cmd = new SqliteCommand(sql, _connection))
+            using (SqliteCommand cmd = new SqliteCommand(sql, GetConnection()))
             {
                 using (SqliteDataReader reader = cmd.ExecuteReader())
                 {
@@ -457,7 +470,7 @@ namespace APSIM.Shared.Utilities
         private SqliteCommand CreateInsertQuery(string tableName, List<string> columnNames)
         {
             string sql = CreateInsertSQL(tableName, columnNames);
-            return new SqliteCommand(sql, _connection);
+            return new SqliteCommand(sql, GetConnection());
         }
 
         /// <summary>
@@ -489,7 +502,7 @@ namespace APSIM.Shared.Utilities
             // Get a list of column names.
             var columnNames = table.Columns.Cast<DataColumn>().Select(col => col.ColumnName);
             var sql = CreateInsertSQL(table.TableName, columnNames);
-            SqliteCommand command = new SqliteCommand(sql, _connection);
+            SqliteCommand command = new SqliteCommand(sql, GetConnection());
             command.Prepare();
             return command;
         }
@@ -690,5 +703,47 @@ namespace APSIM.Shared.Utilities
         {
             return value.ToString("yyyy-MM-dd HH:mm:ss"); 
         }
+
+        /// <summary>
+        /// Get separate connection for each thread
+        /// Unfortunately, SqliteConnection is not thread-safe (with problems
+        /// most likely to occur when the connection is closed).
+        /// Based on code at https://stackoverflow.com/questions/64169084/ensuring-exactly-one-sqlite-connection-per-thread
+        /// </summary>
+        /// <returns>An open SqliteConnection unique to the current thread</returns>
+        private SqliteConnection GetConnection()
+        {
+            Thread currentThread = Thread.CurrentThread;
+            SqliteConnection connection;
+
+            // If this thread already owns a connection, just retrieve it.
+            if (connectionPool.TryGetValue(currentThread, out connection))
+            {
+                return connection;
+            }
+
+            // Looking for a thread that doesn't need its connection anymore.
+            (Thread inactiveThread, SqliteConnection availableConnection) = connectionPool.Where(p => p.Key.ThreadState == ThreadState.Stopped)
+                .Select(p => (p.Key, p.Value))
+                .FirstOrDefault();
+
+            // If an existing connection is not being used, reassign it to this thread.
+            if (availableConnection != null)
+            {
+                if (connectionPool.TryRemove(inactiveThread, out availableConnection))
+                {
+                    connectionPool[currentThread] = availableConnection;
+                    return availableConnection;
+                }
+            }
+
+            // Otherwise create a new connection and open it
+            connection = new SqliteConnection(connectionString);
+            connectionPool[currentThread] = connection;
+            connection.Open();
+            _open = true;
+            return connection;
+        }
+
     }
 }

--- a/Models/CLEM/Activities/RuminantActivityMilking.cs
+++ b/Models/CLEM/Activities/RuminantActivityMilking.cs
@@ -70,6 +70,14 @@ namespace Models.CLEM.Activities
             }
         }
 
+        /// <summary>
+        /// Constructor for milking activity
+        /// </summary>
+        public RuminantActivityMilking()
+        {
+            AllocationStyle = ResourceAllocationStyle.Manual;
+        }
+
         /// <summary>An event handler to allow us to initialise ourselves.</summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
@@ -93,6 +101,13 @@ namespace Models.CLEM.Activities
             foreach (RuminantFemale item in this.CurrentHerd(true).OfType<RuminantFemale>().Where(a => a.IsLactating))
                 // set these females to state milking performed so they switch to the non-suckling milk production curves.
                 item.MilkingPerformed = true;
+        }
+
+        /// <inheritdoc/>
+        [EventSubscribe("CLEMAnimalMilking")]
+        protected override void OnGetResourcesPerformActivity(object sender, EventArgs e)
+        {
+            ManageActivityResourcesAndTasks();
         }
 
         /// <inheritdoc/>

--- a/Models/Storage/DataStoreWriter.cs
+++ b/Models/Storage/DataStoreWriter.cs
@@ -232,12 +232,14 @@ namespace Models.Storage
                 commandRunner.Stop();
                 idle = true;
                 commandRunner = null;
-                commands.Clear();
                 lock (lockObject)
+                {
+                    commands.Clear();
                     simulationIDs.Clear();
-                checkpointIDs.Clear();
-                simulationNamesThatHaveBeenCleanedUp.Clear();
-                units.Clear();
+                    checkpointIDs.Clear();
+                    simulationNamesThatHaveBeenCleanedUp.Clear();
+                    units.Clear();
+                }
             }
         }
 
@@ -265,13 +267,16 @@ namespace Models.Storage
                 {
                     WaitForIdle();
                     stopping = true;
+                    commandRunner.Stop();
                     commandRunner = null;
-                    commands.Clear();
                     lock (lockObject)
+                    {
+                        commands.Clear();
                         simulationIDs.Clear();
-                    checkpointIDs.Clear();
-                    simulationNamesThatHaveBeenCleanedUp.Clear();
-                    units.Clear();
+                        checkpointIDs.Clear();
+                        simulationNamesThatHaveBeenCleanedUp.Clear();
+                        units.Clear();
+                    }
                 }
             }
         }
@@ -291,6 +296,7 @@ namespace Models.Storage
                 {
                     if (commands.Count > 0)
                     {
+                        idle = false;
                         command = commands.Dequeue();
                         // The WaitForIdle() function will wait until there are no jobs
                         // and idle is set to true. Therefore, we should update the value

--- a/Tests/UnitTests/APSIMShared/DBMergerTests.cs
+++ b/Tests/UnitTests/APSIMShared/DBMergerTests.cs
@@ -69,6 +69,8 @@
                                                            new object[] {              3,  20, "str3" },
                                                            new object[] {              4,  21, "str4" }})
                .IsSame(Utilities.GetTableFromDatabase(database1, "Report")), Is.True);
+            database1.CloseDatabase();
+            database2.CloseDatabase();
         }
 
         /// <summary>Ensure two .db files, which have the same simulation names, can be merged.</summary>
@@ -130,6 +132,8 @@
                                                            new object[] {              2,  11, "str2" },
                                                            new object[] {              2,  21, "str4" }})
                .IsSame(Utilities.GetTableFromDatabase(database1, "Report")), Is.True);
+            database1.CloseDatabase();
+            database2.CloseDatabase();
         }
 
         /// <summary>Ensure two .db files, which have different tables, can be merged.</summary>
@@ -197,6 +201,8 @@
                                       new List<object[]> { new object[] {              3,  20, "str3" },
                                                            new object[] {              4,  21, "str4" }})
                .IsSame(Utilities.GetTableFromDatabase(database1, "Report2")), Is.True);
+            database1.CloseDatabase();
+            database2.CloseDatabase();
         }
 
         /// <summary>Ensure two .db files, which have tables that don't have SimulationID, can be merged.</summary>
@@ -254,6 +260,8 @@
                                       new List<object[]> { new object[] {  "Report",          "A",  "g/m2" },
                                                            new object[] {  "Report",          "B", "kg/ha" }})
                .IsSame(Utilities.GetTableFromDatabase(database1, "_Units")), Is.True);
+            database1.CloseDatabase();
+            database2.CloseDatabase();
         }
 
         /// <summary>Create a table</summary>

--- a/Tests/UnitTests/Core/Run/RunnerTests.cs
+++ b/Tests/UnitTests/Core/Run/RunnerTests.cs
@@ -28,14 +28,6 @@
             RunTypeEnum.SingleThreaded
         };
 
-        /// <summary>Initialisation code for all unit tests in this class</summary>
-        [SetUp]
-        public void Initialise()
-        {
-            database = new SQLite();
-            database.OpenDatabase(":memory:", readOnly: false);
-        }
-
         /// <summary>Ensure that runner can run a single simulation.</summary>
         [Test]
         public void EnsureSimulationRuns()
@@ -755,6 +747,7 @@
                 storage.Reader.Refresh();
                 storedData = storage.Reader.GetData(data.TableName);
                 Assert.That(storedData.Rows.Count, Is.EqualTo(1), "Post-simulation tool data was not cleaned when running only post-simulation tools");
+                database.CloseDatabase();
             }
         }
 

--- a/Tests/UnitTests/PostSimulationTools/CreateProfileTableTests.cs
+++ b/Tests/UnitTests/PostSimulationTools/CreateProfileTableTests.cs
@@ -34,6 +34,12 @@ namespace UnitTests
             database.OpenDatabase(":memory:", readOnly: false);
         }
 
+        [TearDown]
+        public void Cleanup()
+        {
+            database?.CloseDatabase();
+        }
+
         [Test]
         public void TestDepth()
         {

--- a/Tests/UnitTests/PostSimulationTools/ExcelInputTests.cs
+++ b/Tests/UnitTests/PostSimulationTools/ExcelInputTests.cs
@@ -54,6 +54,8 @@ namespace UnitTests
             Assert.That(dt.Columns[4].DataType, Is.EqualTo(typeof(DateTime)));
             Assert.That(dt.Columns[5].DataType, Is.EqualTo(typeof(string)));
             Assert.That(dt.Columns[6].DataType, Is.EqualTo(typeof(string)));
+
+            database.CloseDatabase();
         }
     }
 }

--- a/Tests/UnitTests/PostSimulationTools/PredictedObservedTests.cs
+++ b/Tests/UnitTests/PostSimulationTools/PredictedObservedTests.cs
@@ -40,6 +40,12 @@
             database.OpenDatabase(":memory:", readOnly: false);
         }
 
+        [TearDown]
+        public void Cleanup()
+        {
+            database?.CloseDatabase();
+        }
+
         [Test]
         public void PredictedObservedUsingSimulationID()
         {

--- a/Tests/UnitTests/PostSimulationTools/SimulationComparisonTests.cs
+++ b/Tests/UnitTests/PostSimulationTools/SimulationComparisonTests.cs
@@ -35,6 +35,12 @@ namespace UnitTests
             database.OpenDatabase(":memory:", readOnly: false);
         }
 
+        [TearDown]
+        public void Cleanup()
+        {
+            database?.CloseDatabase();
+        }
+
         [Test]
         public void CompareSimulationsOnSingleMatchField()
         {

--- a/Tests/UnitTests/Report/ReportTests.cs
+++ b/Tests/UnitTests/Report/ReportTests.cs
@@ -439,6 +439,7 @@
             DataTable dtActual = storage.Reader.GetData("_Factors");
 
             Assert.That(dtExpected.IsSame(dtActual), Is.True);
+            database.CloseDatabase();
         }
 
         /// <summary>

--- a/Tests/UnitTests/Sheet/PagedDataProviderTests.cs
+++ b/Tests/UnitTests/Sheet/PagedDataProviderTests.cs
@@ -16,23 +16,18 @@
         private IDatabaseConnection database;
         //private string sqliteFileName;
 
-        /// <summary>Find and return the file name of SQLite runtime .dll</summary>
-        public static string FindSqlite3DLL()
-        {
-            string directory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            string[] files = Directory.GetFiles(directory, "sqlite3.dll");
-            if (files.Length == 1)
-                return files[0];
-
-            throw new Exception("Cannot find sqlite3 dll directory");
-        }
-
         /// <summary>Initialisation code for all unit tests in this class</summary>
         [SetUp]
         public void Initialise()
         {
             database = new SQLite();
             database.OpenDatabase(":memory:", readOnly: false);
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            database?.CloseDatabase();
         }
 
         /// <summary>Ensure basic data paging works.</summary>

--- a/Tests/UnitTests/Storage/DataStoreReaderTests.cs
+++ b/Tests/UnitTests/Storage/DataStoreReaderTests.cs
@@ -9,7 +9,7 @@
     using System.Collections.Generic;
     using System.Data;
     using System.IO;
-    using System.Reflection;
+    using System.Linq;
 
     [TestFixture]
     public class DataStoreReaderTests
@@ -24,6 +24,13 @@
             database = new SQLite();
             database.OpenDatabase(":memory:", readOnly: false);
         }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            database?.CloseDatabase();
+        }
+
 
         /// <summary>Read all data from a table</summary>
         [Test]
@@ -189,47 +196,52 @@
             Simulation sim = sims.Node.Find<Simulation>();
             IDataStore storage = sims.Node.Find<IDataStore>();
 
-            // Record checkpoint names before and after running the simulation,
-            // and ensure that they are not the same.
-            string[] checkpointNamesBeforeRun = storage.Reader.CheckpointNames.ToArray();
-
-            // Run the simulation
-            var runner = new Runner(sims);
-            runner.Run();
-            string[] checkpointNamesAfterRun = storage.Reader.CheckpointNames.ToArray();
-
-            Assert.That(checkpointNamesAfterRun, Is.Not.EqualTo(checkpointNamesBeforeRun), "Storage reader failed to update checkpoint names after simulation was run.");
+            try
+            {
+                // Record checkpoint names before and after running the simulation,
+                // and ensure that they are not the same.
+                string[] checkpointNamesBeforeRun = storage.Reader.CheckpointNames.ToArray();
+                // Run the simulation
+                var runner = new Runner(sims);
+                runner.Run();
+                string[] checkpointNamesAfterRun = storage.Reader.CheckpointNames.ToArray();
+                Assert.That(checkpointNamesAfterRun, Is.Not.EqualTo(checkpointNamesBeforeRun), "Storage reader failed to update checkpoint names after simulation was run.");
+            }
+            finally
+            {
+                storage.Close();
+            }
         }
 
         /// <summary>Create a table that we can test</summary>
-        public static void CreateTable(IDatabaseConnection database)
+        public static void CreateTable(IDatabaseConnection dBase)
         {
             // Create a _Checkpoints table.
             List<string> columnNames = new List<string>() { "ID", "Name", "Version", "Date", "OnGraphs" };
             List<string> columnTypes = new List<string>() { "integer", "char(50)", "char(50)", "date", "integer" };
-            database.CreateTable("_Checkpoints", columnNames, columnTypes);
+            dBase.CreateTable("_Checkpoints", columnNames, columnTypes);
             List<object[]> rows = new List<object[]>
             {
                 new object[] { 1, "Current", string.Empty, string.Empty, 0 },
                 new object[] { 2, "Saved1", string.Empty, string.Empty, 0 }
             };
-            database.InsertRows("_Checkpoints", columnNames, rows);
+            dBase.InsertRows("_Checkpoints", columnNames, rows);
 
             // Create a _Simulations table.
             columnNames = new List<string>() { "ID", "Name", "FolderName" };
             columnTypes = new List<string>() { "integer", "char(50)", "char(50)" };
-            database.CreateTable("_Simulations", columnNames, columnTypes);
+            dBase.CreateTable("_Simulations", columnNames, columnTypes);
             rows = new List<object[]>
             {
                 new object[] { 1, "Sim1", string.Empty },
                 new object[] { 2, "Sim2", string.Empty }
             };
-            database.InsertRows("_Simulations", columnNames, rows);
+            dBase.InsertRows("_Simulations", columnNames, rows);
 
             // Create a Report table.
             columnNames = new List<string>() { "CheckpointID", "SimulationID", "Col1", "Col2" };
             columnTypes = new List<string>() { "integer", "integer", "date", "real" };
-            database.CreateTable("Report", columnNames, columnTypes);
+            dBase.CreateTable("Report", columnNames, columnTypes);
             rows = new List<object[]>
             {
                 new object[] { 1, 1, new DateTime(2017, 1, 1), 1.0 },
@@ -241,7 +253,7 @@
                 new object[] { 2, 2, new DateTime(2017, 1, 1), 31.0 },
                 new object[] { 2, 2, new DateTime(2017, 1, 2), 32.0 }
             };
-            database.InsertRows("Report", columnNames, rows);
+            dBase.InsertRows("Report", columnNames, rows);
 
         }
     }

--- a/Tests/UnitTests/Storage/DataStoreTests.cs
+++ b/Tests/UnitTests/Storage/DataStoreTests.cs
@@ -28,6 +28,7 @@ namespace UnitTests.Storage
 
             // The new file name should not be the same as the old one.
             Assert.That(oldDbFileName, Is.Not.EqualTo(newDbFileName));
+            storage.Close();
         }
     }
 }

--- a/Tests/UnitTests/Storage/DataStoreWriterTests.cs
+++ b/Tests/UnitTests/Storage/DataStoreWriterTests.cs
@@ -7,7 +7,6 @@
     using System.Collections.Generic;
     using System.Data;
     using System.IO;
-    using System.Reflection;
 
     [TestFixture]
     public class DataStoreWriterTests
@@ -21,6 +20,12 @@
         {
             database = new SQLite();
             database.OpenDatabase(":memory:", readOnly: false);
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            database?.CloseDatabase();
         }
 
         /// <summary>Write data for 2 simulations into one table. Ensure data was written correctly.</summary>
@@ -299,7 +304,6 @@
             try
             {
                 writer.AddCheckpoint("Saved2", new string[] { file });
-
                 writer.Stop();
 
                 Assert.That(
@@ -317,8 +321,6 @@
                                                             new object[] {              3,              2, new DateTime(2017, 01, 01),    21 },
                                                             new object[] {              3,              2, new DateTime(2017, 01, 02),    22 }})
                 .IsSame(Utilities.GetTableFromDatabase(database, "Report")), Is.True);
-
-
                 Assert.That(
                     Utilities.CreateTable(new string[]                      { "ID",    "Name" },
                                         new List<object[]> { new object[] {    1, "Current" },


### PR DESCRIPTION
Resolves #10475 by always explicitly closing the storage database in unit tests.

Also fixes problems that were causing occasional exceptions when the sqlite database was closed. These were happening because the SqliteConnection objects in Microsoft.Data.Sqlite are NOT thread-safe. This PR ensures that each thread has its own unique SqliteConnection object (when needed). Unfortunately, this also results in a small but noticeable slowdown in writing to the database.