### PR TITLE
Add "AddToType" command.

### DIFF
--- a/Models/Core/ConfigFile/Instruction.cs
+++ b/Models/Core/ConfigFile/Instruction.cs
@@ -60,6 +60,10 @@ namespace Models.Core.ConfigFile
         /// </summary>
         Add,
         /// <summary>
+        /// Makes instruction an AddToType type.
+        /// </summary>
+        AddToType,
+        /// <summary>
         /// Makes instruction a Copy type.
         /// </summary>
         Copy,


### PR DESCRIPTION
Resolves #10406 
Resolves #10559

The `AddToType` command functions like `Add`, but it adds the model to every instance of the specified type.
 
If this is of interest, please let me know so I add a unit test. 

**Example:** 

```
addtotype Simulation Memo MyMemo
addtotype AnApsimFile.apsimx;[Memo]
```