### PR TITLE
Fix for Object reference exception in AgPasture

### DIFF
--- a/Models/AgPasture/PastureSpecies.cs
+++ b/Models/AgPasture/PastureSpecies.cs
@@ -2248,7 +2248,11 @@ namespace Models.AgPasture
         public IBiomass AboveGround
         {
             get
-            {
+            {   
+
+                if(Leaf==null || Stem == null || Stolon == null)
+                    return new Biomass();
+
                 Biomass mass = new Biomass();
                 mass.StructuralWt = (Leaf.StandingHerbageWt + Stem.StandingHerbageWt + Stolon.StandingHerbageWt) / 10.0; // to g/m2
                 mass.StructuralN = (Leaf.StandingHerbageN + Stem.StandingHerbageN + Stolon.StandingHerbageN) / 10.0;    // to g/m2
@@ -2262,11 +2266,17 @@ namespace Models.AgPasture
         public IBiomass AboveGroundHarvestable
         {
             get
-            {
+            {   
+                
+                if(Leaf==null || Stem == null || Stolon == null)
+                    return new Biomass();
+                                   
                 Biomass mass = new Biomass();
                 mass.StructuralWt = Harvestable.Wt / 10.0; // to g/m2
                 mass.StructuralN = Harvestable.N / 10.0;    // to g/m2
-                return mass;
+                return mass; 
+                
+                
             }
         }
 


### PR DESCRIPTION
Resolves  #10908 

A null guard is added when Leaf, stem, and stolon are null  for AboveGround and AboveGroundHarvestable in AgPasture.