### PR TITLE
New creation and auto-scaling validation workflow steps

### DIFF
--- a/.github/workflows/scripts/enable-azure-pool-autoscaling.sh
+++ b/.github/workflows/scripts/enable-azure-pool-autoscaling.sh
@@ -11,4 +11,4 @@ POOL_ID="${DOCKER_METADATA_OUTPUT_VERSION:3}-${INCOMING_COMMIT_SHA:0:6}"
 ENCODED_STRING=$(jq -rn --arg x "$AZURE_ENV_CONTENTS" '$x|@uri')
 # Once the azure env contents are url encoded we can send them via curl
 url="https://digitalag.csiro.au/workflo/enable-autoscale?poolId=${POOL_ID}&envString=${ENCODED_STRING}"
-response=$(curl -f -X 'POST' "$url")
+response=$(curl -f -X POST "$url")

--- a/.github/workflows/scripts/enable-azure-pool-autoscaling.sh
+++ b/.github/workflows/scripts/enable-azure-pool-autoscaling.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # This script is used to enable autoscaling on an existing Azure pool.
 # This is to ensure that the pool removes nodes when they are no longer needed to reduce costs.
 
@@ -6,11 +8,21 @@ test -z "$AZURE_ENV_CONTENTS" && echo "AZURE_ENV_CONTENTS is empty" && exit 1
 test -z "$DOCKER_METADATA_OUTPUT_VERSION" && echo "DOCKER_METADATA_OUTPUT_VERSION is empty" && exit 1 
 test -z "$INCOMING_COMMIT_SHA" && echo "INCOMING_COMMIT_SHA is empty" && exit 1
 
-POOL_ID="${DOCKER_METADATA_OUTPUT_VERSION:3}-${INCOMING_COMMIT_SHA:0:6}"
+# Clean the PR number of any whitespace
+pr_number=${DOCKER_METADATA_OUTPUT_VERSION:3}
+cleaned_pr_number=$(echo "$pr_number" | tr -d '[:space:]')
+
+# Use the cleaned PR number and the first 6 characters of the commit SHA to create a unique pool id.
+POOL_ID="${cleaned_pr_number}-${INCOMING_COMMIT_SHA:0:6}"
+echo "Combined pool id: ${POOL_ID}"
+
 # Make AZURE_ENV_CONTENTS replace windows and linux line endings with a single space.
-AZURE_ENV_CONTENTS=$(echo "$AZURE_ENV_CONTENTS" | tr '\n\r' ' ')
+AZURE_ENV_CONTENTS=$(echo -e "$AZURE_ENV_CONTENTS" | tr -d '\r' | tr '\n' ' ')
+
 # The env contents need to be url encoded before they can be sent via curl.
 ENCODED_STRING=$(jq -rn --arg x "$AZURE_ENV_CONTENTS" '$x|@uri')
+
 # Once the azure env contents are url encoded we can send them via curl
 url="https://digitalag.csiro.au/workflo/enable-autoscale?poolId=${POOL_ID}&envString=${ENCODED_STRING}"
-response=$(curl -f -X POST "$url")
+response=$(curl -f -s -w "%{http_code}" -X POST "${url}")
+echo "Response from server: $response"

--- a/.github/workflows/scripts/enable-azure-pool-autoscaling.sh
+++ b/.github/workflows/scripts/enable-azure-pool-autoscaling.sh
@@ -7,6 +7,8 @@ test -z "$DOCKER_METADATA_OUTPUT_VERSION" && echo "DOCKER_METADATA_OUTPUT_VERSIO
 test -z "$INCOMING_COMMIT_SHA" && echo "INCOMING_COMMIT_SHA is empty" && exit 1
 
 POOL_ID="${DOCKER_METADATA_OUTPUT_VERSION:3}-${INCOMING_COMMIT_SHA:0:6}"
+# Make AZURE_ENV_CONTENTS replace windows and linux line endings with a single space.
+AZURE_ENV_CONTENTS=$(echo "$AZURE_ENV_CONTENTS" | tr '\n\r' ' ')
 # The env contents need to be url encoded before they can be sent via curl.
 ENCODED_STRING=$(jq -rn --arg x "$AZURE_ENV_CONTENTS" '$x|@uri')
 # Once the azure env contents are url encoded we can send them via curl

