### PR TITLE
No longer move and rename APSIMSetup within release github workflow

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -98,7 +98,7 @@ jobs:
     create-windows-release:
       if: github.event.pull_request.merged == true
       env:
-        OUTFILE: Z:\__w\ApsimX\ApsimX\Setup\net8.0\windows\Output\unsignedSetup.exe
+        OUTFILE: /__w/ApsimX/ApsimX/Setup/net8.0/windows/Output/APSIMSetup.exe
       needs: [check-for-resolves, create-releases]
       runs-on: ubuntu-latest
       permissions:

--- a/Setup/net8.0/windows/buildWindowsInstaller
+++ b/Setup/net8.0/windows/buildWindowsInstaller
@@ -34,11 +34,6 @@ dotnet publish -c Release -f net8.0 -r win-x64 -m:1 --no-self-contained "$apsimx
 cd $apsimx
 xvfb-run sh -c "wine /inno/ISCC.exe Setup/net8.0/windows/apsimx.iss"
 
-#rename installer to correct name
-mv $apsimx/Setup/net8.0/windows/Output/APSIMSetup.exe $apsimx/Setup/net8.0/windows/Output/unsignedSetup.exe
-echo "expected installer path: $apsimx/Setup/net8.0/windows/Output/APSIMSetup.exe"
-echo "current directory: $(pwd)"
-ls -l $apsimx/Setup/net8.0/windows/Output/APSIMSetup.exe
 
 
 


### PR DESCRIPTION
resolves #11008