### PR TITLE
Allow linux distro users to see apsimx files

### DIFF
--- a/ApsimNG/Presenters/MainPresenter.cs
+++ b/ApsimNG/Presenters/MainPresenter.cs
@@ -1027,7 +1027,7 @@ namespace UserInterface.Presenters
             try
             {
                 string defaultFileSpec = "APSIM files (*.apsimx, *.json)|*.apsimx;*.json";
-                string linuxFileSpec = "APSIM files (*.apsimx, *.json)|*.apsimx";
+                string linuxFileSpec = "APSIM files (*.apsimx)|*.apsimx";
                 if (ProcessUtilities.CurrentOS.IsUnix)
                     defaultFileSpec = linuxFileSpec;
                 string fileName = this.AskUserForOpenFileName(defaultFileSpec);

--- a/ApsimNG/Presenters/MainPresenter.cs
+++ b/ApsimNG/Presenters/MainPresenter.cs
@@ -1026,7 +1026,11 @@ namespace UserInterface.Presenters
         {
             try
             {
-                string fileName = this.AskUserForOpenFileName("APSIM files (*.apsimx, *.json)|*.apsimx;*.json");
+                string defaultFileSpec = "APSIM files (*.apsimx, *.json)|*.apsimx;*.json";
+                string linuxFileSpec = "APSIM files (*.apsimx, *.json)|*.apsimx";
+                if (ProcessUtilities.CurrentOS.IsUnix)
+                    defaultFileSpec = linuxFileSpec;
+                string fileName = this.AskUserForOpenFileName(defaultFileSpec);
                 if (fileName != null)
                 {
                     bool onLeftTabControl = this.view.IsControlOnLeft(sender);


### PR DESCRIPTION
resolves #11231

Linux users should now be able to see apsimx files again in File Dialog windows.

This has been tested on Ubuntu only. I would appreciate if anyone had a moment to test on another Linux distro.