--- a/.github/workflows/scripts/start-azure-pool.sh
+++ b/.github/workflows/scripts/start-azure-pool.sh
@@ -7,6 +7,8 @@ test -z "$DOCKER_METADATA_OUTPUT_VERSION" && echo "DOCKER_METADATA_OUTPUT_VERSIO
 test -z "$INCOMING_COMMIT_SHA" && echo "INCOMING_COMMIT_SHA is empty" && exit 1
 
 POOL_ID="${DOCKER_METADATA_OUTPUT_VERSION:3}-${INCOMING_COMMIT_SHA:0:6}"
+# Make AZURE_ENV_CONTENTS replace windows and linux line endings with a single space.
+AZURE_ENV_CONTENTS=$(echo "$AZURE_ENV_CONTENTS" | tr '\n\r' ' ')
 # The env contents need to be url encoded before they can be sent via curl.
 ENCODED_STRING=$(jq -rn --arg x "$AZURE_ENV_CONTENTS" '$x|@uri')
 # Once the azure env contents are url encoded we can send them via curl

--- a/.github/workflows/scripts/start-azure-pool.sh
+++ b/.github/workflows/scripts/start-azure-pool.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # This script is used to start an Azure pool ahead of time before jobs are created.
 # This is to ensure that the pool is ready to accept jobs when they are created and reduces spin up time.
 
@@ -6,12 +8,19 @@ test -z "$AZURE_ENV_CONTENTS" && echo "AZURE_ENV_CONTENTS is empty" && exit 1
 test -z "$DOCKER_METADATA_OUTPUT_VERSION" && echo "DOCKER_METADATA_OUTPUT_VERSION is empty" && exit 1
 test -z "$INCOMING_COMMIT_SHA" && echo "INCOMING_COMMIT_SHA is empty" && exit 1
 
-POOL_ID="${DOCKER_METADATA_OUTPUT_VERSION:3}-${INCOMING_COMMIT_SHA:0:6}"
+pr_number=${DOCKER_METADATA_OUTPUT_VERSION:3}
+cleaned_pr_number=$(echo "$pr_number" | tr -d '[:space:]')
+POOL_ID="${cleaned_pr_number}-${INCOMING_COMMIT_SHA:0:6}"
+echo "Combined pool id: ${POOL_ID}"
+
 # Make AZURE_ENV_CONTENTS replace windows and linux line endings with a single space.
-AZURE_ENV_CONTENTS=$(echo "$AZURE_ENV_CONTENTS" | tr '\n\r' ' ')
+AZURE_ENV_CONTENTS=$(echo -e "$AZURE_ENV_CONTENTS" | tr -d '\r' | tr '\n' ' ')
+
 # The env contents need to be url encoded before they can be sent via curl.
 ENCODED_STRING=$(jq -rn --arg x "$AZURE_ENV_CONTENTS" '$x|@uri')
+
 # Once the azure env contents are url encoded we can send them via curl
 url="https://digitalag.csiro.au/workflo/create-pool?poolId=${POOL_ID}&envString=${ENCODED_STRING}&nodeNumber=30&isAutoscaled=false"
-response=$(curl -f -X POST "$url")
+response=$(curl -f -s -w "%{http_code}" -X POST "${url}")
+echo "Response from server: $response"
 

--- a/.github/workflows/scripts/start-azure-pool.sh
+++ b/.github/workflows/scripts/start-azure-pool.sh
@@ -11,5 +11,5 @@ POOL_ID="${DOCKER_METADATA_OUTPUT_VERSION:3}-${INCOMING_COMMIT_SHA:0:6}"
 ENCODED_STRING=$(jq -rn --arg x "$AZURE_ENV_CONTENTS" '$x|@uri')
 # Once the azure env contents are url encoded we can send them via curl
 url="https://digitalag.csiro.au/workflo/create-pool?poolId=${POOL_ID}&envString=${ENCODED_STRING}&nodeNumber=30&isAutoscaled=false"
-response=$(curl -f -X 'POST' "$url")
+response=$(curl -f -X POST "$url")
 


### PR DESCRIPTION
resolves #10597 

This adds the functionality to enable the early creation of Azure compute nodes and to also change the auto-scaling of pools after the jobs have been created.

The changes will not come into affect until the next PR after this one is merged.