### PR TITLE
Make Cultivar Editor View use C# syntax highlighting

### DIFF
--- a/ApsimNG/Presenters/EditorPresenter.cs
+++ b/ApsimNG/Presenters/EditorPresenter.cs
@@ -1,13 +1,15 @@
-﻿namespace UserInterface.Presenters
+﻿using System;
+using System.Drawing;
+using System.Linq;
+using Models.Core;
+using UserInterface.Commands;
+using UserInterface.Interfaces;
+using UserInterface.Views;
+using UserInterface.EventArguments;
+
+namespace UserInterface.Presenters
 {
-    using System;
-    using System.Drawing;
-    using EventArguments;
-    using Views;
-    using Interfaces;
-    using Commands;
-    using System.Linq;
-    using Models.Core;
+
 
     /// <summary>
     /// A presenter class for showing a cultivar.
@@ -34,6 +36,7 @@
         {
             this.model = model as ILineEditor;
             this.view = view as IEditorView;
+            (this.view as EditorView).Language = "c-sharp";
             this.explorerPresenter = explorerPresenter;
 
             this.view.Lines = this.model.Lines?.ToArray();


### PR DESCRIPTION
resolves #11061

This does the simple thing and gives the same styling as the Manager script view.

This should help spot values and comments.