### PR TITLE
11394 Handle invalid Enums in property presenter

### DIFF
--- a/ApsimNG/Presenters/PropertyPresenter.cs
+++ b/ApsimNG/Presenters/PropertyPresenter.cs
@@ -134,6 +134,21 @@ namespace UserInterface.Presenters
             
             foreach (PropertyInfo property in allProperties)
             {
+                //Forward check for invalid enum values so this can report an error to the gui
+                object objValue = property.GetValue(obj);
+                if (property.PropertyType.IsEnum)
+                {
+                    try
+                    {
+                        AttributeUtilities.GetEnumDescription((Enum)Enum.Parse(property.PropertyType, objValue?.ToString()));
+                    }
+                    catch (Exception exception)
+                    {
+                        presenter.MainPresenter.ShowError($"Error: Cannot match Enum {property.Name} with value {objValue} to valid Enum Value. Reset to default. " + exception.Message);
+                        property.SetValue(obj, 0); //set the value back to index 0
+                    }
+                }
+
                 // Assign any category attribute details here for category based property presenter (currently in CLEM)
                 if (property.IsDefined(typeof(CategoryAttribute), false))
                 {

--- a/ApsimNG/Presenters/PropertyPresenter.cs
+++ b/ApsimNG/Presenters/PropertyPresenter.cs
@@ -135,17 +135,18 @@ namespace UserInterface.Presenters
             foreach (PropertyInfo property in allProperties)
             {
                 //Forward check for invalid enum values so this can report an error to the gui
-                object objValue = property.GetValue(obj);
                 if (property.PropertyType.IsEnum)
                 {
+                    object objValue = null;
                     try
                     {
+                        objValue = property.GetValue(obj);
                         AttributeUtilities.GetEnumDescription((Enum)Enum.Parse(property.PropertyType, objValue?.ToString()));
                     }
                     catch (Exception exception)
                     {
                         presenter.MainPresenter.ShowError($"Error: Cannot match Enum {property.Name} with value {objValue} to valid Enum Value. Reset to default. " + exception.Message);
-                        property.SetValue(obj, 0); //set the value back to index 0
+                        property.SetValue(obj, Activator.CreateInstance(property.PropertyType));
                     }
                 }
 

--- a/ApsimNG/Presenters/PropertyPresenter.cs
+++ b/ApsimNG/Presenters/PropertyPresenter.cs
@@ -137,17 +137,10 @@ namespace UserInterface.Presenters
                 //Forward check for invalid enum values so this can report an error to the gui
                 if (property.PropertyType.IsEnum)
                 {
-                    object objValue = null;
-                    try
-                    {
-                        objValue = property.GetValue(obj);
-                        AttributeUtilities.GetEnumDescription((Enum)Enum.Parse(property.PropertyType, objValue?.ToString()));
-                    }
-                    catch (Exception exception)
-                    {
-                        presenter.MainPresenter.ShowError($"Error: Cannot match Enum {property.Name} with value {objValue} to valid Enum Value. Reset to default. " + exception.Message);
-                        property.SetValue(obj, Activator.CreateInstance(property.PropertyType));
-                    }
+                    object objValue = property.GetValue(obj);
+                    string text = AttributeUtilities.GetEnumDescription((Enum)Enum.Parse(property.PropertyType, objValue?.ToString()));
+                    if (string.IsNullOrEmpty(text))
+                        presenter.MainPresenter.ShowError($"Error: Cannot match Enum {property.Name} with value {objValue} to valid Enum Value.");
                 }
 
                 // Assign any category attribute details here for category based property presenter (currently in CLEM)

--- a/Models/Utilities/AttributeUtilities.cs
+++ b/Models/Utilities/AttributeUtilities.cs
@@ -91,10 +91,15 @@ public static class AttributeUtilities
     /// <returns></returns>
     public static string GetEnumDescription(Enum value)
     {
-        FieldInfo fi = value.GetType().GetField(value.ToString());
+        if (value == null)
+            return string.Empty;
+
+        FieldInfo fieldInfo = value.GetType().GetField(value.ToString());
+        if (fieldInfo == null)
+            return string.Empty;
 
         DescriptionAttribute[] attributes =
-        (DescriptionAttribute[])fi.GetCustomAttributes(typeof(DescriptionAttribute), false);
+        (DescriptionAttribute[])fieldInfo.GetCustomAttributes(typeof(DescriptionAttribute), false);
 
         if (attributes != null && attributes.Length > 0)
             return attributes[0].ToString();


### PR DESCRIPTION
Resolves #11394

Not a fan how Enums are stored in our apsim file, uses an interger value instead of a name string. 

For now, I've changed the property presenter to reset the value to 0 if it cannot be parse to an enum, but there would also be an issue if the order of enums were changed and people's settings would be changed with no errors shown.