### PR TITLE
Add hourly DCaPST reporting

### DIFF
--- a/Models/DCaPST/DCaPSTModelNG.cs
+++ b/Models/DCaPST/DCaPSTModelNG.cs
@@ -150,6 +150,116 @@ namespace Models.DCAPST
         public DCAPSTModel DcapstModel { get; private set; } = new();
 
         /// <summary>
+        /// Invoked once for each DCaPST calculation interval after the day's
+        /// water-limited biomass calculation has completed.
+        /// </summary>
+        public event EventHandler IntervalStep;
+
+        /// <summary>Date and time of the current DCaPST interval.</summary>
+        [JsonIgnore]
+        public DateTime IntervalDateTime { get; private set; }
+
+        /// <summary>Hour of the current DCaPST interval.</summary>
+        [JsonIgnore]
+        [Units("hours")]
+        public double Hour { get; private set; }
+
+        /// <summary>Air temperature during the current DCaPST interval.</summary>
+        [JsonIgnore]
+        [Units("°C")]
+        public double AirTemperature { get; private set; }
+
+        /// <summary>Leaf area index of the sunlit canopy during the current interval.</summary>
+        [JsonIgnore]
+        [Units("m^2/m^2")]
+        public double SunlitLAI { get; private set; }
+
+        /// <summary>Leaf area index of the shaded canopy during the current interval.</summary>
+        [JsonIgnore]
+        [Units("m^2/m^2")]
+        public double ShadedLAI { get; private set; }
+
+        /// <summary>LAI-weighted canopy temperature during the current interval.</summary>
+        [JsonIgnore]
+        [Units("°C")]
+        public double CanopyTemperature { get; private set; }
+
+        /// <summary>LAI-weighted canopy vapour pressure deficit during the current interval.</summary>
+        [JsonIgnore]
+        [Units("kPa")]
+        public double CanopyVPD { get; private set; }
+
+        /// <summary>Sunlit canopy assimilation during the current interval.</summary>
+        [JsonIgnore]
+        [Units("umol CO2/m^2/s")]
+        public double SunlitAssimilation { get; private set; }
+
+        /// <summary>Sunlit canopy water use during the current interval.</summary>
+        [JsonIgnore]
+        [Units("mm")]
+        public double SunlitWater { get; private set; }
+
+        /// <summary>Sunlit canopy temperature during the current interval.</summary>
+        [JsonIgnore]
+        [Units("°C")]
+        public double SunlitTemperature { get; private set; }
+
+        /// <summary>Sunlit canopy vapour pressure deficit during the current interval.</summary>
+        [JsonIgnore]
+        [Units("kPa")]
+        public double SunlitVPD { get; private set; }
+
+        /// <summary>Sunlit AC1 pathway assimilation during the current interval.</summary>
+        [JsonIgnore]
+        [Units("umol CO2/m^2/s")]
+        public double SunlitAc1 { get; private set; }
+
+        /// <summary>Sunlit AC2 pathway assimilation during the current interval.</summary>
+        [JsonIgnore]
+        [Units("umol CO2/m^2/s")]
+        public double SunlitAc2 { get; private set; }
+
+        /// <summary>Sunlit AJ pathway assimilation during the current interval.</summary>
+        [JsonIgnore]
+        [Units("umol CO2/m^2/s")]
+        public double SunlitAj { get; private set; }
+
+        /// <summary>Shaded canopy assimilation during the current interval.</summary>
+        [JsonIgnore]
+        [Units("umol CO2/m^2/s")]
+        public double ShadedAssimilation { get; private set; }
+
+        /// <summary>Shaded canopy water use during the current interval.</summary>
+        [JsonIgnore]
+        [Units("mm")]
+        public double ShadedWater { get; private set; }
+
+        /// <summary>Shaded canopy temperature during the current interval.</summary>
+        [JsonIgnore]
+        [Units("°C")]
+        public double ShadedTemperature { get; private set; }
+
+        /// <summary>Shaded canopy vapour pressure deficit during the current interval.</summary>
+        [JsonIgnore]
+        [Units("kPa")]
+        public double ShadedVPD { get; private set; }
+
+        /// <summary>Shaded AC1 pathway assimilation during the current interval.</summary>
+        [JsonIgnore]
+        [Units("umol CO2/m^2/s")]
+        public double ShadedAc1 { get; private set; }
+
+        /// <summary>Shaded AC2 pathway assimilation during the current interval.</summary>
+        [JsonIgnore]
+        [Units("umol CO2/m^2/s")]
+        public double ShadedAc2 { get; private set; }
+
+        /// <summary>Shaded AJ pathway assimilation during the current interval.</summary>
+        [JsonIgnore]
+        [Units("umol CO2/m^2/s")]
+        public double ShadedAj { get; private set; }
+
+        /// <summary>
         /// The biological transpiration limit of a plant
         /// </summary>
         public double Biolimit { get; set; } = 0;
