### PR TITLE
CLEM Ensure amount to be milked is defined each time step

### DIFF
--- a/Models/CLEM/Activities/RuminantActivityMilking.cs
+++ b/Models/CLEM/Activities/RuminantActivityMilking.cs
@@ -113,13 +113,13 @@ namespace Models.CLEM.Activities
         /// <inheritdoc/>
         public override List<ResourceRequest> RequestResourcesForTimestep(double argument = 0)
         {
-            amountToDo = 0;
             amountToSkip = 0;
             numberToDo = 0;
             numberToSkip = 0;
             IEnumerable<RuminantFemale> herd = GetIndividuals<RuminantFemale>(GetRuminantHerdSelectionStyle.AllOnFarm).Where(a => a.IsLactating);
             uniqueIndividuals = GetUniqueIndividuals<RuminantFemale>(filterGroups, herd, Structure);
             numberToDo = uniqueIndividuals?.Count() ?? 0;
+            amountToDo = uniqueIndividuals.Sum(a => a.MilkCurrentlyAvailable);
 
             // provide updated measure for companion models
             foreach (var valueToSupply in valuesForCompanionModels)
@@ -147,7 +147,6 @@ namespace Models.CLEM.Activities
                                 valuesForCompanionModels[valueToSupply.Key] = 1;
                                 break;
                             case "per L milked":
-                                amountToDo = uniqueIndividuals.Sum(a => a.MilkCurrentlyAvailable);
                                 valuesForCompanionModels[valueToSupply.Key] = amountToDo;
                                 break;
                             default:


### PR DESCRIPTION
Resolves #10862

Ruminant Activity Milk needs to have the amount milked set each time step to ensure more than one individual is included in the milking activity.