### PR TITLE
Added more checks for NaN in WaterBalance and its submodels

### DIFF
--- a/Models/Soils/WaterModel/SaturatedFlow.cs
+++ b/Models/Soils/WaterModel/SaturatedFlow.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using APSIM.Numerics;
 using APSIM.Shared.Utilities;
 using Models.Core;
@@ -132,6 +133,9 @@ namespace Models.WaterModel
                     // drainage out of this layer goes into next layer down
                     w_in = w_out;
                 }
+
+                if (flux.Any(w => double.IsNaN(w)))
+                    throw new Exception($"SaturatedFlow model produced NaN: {string.Join(", ", flux)}");
 
                 return flux;
             }

--- a/Models/Soils/WaterModel/UnsaturatedFlow.cs
+++ b/Models/Soils/WaterModel/UnsaturatedFlow.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using APSIM.Numerics;
 using APSIM.Shared.Utilities;
 using Models.Core;
@@ -140,6 +141,9 @@ namespace Models.WaterModel
                     // when calculating theta1 and sw1.
                     w_out = flow[i];
                 }
+
+                if (flow.Any(w => double.IsNaN(w)))
+                    throw new Exception($"UnsaturatedFlow model produced NaN: {string.Join(",", flow)}");
 
                 return flow;
             }

--- a/Models/Soils/WaterModel/WaterBalance.cs
+++ b/Models/Soils/WaterModel/WaterBalance.cs
@@ -229,6 +229,9 @@ namespace Models.WaterModel
             get { return waterMM; }
             set
             {
+                if (value.Any(w => double.IsNaN(w)))
+                    throw new Exception($"Input soil moisture array (Water, mm) contains NaN: {string.Join(", ", value)}");
+
                 waterMM = value;
                 if (value == null)
                     waterVolumetric = null;
@@ -244,6 +247,9 @@ namespace Models.WaterModel
             get { return waterVolumetric; }
             set
             {
+                if (value.Any(w => double.IsNaN(w)))
+                    throw new Exception($"Input soil moisture array (SW, mm/mm) contains NaN: {string.Join(", ", value)}");
+
                 waterVolumetric = value;
                 waterMM = MathUtilities.Multiply(value, soilPhysical.Thickness);
             }
@@ -581,6 +587,9 @@ namespace Models.WaterModel
 
             // Update the variable in the water model.
             water.Volumetric = waterVolumetric;
+
+            if (waterVolumetric.Any(w => double.IsNaN(w)))
+                throw new Exception($"WaterBalance model produced NaN: {string.Join(", ", waterVolumetric)}");
         }
 
         /// <summary>


### PR DESCRIPTION
Resolves #10540

Initial soil moisture is validated when entered through the GUI; however, users can still input invalid arrays via manager scripts.