### PR TITLE
Throws exception for invalid characters in alias

### DIFF
--- a/Models/Report/ReportColumn.cs
+++ b/Models/Report/ReportColumn.cs
@@ -274,17 +274,25 @@ namespace Models
         /// <returns>The successful RegEx match instance.</returns>
         private Match ParseReportLine(string descriptor)
         {
-            var pattern = @"((?<agg>sum|Sum|mean|Mean|min|Min|max|Max|first|First|last|Last|" + // aggregation
-                          @"diff|Diff|stddev|Stddev|prod|Prod)\s+of\s+)?" +                     // more aggregation
-                          $@"(?<var>((?!\s+from\s+|\s+as\s+|\s+on\s+).)+)" +                    // APSIM variable or expression
-                          $@"(\s+on\s+(?<on>((?!\s+from\s+|\s+as\s+).)+))?" +                   // on keyword
-                          $@"(\s+from\s+(?<from>\S+)\s+to\s+(?<to>((?!\s+as)\S)+))?" +          // from and to keywords
-                          @"(\s+as\s+(?<alias>[\w.@]+))?";                                      // alias
-
+            var pattern =
+                @"((?<agg>sum|Sum|mean|Mean|min|Min|max|Max|first|First|last|Last|" +
+                @"diff|Diff|stddev|Stddev|prod|Prod)\s+of\s+)?" +                     // aggregation
+                @"(?<var>.+?)(?=\s+(from|as|on)\s+|$)" +                              // variable/expression
+                @"(\s+on\s+(?<on>((?!\s+from\s+|\s+as\s+).)+))?" +                    // on keyword
+                @"(\s+from\s+(?<from>\S+)\s+to\s+(?<to>((?!\s+as)\S)+))?" +           // from/to window
+                @"(\s+as\s+(?<alias>\S+))?";                                          // alias (full token)
             var regEx = new Regex(pattern);
             var match = regEx.Match(descriptor);
             if (!match.Success)
                 throw new Exception($"Invalid format for report aggregation variable {descriptor}");
+                
+            if(descriptor.Contains(" as "))
+            {
+                var alias = match.Groups["alias"].Value;
+                // Allowed characters in alias: letters, digits, _, ., @
+                if (!Regex.IsMatch(alias, @"^[\w.@]+$"))
+                    throw new Exception($"Alias '{alias}' contains invalid characters.");
+            }
             return match;
         }
 


### PR DESCRIPTION
Resolves #11338

This PR resolves issue 1138. It throws an exception when an invalid character is used in aliases.