### PR TITLE
Fix for intellisense when part of the path is null. 

### DIFF
--- a/ApsimNG/EventArguments/NeedContextItemsArgs.cs
+++ b/ApsimNG/EventArguments/NeedContextItemsArgs.cs
@@ -251,6 +251,12 @@
             object node = GetNodeFromPath(relativeTo, objectName);
             if (node == null)
                 node = relativeTo.Node.Get(objectName);
+            if (node == null)
+            {
+                node = relativeTo.Node.GetObject(objectName);
+                if (node is VariableComposite variableComposite)
+                    node = variableComposite.DataType;
+            }
             if (node != null)
             {
                 contextItems = ExamineObjectForContextItems(node, properties, methods, publishedEvents, subscribedEvents);

--- a/Tests/UnitTests/APSIMNG/IntellisenseTests.cs
+++ b/Tests/UnitTests/APSIMNG/IntellisenseTests.cs
@@ -1,4 +1,5 @@
 ﻿using APSIM.Core;
+using Models.Soils.Nutrients;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Data;
@@ -29,5 +30,18 @@ public class IntellisenseTests
     Assert.That(items.Select(i => i.TypeName), Is.EqualTo(new List<string>
       { "List<IModel>", "Boolean", "DateTime", "Double", "String", "Boolean", "String", "Node",
         "Int32", "IModel", "Boolean", "String", "DateTime" ,"DateTime"}));
+  }
+
+  /// <summary>Ensure basic intellisense works for models. Issue #9987</summary>
+  [Test]
+  public void EnsureIntellisenseWorksWorksWithNullProperties()
+  {
+    var nutrient = new Nutrient() { };
+    Node.Create(nutrient);
+
+    var items = NeedContextItemsArgs.ExamineModelForContextItemsV2(nutrient, "[Nutrient].FOM", true, false, false, false);
+
+    Assert.That(items.Count, Is.EqualTo(3));
+    Assert.That(items.Select(i => i.Name), Is.EqualTo([ "C", "N", "P"]));
   }
 }


### PR DESCRIPTION
e.g. if the report variable is ```[Nutrient].FOM``` and FOM is null then FOM's properties (C, N, P) are not displayed in report intellisense

Resolves #9987