### PR TITLE
Provide a better error message when the destination solute is missing in PFlow

### DIFF
--- a/Models/Soils/Nutrients/PFlow.cs
+++ b/Models/Soils/Nutrients/PFlow.cs
@@ -74,7 +74,10 @@ namespace Models.Soils.Nutrients
 
                 double[] destination = null;
                 if (destinationName != null)
-                    destination = destinationSolute.kgha;
+                    if (destinationSolute == null)
+                        throw new ApsimXException(this, $"Cannot find destination solute: {destinationName}");
+                    else
+                        destination = destinationSolute.kgha;
 
                 for (int i = 0; i < numLayers; i++)
                 {


### PR DESCRIPTION
resolves #11118

Shows a better error message to the user when a destination solute is missing