### PR TITLE
Use different PR version variable in workflow

### DIFF
--- a/.github/workflows/run-model-validations.yml
+++ b/.github/workflows/run-model-validations.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   run-model-validations:
     name: run-model-validations
-    #if: github.repository_owner == 'APSIMInitiative'
+    if: github.repository_owner == 'APSIMInitiative'
     runs-on: ubuntu-latest
     env:
       ALL_APSIM_FILES: ""


### PR DESCRIPTION
resolves #10626

This uses the version object from the docker metadata step to get a better variable for use in subsequent steps.