### PR TITLE
10833 Locator through properties that are null

### DIFF
--- a/APSIM.Core/Locate/Locator.cs
+++ b/APSIM.Core/Locate/Locator.cs
@@ -261,7 +261,12 @@ internal class Locator
                 //if the property evaluates to null (has not been set), instantiate a copy of that class so it can continue searching the properties.
                 //that way we can continuing search below this object without the relativeToObject being null and breaking the search
                 if (relativeToObject == null && !composite.Property.DeclaringType.IsAbstract)
-                    relativeToObject = Activator.CreateInstance(composite.Property.DeclaringType);
+                {
+                    //Can only create a blank instance if the class has a default constructor, abandon if it doesnt.
+                    ConstructorInfo ctor = composite.Property.DeclaringType.GetConstructor(Type.EmptyTypes);
+                    if (ctor != null)
+                        relativeToObject = Activator.CreateInstance(composite.Property.DeclaringType);
+                }
             }
             else if ((objectInfo as MethodInfo) != null)
             {


### PR DESCRIPTION
Resolves #10833

I think this solves the problem that Adam was encountering. When a property is null, the locator can't search more than one layer below that property because all the children properties have a null relativeToObject value. This make a new instance of that class to act as the relative object so the search can continue.

It's a locator change, so may need to really think if this is the best way.