### PR TITLE
11423 Add Command Refactor

### DIFF
--- a/APSIM.Core/CommandProcessor/Commands/AddCommand.cs
+++ b/APSIM.Core/CommandProcessor/Commands/AddCommand.cs
@@ -9,13 +9,13 @@ internal partial class AddCommand : IModelCommand
     private readonly IModelReference modelReference;
 
     /// <summary>The path of a model to add a model to.</summary>
-    private readonly string toPath;
+    private readonly string _toPath;
 
     /// <summary>Do as many replacements as possible?</summary>
-    private readonly bool multiple;
+    private readonly bool _multiple;
 
     /// <summary>A new name for the added model.</summary>
-    private readonly string newName;
+    private readonly string _newName;
 
     /// <summary>
     /// Constructor. Add a new model to a parent model and optionally name it.
@@ -27,9 +27,9 @@ internal partial class AddCommand : IModelCommand
     public AddCommand(IModelReference modelReference, string toPath, bool multiple, string newName = null)
     {
         this.modelReference = modelReference;
-        this.toPath = toPath;
-        this.multiple = multiple;
-        this.newName = newName;
+        this._toPath = toPath;
+        this._multiple = multiple;
+        this._newName = newName;
     }
 
     /// <summary>
@@ -40,24 +40,24 @@ internal partial class AddCommand : IModelCommand
     INodeModel IModelCommand.Run(INodeModel relativeTo, IRunner runner)
     {
         INodeModel modelToAdd = modelReference.GetModel();
-        if (!string.IsNullOrEmpty(newName))
-            modelToAdd.Rename(newName);
+        if (!string.IsNullOrEmpty(_newName))
+            modelToAdd.Rename(_newName);
 
         IEnumerable<INodeModel> toModels;
 
-        if (multiple)
+        if (_multiple)
         {
-            var toPathWithoutBrackets = toPath.Replace("[", string.Empty)
+            var toPathWithoutBrackets = _toPath.Replace("[", string.Empty)
                                               .Replace("]", string.Empty);
             Type t = ModelRegistry.ModelNameToType(toPathWithoutBrackets);
             toModels = relativeTo.Node.FindAll(type: t);
             if (!toModels.Any())
-                 throw new Exception($"Cannot find any models that match: {toPath}");
+                 throw new Exception($"Cannot find any models that match: {_toPath}");
         }
         else
         {
-            var toModel = (INodeModel)relativeTo.Node.Get(toPath, relativeTo: relativeTo)
-                 ?? throw new Exception($"Cannot find model: {toPath}");
+            var toModel = (INodeModel)relativeTo.Node.Get(_toPath, relativeTo: relativeTo)
+                 ?? throw new Exception($"Cannot find model: {_toPath}");
             toModels = [toModel];
         }
 

--- a/APSIM.Core/CommandProcessor/Commands/SetPropertyCommand.cs
+++ b/APSIM.Core/CommandProcessor/Commands/SetPropertyCommand.cs
@@ -1,4 +1,3 @@
-using System.ServiceModel;
 using Newtonsoft.Json;
 
 namespace APSIM.Core;
@@ -10,17 +9,17 @@ namespace APSIM.Core;
 public partial class SetPropertyCommand : IModelCommand
 {
     [JsonProperty]
-    private readonly string name;
+    private readonly string _name;
     [JsonProperty]
-    private readonly string value;
+    private readonly string _value;
     [JsonProperty]
-    private readonly string fileName;
+    private readonly string _fileName;
     [JsonProperty]
-    private readonly string oper;
+    private readonly string _oper;
     [JsonProperty]
-    private readonly bool multiple;
-    private readonly List<VariableComposite> obj = [];
-    private readonly List<object> oldValues = [];
+    private readonly bool _multiple;
+    private readonly List<VariableComposite> _obj = [];
+    private readonly List<object> _oldValues = [];
 
     /// <summary>
     /// Constructor.
@@ -32,15 +31,15 @@ public partial class SetPropertyCommand : IModelCommand
     /// <param name="multiple">Perform property set for multiple instances?</param>
     public SetPropertyCommand(string name, string oper, string value, string fileName = null, bool multiple = false)
     {
-        this.name = name;
-        this.oper = oper;
-        this.value = value;
-        this.fileName = fileName;
-        this.multiple = multiple;
+        this._name = name;
+        this._oper = oper;
+        this._value = value;
+        this._fileName = fileName;
+        this._multiple = multiple;
     }
 
     /// <summary>Property value.</summary>
-    internal object Value => value;
+    internal object Value => _value;
 
     /// <summary>
     /// Run the command.
@@ -50,36 +49,36 @@ public partial class SetPropertyCommand : IModelCommand
     INodeModel IModelCommand.Run(INodeModel relativeTo, IRunner runner)
     {
         // Read the property value from an external file if necessary.
-        string propertyValue = value;
-        if (fileName != null)
+        string propertyValue = _value;
+        if (_fileName != null)
         {
-            if (!File.Exists(fileName))
-                throw new Exception($"Cannot find file : {fileName}");
-            propertyValue = File.ReadAllText(fileName);
+            if (!File.Exists(_fileName))
+                throw new Exception($"Cannot find file : {_fileName}");
+            propertyValue = File.ReadAllText(_fileName);
         }
 
         // Get all model instances that need a property set.
         IEnumerable<VariableComposite> instances = null;
-        if (multiple)
-            instances = relativeTo.Node.GetAllObjects(name, flags: LocatorFlags.PropertiesOnly | LocatorFlags.CaseSensitive | LocatorFlags.IncludeDisabled);
+        if (_multiple)
+            instances = relativeTo.Node.GetAllObjects(_name, flags: LocatorFlags.PropertiesOnly | LocatorFlags.CaseSensitive | LocatorFlags.IncludeDisabled);
         else
         {
-            var instance = relativeTo.Node.GetObject(name);
+            var instance = relativeTo.Node.GetObject(_name);
             if (instance != null)
                 instances = [instance];
         }
 
         if (instances == null || !instances.Any())
-            throw new Exception($"Cannot find property {name}");
+            throw new Exception($"Cannot find property {_name}");
 
         // Perform multiple property sets.
         foreach (var instance in instances)
         {
             // Capture the old value so that we can perform an undo if necessary.
-            obj.Add(instance);
-            oldValues.Add(instance.Value);
+            _obj.Add(instance);
+            _oldValues.Add(instance.Value);
 
-            if (oper == "=")
+            if (_oper == "=")
             {
                 // If "null" was specified then set the object value to null. Otherwise convert
                 // the value into correct type.
@@ -112,11 +111,11 @@ public partial class SetPropertyCommand : IModelCommand
             {
                 // Throw if trying to add or remove from a scalar.
                 if (!ApsimConvert.IsIList(instance.DataType))
-                    throw new Exception($"Property {name} is not an array type. Cannot use += or -= operators.");
+                    throw new Exception($"Property {_name} is not an array type. Cannot use += or -= operators.");
 
                 // Throw if trying to add or remove from an array that isn't a string array.
                 if (DataAccessor.GetElementTypeOfIList(instance.DataType) != typeof(string))
-                    throw new Exception($"Property {name} is not a string array. Cannot use += or -= operators.");
+                    throw new Exception($"Property {_name} is not a string array. Cannot use += or -= operators.");
 
                 // Get the current array as a list of strings.
                 object valueAsObject = instance.Value ?? throw new Exception($" Cannot use += or -= operators on a null array.");
@@ -124,16 +123,16 @@ public partial class SetPropertyCommand : IModelCommand
                 if (strings == null)
                     throw new Exception("Cannot use += or -= operators on a null array.");
 
-                string[] tokens = [.. value.Split('=').Select(part => part.Trim())];
+                string[] tokens = [.. _value.Split('=').Select(part => part.Trim())];
 
                 // Add or remove a string.
-                if (oper == "+=")
+                if (_oper == "+=")
                 {
                     int index = strings.FindIndex(s => s.Split('=')[0].Trim() == tokens.First());
                     if (index >= 0)
-                        strings[index] = value;
+                        strings[index] = _value;
                     else
-                        strings.Add(value);
+                        strings.Add(_value);
 
                 }
                 else
@@ -153,8 +152,8 @@ public partial class SetPropertyCommand : IModelCommand
     /// </summary>
     public void Undo()
     {
-        for (int i = 0; i < obj.Count; i++)
-            obj[i].Value = oldValues[i];
+        for (int i = 0; i < _obj.Count; i++)
+            _obj[i].Value = _oldValues[i];
     }
 
     /// <summary>
@@ -162,7 +161,7 @@ public partial class SetPropertyCommand : IModelCommand
     /// </summary>
     public override int GetHashCode()
     {
-        return (name, value, fileName, oper, multiple).GetHashCode();
+        return (_name, _value, _fileName, _oper, _multiple).GetHashCode();
     }
 
 }

--- a/APSIM.Core/CommandProcessor/Language/AddCommandLanguage.cs
+++ b/APSIM.Core/CommandProcessor/Language/AddCommandLanguage.cs
@@ -31,38 +31,13 @@ internal partial class AddCommand: IModelCommand
     /// </remarks>
     public static IModelCommand Create(string command, INodeModel relativeTo, string relativeToDirectory)
     {
+        if (!command.ToLower().Trim().StartsWith("add"))
+            throw new Exception($"Invalid command: {command}");
+
         //Determine what required and optional keywords are in the command
         //Order of keywords is important
         string[] keywords = [KEYWORD_ADD, KEYWORD_FROM, KEYWORD_TO, KEYWORD_NAME];
-
-        int[] positions = new int[keywords.Length];
-        int lastPosition = 0;
-        for(int i = 0; i < keywords.Length; i++)
-        {
-            positions[i] = command.IndexOf(keywords[i], lastPosition);
-            if (positions[i] > 0)
-                lastPosition = positions[i];
-        }
-
-        //Break the command into parts based on the keywords
-        List<string> segments = new List<string>();
-        for(int i = 0; i < positions.Length; i++)
-        {
-            int startIndex = positions[i];
-            if (startIndex >= 0)
-            {
-                int endIndex = -1;
-                for(int j = i+1; j < positions.Length && endIndex < 0; j++)
-                    if (positions[j] >= 0)
-                        endIndex = positions[j];
-                string segment;
-                if (endIndex >= 0)
-                    segment = command.Substring(startIndex, endIndex-startIndex);
-                else
-                    segment = command.Substring(startIndex);
-                segments.Add(segment);
-            }
-        }
+        IEnumerable<string> segments = CommandLanguage.BreakCommandIntoSegements(command, keywords);
 
         bool usesNew = false;
         bool usesAll = false;
@@ -103,7 +78,7 @@ internal partial class AddCommand: IModelCommand
                 Match match = Regex.Match(segment, PATTERN_NAME);
                 if (!match.Success)
                     throw new Exception($"Invalid command: {command}");
-                name = match.Groups["name"].ToString();
+                name = match.Groups["name"].ToString().Trim();
                 if (string.IsNullOrEmpty(name))
                     throw new Exception($"Invalid command: {command}");
             }

--- a/APSIM.Core/CommandProcessor/Language/AddCommandLanguage.cs
+++ b/APSIM.Core/CommandProcessor/Language/AddCommandLanguage.cs
@@ -4,6 +4,18 @@ namespace APSIM.Core;
 
 internal partial class AddCommand: IModelCommand
 {
+    //Keywords for the command, in order they can appear in the command
+    private const string KEYWORD_ADD = "add ";
+    private const string KEYWORD_FROM = " from ";
+    private const string KEYWORD_TO = " to ";
+    private const string KEYWORD_NAME = " name ";
+
+    //Regex patterns to read the text between keywords
+    private const string PATTERN_ADD = $@"{KEYWORD_ADD}(?<new>new )*(?<model>{CommandLanguage.PATTERN_MODEL_PATH})";
+    private const string PATTERN_FROM = $@"{KEYWORD_FROM}(?<file>{CommandLanguage.PATTERN_FILE_PATH})";
+    private const string PATTERN_TO = $@"{KEYWORD_TO}(?<all>all )*(?<model>{CommandLanguage.PATTERN_MODEL_PATH})";
+    private const string PATTERN_NAME = $@"{KEYWORD_NAME}(?<name>{CommandLanguage.PATTERN_NAME_TEXT})";
+
     /// <summary>
     /// Create an add command.
     /// </summary>
@@ -19,46 +31,111 @@ internal partial class AddCommand: IModelCommand
     /// </remarks>
     public static IModelCommand Create(string command, INodeModel relativeTo, string relativeToDirectory)
     {
-        string modelNameWithBrackets = @"[\w\d\[\]\.]+";
-        string modelNamePattern = @"[\w\d]+";
-        string fileNamePattern = @"[\w\d-_\.\\:/]+";
+        //Determine what required and optional keywords are in the command
+        //Order of keywords is important
+        string[] keywords = [KEYWORD_ADD, KEYWORD_FROM, KEYWORD_TO, KEYWORD_NAME];
 
-        string pattern = $@"add (?<new>new)*" + @"\s*" +
-                         $@"(?<modelname>{modelNameWithBrackets})" + @"\s+" +
-                         $@"(?:from\s+(?<filename>{fileNamePattern})\s+)*" +
-                         $@"to\s+" +
-                         $@"(?<all>all)*\s*" +
-                         $@"(?<topath>{modelNameWithBrackets})\s*" +
-                         $@"(?:name\s+(?<name>{modelNamePattern}))*";
+        int[] positions = new int[keywords.Length];
+        int lastPosition = 0;
+        for(int i = 0; i < keywords.Length; i++)
+        {
+            positions[i] = command.IndexOf(keywords[i], lastPosition);
+            if (positions[i] > 0)
+                lastPosition = positions[i];
+        }
 
-        Match match;
-        if ((match = Regex.Match(command, pattern)) == null || !match.Success ||
-             command.Length != match.Length)
+        //Break the command into parts based on the keywords
+        List<string> segments = new List<string>();
+        for(int i = 0; i < positions.Length; i++)
+        {
+            int startIndex = positions[i];
+            if (startIndex >= 0)
+            {
+                int endIndex = -1;
+                for(int j = i+1; j < positions.Length && endIndex < 0; j++)
+                    if (positions[j] >= 0)
+                        endIndex = positions[j];
+                string segment;
+                if (endIndex >= 0)
+                    segment = command.Substring(startIndex, endIndex-startIndex);
+                else
+                    segment = command.Substring(startIndex);
+                segments.Add(segment);
+            }
+        }
+
+        bool usesNew = false;
+        bool usesAll = false;
+        string source = "";
+        string filepath = "";
+        string destination = "";
+        string name = "";
+        //Use regex to quality check the inputs
+        foreach(string segment in segments)
+        {
+            if (segment.StartsWith(KEYWORD_ADD))
+            {
+                Match match = Regex.Match(segment, PATTERN_ADD);
+                if (!match.Success)
+                    throw new Exception($"Invalid command: {command}");
+                if (!string.IsNullOrEmpty(match.Groups["new"].ToString()))
+                    usesNew = true;
+                source = match.Groups["model"].ToString();
+            }
+            else if (segment.StartsWith(KEYWORD_FROM))
+            {
+                Match match = Regex.Match(segment, PATTERN_FROM);
+                if (!match.Success)
+                    throw new Exception($"Invalid command: {command}");
+                filepath = match.Groups["file"].ToString();
+            }
+            else if (segment.StartsWith(KEYWORD_TO))
+            {
+                Match match = Regex.Match(segment, PATTERN_TO);
+                if (!match.Success)
+                    throw new Exception($"Invalid command: {command}");
+                if (!string.IsNullOrEmpty(match.Groups["all"].ToString()))
+                    usesAll = true;
+                destination = match.Groups["model"].ToString();
+            }
+            else if (segment.StartsWith(KEYWORD_NAME))
+            {
+                Match match = Regex.Match(segment, PATTERN_NAME);
+                if (!match.Success)
+                    throw new Exception($"Invalid command: {command}");
+                name = match.Groups["name"].ToString();
+                if (string.IsNullOrEmpty(name))
+                    throw new Exception($"Invalid command: {command}");
+            }
+        }
+
+        if (string.IsNullOrEmpty(source))
+            throw new Exception($"Invalid command: {command}");
+        if (string.IsNullOrEmpty(destination))
             throw new Exception($"Invalid command: {command}");
 
+        //find or create the model being added
         IModelReference modelReference;
-        if (match.Groups["new"]?.ToString() == "new")
-            modelReference = new NewModelReference(match.Groups["modelname"]?.ToString());
-        else if (!string.IsNullOrEmpty(match.Groups["filename"]?.ToString()))
+        if (usesNew)
+        {
+            modelReference = new NewModelReference(source);
+        }
+        else if (!string.IsNullOrEmpty(filepath))
         {
             // If filename is relative, make it absolute
-            string fileName = match.Groups["filename"].ToString();
             if (relativeToDirectory != null)
-                fileName = Path.GetFullPath(fileName, relativeToDirectory);
-            modelReference = new ModelInFileReference(fileName, match.Groups["modelname"]?.ToString());
+                filepath = Path.GetFullPath(filepath, relativeToDirectory);
+            modelReference = new ModelInFileReference(filepath, source);
         }
         else
         {
-            string modelName = match.Groups["modelname"].ToString().Trim();
-            if (!modelName.StartsWith('[') && !modelName.EndsWith(']'))
-                modelName = $"[{modelName}]";
-            modelReference = new ModelLocatorReference(relativeTo, modelName);
+            if (!source.StartsWith('[') && !source.EndsWith(']'))
+                source = $"[{source}]";
+            modelReference = new ModelLocatorReference(relativeTo, source);
         }
 
-        return new AddCommand(modelReference,
-                              toPath: match.Groups["topath"]?.ToString(),
-                              multiple: match.Groups["all"].Success,
-                              newName: match.Groups["name"]?.ToString());
+        //make the command
+        return new AddCommand(modelReference, toPath: destination, multiple: usesAll, newName: name);
     }
 
     /// <summary>
@@ -85,15 +162,15 @@ internal partial class AddCommand: IModelCommand
 
         parts.Add("to");
 
-        if (multiple)
+        if (_multiple)
             parts.Add("all");
 
-        parts.Add(toPath);
+        parts.Add(_toPath);
 
-        if (!string.IsNullOrEmpty(newName))
+        if (!string.IsNullOrEmpty(_newName))
         {
             parts.Add("name");
-            parts.Add(newName);
+            parts.Add(_newName);
         }
 
         return string.Join(" ", parts);

--- a/APSIM.Core/CommandProcessor/Language/CommandLanguage.cs
+++ b/APSIM.Core/CommandProcessor/Language/CommandLanguage.cs
@@ -24,13 +24,13 @@ namespace APSIM.Core;
 public class CommandLanguage
 {
     /// <summary>Regex pattern for getting a model path</summary>
-    public const string PATTERN_MODEL_PATH = @"[\w\d-\[\]\. ]+";
+    public const string PATTERN_MODEL_PATH = @"[\w\d\-\[\]\. ]+";
 
     /// <summary>Regex pattern for getting a file path</summary>
-    public const string PATTERN_FILE_PATH = @"[\w\d-_\.\\:/ ]+";
+    public const string PATTERN_FILE_PATH = @"[\w\d\-_\.\\:/ ]+";
 
     /// <summary>Regex pattern for a model name</summary>
-    public const string PATTERN_NAME_TEXT = @"[\w\d- ]+";
+    public const string PATTERN_NAME_TEXT = @"[\w\d\- ]+";
 
     /// <summary>
     /// Parse a collection of lines into a collection of model commands.
@@ -95,6 +95,80 @@ public class CommandLanguage
         foreach (var command in commands)
             lines.Add(command.ToString());
         return lines;
+    }
+
+    public static IEnumerable<string> BreakCommandIntoSegements(string command, string[] keywords)
+    {
+        //remove quoted sections prior to searching for keywords
+        List<(int, string)> quotes = new List<(int, string)>();
+        string commandWithoutQuotedSections = "";
+        string quotedSection = "";
+        bool inQuotes = false;
+        foreach(char character in command)
+        {
+            if (character == '"')
+            {
+                inQuotes = !inQuotes;
+                if (inQuotes)
+                    quotedSection = "";
+                else
+                    quotes.Add((commandWithoutQuotedSections.Length, quotedSection));
+            }
+            else
+            {
+                if (!inQuotes)
+                    commandWithoutQuotedSections += character;
+                else
+                    quotedSection += character;
+            }
+        }
+        quotes.Reverse();
+
+        //work out where the keywords are in the quoteless command
+        int[] positions = new int[keywords.Length];
+        int lastPosition = 0;
+        for(int i = 0; i < keywords.Length; i++)
+        {
+            positions[i] = commandWithoutQuotedSections.IndexOf(keywords[i], lastPosition);
+            if (positions[i] > 0)
+                lastPosition = positions[i];
+        }
+        
+        //remove quote characters from original command as our positions are created based on them
+        //not being there
+        string commandWithoutQuoteMarkers = command.Replace("\"", "");
+
+        //adjust positions based on if text was quoted out
+        foreach((int, string) quote in quotes)
+        {
+            for(int i = positions.Length-1; i >= 0; i--)
+            {
+                if (positions[i] >= quote.Item1)
+                    positions[i] += quote.Item2.Length;
+            }
+        }
+
+        //Break the command into parts based on the keywords
+        List<string> segments = new List<string>();
+        for(int i = 0; i < positions.Length; i++)
+        {
+            int startIndex = positions[i];
+            if (startIndex >= 0)
+            {
+                int endIndex = -1;
+                for(int j = i+1; j < positions.Length && endIndex < 0; j++)
+                    if (positions[j] >= 0)
+                        endIndex = positions[j];
+                string segment;
+                if (endIndex >= 0)
+                    segment = commandWithoutQuoteMarkers.Substring(startIndex, endIndex-startIndex);
+                else
+                    segment = commandWithoutQuoteMarkers.Substring(startIndex);
+                segments.Add(segment);
+            }
+        }
+
+        return segments;
     }
 
     /// <summary>

--- a/APSIM.Core/CommandProcessor/Language/CommandLanguage.cs
+++ b/APSIM.Core/CommandProcessor/Language/CommandLanguage.cs
@@ -23,6 +23,15 @@ namespace APSIM.Core;
 /// </remarks>
 public class CommandLanguage
 {
+    /// <summary>Regex pattern for getting a model path</summary>
+    public const string PATTERN_MODEL_PATH = @"[\w\d-\[\]\. ]+";
+
+    /// <summary>Regex pattern for getting a file path</summary>
+    public const string PATTERN_FILE_PATH = @"[\w\d-_\.\\:/ ]+";
+
+    /// <summary>Regex pattern for a model name</summary>
+    public const string PATTERN_NAME_TEXT = @"[\w\d- ]+";
+
     /// <summary>
     /// Parse a collection of lines into a collection of model commands.
     /// </summary>

--- a/APSIM.Core/CommandProcessor/Language/SetPropertyCommandLanguage.cs
+++ b/APSIM.Core/CommandProcessor/Language/SetPropertyCommandLanguage.cs
@@ -15,8 +15,7 @@ public partial class SetPropertyCommand: IModelCommand
     /// </remarks>
     public static IModelCommand Create(string command, string relativeToDirectory)
     {
-        string modelNameWithBrackets = @"[\[\.][\w\d\[\]\.\: ]*[\w\d\[\]\.\:]";
-        
+        string modelNameWithBrackets = @"[\[\.][\w\d\[\]\.:\- ]*[\w\d\[\]\.:\-]";
         string pattern = $@"^(?<keyword>{modelNameWithBrackets})\s*(?<operator>=|\+=|-=)\s*(?<pipe>\<)?\s*(?<value>[^\<]+)?$";
 
         Match match = Regex.Match(command, pattern);
@@ -47,10 +46,10 @@ public partial class SetPropertyCommand: IModelCommand
     /// <returns>A command language string.</returns>
     public override string ToString()
     {
-        if (fileName == null)
-            return $"{name}{oper}{value}";
+        if (_fileName == null)
+            return $"{_name}{_oper}{_value}";
         else
-            return $"{name}=<{fileName}";
+            return $"{_name}=<{_fileName}";
     }
 
 }

--- a/Tests/UnitTests/APSIM.Core/CommandLanguageTests.cs
+++ b/Tests/UnitTests/APSIM.Core/CommandLanguageTests.cs
@@ -74,9 +74,13 @@ public class CommandLanguageTests
 
     /// <summary>Test that invalid commands throw.</summary>
     [Test]
+    [TestCase("add to from name", ExpectedResult = "Invalid command: add to from name")]
+    [TestCase("addtofromname", ExpectedResult = "Invalid command: addtofromname")]
+    [TestCase("add to [Zone] new Report", ExpectedResult = "Invalid command: add to [Zone] new Report")]
+    [TestCase("add Reportto [Zone]", ExpectedResult = "Invalid command: add Reportto [Zone]")]
     [TestCase("add Report to", ExpectedResult = "Invalid command: add Report to")]
+    [TestCase("add Report to ", ExpectedResult = "Invalid command: add Report to")]
     [TestCase("add new Report", ExpectedResult = "Invalid command: add new Report")]
-    [TestCase("add new Report to [Simulation] name", ExpectedResult = "Invalid command: add new Report to [Simulation] name")]
     [TestCase("delete", ExpectedResult = "Invalid command: delete")]
     [TestCase("duplicate", ExpectedResult = "Invalid command: duplicate")]
     [TestCase("save", ExpectedResult = "Invalid command: save")]

--- a/Tests/UnitTests/APSIM.Core/CommandLanguageTests.cs
+++ b/Tests/UnitTests/APSIM.Core/CommandLanguageTests.cs
@@ -82,7 +82,7 @@ public class CommandLanguageTests
     [TestCase("add Report to ", ExpectedResult = "Invalid command: add Report to")]
     [TestCase("add new Report", ExpectedResult = "Invalid command: add new Report")]
     [TestCase("add new Report to to [Zone]")]
-    [TestCase("add new Report to [Simulation] name", ExpectedResult = "Invalid command: add new Report to [Simulation] name")]
+    [TestCase("add new Report to [Simulation] name ", ExpectedResult = "Invalid command: add new Report to [Simulation] name ")]
     [TestCase("delete", ExpectedResult = "Invalid command: delete")]
     [TestCase("duplicate", ExpectedResult = "Invalid command: duplicate")]
     [TestCase("save", ExpectedResult = "Invalid command: save")]

--- a/Tests/UnitTests/APSIM.Core/CommandLanguageTests.cs
+++ b/Tests/UnitTests/APSIM.Core/CommandLanguageTests.cs
@@ -81,7 +81,6 @@ public class CommandLanguageTests
     [TestCase("add Report to", ExpectedResult = "Invalid command: add Report to")]
     [TestCase("add Report to ", ExpectedResult = "Invalid command: add Report to")]
     [TestCase("add new Report", ExpectedResult = "Invalid command: add new Report")]
-    [TestCase("add new Report to [Simulation] name ", ExpectedResult = "Invalid command: add new Report to [Simulation] name ")]
     [TestCase("delete", ExpectedResult = "Invalid command: delete")]
     [TestCase("duplicate", ExpectedResult = "Invalid command: duplicate")]
     [TestCase("save", ExpectedResult = "Invalid command: save")]

--- a/Tests/UnitTests/APSIM.Core/CommandLanguageTests.cs
+++ b/Tests/UnitTests/APSIM.Core/CommandLanguageTests.cs
@@ -81,7 +81,6 @@ public class CommandLanguageTests
     [TestCase("add Report to", ExpectedResult = "Invalid command: add Report to")]
     [TestCase("add Report to ", ExpectedResult = "Invalid command: add Report to")]
     [TestCase("add new Report", ExpectedResult = "Invalid command: add new Report")]
-    [TestCase("add new Report to to [Zone]")]
     [TestCase("add new Report to [Simulation] name ", ExpectedResult = "Invalid command: add new Report to [Simulation] name ")]
     [TestCase("delete", ExpectedResult = "Invalid command: delete")]
     [TestCase("duplicate", ExpectedResult = "Invalid command: duplicate")]

--- a/Tests/UnitTests/APSIM.Core/CommandLanguageTests.cs
+++ b/Tests/UnitTests/APSIM.Core/CommandLanguageTests.cs
@@ -15,6 +15,7 @@ public class CommandLanguageTests
     [TestCase("add new Report to all [Zone] name MyReport")]
     [TestCase("add [Report] to [Zone] name MyReport")]
     [TestCase("add [Report] from anotherfile.apsimx to all [Zone]")]
+    [TestCase("add new \"Report to\" to [Zone]")]
     [TestCase("delete [Zone].Report")]
     [TestCase("duplicate [Zone].Report")]
     [TestCase("duplicate [Zone].Report name NewName")]
@@ -32,11 +33,10 @@ public class CommandLanguageTests
     [TestCase("replace all [Report] with [ChildReport]")]
     [TestCase("replace all [Report] with [ChildReport] from anotherfile.apsimx")]
     [TestCase("replace all [Report] with [ChildReport] from anotherfile.apsimx name NewName")]
-
     public void EnsureLanguageParsingWorks(string commandString)
     {
         var commands = CommandLanguage.StringToCommands([commandString], relativeTo: null, relativeToDirectory: null);
-        Assert.That(commands.First().ToString(), Is.EqualTo(commandString));
+        Assert.That(commands.First().ToString(), Is.EqualTo(commandString.Replace("\"", "")));
     }
 
     // Ensure commented lines are ignored.
@@ -81,6 +81,8 @@ public class CommandLanguageTests
     [TestCase("add Report to", ExpectedResult = "Invalid command: add Report to")]
     [TestCase("add Report to ", ExpectedResult = "Invalid command: add Report to")]
     [TestCase("add new Report", ExpectedResult = "Invalid command: add new Report")]
+    [TestCase("add new Report to to [Zone]")]
+    [TestCase("add new Report to [Simulation] name", ExpectedResult = "Invalid command: add new Report to [Simulation] name")]
     [TestCase("delete", ExpectedResult = "Invalid command: delete")]
     [TestCase("duplicate", ExpectedResult = "Invalid command: duplicate")]
     [TestCase("save", ExpectedResult = "Invalid command: save")]


### PR DESCRIPTION
Resolves #11423 

With all the keywords and optionals on the Add command, the regex it was using was getting way to big to work correctly, meaning it was time for a refactor.

Instead of trying to parse all the command at once, it will now use the 4 defined keywords to break it into smaller chunks, which then each have a regex to handle the allowed values and optional keywords. This makes the entire parsing much more robust and flexible, and the regex entries much easier to read and understand.

I've also moved the regex definitions of what a model path, model name and file path are supposed to look like to constants on the CommandLangauge class, with an intention in the future to share that across all the commands when they are next changed.

The Set command was also updated, however not fully refactored as including space into that regex was fairly simple still.

Other changes include marking private variables with an underscore prefix and adding some more unit tests to test for things that should break the new parser, but didn't on the old one (and threw later errors).