### PR TITLE
10417 Weather Path Fixes

### DIFF
--- a/APSIM.Shared/Utilities/PathUtilities.cs
+++ b/APSIM.Shared/Utilities/PathUtilities.cs
@@ -102,10 +102,7 @@
             if (relativeDirectory != null && !Path.IsPathRooted(path))
                     path = Path.Combine(relativeDirectory, path);
 
-            // Convert slashes.
-            path = ConvertSlashes(path);
-
-            return Path.GetFullPath(path);
+            return ConvertSlashes(Path.GetFullPath(path));
         }
 
         /// <summary>
@@ -119,15 +116,37 @@
             if (string.IsNullOrEmpty(path) || string.IsNullOrEmpty(relativePath))
                 return path;
 
-            // Make sure we have a relative directory 
-            string relativeDirectory = Path.GetDirectoryName(relativePath);
-            if (!string.IsNullOrEmpty(relativeDirectory))
+            //Convert both paths to using linux style slashes
+            string correctedPath = ConvertSlashes(path);
+            string correctedRelativePath = ConvertSlashes(relativePath);
+
+            //if path has backtracking in path, convert to absolute
+            if (correctedPath.Contains("../"))
+                correctedPath = GetAbsolutePath(correctedPath, correctedRelativePath);
+
+            //Get the program path to replace %root%
+            string programPath = GetAbsolutePath("%root%", null);
+            correctedPath = correctedPath.Replace("%root%", programPath);
+            
+            //check if our path is the same as the absolute path, if it is, see if it contains the relative path to shorten it
+            string absolutePath = GetAbsolutePath(correctedPath, correctedRelativePath);
+            if (absolutePath == correctedPath)
             {
-                // Try getting rid of the relative directory.
-                path = path.Replace(relativeDirectory + Path.DirectorySeparatorChar, "");  // the relative path should not have a preceding \
+                string relativeDirectory = ConvertSlashes(Path.GetDirectoryName(correctedRelativePath));
+                if (!string.IsNullOrEmpty(relativeDirectory))
+                {
+                    if (!relativeDirectory.EndsWith("/"))
+                        relativeDirectory = relativeDirectory + "/";
+                    correctedPath = correctedPath.Replace(relativeDirectory, "");
+                }
             }
 
-            return ConvertSlashes(path);
+            //check now if the path matches the absolute path. if it is, see if we can shorten it with %root%
+            if (absolutePath == correctedPath)
+                correctedPath = correctedPath.Replace(programPath, "%root%");
+
+            //We should now have the best version of this path, in order of relative, %root% and absolute
+            return correctedPath;
         }
 
         /// <summary>
@@ -160,10 +179,7 @@
         /// </summary>
         private static string ConvertSlashes(string path)
         {
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT || Environment.OSVersion.Platform == PlatformID.Win32Windows)
-                return path.Replace("/", @"\");
-
-            return path.Replace(@"\", "/");
+            return path.Replace("\\", "/");
         }
 
 
@@ -187,6 +203,21 @@
             }
 
             return apsimxFiles;
+        }
+        
+        /// <summary>
+        /// Compares two filepaths and determines if they are the same. Can compare relative against full path.
+        /// </summary>
+        /// <returns>True if the file paths match</returns>
+        public static bool ComparePaths(string path1, string path2, string apsimxFilepath)
+        {
+            string fullpath1 = PathUtilities.GetAbsolutePath(path1, apsimxFilepath);
+            string fullpath2 = PathUtilities.GetAbsolutePath(path2, apsimxFilepath);
+
+            if (fullpath1 == fullpath2)
+                return true;
+            else
+                return false;
         }
 
     }

--- a/ApsimNG/Presenters/MetDataPresenter.cs
+++ b/ApsimNG/Presenters/MetDataPresenter.cs
@@ -77,8 +77,8 @@ namespace UserInterface.Presenters
             this.weatherDataView.ConstantsFileSelected += OnConstantsFileSelected;
             this.weatherDataView.ExcelSheetChangeClicked += this.ExcelSheetValueChanged;
 
