### PR TITLE
Fix calculation for QMax

### DIFF
--- a/APSIM.Shared/Utilities/MetUtilities.cs
+++ b/APSIM.Shared/Utilities/MetUtilities.cs
@@ -250,16 +250,14 @@
             double LATr = 0;
             double HSmax = 0;
 
+            DEC = 23.45 * System.Math.Sin(2.0 * System.Math.PI / 365.25 * (day - 79.25));
+            DECr = DEC * 2.0 * System.Math.PI / 360.0;
+            LATr = lat * 2.0 * System.Math.PI / 360.0;
             HSmax = System.Math.Acos(-System.Math.Tan(LATr) * System.Math.Tan(DECr));
             // half daylength
 
-            if ((HS <= HSmax))
+            if (HS <= HSmax)
             {
-                DEC = 23.45 * System.Math.Sin(2.0 * System.Math.PI / 365.25 * (day - 79.25));
-
-                DECr = DEC * 2.0 * System.Math.PI / 360.0;
-                LATr = lat * 2.0 * System.Math.PI / 360.0;
-
                 functionReturnValue = 1360.0 * (System.Math.Sin(LATr) * System.Math.Sin(DECr) + System.Math.Cos(LATr) * System.Math.Cos(DECr) * System.Math.Cos(HS));
                 functionReturnValue = functionReturnValue / 1000000.0;
                 // Convert to MJ


### PR DESCRIPTION
resolves #11348

This fixes an issue in the ordering of variable calculations in the Q0i method which is used in QMax calculations.