### PR TITLE
10533 Add check if compiled

### DIFF
--- a/Models/Management/Manager.cs
+++ b/Models/Management/Manager.cs
@@ -136,7 +136,7 @@ namespace Models
             GetParametersFromScriptModel();
             SetParametersInScriptModel();
 
-            if (CodeForLastSuccessfullCompile == null)
+            if (CodeForLastSuccessfullCompile == null && !string.IsNullOrEmpty(Code))
                 throw new Exception($"Errors found in manager model {Name}{Environment.NewLine}{Errors}");
         }
 

--- a/Tests/UnitTests/Manager/ManagerTests.cs
+++ b/Tests/UnitTests/Manager/ManagerTests.cs
@@ -311,6 +311,11 @@ namespace UnitTests.ManagerTests
             Assert.That(testManager.Parameters.Count, Is.EqualTo(1));
 
             //should not work
+            //empty string should be allowed, but would do nothing
+            testManager.Code = "";
+            Assert.DoesNotThrow(() => typeof(Manager).InvokeMember("OnStartOfSimulation", reflectionFlagsMethods, null, testManager, new object[] { new object(), new EventArgs() }));
+
+            //should not work
             //need to wrap this in a try catch as it will throw an exception for bad code
             try { testManager.Code = "asdf"; } catch { }
             Assert.Throws<TargetInvocationException>(() => typeof(Manager).InvokeMember("OnStartOfSimulation", reflectionFlagsMethods, null, testManager, new object[] { new object(), new EventArgs() }));


### PR DESCRIPTION
Resolves #10533

Something must have been accidently changed in the refactoring over the last few months, and there wasn't a check in the code to make sure the manager had actually compiled, nor a unit test to check if the OnSimulationStart method would fail if it wasn't compiled.

Added a check and unit test and seems to have fixed the problem.