### PR TITLE
Added %root% to path for input files in CLEM examples

### DIFF
--- a/Examples/CLEM/CLEM_Example_Cropping.apsimx
+++ b/Examples/CLEM/CLEM_Example_Cropping.apsimx
@@ -84,7 +84,7 @@
               "Children": [
                 {
                   "$type": "Models.CLEM.FileCrop, Models",
-                  "FileName": "FileCrop_Maize.prn",
+                  "FileName": "%root%\\Examples\\CLEM\\FileCrop_Maize.prn",
                   "ExcelWorkSheetName": null,
                   "CropNameColumnName": "CropName",
                   "SoilTypeColumnName": "SoilNum",
@@ -103,7 +103,7 @@
                 },
                 {
                   "$type": "Models.CLEM.FileCrop, Models",
-                  "FileName": "FileCrop_Vegetables.prn",
+                  "FileName": "%root%\\Examples\\CLEM\\FileCrop_Vegetables.prn",
                   "ExcelWorkSheetName": null,
                   "CropNameColumnName": "CropName",
                   "SoilTypeColumnName": "SoilNum",
@@ -1647,7 +1647,7 @@
               "Children": [
                 {
                   "$type": "Models.CLEM.FileCrop, Models",
-                  "FileName": "FileCrop_SorgWheat.prn",
+                  "FileName": "%root%\\Examples\\CLEM\\FileCrop_SorgWheat.prn",
                   "ExcelWorkSheetName": null,
                   "CropNameColumnName": "CropName",
                   "SoilTypeColumnName": "SoilNum",

--- a/Examples/CLEM/CLEM_Example_Grazing.apsimx
+++ b/Examples/CLEM/CLEM_Example_Grazing.apsimx
@@ -92,7 +92,7 @@
               "Children": [
                 {
                   "$type": "Models.CLEM.FileCrop, Models",
-                  "FileName": "FileForage.prn",
+                  "FileName": "%root%\\Examples\\CLEM\\FileForage.prn",
                   "ExcelWorkSheetName": null,
                   "CropNameColumnName": "CropName",
                   "SoilTypeColumnName": "SoilNum",

--- a/Examples/CLEM/CLEM_Sensibility_HerdManagement.apsimx
+++ b/Examples/CLEM/CLEM_Sensibility_HerdManagement.apsimx
@@ -79,7 +79,7 @@
           "Children": [
             {
               "$type": "Models.CLEM.FileCrop, Models",
-              "FileName": "FileForage.prn",
+              "FileName": "%root%\\Examples\\CLEM\\FileForage.prn",
               "ExcelWorkSheetName": null,
               "CropNameColumnName": "CropName",
               "SoilTypeColumnName": "SoilNum",
@@ -1139,7 +1139,7 @@
           "Children": [
             {
               "$type": "Models.CLEM.FileCrop, Models",
-              "FileName": "FileForage.prn",
+              "FileName": "%root%\\Examples\\CLEM\\FileForage.prn",
               "ExcelWorkSheetName": null,
               "CropNameColumnName": "CropName",
               "SoilTypeColumnName": "SoilNum",
@@ -2199,7 +2199,7 @@
           "Children": [
             {
               "$type": "Models.CLEM.FileCrop, Models",
-              "FileName": "FileForage.prn",
+              "FileName": "%root%\\Examples\\CLEM\\FileForage.prn",
               "ExcelWorkSheetName": null,
               "CropNameColumnName": "CropName",
               "SoilTypeColumnName": "SoilNum",
@@ -3291,7 +3291,7 @@
           "Children": [
             {
               "$type": "Models.CLEM.FileCrop, Models",
-              "FileName": "FileForage.prn",
+              "FileName": "%root%\\Examples\\CLEM\\FileForage.prn",
               "ExcelWorkSheetName": null,
               "CropNameColumnName": "CropName",
               "SoilTypeColumnName": "SoilNum",
@@ -4447,7 +4447,7 @@
           "Children": [
             {
               "$type": "Models.CLEM.FileCrop, Models",
-              "FileName": "FileForage.prn",
+              "FileName": "%root%\\Examples\\CLEM\\FileForage.prn",
               "ExcelWorkSheetName": null,
               "CropNameColumnName": "CropName",
               "SoilTypeColumnName": "SoilNum",
@@ -5603,7 +5603,7 @@
           "Children": [
             {
               "$type": "Models.CLEM.FileCrop, Models",
-              "FileName": "FileForage.prn",
+              "FileName": "%root%\\Examples\\CLEM\\FileForage.prn",
               "ExcelWorkSheetName": null,
               "CropNameColumnName": "CropName",
               "SoilTypeColumnName": "SoilNum",


### PR DESCRIPTION
Resolves #10706 

Added the new %root% prefix to filenames and pointed to \\Examples\\CLEM in all example simulations.