### PR TITLE
Make MemoView Arrange TextViews Horizontially rather than vertically.

### DIFF
--- a/ApsimNG/Resources/Glade/MemoView.glade
+++ b/ApsimNG/Resources/Glade/MemoView.glade
@@ -48,6 +48,7 @@
       <object class="GtkPaned" id="vpaned1">
         <property name="visible">True</property>
         <property name="can-focus">True</property>
+        <property name="orientation">horizontal</property>
         <child>
           <object class="GtkFrame" id="previewBox">
             <property name="visible">True</property>


### PR DESCRIPTION
resolves #10956

This simply arranges the textviews horizontally in the MemoView.
It does make editing memo/documentation models easier on small screens.