### PR TITLE
Fix pasture level timer and add warning if herd scaling not possible

### DIFF
--- a/Models/CLEM/Activities/RuminantActivityManage.cs
+++ b/Models/CLEM/Activities/RuminantActivityManage.cs
@@ -581,6 +581,12 @@ namespace Models.CLEM.Activities
             // calculate the number of breeders, sucklings, weaners and prebreeders
             if (AdjustBreedingFemalesAtStartup)
             {
+                if (cohorts.Where(a => a.Sex == Sex.Female && a.Weight == 0).Any())
+                {
+                    warn = $"Problem with [Adjust breeding females at start-up] using [a={this.Name}].{Environment.NewLine}Female cohorts with no Weight provided (i.e. using normalised weight for age) cannot currently be assessed for maturity and will not be included in the number of breeders present for calculations.";
+                    Warnings.CheckAndWrite(warn, Summary, this, MessageType.Warning);
+                }
+
                 var breederFemales = cohorts.Where(a => a.Sex == Sex.Female && a.Weight >= herds.FirstOrDefault().Parameters.General.MinimumSizeForMaturityFemale * herds.FirstOrDefault().Parameters.General.SRWFemale);
                 if (breederFemales.Any())
                 {

--- a/Models/CLEM/Resources/RuminantIntake.cs
+++ b/Models/CLEM/Resources/RuminantIntake.cs
@@ -117,7 +117,7 @@ namespace Models.CLEM.Resources
                 double RS = 0;
                 double RQ = Math.Min(1.0, 1 - ind.Parameters.GrowPF_CI.DigestibilitySlope_CR3 * (ind.Parameters.GrowPF_CI.DigestibilityPeak_CR1 - (item.Value.Details.DryMatterDigestibility/100.0)));
 
-                double offered_adj = (item.Value.Details.Amount/solidIntake)*RQ;
+                double offered_adj = (item.Value.Details.Amount/solidIntake)/RQ;
                 double unsatisfied_adj = Math.Max(0, 1-sumFs);
                 double quality_adj = (isLactating? ind.Parameters.GrowPF_CI.QualityIntakeSubsititutionFactorLactating_CR20:ind.Parameters.GrowPF_CI.QualityIntakeSubsititutionFactorNonLactating_CR11)/item.Value.Details.MEContent;
 

--- a/Models/CLEM/Timers/ActivityTimerPastureLevel.cs
+++ b/Models/CLEM/Timers/ActivityTimerPastureLevel.cs
@@ -50,7 +50,7 @@ namespace Models.CLEM.Timers
         /// paddock or pasture to graze
         /// </summary>
         [JsonIgnore]
-        public GrazeFoodStoreType GrazeFoodStoreModel { get; set; }
+        public IGrazeFoodStoreType GrazeFoodStoreModel { get; set; }
 
         /// <summary>
         /// Minimum pasture level
@@ -77,7 +77,7 @@ namespace Models.CLEM.Timers
         [EventSubscribe("CLEMInitialiseActivity")]
         private void OnCLEMInitialiseActivity(object sender, EventArgs e)
         {
-            GrazeFoodStoreModel = resources.FindResourceType<GrazeFoodStore, GrazeFoodStoreType>(this, GrazeFoodStoreTypeName, OnMissingResourceActionTypes.ReportErrorAndStop, OnMissingResourceActionTypes.ReportErrorAndStop);
+            GrazeFoodStoreModel = resources.FindResourceType<GrazeFoodStore, IGrazeFoodStoreType>(this, GrazeFoodStoreTypeName, OnMissingResourceActionTypes.ReportErrorAndStop, OnMissingResourceActionTypes.ReportErrorAndStop);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Resolves #11373 

Paster level activity timer updated to work with APSIMLink graze food store
Added a warning when no breeder weight specified in initial cohort stops resize breeder at startup.
Fix error in equation for feed_offered component of intake reduction based on feed quality.