### PR TITLE
Simplify job definition in workflow file

### DIFF
--- a/.github/workflows/run-apsimx-unit-tests.yml
+++ b/.github/workflows/run-apsimx-unit-tests.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   build-and-test:
-    name: build-and-test
     # Run all subsequent steps on the specified operating systems.
     if: github.repository_owner == 'APSIMInitiative'
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Removed the explicit job name to streamline the workflow configuration. This is to try and make the workflows for unit testing display as one status for PRs.