### PR TITLE
Add bootstrap class breakpoints to improve APSIM.Docs version of docs

### DIFF
--- a/APSIM.Documentation/WebDocs.cs
+++ b/APSIM.Documentation/WebDocs.cs
@@ -177,7 +177,7 @@ namespace APSIM.Documentation
         public static string GetNavigationHTML(List<ITag> tags)
         {
 
-            string html = "<div class=\"docs-navcontainer\">\n";
+            string html = "<div class=\"col-xxl-8 col-xl-9 col-lg-8 col-md-7 col-sm-7 col-10 docs-navcontainer\">\n";
             html += "<div class=\"docs-navbar\">\n";
             foreach(ITag tag in tags)
             {
@@ -568,9 +568,9 @@ namespace APSIM.Documentation
         public static string AddContentWrapper(string navigation, string content)
         {
             string output = "";
-            output += "<div class=\"docs-wrapper\">\n";
+            output += "<div class=\"row docs-wrapper\">\n";
             output += navigation;
-            output += "<div class=\"docs-content\">\n";
+            output += "<div class=\"col-xxl-12 col-xl-10 col-lg-9 col-md-6 col-sm-6 col-5 docs-content\">\n";
             output += content;
             output += "</div>\n";
             output += "</div>\n";


### PR DESCRIPTION
resolves #APSIMInitiative/APSIM.Docs#28

This greatly improves readability for smaller screened devices for docs shown on the docs.apsim.info website.

This does not improve the docs generated from the APSIM UI.

More work could be done to improve tables but that can tackled at a later date.