### PR TITLE
Parse DateTime strings with `DateUtilities.cs` if a FormatException is thrown in `ReflectionUtilities.cs`

### DIFF
--- a/APSIM.Shared/Utilities/ReflectionUtilities.cs
+++ b/APSIM.Shared/Utilities/ReflectionUtilities.cs
@@ -623,8 +623,7 @@
 
             try
             {
-                var changeObject = Convert.ChangeType(newValue, dataType, format);
-                return changeObject;
+                return Convert.ChangeType(newValue, dataType, format);
             }
             catch (FormatException fex)
             {

--- a/Tests/UnitTests/CommandLineArgsTests.cs
+++ b/Tests/UnitTests/CommandLineArgsTests.cs
@@ -1242,7 +1242,6 @@ run";
             string newTempConfigFile = Path.Combine(Path.GetTempPath(), "config1.txt");
             File.WriteAllText(newTempConfigFile, newFileString);
 
-            bool fileExists = File.Exists(newTempConfigFile);
             Assert.That(File.Exists(newTempConfigFile), Is.True);
 
             Utilities.RunModels(file, $"--apply {newTempConfigFile}");


### PR DESCRIPTION
resolves #10611

This PR implements a change to ReflectionUtilitites.cs that when trying to convert a string object to a type that can be parsed as a DateTime object, it will use the existing DateUtilities class to parse it when a FormatException is thrown.

A unit test has also been created to demonstrate it working with the issue encountered.