### PR TITLE
Add sleep step to allow azure nodes to pick up workflow jobs

### DIFF
--- a/.github/workflows/run-model-validations.yml
+++ b/.github/workflows/run-model-validations.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   run-model-validations:
     name: run-model-validations
-    #if: github.repository_owner == 'APSIMInitiative'
+    if: github.repository_owner == 'APSIMInitiative'
     runs-on: ubuntu-latest
     env:
       ALL_APSIM_FILES: ""


### PR DESCRIPTION
resolves #10629

This simply adds a sleep step to the workflow to allow jobs to be picked up by nodes before the auto-scale setting that gets enabled, brings them down.