@@ -402,6 +512,58 @@ namespace Models.DCAPST
             {
                 throw new InvalidOperationException($"Unable to set biomass from unknown leaf type {leaf.GetType()}");
             }
+
+            PublishIntervalOutputs();
+        }
+
+        /// <summary>
+        /// Copies each calculated interval into reportable scalar properties and
+        /// raises <see cref="IntervalStep"/> for the report model.
+        /// </summary>
+        private void PublishIntervalOutputs()
+        {
+            if (IntervalStep is null || DcapstModel?.Intervals is null)
+                return;
+
+            foreach (IntervalValues interval in DcapstModel.Intervals)
+            {
+                Hour = interval.Time;
+                IntervalDateTime = clock.Today.Date.AddHours(Hour);
+                AirTemperature = interval.AirTemperature;
+                SunlitLAI = interval.SunlitLAI;
+                ShadedLAI = interval.ShadedLAI;
+
+                SunlitAssimilation = interval.Sunlit.A;
+                SunlitWater = interval.Sunlit.Water;
+                SunlitTemperature = interval.Sunlit.Temperature;
+                SunlitVPD = interval.Sunlit.VPD;
+                SunlitAc1 = interval.Sunlit.Ac1.Assimilation;
+                SunlitAc2 = interval.Sunlit.Ac2.Assimilation;
+                SunlitAj = interval.Sunlit.Aj.Assimilation;
+
+                ShadedAssimilation = interval.Shaded.A;
+                ShadedWater = interval.Shaded.Water;
+                ShadedTemperature = interval.Shaded.Temperature;
+                ShadedVPD = interval.Shaded.VPD;
+                ShadedAc1 = interval.Shaded.Ac1.Assimilation;
+                ShadedAc2 = interval.Shaded.Ac2.Assimilation;
+                ShadedAj = interval.Shaded.Aj.Assimilation;
+
+                double totalLAI = SunlitLAI + ShadedLAI;
+                CanopyTemperature = LAIWeightedMean(SunlitTemperature, SunlitLAI, ShadedTemperature, ShadedLAI, totalLAI);
+                CanopyVPD = LAIWeightedMean(SunlitVPD, SunlitLAI, ShadedVPD, ShadedLAI, totalLAI);
+
+                IntervalStep.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        /// <summary>Calculates a canopy mean weighted by sunlit and shaded leaf area.</summary>
+        private static double LAIWeightedMean(double sunlitValue, double sunlitLAI, double shadedValue, double shadedLAI, double totalLAI)
+        {
+            if (totalLAI <= 0)
+                return 0;
+
+            return (sunlitValue * sunlitLAI + shadedValue * shadedLAI) / totalLAI;
         }
 
         private double GetSoilWaterAvailable()

--- a/Models/DCaPST/DCaPSTModelNG.cs
+++ b/Models/DCaPST/DCaPSTModelNG.cs
@@ -153,111 +153,14 @@ namespace Models.DCAPST
         /// Invoked once for each DCaPST calculation interval after the day's
         /// water-limited biomass calculation has completed.
         /// </summary>
-        public event EventHandler IntervalStep;
+        public event EventHandler<DCaPSTIntervalOutput> IntervalStep;
 
-        /// <summary>Date and time of the current DCaPST interval.</summary>
+        /// <summary>
+        /// The interval currently being published. This is non-null only while
+        /// <see cref="IntervalStep"/> subscribers are running.
+        /// </summary>
         [JsonIgnore]
-        public DateTime IntervalDateTime { get; private set; }
-
-        /// <summary>Hour of the current DCaPST interval.</summary>
-        [JsonIgnore]
-        [Units("hours")]
-        public double Hour { get; private set; }
-
-        /// <summary>Air temperature during the current DCaPST interval.</summary>
-        [JsonIgnore]
-        [Units("°C")]
-        public double AirTemperature { get; private set; }
-
-        /// <summary>Leaf area index of the sunlit canopy during the current interval.</summary>
-        [JsonIgnore]
-        [Units("m^2/m^2")]
-        public double SunlitLAI { get; private set; }
-
-        /// <summary>Leaf area index of the shaded canopy during the current interval.</summary>
-        [JsonIgnore]
-        [Units("m^2/m^2")]
-        public double ShadedLAI { get; private set; }
-
-        /// <summary>LAI-weighted canopy temperature during the current interval.</summary>
-        [JsonIgnore]
-        [Units("°C")]
-        public double CanopyTemperature { get; private set; }
-
-        /// <summary>LAI-weighted canopy vapour pressure deficit during the current interval.</summary>
-        [JsonIgnore]
-        [Units("kPa")]
-        public double CanopyVPD { get; private set; }
-
-        /// <summary>Sunlit canopy assimilation during the current interval.</summary>
-        [JsonIgnore]
-        [Units("umol CO2/m^2/s")]
-        public double SunlitAssimilation { get; private set; }
-
-        /// <summary>Sunlit canopy water use during the current interval.</summary>
-        [JsonIgnore]
-        [Units("mm")]
-        public double SunlitWater { get; private set; }
-
-        /// <summary>Sunlit canopy temperature during the current interval.</summary>
-        [JsonIgnore]
-        [Units("°C")]
-        public double SunlitTemperature { get; private set; }
-
-        /// <summary>Sunlit canopy vapour pressure deficit during the current interval.</summary>
-        [JsonIgnore]
-        [Units("kPa")]
-        public double SunlitVPD { get; private set; }
-
-        /// <summary>Sunlit AC1 pathway assimilation during the current interval.</summary>
-        [JsonIgnore]
-        [Units("umol CO2/m^2/s")]
-        public double SunlitAc1 { get; private set; }
-
-        /// <summary>Sunlit AC2 pathway assimilation during the current interval.</summary>
-        [JsonIgnore]
-        [Units("umol CO2/m^2/s")]
-        public double SunlitAc2 { get; private set; }
-
-        /// <summary>Sunlit AJ pathway assimilation during the current interval.</summary>
-        [JsonIgnore]
-        [Units("umol CO2/m^2/s")]
-        public double SunlitAj { get; private set; }
-
-        /// <summary>Shaded canopy assimilation during the current interval.</summary>
-        [JsonIgnore]
-        [Units("umol CO2/m^2/s")]
-        public double ShadedAssimilation { get; private set; }
-
-        /// <summary>Shaded canopy water use during the current interval.</summary>
-        [JsonIgnore]
-        [Units("mm")]
-        public double ShadedWater { get; private set; }
-
-        /// <summary>Shaded canopy temperature during the current interval.</summary>
-        [JsonIgnore]
-        [Units("°C")]
-        public double ShadedTemperature { get; private set; }
-
-        /// <summary>Shaded canopy vapour pressure deficit during the current interval.</summary>
-        [JsonIgnore]
-        [Units("kPa")]
-        public double ShadedVPD { get; private set; }
-
-        /// <summary>Shaded AC1 pathway assimilation during the current interval.</summary>
-        [JsonIgnore]
-        [Units("umol CO2/m^2/s")]
-        public double ShadedAc1 { get; private set; }
-
-        /// <summary>Shaded AC2 pathway assimilation during the current interval.</summary>
-        [JsonIgnore]
-        [Units("umol CO2/m^2/s")]
-        public double ShadedAc2 { get; private set; }
-
-        /// <summary>Shaded AJ pathway assimilation during the current interval.</summary>
-        [JsonIgnore]
-        [Units("umol CO2/m^2/s")]
-        public double ShadedAj { get; private set; }
+        public DCaPSTIntervalOutput CurrentInterval { get; private set; }
 
         /// <summary>
         /// The biological transpiration limit of a plant
@@ -517,8 +420,9 @@ namespace Models.DCAPST
         }
 
         /// <summary>
-        /// Copies each calculated interval into reportable scalar properties and
-        /// raises <see cref="IntervalStep"/> for the report model.
+        /// Publishes each calculated interval through <see cref="IntervalStep"/>.
+        /// The output is exposed through <see cref="CurrentInterval"/> only for
+        /// the duration of the event so that the report model can read it.
         /// </summary>
         private void PublishIntervalOutputs()
         {
@@ -527,43 +431,16 @@ namespace Models.DCAPST
 
             foreach (IntervalValues interval in DcapstModel.Intervals)
             {
-                Hour = interval.Time;
-                IntervalDateTime = clock.Today.Date.AddHours(Hour);
-                AirTemperature = interval.AirTemperature;
-                SunlitLAI = interval.SunlitLAI;
-                ShadedLAI = interval.ShadedLAI;
-
-                SunlitAssimilation = interval.Sunlit.A;
-                SunlitWater = interval.Sunlit.Water;
-                SunlitTemperature = interval.Sunlit.Temperature;
-                SunlitVPD = interval.Sunlit.VPD;
-                SunlitAc1 = interval.Sunlit.Ac1.Assimilation;
-                SunlitAc2 = interval.Sunlit.Ac2.Assimilation;
-                SunlitAj = interval.Sunlit.Aj.Assimilation;
-
-                ShadedAssimilation = interval.Shaded.A;
-                ShadedWater = interval.Shaded.Water;
-                ShadedTemperature = interval.Shaded.Temperature;
-                ShadedVPD = interval.Shaded.VPD;
-                ShadedAc1 = interval.Shaded.Ac1.Assimilation;
-                ShadedAc2 = interval.Shaded.Ac2.Assimilation;
-                ShadedAj = interval.Shaded.Aj.Assimilation;
-
-                double totalLAI = SunlitLAI + ShadedLAI;
-                CanopyTemperature = LAIWeightedMean(SunlitTemperature, SunlitLAI, ShadedTemperature, ShadedLAI, totalLAI);
-                CanopyVPD = LAIWeightedMean(SunlitVPD, SunlitLAI, ShadedVPD, ShadedLAI, totalLAI);
-
-                IntervalStep.Invoke(this, EventArgs.Empty);
+                CurrentInterval = new DCaPSTIntervalOutput(clock.Today, interval);
+                try
+                {
+                    IntervalStep.Invoke(this, CurrentInterval);
+                }
+                finally
+                {
+                    CurrentInterval = null;
+                }
             }
-        }
-
-        /// <summary>Calculates a canopy mean weighted by sunlit and shaded leaf area.</summary>
-        private static double LAIWeightedMean(double sunlitValue, double sunlitLAI, double shadedValue, double shadedLAI, double totalLAI)
-        {
-            if (totalLAI <= 0)
-                return 0;
-
-            return (sunlitValue * sunlitLAI + shadedValue * shadedLAI) / totalLAI;
         }
 
         private double GetSoilWaterAvailable()

--- a/Models/DCaPST/Models/Assimilation/AreaValues.cs
+++ b/Models/DCaPST/Models/Assimilation/AreaValues.cs
@@ -23,6 +23,11 @@
         public double Temperature;
 
         /// <summary>
+        /// Vapour pressure deficit for the limiting assimilation pathway.
+        /// </summary>
+        public double VPD;
+
+        /// <summary>
         /// 
         /// </summary>
         /// <value></value>

--- a/Models/DCaPST/Models/Assimilation/AssimilationArea.cs
+++ b/Models/DCaPST/Models/Assimilation/AssimilationArea.cs
@@ -183,7 +183,7 @@ namespace Models.DCAPST.Canopy
         public AreaValues GetAreaValues()
         {
             // Casting to an array to ensure we don't change pathways outside of this method
-            var temp = pathways.ToArray().OrderBy(p => p.CO2Rate).First().Temperature;
+            var limitingPath = pathways.ToArray().OrderBy(p => p.CO2Rate).First().GetPathValues();
 
             var ac1 = pathways.FirstOrDefault(p => p.Type == PathwayType.Ac1).GetPathValues();
 
@@ -196,7 +196,8 @@ namespace Models.DCAPST.Canopy
             {
                 A = CO2AssimilationRate,
                 Water = WaterUse,
-                Temperature = temp,
+                Temperature = limitingPath.Temperature,
+                VPD = limitingPath.VPD,
                 Ac1 = ac1,
                 Ac2 = ac2,
                 Aj = aj

--- a/Models/DCaPST/Models/DCAPSTModel.cs
+++ b/Models/DCaPST/Models/DCAPSTModel.cs
@@ -450,6 +450,9 @@ namespace Models.DCAPST
         {
             Canopy.DoTimestepAdjustment(Radiation);
 
+            interval.SunlitLAI = Canopy.Sunlit.LAI;
+            interval.ShadedLAI = Canopy.Shaded.LAI;
+
             var totalHeat = Canopy.CalcBoundaryHeatConductance();
             var sunlitHeat = Canopy.CalcSunlitBoundaryHeatConductance();
 

--- a/Models/DCaPST/Models/DCaPSTIntervalOutput.cs
+++ b/Models/DCaPST/Models/DCaPSTIntervalOutput.cs
@@ -1,0 +1,143 @@
+using Models.Core;
+using System;
+
+namespace Models.DCAPST
+{
+    /// <summary>
+    /// Values calculated by DCaPST for one sub-daily interval.
+    /// </summary>
+    public class DCaPSTIntervalOutput : EventArgs
+    {
+        /// <summary>
+        /// Creates an empty interval output. This supports discovery of nested
+        /// properties by the report variable locator.
+        /// </summary>
+        public DCaPSTIntervalOutput()
+        {
+        }
+
+        /// <summary>Creates an output from a calculated DCaPST interval.</summary>
+        /// <param name="date">Date on which the interval was calculated.</param>
+        /// <param name="interval">Calculated interval values.</param>
+        internal DCaPSTIntervalOutput(DateTime date, IntervalValues interval)
+        {
+            Hour = interval.Time;
+            IntervalDateTime = date.Date.AddHours(Hour);
+            AirTemperature = interval.AirTemperature;
+            SunlitLAI = interval.SunlitLAI;
+            ShadedLAI = interval.ShadedLAI;
+
+            SunlitAssimilation = interval.Sunlit.A;
+            SunlitWater = interval.Sunlit.Water;
+            SunlitTemperature = interval.Sunlit.Temperature;
+            SunlitVPD = interval.Sunlit.VPD;
+            SunlitAc1 = interval.Sunlit.Ac1.Assimilation;
+            SunlitAc2 = interval.Sunlit.Ac2.Assimilation;
+            SunlitAj = interval.Sunlit.Aj.Assimilation;
+
+            ShadedAssimilation = interval.Shaded.A;
+            ShadedWater = interval.Shaded.Water;
+            ShadedTemperature = interval.Shaded.Temperature;
+            ShadedVPD = interval.Shaded.VPD;
+            ShadedAc1 = interval.Shaded.Ac1.Assimilation;
+            ShadedAc2 = interval.Shaded.Ac2.Assimilation;
+            ShadedAj = interval.Shaded.Aj.Assimilation;
+
+            double totalLAI = SunlitLAI + ShadedLAI;
+            CanopyTemperature = LAIWeightedMean(SunlitTemperature, SunlitLAI, ShadedTemperature, ShadedLAI, totalLAI);
+            CanopyVPD = LAIWeightedMean(SunlitVPD, SunlitLAI, ShadedVPD, ShadedLAI, totalLAI);
+        }
+
+        /// <summary>Date and time of the interval.</summary>
+        public DateTime IntervalDateTime { get; private set; }
+
+        /// <summary>Hour of the interval.</summary>
+        [Units("hours")]
+        public double Hour { get; private set; }
+
+        /// <summary>Air temperature during the interval.</summary>
+        [Units("°C")]
+        public double AirTemperature { get; private set; }
+
+        /// <summary>Leaf area index of the sunlit canopy.</summary>
+        [Units("m^2/m^2")]
+        public double SunlitLAI { get; private set; }
+
+        /// <summary>Leaf area index of the shaded canopy.</summary>
+        [Units("m^2/m^2")]
+        public double ShadedLAI { get; private set; }
+
+        /// <summary>LAI-weighted canopy temperature.</summary>
+        [Units("°C")]
+        public double CanopyTemperature { get; private set; }
+
+        /// <summary>LAI-weighted canopy vapour pressure deficit.</summary>
+        [Units("kPa")]
+        public double CanopyVPD { get; private set; }
+
+        /// <summary>Sunlit canopy assimilation.</summary>
+        [Units("umol CO2/m^2/s")]
+        public double SunlitAssimilation { get; private set; }
+
+        /// <summary>Sunlit canopy water use.</summary>
+        [Units("mm")]
+        public double SunlitWater { get; private set; }
+
+        /// <summary>Sunlit canopy temperature.</summary>
+        [Units("°C")]
+        public double SunlitTemperature { get; private set; }
+
+        /// <summary>Sunlit canopy vapour pressure deficit.</summary>
+        [Units("kPa")]
+        public double SunlitVPD { get; private set; }
+
+        /// <summary>Sunlit AC1 pathway assimilation.</summary>
+        [Units("umol CO2/m^2/s")]
+        public double SunlitAc1 { get; private set; }
+
+        /// <summary>Sunlit AC2 pathway assimilation.</summary>
+        [Units("umol CO2/m^2/s")]
+        public double SunlitAc2 { get; private set; }
+
+        /// <summary>Sunlit AJ pathway assimilation.</summary>
+        [Units("umol CO2/m^2/s")]
+        public double SunlitAj { get; private set; }
+
+        /// <summary>Shaded canopy assimilation.</summary>
+        [Units("umol CO2/m^2/s")]
+        public double ShadedAssimilation { get; private set; }
+
+        /// <summary>Shaded canopy water use.</summary>
+        [Units("mm")]
+        public double ShadedWater { get; private set; }
+
+        /// <summary>Shaded canopy temperature.</summary>
+        [Units("°C")]
+        public double ShadedTemperature { get; private set; }
+
+        /// <summary>Shaded canopy vapour pressure deficit.</summary>
+        [Units("kPa")]
+        public double ShadedVPD { get; private set; }
+
+        /// <summary>Shaded AC1 pathway assimilation.</summary>
+        [Units("umol CO2/m^2/s")]
+        public double ShadedAc1 { get; private set; }
+
+        /// <summary>Shaded AC2 pathway assimilation.</summary>
+        [Units("umol CO2/m^2/s")]
+        public double ShadedAc2 { get; private set; }
+
+        /// <summary>Shaded AJ pathway assimilation.</summary>
+        [Units("umol CO2/m^2/s")]
+        public double ShadedAj { get; private set; }
+
+        /// <summary>Calculates a canopy mean weighted by sunlit and shaded leaf area.</summary>
+        private static double LAIWeightedMean(double sunlitValue, double sunlitLAI, double shadedValue, double shadedLAI, double totalLAI)
+        {
+            if (totalLAI <= 0)
+                return 0;
+
+            return (sunlitValue * sunlitLAI + shadedValue * shadedLAI) / totalLAI;
+        }
+    }
+}

--- a/Models/DCaPST/Models/IntervalValues.cs
+++ b/Models/DCaPST/Models/IntervalValues.cs
@@ -18,6 +18,16 @@ namespace Models.DCAPST
         public double AirTemperature { get; set; }
 
         /// <summary>
+        /// Leaf area index of the sunlit canopy during the interval.
+        /// </summary>
+        public double SunlitLAI { get; set; }
+
+        /// <summary>
+        /// Leaf area index of the shaded canopy during the interval.
+        /// </summary>
+        public double ShadedLAI { get; set; }
+
+        /// <summary>
         /// Area values for the sunlit canopy
         /// </summary>
         public AreaValues Sunlit { get; set; }

--- a/Tests/UnitTests/DCaPST/DCaPSTHourlyReportingTests.cs
+++ b/Tests/UnitTests/DCaPST/DCaPSTHourlyReportingTests.cs
@@ -1,0 +1,150 @@
+using Models;
+using Models.DCAPST;
+using Models.DCAPST.Canopy;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+
+namespace UnitTests.DCaPST
+{
+    [TestFixture]
+    public class DCaPSTHourlyReportingTests
+    {
+        [Test]
+        public void PublishIntervalOutputsRaisesAnEventForEachInterval()
+        {
+            var model = new DCaPSTModelNG();
+            var clock = new Clock();
+            var today = new DateTime(2026, 7, 17);
+            Utilities.SetProperty(clock, nameof(Clock.Today), today);
+            Utilities.InjectLink(model, "clock", clock);
+
+            model.DcapstModel.Intervals = new[]
+            {
+                CreateInterval(6, 20, 1),
+                CreateInterval(7, 21, 101)
+            };
+
+            var outputs = new List<IntervalOutput>();
+            model.IntervalStep += (_, _) => outputs.Add(new IntervalOutput
+            {
+                DateTime = model.IntervalDateTime,
+                Hour = model.Hour,
+                AirTemperature = model.AirTemperature,
+                SunlitLAI = model.SunlitLAI,
+                ShadedLAI = model.ShadedLAI,
+                CanopyTemperature = model.CanopyTemperature,
+                CanopyVPD = model.CanopyVPD,
+                SunlitAssimilation = model.SunlitAssimilation,
+                SunlitWater = model.SunlitWater,
+                SunlitTemperature = model.SunlitTemperature,
+                SunlitVPD = model.SunlitVPD,
+                SunlitAc1 = model.SunlitAc1,
+                SunlitAc2 = model.SunlitAc2,
+                SunlitAj = model.SunlitAj,
+                ShadedAssimilation = model.ShadedAssimilation,
+                ShadedWater = model.ShadedWater,
+                ShadedTemperature = model.ShadedTemperature,
+                ShadedVPD = model.ShadedVPD,
+                ShadedAc1 = model.ShadedAc1,
+                ShadedAc2 = model.ShadedAc2,
+                ShadedAj = model.ShadedAj
+            });
+
+            Utilities.CallMethod(model, "PublishIntervalOutputs", Array.Empty<object>());
+
+            Assert.That(outputs, Has.Count.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(outputs[0].DateTime, Is.EqualTo(today.AddHours(6)));
+                Assert.That(outputs[0].Hour, Is.EqualTo(6));
+                Assert.That(outputs[0].AirTemperature, Is.EqualTo(20));
+                Assert.That(outputs[0].SunlitLAI, Is.EqualTo(1));
+                Assert.That(outputs[0].ShadedLAI, Is.EqualTo(3));
+                Assert.That(outputs[0].CanopyTemperature, Is.EqualTo(10.5));
+                Assert.That(outputs[0].CanopyVPD, Is.EqualTo(14.5));
+                Assert.That(outputs[0].SunlitAssimilation, Is.EqualTo(1));
+                Assert.That(outputs[0].SunlitWater, Is.EqualTo(2));
+                Assert.That(outputs[0].SunlitTemperature, Is.EqualTo(3));
+                Assert.That(outputs[0].SunlitVPD, Is.EqualTo(7));
+                Assert.That(outputs[0].SunlitAc1, Is.EqualTo(4));
+                Assert.That(outputs[0].SunlitAc2, Is.EqualTo(5));
+                Assert.That(outputs[0].SunlitAj, Is.EqualTo(6));
+                Assert.That(outputs[0].ShadedAssimilation, Is.EqualTo(11));
+                Assert.That(outputs[0].ShadedWater, Is.EqualTo(12));
+                Assert.That(outputs[0].ShadedTemperature, Is.EqualTo(13));
+                Assert.That(outputs[0].ShadedVPD, Is.EqualTo(17));
+                Assert.That(outputs[0].ShadedAc1, Is.EqualTo(14));
+                Assert.That(outputs[0].ShadedAc2, Is.EqualTo(15));
+                Assert.That(outputs[0].ShadedAj, Is.EqualTo(16));
+                Assert.That(outputs[1].DateTime, Is.EqualTo(today.AddHours(7)));
+                Assert.That(outputs[1].Hour, Is.EqualTo(7));
+                Assert.That(outputs[1].SunlitAssimilation, Is.EqualTo(101));
+            });
+        }
+
+        [Test]
+        public void PublishIntervalOutputsDoesNothingWhenNoIntervalsWereCalculated()
+        {
+            var model = new DCaPSTModelNG();
+            int eventCount = 0;
+            model.IntervalStep += (_, _) => eventCount++;
+
+            Utilities.CallMethod(model, "PublishIntervalOutputs", Array.Empty<object>());
+
+            Assert.That(eventCount, Is.Zero);
+        }
+
+        private static IntervalValues CreateInterval(double hour, double airTemperature, double value)
+        {
+            return new IntervalValues
+            {
+                Time = hour,
+                AirTemperature = airTemperature,
+                SunlitLAI = 1,
+                ShadedLAI = 3,
+                Sunlit = CreateArea(value),
+                Shaded = CreateArea(value + 10)
+            };
+        }
+
+        private static AreaValues CreateArea(double value)
+        {
+            return new AreaValues
+            {
+                A = value,
+                Water = value + 1,
+                Temperature = value + 2,
+                VPD = value + 6,
+                Ac1 = new PathValues { Assimilation = value + 3 },
+                Ac2 = new PathValues { Assimilation = value + 4 },
+                Aj = new PathValues { Assimilation = value + 5 }
+            };
+        }
+
+        private class IntervalOutput
+        {
+            public DateTime DateTime { get; set; }
+            public double Hour { get; set; }
+            public double AirTemperature { get; set; }
+            public double SunlitLAI { get; set; }
+            public double ShadedLAI { get; set; }
+            public double CanopyTemperature { get; set; }
+            public double CanopyVPD { get; set; }
+            public double SunlitAssimilation { get; set; }
+            public double SunlitWater { get; set; }
+            public double SunlitTemperature { get; set; }
+            public double SunlitVPD { get; set; }
+            public double SunlitAc1 { get; set; }
+            public double SunlitAc2 { get; set; }
+            public double SunlitAj { get; set; }
+            public double ShadedAssimilation { get; set; }
+            public double ShadedWater { get; set; }
+            public double ShadedTemperature { get; set; }
+            public double ShadedVPD { get; set; }
+            public double ShadedAc1 { get; set; }
+            public double ShadedAc2 { get; set; }
+            public double ShadedAj { get; set; }
+        }
+    }
+}

--- a/Tests/UnitTests/DCaPST/DCaPSTHourlyReportingTests.cs
+++ b/Tests/UnitTests/DCaPST/DCaPSTHourlyReportingTests.cs
@@ -1,9 +1,11 @@
+using APSIM.Core;
 using Models;
 using Models.DCAPST;
 using Models.DCAPST.Canopy;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace UnitTests.DCaPST
 {
@@ -13,7 +15,8 @@ namespace UnitTests.DCaPST
         [Test]
         public void PublishIntervalOutputsRaisesAnEventForEachInterval()
         {
-            var model = new DCaPSTModelNG();
+            var model = new DCaPSTModelNG { Name = "DCaPST" };
+            Node modelNode = Node.Create(model);
             var clock = new Clock();
             var today = new DateTime(2026, 7, 17);
             Utilities.SetProperty(clock, nameof(Clock.Today), today);
@@ -25,38 +28,24 @@ namespace UnitTests.DCaPST
                 CreateInterval(7, 21, 101)
             };
 
-            var outputs = new List<IntervalOutput>();
-            model.IntervalStep += (_, _) => outputs.Add(new IntervalOutput
+            var outputs = new List<DCaPSTIntervalOutput>();
+            var locatedHours = new List<object>();
+            model.IntervalStep += (_, output) =>
             {
-                DateTime = model.IntervalDateTime,
-                Hour = model.Hour,
-                AirTemperature = model.AirTemperature,
-                SunlitLAI = model.SunlitLAI,
-                ShadedLAI = model.ShadedLAI,
-                CanopyTemperature = model.CanopyTemperature,
-                CanopyVPD = model.CanopyVPD,
-                SunlitAssimilation = model.SunlitAssimilation,
-                SunlitWater = model.SunlitWater,
-                SunlitTemperature = model.SunlitTemperature,
-                SunlitVPD = model.SunlitVPD,
-                SunlitAc1 = model.SunlitAc1,
-                SunlitAc2 = model.SunlitAc2,
-                SunlitAj = model.SunlitAj,
-                ShadedAssimilation = model.ShadedAssimilation,
-                ShadedWater = model.ShadedWater,
-                ShadedTemperature = model.ShadedTemperature,
-                ShadedVPD = model.ShadedVPD,
-                ShadedAc1 = model.ShadedAc1,
-                ShadedAc2 = model.ShadedAc2,
-                ShadedAj = model.ShadedAj
-            });
+                Assert.That(model.CurrentInterval, Is.SameAs(output));
+                outputs.Add(output);
+                locatedHours.Add(modelNode.Get("[DCaPST].CurrentInterval.Hour", relativeTo: model));
+            };
 
             Utilities.CallMethod(model, "PublishIntervalOutputs", Array.Empty<object>());
 
             Assert.That(outputs, Has.Count.EqualTo(2));
+            Assert.That(locatedHours, Is.EqualTo(new object[] { 6.0, 7.0 }));
+            Assert.That(model.CurrentInterval, Is.Null);
+            Assert.That(modelNode.Get("[DCaPST].CurrentInterval.Hour", relativeTo: model), Is.Null);
             Assert.Multiple(() =>
             {
-                Assert.That(outputs[0].DateTime, Is.EqualTo(today.AddHours(6)));
+                Assert.That(outputs[0].IntervalDateTime, Is.EqualTo(today.AddHours(6)));
                 Assert.That(outputs[0].Hour, Is.EqualTo(6));
                 Assert.That(outputs[0].AirTemperature, Is.EqualTo(20));
                 Assert.That(outputs[0].SunlitLAI, Is.EqualTo(1));
@@ -77,7 +66,7 @@ namespace UnitTests.DCaPST
                 Assert.That(outputs[0].ShadedAc1, Is.EqualTo(14));
                 Assert.That(outputs[0].ShadedAc2, Is.EqualTo(15));
                 Assert.That(outputs[0].ShadedAj, Is.EqualTo(16));
-                Assert.That(outputs[1].DateTime, Is.EqualTo(today.AddHours(7)));
+                Assert.That(outputs[1].IntervalDateTime, Is.EqualTo(today.AddHours(7)));
                 Assert.That(outputs[1].Hour, Is.EqualTo(7));
                 Assert.That(outputs[1].SunlitAssimilation, Is.EqualTo(101));
             });
@@ -93,6 +82,26 @@ namespace UnitTests.DCaPST
             Utilities.CallMethod(model, "PublishIntervalOutputs", Array.Empty<object>());
 
             Assert.That(eventCount, Is.Zero);
+        }
+
+        [Test]
+        public void PublishIntervalOutputsClearsCurrentIntervalWhenSubscriberThrows()
+        {
+            var model = new DCaPSTModelNG();
+            var clock = new Clock();
+            Utilities.SetProperty(clock, nameof(Clock.Today), new DateTime(2026, 7, 17));
+            Utilities.InjectLink(model, "clock", clock);
+            model.DcapstModel.Intervals = new[] { CreateInterval(6, 20, 1) };
+            model.IntervalStep += (_, _) => throw new InvalidOperationException("Subscriber failed");
+
+            var error = Assert.Throws<TargetInvocationException>(() =>
+                Utilities.CallMethod(model, "PublishIntervalOutputs", Array.Empty<object>()));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(error.InnerException, Is.TypeOf<InvalidOperationException>());
+                Assert.That(model.CurrentInterval, Is.Null);
+            });
         }
 
         private static IntervalValues CreateInterval(double hour, double airTemperature, double value)
