### PR TITLE
4631 Update the water in Narrabri Deficit trial to correct values

### DIFF
--- a/Tests/UnderReview/Cotton/Cotton.apsimx
+++ b/Tests/UnderReview/Cotton/Cotton.apsimx
@@ -1,6 +1,6 @@
 {
   "$type": "Models.Core.Simulations, Models",
-  "Version": 209,
+  "Version": 210,
   "Name": "Simulations",
   "ResourceName": null,
   "Children": [
@@ -50811,15 +50811,15 @@
                                 200.0
                               ],
                               "InitialValues": [
-                                0.12,
-                                0.438,
-                                0.437,
-                                0.437,
-                                0.437,
-                                0.269,
-                                0.264,
-                                0.264,
-                                0.264
+                                0.475,
+                                0.32629000000000014,
+                                0.22,
+                                0.25,
+                                0.24,
+                                0.24,
+                                0.29,
+                                0.3,
+                                0.3
                               ],
                               "FilledFromTop": true,
                               "Name": "Water",


### PR DESCRIPTION
Working on #4631

Updates the initial water in the Narrabri Deficit trial to corrected values, last simulation change between new cotton and master cotton.