### PR TITLE
Further release workflow fixes

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -107,8 +107,8 @@ jobs:
         - name: Setup SM_CLIENT_CERT_FILE from base64 secret data
           run: |
             export SM_CLIENT_CERT_FILE=${RUNNER_TEMP}/sm_client_cert.p12
-            chmod 644 ${SM_CLIENT_CERT_FILE}
             echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > ${SM_CLIENT_CERT_FILE}
+            chmod 775 ${SM_CLIENT_CERT_FILE}
             shell: bash
         - name: Setup Software Trust Manager
           uses: digicert/code-signing-software-trust-action@v1


### PR DESCRIPTION
resolves #11008

Unfortunately, github workflows cannot be tested locally, and as such have to be developed live. This is another attempted fix.