@@ -122,29 +131,5 @@ namespace UnitTests.DCaPST
             };
         }
 
-        private class IntervalOutput
-        {
-            public DateTime DateTime { get; set; }
-            public double Hour { get; set; }
-            public double AirTemperature { get; set; }
-            public double SunlitLAI { get; set; }
-            public double ShadedLAI { get; set; }
-            public double CanopyTemperature { get; set; }
-            public double CanopyVPD { get; set; }
-            public double SunlitAssimilation { get; set; }
-            public double SunlitWater { get; set; }
-            public double SunlitTemperature { get; set; }
-            public double SunlitVPD { get; set; }
-            public double SunlitAc1 { get; set; }
-            public double SunlitAc2 { get; set; }
-            public double SunlitAj { get; set; }
-            public double ShadedAssimilation { get; set; }
-            public double ShadedWater { get; set; }
-            public double ShadedTemperature { get; set; }
-            public double ShadedVPD { get; set; }
-            public double ShadedAc1 { get; set; }
-            public double ShadedAc2 { get; set; }
-            public double ShadedAj { get; set; }
-        }
     }
 }


### PR DESCRIPTION
## Resolves https://github.com/APSIMInitiative/ApsimX/issues/9833
- Add a DCaPST `IntervalStep` event for native hourly reporting.
- Expose hourly sunlit and shaded assimilation, water use, temperature, VPD, and LAI values through the Report model.
- Add LAI-weighted canopy temperature and VPD outputs.
- Retain the calculated sunlit and shaded LAI for each DCaPST interval.

## Rationale

DCaPST calculates hourly values internally from 06:00 through 18:00, but these values could not previously be exported by an APSIM Report. The new event is emitted after the actual water-limited biomass calculation so reported intervals reflect the values used for daily biomass production.

Reports can subscribe to `[DCaPST].IntervalStep` and select the required hourly properties.

This PR could have an `Improvement` label if someone could add that for me please.