### PR TITLE
Change references of net8 to net10 for subsequent dotnet 10 upgrade

### DIFF
--- a/.github/workflows/scripts/create-azure-jobs.sh
+++ b/.github/workflows/scripts/create-azure-jobs.sh
@@ -30,7 +30,7 @@ echo "author variable: ${author}"
 # substrings the variable so we get the number only after the 'pr-' part.
 echo "PR Number: ${DOCKER_METADATA_OUTPUT_VERSION:3}"
 # makes the variable available in subsequent steps.
-jobcount=$(dotnet ./bin/Release/net8.0/APSIM.Workflow.dll --sim-count)
+jobcount=$(dotnet ./bin/Release/net10.0/APSIM.Workflow.dll --sim-count)
 echo "jobcount: ${jobcount}"
 if test -z "${jobcount}"; then
     echo "The job count was found to be empty. Exiting."
@@ -42,4 +42,4 @@ echo "POStats2 open URL: ${url}"
 response=$(curl -f "${url}" || exit 1)
 echo "POStats2 open response: ${response}"
 echo "Start creating payload..."
-dotnet ./bin/Release/net8.0/APSIM.Workflow.dll --payload-directory $PAYLOAD_FOLDER_PATH -g $author -t $DOCKER_METADATA_OUTPUT_VERSION --commit-sha $commitsha --pr-number $pr_number --azure-pool $azure_pool -v
+dotnet ./bin/Release/net10.0/APSIM.Workflow.dll --payload-directory $PAYLOAD_FOLDER_PATH -g $author -t $DOCKER_METADATA_OUTPUT_VERSION --commit-sha $commitsha --pr-number $pr_number --azure-pool $azure_pool -v

--- a/.github/workflows/scripts/deploy-installer.sh
+++ b/.github/workflows/scripts/deploy-installer.sh
@@ -66,7 +66,7 @@ if [[ $2 == "build" || -z "$2" ]]; then
     # Build the installer.
     echo Building installer...
     outfile="$DIR"/apsim-$version.$ext
-    bash ./Setup/net8.0/$script $full_version "$outfile"
+    bash ./Setup/net10.0/$script $full_version "$outfile"
 fi
 
 if [[ "$2" == "upload" || -z "$2" ]]; then

--- a/.github/workflows/scripts/split-large-files.sh
+++ b/.github/workflows/scripts/split-large-files.sh
@@ -1,13 +1,13 @@
 # Split Wheat Validation Files
-dotnet ./bin/Release/net8.0/APSIM.Workflow.dll -d ./Tests/Validation/Wheat/Wheat.apsimx -s ./Tests/Validation/Wheat/split.json
+dotnet ./bin/Release/net10.0/APSIM.Workflow.dll -d ./Tests/Validation/Wheat/Wheat.apsimx -s ./Tests/Validation/Wheat/split.json
 # Split FAR Validation
-dotnet ./bin/Release/net8.0/APSIM.Workflow.dll -d ./Tests/Validation/Wheat/FAR/FAR.apsimx -s ./Tests/Validation/Wheat/FAR/split.json
+dotnet ./bin/Release/net10.0/APSIM.Workflow.dll -d ./Tests/Validation/Wheat/FAR/FAR.apsimx -s ./Tests/Validation/Wheat/FAR/split.json
 # Split Wheat Phenology Validation
-dotnet ./bin/Release/net8.0/APSIM.Workflow.dll -d ./Tests/Validation/Wheat/Phenology/Phenology.apsimx -s ./Tests/Validation/Wheat/Phenology/split.json
+dotnet ./bin/Release/net10.0/APSIM.Workflow.dll -d ./Tests/Validation/Wheat/Phenology/Phenology.apsimx -s ./Tests/Validation/Wheat/Phenology/split.json
 # Split Eucalyptus Validation
-dotnet ./bin/Release/net8.0/APSIM.Workflow.dll -d ./Tests/Validation/Eucalyptus/Eucalyptus.apsimx -s ./Tests/Validation/Eucalyptus/split.json
-dotnet ./bin/Release/net8.0/APSIM.Workflow.dll -d "./Tests/Validation/Eucalyptus/EKB.250603b/EKB 250603b.apsimx" -s ./Tests/Validation/Eucalyptus/EKB.250603b/split.json
+dotnet ./bin/Release/net10.0/APSIM.Workflow.dll -d ./Tests/Validation/Eucalyptus/Eucalyptus.apsimx -s ./Tests/Validation/Eucalyptus/split.json
+dotnet ./bin/Release/net10.0/APSIM.Workflow.dll -d "./Tests/Validation/Eucalyptus/EKB.250603b/EKB 250603b.apsimx" -s ./Tests/Validation/Eucalyptus/EKB.250603b/split.json
 # Split Barley Validation
-dotnet ./bin/Release/net8.0/APSIM.Workflow.dll -d ./Tests/Validation/Barley/Barley.apsimx -s ./Tests/Validation/Barley/split.json
+dotnet ./bin/Release/net10.0/APSIM.Workflow.dll -d ./Tests/Validation/Barley/Barley.apsimx -s ./Tests/Validation/Barley/split.json
 # Split Pinus Validation
-dotnet ./bin/Release/net8.0/APSIM.Workflow.dll -d ./Tests/Validation/Pinus/Pinus.apsimx -s ./Tests/Validation/Pinus/split.json
+dotnet ./bin/Release/net10.0/APSIM.Workflow.dll -d ./Tests/Validation/Pinus/Pinus.apsimx -s ./Tests/Validation/Pinus/split.json


### PR DESCRIPTION
working on #11315

This upgrades the references in the GitHub scripts to allow proper testing of the existing PR #11318.

This can be merged without testing.