### PR TITLE
Root depth should not be greater than the actual maximum potential depth

### DIFF
--- a/Models/AgPasture/PastureBelowGroundOrgan.cs
+++ b/Models/AgPasture/PastureBelowGroundOrgan.cs
@@ -297,7 +297,7 @@ namespace Models.AgPasture
                 { // root depth limited by some soil issue
                     if (z > 0)
                     {
-                        MaximumAllowedRootingDepth = soilPhysical.ThicknessCumulative[z - 1];
+                        MaximumAllowedRootingDepth = Math.Min(MaximumAllowedRootingDepth, soilPhysical.ThicknessCumulative[z - 1]);
                         break;
                     }
                     else

--- a/Models/AgPasture/PastureBelowGroundOrgan.cs
+++ b/Models/AgPasture/PastureBelowGroundOrgan.cs
@@ -297,7 +297,7 @@ namespace Models.AgPasture
                 { // root depth limited by some soil issue
                     if (z > 0)
                     {
-                        MaximumAllowedRootingDepth = Math.Min(MaximumAllowedRootingDepth, soilPhysical.ThicknessCumulative[z - 1]);
+                        MaximumAllowedRootingDepth = Math.Min(MaximumAllowedRootingDepth, soilPhysical.ThicknessCumulative[z - 1]); 
                         break;
                     }
                     else


### PR DESCRIPTION
Fixing a bug in the logic of setting the maximum rooting depth.

@rcichota 

resolves #11271 