### PR TITLE
Use FileName instead of FullFileName in Weather.cs

### DIFF
--- a/ApsimNG/Presenters/MetDataPresenter.cs
+++ b/ApsimNG/Presenters/MetDataPresenter.cs
@@ -229,10 +229,10 @@ namespace UserInterface.Presenters
                     try
                     {
                         this.weatherData.ExcelWorkSheetName = sheetName;
-                        string newFileName = PathUtilities.GetAbsolutePath(filename, this.explorerPresenter.ApsimXFile.FileName);
+                        string newFileName = PathUtilities.GetRelativePath(filename, this.explorerPresenter.ApsimXFile.FileName);
                         var changes = new List<ChangeProperty.Property>();
-                        if (weatherData.FullFileName != newFileName)
-                            changes.Add(new ChangeProperty.Property(weatherData, nameof(weatherData.FullFileName), newFileName));
+                        if (weatherData.FileName != newFileName)
+                            changes.Add(new ChangeProperty.Property(weatherData, nameof(weatherData.FileName), newFileName));
                         // Set constants file name to null iff the new file name is not a csv file.
                         if (Path.GetExtension(newFileName) != ".csv" && weatherData.ConstantsFile != null)
                             changes.Add(new ChangeProperty.Property(weatherData, nameof(weatherData.ConstantsFile), null));

--- a/ApsimNG/Utility/WeatherDownloadDialog.cs
+++ b/ApsimNG/Utility/WeatherDownloadDialog.cs
@@ -254,7 +254,7 @@ namespace Utility
                             else if (dest is Simulation)
                             {
                                 Weather newWeather = new Weather();
-                                newWeather.FullFileName = newWeatherPath;
+                                newWeather.FileName = newWeatherPath;
                                 var command = new AddModelCommand(replaceNode, newWeather, explorerPresenter.GetNodeDescription);
                                 explorerPresenter.CommandHistory.Add(command, true);
                             }

--- a/Models/Climate/Weather.cs
+++ b/Models/Climate/Weather.cs
@@ -190,10 +190,7 @@ namespace Models.Climate
                         return PathUtilities.GetAbsolutePath(this.FileName, "");
                 }
             }
-            set
-            {
-                this.FileName = value;
-            }
+
         }
 
         /// <summary>

--- a/Tests/UnitTests/Management/BiomassRemovalEventsTests.cs
+++ b/Tests/UnitTests/Management/BiomassRemovalEventsTests.cs
@@ -33,7 +33,7 @@ namespace UnitTests.Core
             // prepare the simulation to run
             Simulations sims = FileFormat.ReadFromString<Simulations>(json).Model as Simulations;
             Models.Climate.Weather weather = sims.Node.FindChild<Models.Climate.Weather>(recurse: true);
-            weather.FullFileName = metFile;
+            weather.FileName = metFile;
 
             // run the simulation and get list of errors
             Runner runner = new Runner(sims);

--- a/Tests/UnitTests/Soils/NutrientTests.cs
+++ b/Tests/UnitTests/Soils/NutrientTests.cs
@@ -27,7 +27,7 @@ namespace UnitTests.SurfaceOrganicMatterTests
             Simulations file = FileFormat.ReadFromString<Simulations>(json).Model as Simulations;
             Models.Climate.Weather weather = file.Node.FindChild<Models.Climate.Weather>(recurse: true);
             string properWeatherFilePath = PathUtilities.GetRelativePath(weather.FullFileName, null);
-            weather.FullFileName = properWeatherFilePath;
+            weather.FileName = properWeatherFilePath;
 
 
             // Run the file.

--- a/Tests/UnitTests/Weather/WeatherTests.cs
+++ b/Tests/UnitTests/Weather/WeatherTests.cs
@@ -45,7 +45,7 @@ namespace UnitTests.Weather
                     new Models.Climate.Weather()
                     {
                         Name = "Weather",
-                        FullFileName = weatherFilePath,
+                        FileName = weatherFilePath,
                         ExcelWorkSheetName = "Sheet1"
                     },
                     new Clock()
@@ -88,7 +88,7 @@ namespace UnitTests.Weather
                     new Models.Climate.Weather()
                     {
                         Name = "Weather",
-                        FullFileName = weatherFilePath
+                        FileName = weatherFilePath
                     },
                     new Clock()
                     {
@@ -129,7 +129,7 @@ namespace UnitTests.Weather
             Models.Climate.Weather weather = new()
             {
                 Name = "Weather",
-                FullFileName = weatherFilePath,
+                FileName = weatherFilePath,
                 ExcelWorkSheetName = "Sheet1"
             };
             Node.Create(weather);
@@ -159,7 +159,7 @@ namespace UnitTests.Weather
                         new MockSummary(),
                         new Models.Climate.Weather()
                         {
-                            FullFileName = metFile
+                            FileName = metFile
                         },
                         new Models.Report()
                         {
@@ -225,7 +225,7 @@ namespace UnitTests.Weather
                         new Models.Climate.Weather()
                         {
                             Name = "Weather",
-                            FullFileName = weatherFilePath,
+                            FileName = weatherFilePath,
                             ExcelWorkSheetName = "Sheet1"
                         },
                         new Clock()
@@ -278,7 +278,7 @@ namespace UnitTests.Weather
             {
                 Children =
                 [
-                    new Models.Climate.Weather() { FullFileName = metFile }
+                    new Models.Climate.Weather() { FileName = metFile }
                 ]
             };
             var weather = simulations.Children[0] as Models.Climate.Weather;


### PR DESCRIPTION
resolves #10417

This resolves an issue where apsim files would have the absolute path saved instead of the relative path, which can cause issues when the file is run outside of the environment where it was last saved (such as on Jenkins when model validation is run).

The issue was that FullFileName was the property being used in many places. This property always fetched the absolute path and updated FileName at the same time if it was every changed.