### PR TITLE
Specify a .net core compatible Humanizer package to stop odd versions of the package from being restored in github runners

### DIFF
--- a/APSIM.Workflow/APSIM.Workflow.csproj
+++ b/APSIM.Workflow/APSIM.Workflow.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
     <PackageReference Include="ClosedXML" Version="0.105.0" />
-    <PackageReference Include="Humanizer" Version="3.0.10" />
+    <PackageReference Include="Humanizer.Core" Version="3.0.10" />
   </ItemGroup>
 
   <!-- Local package references -->


### PR DESCRIPTION
resolves #11350

Sets the Package to Humanizer.Core to hopefully prevent odd non-core packages from being used within GitHub Action Workflows.