### PR TITLE
11269 Fix Simple grazing gui

### DIFF
--- a/ApsimNG/Presenters/PropertyPresenter.cs
+++ b/ApsimNG/Presenters/PropertyPresenter.cs
@@ -295,6 +295,9 @@ namespace UserInterface.Presenters
             ICommand updateModel = new ChangeProperty(changedObject, property.Name, newValue);
             presenter.CommandHistory.Add(updateModel);
 
+            //update the view components
+            RefreshView(model);
+
             // Re-attach the model changed handler, so we can continue to trap
             // changes to the model from other sources (e.g. undo/redo).
             ConnectEvents();


### PR DESCRIPTION
Resolves #11269

Recent refactor of the presenter view accidently stoped it from updating sub-components of the view when the model changed. This has been added back in.