-            this.weatherDataView.ShowConstantsFile(Path.GetExtension(weatherData.FullFileName) == ".csv");
-            this.WriteTableAndSummary(this.weatherData.FullFileName, this.weatherData.ExcelWorkSheetName);
+            this.weatherDataView.ShowConstantsFile(Path.GetExtension(weatherData.FileName) == ".csv");
+            this.WriteTableAndSummary(this.weatherData.FileName, this.weatherData.ExcelWorkSheetName);
             this.weatherDataView.TabIndex = this.weatherData.ActiveTabIndex;
             if (this.weatherData.StartYear >= 0)
                 this.weatherDataView.GraphStartYearValue = this.weatherData.StartYear;
@@ -103,7 +103,8 @@ namespace UserInterface.Presenters
         {
             bool isCsv = Path.GetExtension(fileName) == ".csv";
             this.weatherDataView.ShowConstantsFile(isCsv);
-            if (this.weatherData.FullFileName != PathUtilities.GetAbsolutePath(fileName, this.explorerPresenter.ApsimXFile.FileName))
+
+            if (!PathUtilities.ComparePaths(this.weatherData.FileName, fileName, this.explorerPresenter.ApsimXFile.FileName))
             {
                 if (ExcelUtilities.IsExcelFile(fileName))
                 {
@@ -111,10 +112,6 @@ namespace UserInterface.Presenters
                     this.weatherDataView.ShowExcelSheets(true);
                     this.sheetNames = ExcelUtilities.GetWorkSheetNames(fileName);
                     this.weatherDataView.PopulateDropDownData(this.sheetNames);
-
-                    // We want to attempt to update the table/summary now. This may fail if the
-                    // sheet name is incorrect/not set.
-                    this.WriteTableAndSummary(fileName);
                 }
                 else
                 {
@@ -123,8 +120,9 @@ namespace UserInterface.Presenters
 
                     // as a precaution, set this to nothing
                     this.weatherData.ExcelWorkSheetName = string.Empty;
-                    this.WriteTableAndSummary(fileName);
+
                 }
+                this.WriteTableAndSummary(fileName);
             }
         }
 
