### PR TITLE
10929 Fix Phenology graphs in Barley

### DIFF
--- a/Models/Graph/SeriesDefinition.cs
+++ b/Models/Graph/SeriesDefinition.cs
@@ -328,6 +328,11 @@ namespace Models
                 filter = filter?.Replace('\"', '\'');
                 filter = RemoveMiddleWildcards(filter);
 
+                //Filter out any columns with empty values that might get converted wrongly by the graph system
+                foreach (DataColumn field in data.Columns)
+                    if (field.DataType != typeof(string) && field.ColumnName != "CheckpointName"&& field.ColumnName != "SimulationName")
+                        filter = AddToFilter(filter, $"{field.ColumnName} IS NOT NULL");
+
                 //apply our filter to the data
                 View = new DataView(data);
                 try


### PR DESCRIPTION
Resolves #10929

Values of null were getting read into the graph system where they were then getting set to a default value. The solution ended up being very similar to #10920, except instead of filtering string columns (which broke other things), I've instead filtered out nulls from non string columns.

I went through a few different kinds of graphs and nothing seems to have broken this time.