### PR TITLE
11239 Fix Split error

### DIFF
--- a/APSIM.Workflow/PayloadUtilities.cs
+++ b/APSIM.Workflow/PayloadUtilities.cs
@@ -55,7 +55,10 @@ public static class PayloadUtilities
                 "/Tests/Validation/Wheat/Wheat.apsimx", //TODO: Leave wheat out for now as it gets split into smaller files automatically.
                 "/Tests/Validation/Wheat/FAR/FAR.apsimx", //TODO: Leave FAR out for now as it gets split into smaller files automatically.
                 "/Tests/Validation/Wheat/Phenology/Phenology.apsimx", //TODO: Leave Phenology out for now as it gets split into smaller files automatically.
-                "/Tests/Validation/Eucalyptus/Eucalyptus.apsimx"
+                "/Tests/Validation/Eucalyptus/Eucalyptus.apsimx",
+                "/Tests/Validation/Eucalyptus/EKB.250603b/EKB 250603b.apsimx",
+                "/Tests/Validation/Barley/Barley.apsimx",
+                "/Tests/Validation/Pinus/Pinus.apsimx"
             };
 
     // // Development submit azure URL


### PR DESCRIPTION
Resolves #11239

Needed to add files being split to the ignore list, was causing doubling up on postats.