### PR TITLE
10969 Allow file dialog to open .json by default

### DIFF
--- a/ApsimNG/Presenters/MainPresenter.cs
+++ b/ApsimNG/Presenters/MainPresenter.cs
@@ -1004,7 +1004,7 @@ namespace UserInterface.Presenters
         {
             try
             {
-                string fileName = this.AskUserForOpenFileName("ApsimX files|*.apsimx");
+                string fileName = this.AskUserForOpenFileName("APSIM files (*.apsimx, *.json)|*.apsimx;*.json");
                 if (fileName != null)
                 {
                     bool onLeftTabControl = this.view.IsControlOnLeft(sender);


### PR DESCRIPTION
Resolves #10969

Instead of having to click to 'All Files' to see json resource files, this allows the fie dialog to show them by default.