### PR TITLE
10919 Revert PR 10920

### DIFF
--- a/Models/Graph/SeriesDefinition.cs
+++ b/Models/Graph/SeriesDefinition.cs
@@ -323,12 +323,7 @@ namespace Models
                     if (columnNames.Contains("SimulationID"))
                         filter = AddToFilter(filter, $"SimulationID in ({simulationIdsCSV})");
                 }
-
-                //Filter out any string columns with empty values that might cause doubles to be read as strings after being filtered in the dataview
-                foreach (DataColumn field in data.Columns)
-                    if (field.DataType == typeof(string) && field.ColumnName != "CheckpointName"&& field.ColumnName != "SimulationName")
-                        filter = AddToFilter(filter, $"{field.ColumnName} <> \"\"");
-
+                
                 //cleanup filter
                 filter = filter?.Replace('\"', '\'');
                 filter = RemoveMiddleWildcards(filter);


### PR DESCRIPTION
Resolves #10919

The filter added in PR #10920 broke graphs with event names on them. Reverting that change as PR #10925 will also resolve the original issue.