### PR TITLE
10919 Add filter to graph data fetch to cut out empty string entries

### DIFF
--- a/Models/Graph/SeriesDefinition.cs
+++ b/Models/Graph/SeriesDefinition.cs
@@ -324,6 +324,11 @@ namespace Models
                         filter = AddToFilter(filter, $"SimulationID in ({simulationIdsCSV})");
                 }
 
+                //Filter out any string columns with empty values that might cause doubles to be read as strings after being filtered in the dataview
+                foreach (DataColumn field in data.Columns)
+                    if (field.DataType == typeof(string) && field.ColumnName != "CheckpointName"&& field.ColumnName != "SimulationName")
+                        filter = AddToFilter(filter, $"{field.ColumnName} <> \"\"");
+
                 //cleanup filter
                 filter = filter?.Replace('\"', '\'');
                 filter = RemoveMiddleWildcards(filter);
@@ -418,6 +423,7 @@ namespace Models
             }
             if (!string.IsNullOrEmpty(userFilter))
                 filter = AddToFilter(filter, userFilter);
+
             return filter;
         }
 


### PR DESCRIPTION
Resolves #10919

Graphing code was not handling situations where it was getting both empty cells and doubles in a dataset. Added a filter soon after fetching data from datastore to get rid of any empty string value.