### PR TITLE
Enhance release workflow to check for resolves in PR

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -21,21 +21,33 @@ jobs:
       if: github.event.pull_request.merged == true
       runs-on: ubuntu-latest
       steps:
+      
       - name: Check for "resolves \#" in PR description
-        uses: Khan/pull-request-comment-trigger@v1.1.0
-        id: pr_check
+        uses: shanegenschaw/pull-request-comment-trigger@v3.0.0
+        id: pr_check_lowercase
         with:
           trigger: 'resolves #'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Check for "Resolves \#" in PR description
+        uses: shanegenschaw/pull-request-comment-trigger@v3.0.0
+        id: pr_check_captilised
+        with:
+          trigger: 'Resolves #'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          
       - name: fail if no resolves found
-        if: steps.pr_check.outputs.triggered != 'true'
+        id: resolves_check
+        if: steps.pr_check_lowercase.outputs.triggered == 'false' && steps.pr_check_captilised.outputs.triggered == 'false'
         run: |
-          echo "No 'resolves #' found in PR description. Skipping release creation."
+          echo "No 'resolves #' or 'Resolves #' found in PR description. Skipping release creation."
           exit 1
+        continue-on-error: true
 
     create-releases:
-      if: github.event.pull_request.merged == true
+      if: github.event.pull_request.merged == true && steps.resolves_check.outcome == 'success'
       needs: check-for-resolves
       strategy:
         fail-fast: false # allow other jobs to complete if one fails
@@ -91,7 +103,7 @@ jobs:
     
     # Creates docker containers for APSIM releases.
     create-docker-containers:
-      if: github.event.pull_request.merged == true
+      if: github.event.pull_request.merged == true && steps.resolves_check.outcome == 'success'
       needs: check-for-resolves
       runs-on: ubuntu-latest
       steps:
@@ -115,7 +127,7 @@ jobs:
     # Upload release to builds.apsim.info
     upload-release-assets:
       # only run if the PR description contains "resolves #"
-      if: github.event.pull_request.merged == true
+      if: github.event.pull_request.merged == true && steps.resolves_check.outcome == 'success'
       needs: [create-docker-containers, create-releases]
       runs-on: ubuntu-latest 
       steps:


### PR DESCRIPTION
Resolves #10773 

Updated the workflow to check for both 'resolves #' and 'Resolves #' in PR descriptions before creating releases.

Also skips steps, rather than fails, when the merged PR doesn't contain resolves comment.

This also changes the action used for performing resolves comments checks. The previous version had node.js errors and as the action was no longer being maintained an action forked from the original was substituted.