### PR TITLE
10558 Remove tests without output

### DIFF
--- a/APSIM.Workflow/PayloadUtilities.cs
+++ b/APSIM.Workflow/PayloadUtilities.cs
@@ -49,6 +49,9 @@ public static class PayloadUtilities
     public static string[] EXCLUDED_SIMS_FILEPATHS = {
                 "/Prototypes/CroptimizR/template.apsimx",
                 "/Examples/Optimisation/CroptimizRExample.apsimx",
+                "/Examples/CsvWeather.apsimx", //has no output
+                "/Tests/Simulation/SoilNitrogenPatch/PaddockSims/Edited_v2_BivariateNormal.apsimx", //has no output
+                "/Tests/Simulation/SoilNitrogenPatch/PaddockSims/Edited_v5_BivariateNormal.apsimx", //has no output
                 "/Tests/Validation/Wheat/Wheat.apsimx", //Leave wheat out for now as it gets split into smaller files automatically.
                 "/Tests/Validation/Wheat/FAR/FAR.apsimx" //Leave FAR out for now as it gets split into smaller files automatically.
             };


### PR DESCRIPTION
Working on #10558

These three apsim files don't report anything but are run by the validation, this causes them to throw an exception. Adding them to the ignore list for now so they don't throw an error in the new system.