### PR TITLE
Make SWIM's hydraulic effective depth and exponent settable

### DIFF
--- a/Models/Soils/SWIM/Swim.cs
+++ b/Models/Soils/SWIM/Swim.cs
@@ -125,11 +125,13 @@ namespace Models.Soils
         private const double slcerr = 0.000001;
 
         /// <summary>Depth in the soil to assess water content for runoff effect (mm).</summary>
-        [Description("Hydraulically-effective depth in the soil  (mm). Default: 450 mm")]
+        [Description("Hydraulically-effective depth in the soil (mm). Default: 450 mm")]
+        [Bounds(Lower = 1.0, Upper = 1000.0)]
         public double hydrol_effective_depth { get; set; } = 450;
 
-        /// <summary>Exponent in the equation for hydraulically effectiveness for runoff (-).</summary>
+        /// <summary>Exponent in the equation for hydraulic effectiveness for runoff (-).</summary>
         [Description("Exponent in the hydraulically-effective depth equation (-). Default: 4.16")]
+        [Bounds(Lower = 0.1, Upper = 10.0)]
         public double hydrol_effective_exponent { get; set; } = 4.16;
 
         private double[] _swf;
@@ -2336,7 +2338,7 @@ namespace Models.Soils
                 // assume water content to c%hydrol_effective_depth affects runoff
                 // sum of wf should = 1 - may need to be bounded? <dms 7-7-95>
 
-                wx = scale_fact * (1.0 - Math.Exp(-1 * hydrol_effective_exponent * cum_depth / hydrolEffectiveDepth));
+                wx = scale_fact * (1.0 - Math.Exp(-hydrol_effective_exponent * cum_depth / hydrolEffectiveDepth));
                 runoff_wf[layer] = wx - xx;
                 xx = wx;
 

--- a/Models/Soils/SWIM/Swim.cs
+++ b/Models/Soils/SWIM/Swim.cs
@@ -124,7 +124,13 @@ namespace Models.Soils
         /// </summary>
         private const double slcerr = 0.000001;
 
-        private const double hydrol_effective_depth = 450;
+        /// <summary>Depth in the soil to assess water content for runoff effect (mm).</summary>
+        [Description("Hydraulically-effective depth in the soil  (mm). Default: 450 mm")]
+        public double hydrol_effective_depth { get; set; } = 450;
+
+        /// <summary>Exponent in the equation for hydraulically effectiveness for runoff (-).</summary>
+        [Description("Exponent in the hydraulically-effective depth equation (-). Default: 4.16")]
+        public double hydrol_effective_exponent { get; set; } = 4.16;
 
         private double[] _swf;
         private string rain_time = null;
@@ -2319,7 +2325,7 @@ namespace Models.Soils
 
             hydrolEffectiveDepth = Math.Min(hydrol_effective_depth, profile_depth);
 
-            scale_fact = 1.0 / (1.0 - Math.Exp(-4.16));
+            scale_fact = 1.0 / (1.0 - Math.Exp(-hydrol_effective_exponent));
             hydrolEffectiveLayer = FindSwimLayer(hydrolEffectiveDepth);
 
             for (layer = 0; layer <= hydrolEffectiveLayer; layer++)
@@ -2330,7 +2336,7 @@ namespace Models.Soils
                 // assume water content to c%hydrol_effective_depth affects runoff
                 // sum of wf should = 1 - may need to be bounded? <dms 7-7-95>
 
-                wx = scale_fact * (1.0 - Math.Exp(-4.16 * cum_depth / hydrolEffectiveDepth));
+                wx = scale_fact * (1.0 - Math.Exp(-1 * hydrol_effective_exponent * cum_depth / hydrolEffectiveDepth));
                 runoff_wf[layer] = wx - xx;
                 xx = wx;
 


### PR DESCRIPTION
resolves #11383 

This is needed for the work on testing/improving the runoff functions and makes two of the previously hard-coded parameters (the hydraulically-effective depth and exponent) settable.