@@ -171,10 +169,9 @@ namespace UserInterface.Presenters
         /// <param name="sheetName">The sheet name</param>
         public void ExcelSheetValueChanged(string fileName, string sheetName)
         {
-            if (!string.IsNullOrEmpty(sheetName))
+            if (!string.IsNullOrEmpty(fileName) && !string.IsNullOrEmpty(sheetName))
             {
-                if ((this.weatherData.FullFileName != PathUtilities.GetAbsolutePath(fileName, this.explorerPresenter.ApsimXFile.FileName)) ||
-                    (this.weatherData.ExcelWorkSheetName != sheetName))
+                if (!PathUtilities.ComparePaths(this.weatherData.FileName, fileName, this.explorerPresenter.ApsimXFile.FileName) || (this.weatherData.ExcelWorkSheetName != sheetName))
                 {
                     this.WriteTableAndSummary(fileName, sheetName);
                 }
@@ -357,7 +354,7 @@ namespace UserInterface.Presenters
         private void WriteSummary(DataTable table)
         {
             StringBuilder summary = new StringBuilder();
-            summary.AppendLine("File name : " + Path.GetFileName(this.weatherData.FileName));
+            summary.AppendLine("File name : " + this.weatherData.FileName);
             if (!string.IsNullOrEmpty(this.weatherData.ExcelWorkSheetName))
             {
                 summary.AppendLine("Sheet Name: " + this.weatherData.ExcelWorkSheetName.ToString());

--- a/Tests/UnitTests/Weather/WeatherTests.cs
+++ b/Tests/UnitTests/Weather/WeatherTests.cs
@@ -320,90 +320,83 @@ namespace UnitTests.Weather
         [Test]
         public void TestWeatherFileNameAndFullName()
         {
-            var tempFile = Path.GetTempFileName().Replace(".tmp", ".met");
-            File.WriteAllText(tempFile, ReflectionUtilities.GetResourceAsString("UnitTests.Weather.CustomMetData.met"));
-            var tempDir = Path.GetDirectoryName(tempFile);
+            string tempfile = Path.GetTempFileName().Replace("\\", "/");
+            string tempDir = Path.GetDirectoryName(tempfile).Replace("\\", "/");
+            string tempDirUpOne = tempDir.Remove(tempDir.LastIndexOf('/'));
+            string rootPath = PathUtilities.GetAbsolutePath("%root%", tempDir);
+            tempDir += "/";
+            tempDirUpOne += "/";
+            rootPath += "/";
+
+            tempfile = Path.GetFileName(tempfile);
+
+            string metfile = tempfile.Replace(".tmp", ".met");
+            File.WriteAllText(metfile, ReflectionUtilities.GetResourceAsString("UnitTests.Weather.CustomMetData.met"));
+
+            string apsimfile = tempfile.Replace(".tmp", ".apsimx");
 
             // Now set the apsimx file name and ensure that the weather file name is still the same but the full file name is now absolute.
-            var sims = new Simulations()
+            Simulations sims = new Simulations()
             {
-                FileName = Path.Combine(tempDir, "temp.apsimx"),
                 Children = new List<IModel>()
                 {
                     new Simulation()
                     {
-                        Name = "Base",
-                        FileName = Path.Combine(tempDir, "temp.apsimx"),
                         Children = new List<IModel>()
-                            {
-                                new Models.Climate.Weather()
-                                {
-                                    Name = "Weather",
-                                    FileName = tempFile,
-                                    ExcelWorkSheetName = "Sheet1"
-                                },
-                                new Clock()
-                                {
-                                    Name = "Clock",
-                                },
-                                new MockSummary()
-                            }
+                        {
+                            new Models.Climate.Weather(),
+                            new MockClock(),
+                            new MockSummary()
+                        }
                     }
                 },
             };
 
-            Node.Create(sims, fileName: sims.FileName);
-            sims.Write(sims.FileName);
-            var weather = sims.Node.FindChild<Models.Climate.Weather>(recurse: true);
-            weather.FileName = tempFile;
-            Assert.That(weather.FileName, Is.EqualTo(Path.GetFileName(tempFile)));
-            Assert.That(weather.FullFileName, Is.EqualTo(tempFile));
-        }
+            sims.Node = Node.Create(sims, fileName: tempDir + apsimfile);
+            sims.Write(tempDir + apsimfile);
 
-        /// <summary>
-        /// Tests that a weather file with %root% in the filename is correctly interpreted.
-        /// </summary>
-        [Test]
-        public void TestFileNameInterpretsRootVariable()
-        {
-            var tempFile = Path.GetTempFileName().Replace(".tmp", ".met");
-            File.WriteAllText(tempFile, ReflectionUtilities.GetResourceAsString("Examples.WeatherFiles.AU_Dalby.met"));
-            var tempDir = Path.GetDirectoryName(tempFile);
-            var apsimxFile = Path.Combine(tempDir, "temp.apsimx");
+            Models.Climate.Weather weather = sims.Node.FindChild<Models.Climate.Weather>(recurse: true);
 
-            var sims = new Simulations()
+            List<(string, string)> inputs = new List<(string, string)>();
+            inputs.Add(("fileInSameFolder.met", "fileInSameFolder.met"));
+            inputs.Add((tempDir + "fileInSameFolder.met", "fileInSameFolder.met"));
+            inputs.Add((tempDir + "fileInSameFolder.met", "fileInSameFolder.met"));
+            inputs.Add(("subfolder/fileSubFolder.met", "subfolder/fileSubFolder.met"));
+            inputs.Add((tempDir + "subfolder/fileSubFolder.met", "subfolder/fileSubFolder.met"));
+            inputs.Add(("../fileInFolderAbove.met", tempDirUpOne + "fileInFolderAbove.met"));
+            inputs.Add((tempDirUpOne + "fileInFolderAbove.met", tempDirUpOne + "fileInFolderAbove.met"));
+            inputs.Add(("../AnotherFolder/fileInAnotherFolder.met", tempDirUpOne + "AnotherFolder/fileInAnotherFolder.met"));
+            inputs.Add((tempDirUpOne + "AnotherFolder/fileInAnotherFolder.met", tempDirUpOne + "AnotherFolder/fileInAnotherFolder.met"));
+            inputs.Add(("T:/A/Full/Path/to/file.met", "T:/A/Full/Path/to/file.met"));
+            inputs.Add(("%root%/file.met", "%root%/file.met"));
+            inputs.Add((rootPath + "file.met", "%root%/file.met"));
+
+            foreach ((string, string) input in inputs)
             {
-                FileName = apsimxFile,
-                Children = new List<IModel>()
-                {
-                    new Simulation()
-                    {
-                        Name = "Base",
-                        FileName = apsimxFile,
-                        Children = new List<IModel>()
-                            {
-                                new Models.Climate.Weather()
-                                {
-                                    Name = "Weather",
-                                    FileName = "%root%/Examples/WeatherFiles/AU_Dalby.met",
-                                    ExcelWorkSheetName = "Sheet1"
-                                },
-                                new Clock()
-                                {
-                                    Name = "Clock",
-                                },
-                                new MockSummary()
-                            }
-                    }
-                },
-            };
+                weather.FileName = input.Item1;
+                Assert.That(weather.FileName, Is.EqualTo(input.Item2));
 
-            Node.Create(sims, fileName: sims.FileName);
-            sims.Write(sims.FileName);
-            var weather = sims.Node.FindChild<Models.Climate.Weather>(recurse: true);
-            weather.FileName = "%root%/Examples/WeatherFiles/AU_Dalby.met";
-            Assert.That(weather.FileName, Is.EqualTo(Path.Combine("%root%", "Examples", "WeatherFiles", "AU_Dalby.met")));
-            Assert.That(weather.FullFileName, Does.Not.Contain("%root%"));
+                weather.FileName = input.Item1.Replace("/", "\\");
+                Assert.That(weather.FileName, Is.EqualTo(input.Item2));
+            }
+
+            //now "move" the simulations to under the root path and do the same checks again
+            sims.Node = Node.Create(sims, fileName: rootPath + "temp/" + apsimfile);
+
+
+            inputs.Add(("%root%/temp/file.met", "file.met"));
+            inputs.Add((rootPath + "temp/file.met", "file.met"));
+
+            foreach ((string, string) input in inputs)
+            {
+                string beforePath = input.Item1.Replace(tempDir, rootPath + "temp/");
+                beforePath = beforePath.Replace(tempDirUpOne, rootPath);
+
+                string afterPath = input.Item2.Replace(tempDirUpOne, "%root%/");
+
+                weather.FileName = beforePath;
+                Assert.That(weather.FileName, Is.EqualTo(afterPath));
+            }
         }
 
         /*


### PR DESCRIPTION
Resolves #10417

@hut104 ran into the GUI changing his weather paths again today, so I've gone in and spent a few hours trying to resolve this problem.

I've rewritten the Relative path function in PathUtilities so that it goes through each case correctly. It will take the given string and see if it can be a relative path, a %root% path or an absolute path, with preference in that order. If a relative path is provided that goes upwards (aka ../../file.met) it will be converted to an absolute path, unless that directory is within the apsim folder, in which case it becomes a %root% path instead.

I've then taken one of the unit tests from the last attempt at fixing this, and rewrote it with as many different use cases that I could think of. All the rules above are tested and in as many combinations as possible.

The filename Get and Set in weather have been rewritten, so any fixes are now only applied in the getter with a default setter. That will hopefully simplify this a bit as well. I also noted that in the OnSimulationCommencing that the filenames were converted to be relative, so that has also been removed as it should not be needed if that's what filename is supposed to provide.

In the GUI side, I've removed places where it was doing conversions between full and relative, and added a new comparision function into PathUtilities to help with comparing paths in the future.

Lastly I changed the ConvertSlashes function in PathUtilities to always convert to linux style / instead of using \\ when on windows. Windows will work fine with the linux style, and this will prevent all the filepaths changing if someone opens an apsimx file on linux or mac in the future. It also simplifies things when working with the paths if you always know which slash style you are dealing with.