### PR TITLE
Made chages to report urine N and DungN to report when grazing is triggered.

### DIFF
--- a/Models/AgPasture/SimpleGrazing.cs
+++ b/Models/AgPasture/SimpleGrazing.cs
@@ -519,6 +519,8 @@ namespace Models.AgPasture
             PostGrazeDM = 0;
             ClippingsWtReturned = 0;
             ClippingsNReturned = 0;
+            AmountDungNReturned = 0;
+            AmountUrineNReturned = 0;
             foreach (var zone in zones)
                 zone.OnStartOfDay();
         }


### PR DESCRIPTION
Resolves #10883

- Dung weight is calculated inside each ZoneWithForage and only changes during grazing.
- Dung and Urine N is stored directly on SimpleGrazing and is never reset, so APSIM reports the last value every day.
This PR resolves the issue ensuring Urine and dung N are calculated when grazing occurs. 

Please find the zip which include simulations for testing.
[Poukawa (2).zip](https://github.com/user-attachments/files/29361433/Poukawa.2.zip)
