### PR TITLE
fix download apsim link in Linux installation documentation

### DIFF
--- a/Docs/content/Install/linux.md
+++ b/Docs/content/Install/linux.md
@@ -7,7 +7,7 @@ draft: false
 
 ## Download debian binary
 
-1. Download the debian file from the <a href="https://apsim.info/download-apsim/" target="_blank" >APSIM website</a>.
+1. Download the debian file from the <a href="https://www.apsim.info/download-apsim/" target="_blank" >APSIM website</a>.
 
 ## Installing
 
@@ -20,4 +20,3 @@ draft: false
 ## Install using docker
 
 * To do this see the instructions <a href="../../../usage/commandline/command-line-linux">here</a>
-


### PR DESCRIPTION
resolves #10687
resolves #10575

This simply fixes a broken documentation link.