### PR TITLE
11425 Allow multiple datastores

### DIFF
--- a/APSIM.Core/Nodes/Node.cs
+++ b/APSIM.Core/Nodes/Node.cs
@@ -477,6 +477,12 @@ public class Node : IStructure
             RemoveChild(child.Model);
     }
 
+    /// <summary>Find and return the root node</summary>
+    public Node Root()
+    {
+        return WalkParents().FirstOrDefault(n => n.Parent == null)
+               ?? this;
+    }
 
     /// <summary>
     /// Constructor
@@ -492,13 +498,6 @@ public class Node : IStructure
 
         Name = model.Name;
         Model = model;
-    }
-
-    /// <summary>Find and return the root node</summary>
-    internal Node Root()
-    {
-        return WalkParents().FirstOrDefault(n => n.Parent == null)
-               ?? this;
     }
 
     /// <summary>

--- a/ApsimNG/Presenters/CheckpointsPresenter.cs
+++ b/ApsimNG/Presenters/CheckpointsPresenter.cs
@@ -150,7 +150,7 @@ namespace UserInterface.Presenters
                     try
                     {
                         storage.Writer.DeleteCheckpoint(checkpointName);
-                        storage.Reader.Refresh();
+                        storage.Refresh();
                         PopulateList();
                         explorerPresenter.MainPresenter.ShowMessage("Checkpoint deleted", Simulation.MessageType.Information);
                     }
@@ -171,7 +171,7 @@ namespace UserInterface.Presenters
             var checkpoint = rootNode.Children.Find(node => node.Name == checkpointName);
 
             storage.Writer.SetCheckpointShowGraphs(checkpoint.Name, !checkpoint.ResourceNameForImage.Contains("Check"));
-            storage.Reader.Refresh();
+            storage.Refresh();
             PopulateList();
         }
     }

--- a/Models/CLEM/Reporting/ReportPivot.cs
+++ b/Models/CLEM/Reporting/ReportPivot.cs
@@ -177,7 +177,7 @@ namespace Models.CLEM.Reporting
 
             if (report is null)
             {
-                storage.Reader.Refresh();
+                storage.Refresh();
             }
 
             report = storage.Reader.GetData(Parent.Name);

--- a/Models/Core/Run/SimulationGroup.cs
+++ b/Models/Core/Run/SimulationGroup.cs
@@ -210,7 +210,7 @@ namespace Models.Core.Run
         public void StorageFinishWriting()
         {
             storage?.Writer.Stop();
-            storage?.Reader.Refresh();
+            storage?.Refresh();
         }
 
         /// <summary>Initialise the instance.</summary>
@@ -351,7 +351,7 @@ namespace Models.Core.Run
             foreach (IPreSimulationTool tool in FindPreSimulationTools())
             {
                 storage?.Writer.WaitForIdle();
-                storage?.Reader.Refresh();
+                storage?.Refresh();
                 try
                 {
                     if (tool.Enabled)
@@ -382,7 +382,7 @@ namespace Models.Core.Run
             foreach (IPostSimulationTool tool in FindPostSimulationTools())
             {
                 storage?.Writer.WaitForIdle();
-                storage?.Reader.Refresh();
+                storage?.Refresh();
 
                 DateTime startTime = DateTime.Now;
                 Exception exception = null;
@@ -415,7 +415,7 @@ namespace Models.Core.Run
         private void RunTests()
         {
             storage?.Writer.WaitForIdle();
-            storage?.Reader.Refresh();
+            storage?.Refresh();
 
             List<object> services;
             if (relativeTo is Simulations)

--- a/Models/Core/Run/SimulationGroup.cs
+++ b/Models/Core/Run/SimulationGroup.cs
@@ -179,8 +179,9 @@ namespace Models.Core.Run
             if (!initialised)
                 SpinWait.SpinUntil(() => initialised);
 
-            if (storage?.Writer != null)
-                storage.Writer.TablesModified.Clear();
+            foreach (IDataStore datastore in rootModel.Node.FindAll<IDataStore>())
+                if (datastore.Writer != null)
+                    datastore.Writer.TablesModified.Clear();
 
             if (runPreAndPostSimulationTools)
             {
@@ -267,7 +268,7 @@ namespace Models.Core.Run
                     e.Publish("BeginRun", new object[] { this, new EventArgs() });
 
                     // Find a storage model.
-                    storage = rootModel.Node.FindChild<IDataStore>();
+                    storage = rootModel.Node.FindChild<IDataStore>(recurse: true);
 
                     // Find simulations to run.
                     if (runSimulations)
@@ -350,7 +351,6 @@ namespace Models.Core.Run
             // Call all pre simulation tools.
             foreach (IPreSimulationTool tool in FindPreSimulationTools())
             {
-                storage?.Writer.WaitForIdle();
                 storage?.Refresh();
                 try
                 {
@@ -381,7 +381,6 @@ namespace Models.Core.Run
             object[] args = new object[] { this, new EventArgs() };
             foreach (IPostSimulationTool tool in FindPostSimulationTools())
             {
-                storage?.Writer.WaitForIdle();
                 storage?.Refresh();
 
                 DateTime startTime = DateTime.Now;
@@ -414,7 +413,6 @@ namespace Models.Core.Run
         /// <summary>Run all tests.</summary>
         private void RunTests()
         {
-            storage?.Writer.WaitForIdle();
             storage?.Refresh();
 
             List<object> services;

--- a/Models/Core/Simulations.cs
+++ b/Models/Core/Simulations.cs
@@ -182,7 +182,7 @@ namespace Models.Core
                 else if (child is DataStore)
                 {
                     DataStore storage = child as DataStore;
-                    storage.UseInMemoryDB = storage.UseInMemoryDB; //this refreshes the filename status
+                    storage.UpdateFileName();
                 }
             }
         }

--- a/Models/Core/Simulations.cs
+++ b/Models/Core/Simulations.cs
@@ -110,7 +110,7 @@ namespace Models.Core
             if (storage != null)
             {
                 storage.Writer.AddCheckpoint(checkpointName, filesReferenced);
-                storage.Reader.Refresh();
+                storage.Refresh();
             }
         }
 
@@ -182,9 +182,7 @@ namespace Models.Core
                 else if (child is DataStore)
                 {
                     DataStore storage = child as DataStore;
-                    storage.Close();
-                    storage.UpdateFileName();
-                    storage.Open();
+                    storage.UseInMemoryDB = storage.UseInMemoryDB; //this refreshes the filename status
                 }
             }
         }

--- a/Models/Optimisation/CroptimizR.cs
+++ b/Models/Optimisation/CroptimizR.cs
@@ -533,9 +533,8 @@ namespace Models.Optimisation
             CommandProcessor.Run(optimalValues, relativeTo: clonedSims, runner: null);
 
             DataStore clonedStorage = Structure.FindChild<DataStore>(relativeTo: clonedSims);
-            clonedStorage.Close();
+            clonedStorage.FileName = storage.FileName;
             clonedStorage.CustomFileName = storage.FileName;
-            clonedStorage.Open();
 
             // Run the child models of the cloned CroptimizR.
             Runner runner = new Runner(clonedSims);

--- a/Models/PostSimulationTools/SerialPostSimulationTool.cs
+++ b/Models/PostSimulationTools/SerialPostSimulationTool.cs
@@ -32,7 +32,7 @@ namespace Models.PostSimulationTools
             {
                 links.Resolve(tool);
                 tool.Run();
-                storage.Reader.Refresh();
+                storage.Refresh();
             }
         }
     }

--- a/Models/PreSimulationTools/Observations.cs
+++ b/Models/PreSimulationTools/Observations.cs
@@ -169,7 +169,7 @@ namespace Models.PreSimulationTools
                 storage = Node.FindParent<DataStore>(recurse: true);
 
             //Clear the tables at the start, since we need to read into them again
-            storage.Reader.Refresh();
+            storage.Refresh();
 
             // Check for conflicts between sheet names and Report model names.
             // A Report model's table name equals its model name, so importing an observed
@@ -268,7 +268,7 @@ namespace Models.PreSimulationTools
             }
 
             storage.Writer.Stop();
-            storage.Reader.Refresh();
+            storage.Refresh();
 
             ColumnData = new List<ColumnInfo>();
             DerivedData = new List<DerivedInfo>();

--- a/Models/Storage/DataStore.cs
+++ b/Models/Storage/DataStore.cs
@@ -334,7 +334,7 @@ namespace Models.Storage
                         datastore.Writer.WaitForIdle();
                 foreach (IDataStore datastore in rootModel.Node.FindAll<IDataStore>())
                     if (datastore.Reader != null)
-                        datastore.Refresh();
+                        datastore.Reader.Refresh();
             }
         }
     }

--- a/Models/Storage/DataStore.cs
+++ b/Models/Storage/DataStore.cs
@@ -15,26 +15,22 @@ namespace Models.Storage
     [ViewName("ApsimNG.Resources.Glade.DataStoreView.glade")]
     [PresenterName("UserInterface.Presenters.DataStorePresenter")]
     [ValidParent(ParentType = typeof(Simulations))]
-    public class DataStore : Model, IDataStore, IDisposable, IStructureDependency
+    public class DataStore : Model, IDataStore, IDisposable
     {
-        /// <summary>Structure instance supplied by APSIM.core.</summary>
-        [field: NonSerialized]
-        public IStructure Structure { private get; set; }
-
         /// <summary>A database connection</summary>
         [NonSerialized]
-        private IDatabaseConnection connection = null;
+        private IDatabaseConnection _connection = null;
 
         [NonSerialized]
-        private DataStoreReader dbReader = new DataStoreReader();
+        private DataStoreReader _dbReader = new DataStoreReader();
 
         [NonSerialized]
-        private DataStoreWriter dbWriter = new DataStoreWriter();
+        private DataStoreWriter _dbWriter = new DataStoreWriter();
 
-        private bool useInMemoryDB;
+        private bool _useInMemoryDB;
 
         [JsonIgnore]
-        private string fileName;
+        private string _fileName;
 
         /// <summary>
         /// Controls whether the database connection is an in-memory DB.
@@ -44,14 +40,12 @@ namespace Models.Storage
         {
             get
             {
-                return useInMemoryDB;
+                return _useInMemoryDB;
             }
             set
             {
-                useInMemoryDB = value;
-                Close();
+                _useInMemoryDB = value;
                 UpdateFileName();
-                Open();
             }
         }
 
@@ -65,11 +59,11 @@ namespace Models.Storage
         {
             get
             {
-                return string.IsNullOrWhiteSpace(CustomFileName) ? fileName : CustomFileName;
+                return string.IsNullOrWhiteSpace(CustomFileName) ? _fileName : CustomFileName;
             }
             set
             {
-                fileName = value;
+                UpdateFileName(value);
             }
         }
 
@@ -79,10 +73,10 @@ namespace Models.Storage
         public string CustomFileName { get; set; } = null;
 
         /// <summary>Get a reader to perform read operations on the datastore.</summary>
-        public IStorageReader Reader { get { return dbReader; } }
+        public IStorageReader Reader { get { return _dbReader; } }
 
         /// <summary>Get a writer to perform write operations on the datastore.</summary>
-        public IStorageWriter Writer { get { return dbWriter; } }
+        public IStorageWriter Writer { get { return _dbWriter; } }
 
         /// <summary>Constructor</summary>
         public DataStore()
@@ -92,20 +86,20 @@ namespace Models.Storage
         /// <summary>Constructor</summary>
         public DataStore(string fileNameToUse)
         {
-            FileName = fileNameToUse;
+            _fileName = fileNameToUse;
             SQLite database = new SQLite();
-            database.OpenDatabase(fileName, true);
-            connection = database;
-            dbReader.SetConnection(connection);
-            dbWriter.SetConnection(connection);
+            database.OpenDatabase(_fileName, true);
+            _connection = database;
+            _dbReader.SetConnection(_connection);
+            _dbWriter.SetConnection(_connection);
         }
 
         /// <summary>Constructor</summary>
         public DataStore(IDatabaseConnection db)
         {
-            connection = db;
-            dbReader.SetConnection(connection);
-            dbWriter.SetConnection(connection);
+            _connection = db;
+            _dbReader.SetConnection(_connection);
+            _dbWriter.SetConnection(_connection);
         }
 
         /// <summary>
@@ -179,51 +173,82 @@ namespace Models.Storage
         public override void OnCreated()
         {
             base.OnCreated();
-            if (connection == null)
+
+            if (_connection == null)
+            {
+                UpdateFileName();
                 Open();
+            }
         }
 
         /// <summary>
         /// Updates the file name of the database file, based on the file name
         /// of the parent Simulations object.
         /// </summary>
-        public void UpdateFileName()
+        public void UpdateFileName(string fileName = null)
         {
-            string extension = ".db";
+            bool connectionOpen = false;
+            if (_connection != null)
+                connectionOpen = true;
+            
+            if (connectionOpen)
+                Close();
 
-            Simulations simulations = Structure?.FindParent<Simulations>(recurse: true);
+            if (_useInMemoryDB)
+            {
+                _fileName = ":memory:";
+                if (connectionOpen)
+                    Open();
+                return;
+            }
+
+            if (Node == null)
+            {
+                _fileName = "";
+                if (connectionOpen)
+                    Open();
+                return;
+            }
+            
+            if (fileName != null)
+            {
+                _fileName = fileName;
+                if (connectionOpen)
+                    Open();
+                return;
+            }
+
+            Simulations simulations = Node.FindParent<Simulations>(recurse: true);
 
             // If we have been cloned prior to a run, then we won't be able to locate
             // the simulations object. In this situation we can fallback to using the
             // parent simulation's filename (which should be the same anyway).
-            Simulation simulation = Structure?.FindParent<Simulation>(recurse: true);
+            Simulation simulation = Node.FindParent<Simulation>(recurse: true);
 
-            if (useInMemoryDB)
-                FileName = ":memory:";
-            else if (simulations != null && simulations.FileName != null)
-                FileName = Path.ChangeExtension(simulations.FileName, extension);
+            string extension = ".db";
+            if (simulations != null && simulations.FileName != null)
+                _fileName = Path.ChangeExtension(simulations.FileName, extension);
             else if (simulation != null && simulation.FileName != null)
-                FileName = Path.ChangeExtension(simulation.FileName, extension);
+                _fileName = Path.ChangeExtension(simulation.FileName, extension);
             else
-                FileName = ":memory:";
+                _fileName = ":memory:";
+
+            if (connectionOpen)
+                Open();
         }
 
         /// <summary>Open the database.</summary>
-        public void Open()
+        private void Open()
         {
-            if (FileName == null)
-                UpdateFileName();
-
-            connection = new SQLite();
-
-            connection.OpenDatabase(FileName, readOnly: false);
+            _connection = new SQLite();
+            _connection.OpenDatabase(FileName, readOnly: false);
 
             Exception caughtException = null;
             try
             {
-                if (dbReader == null)
-                    dbReader = new DataStoreReader();
-                dbReader.SetConnection(connection);
+                if (_dbReader == null)
+                    _dbReader = new DataStoreReader();
+                _dbReader.SetConnection(_connection);
             }
             catch (Exception e)
             {
@@ -231,9 +256,9 @@ namespace Models.Storage
             }
             try
             {
-                if (dbWriter == null)
-                    dbWriter = new DataStoreWriter();
-                dbWriter.SetConnection(connection);
+                if (_dbWriter == null)
+                    _dbWriter = new DataStoreWriter();
+                _dbWriter.SetConnection(_connection);
             }
             catch (Exception e)
             {
@@ -246,23 +271,23 @@ namespace Models.Storage
         /// <summary>Close the database.</summary>
         public void Close()
         {
-            if (connection != null)
+            if (_connection != null)
             {
-                connection.CloseDatabase();
-                connection = null;
+                _connection.CloseDatabase();
+                _connection = null;
             }
         }
 
         /// <inheritdoc/>
         public void AddView(string name, string selectSQL)
         {
-            if (connection is SQLite)
+            if (_connection is SQLite)
             {
-                if (connection.ViewExists(name))
+                if (_connection.ViewExists(name))
                 {
-                    connection.ExecuteNonQuery($"DROP VIEW {name}");
+                    _connection.ExecuteNonQuery($"DROP VIEW {name}");
                 }
-                connection.ExecuteNonQuery($"CREATE VIEW {name} AS {selectSQL}");
+                _connection.ExecuteNonQuery($"CREATE VIEW {name} AS {selectSQL}");
             }
             else
             {
@@ -273,11 +298,11 @@ namespace Models.Storage
         /// <inheritdoc/>
         public string GetViewSQL(string name)
         {
-            if (connection is SQLite)
+            if (_connection is SQLite)
             {
-                if (connection.ViewExists(name))
+                if (_connection.ViewExists(name))
                 {
-                    var resultSql = dbReader.GetDataUsingSql($"SELECT sql FROM sqlite_master WHERE type='view' and name='{name}'");
+                    var resultSql = _dbReader.GetDataUsingSql($"SELECT sql FROM sqlite_master WHERE type='view' and name='{name}'");
                     if (resultSql.Rows.Count > 0)
                         return resultSql.Rows[0].ItemArray[0].ToString();
                 }
@@ -287,6 +312,30 @@ namespace Models.Storage
                 throw new NotImplementedException();
             }
             return "";
+        }
+
+        /// <summary>
+        /// Wait until writing has finished to the database, then find and 
+        /// refresh all the datastores in the file.
+        /// </summary>
+        public void Refresh()
+        {
+            if (Node == null)
+            {
+                //used by unit tests where datastore isnt in a simulation
+                Writer.WaitForIdle();
+                Reader.Refresh();
+            }
+            else
+            {
+                IModel rootModel = Node.Root().Model as IModel;
+                foreach (IDataStore datastore in rootModel.Node.FindAll<IDataStore>())
+                    if (datastore.Writer != null)
+                        datastore.Writer.WaitForIdle();
+                foreach (IDataStore datastore in rootModel.Node.FindAll<IDataStore>())
+                    if (datastore.Reader != null)
+                        datastore.Refresh();
+            }
         }
     }
 }

--- a/Models/Storage/DataStore.cs
+++ b/Models/Storage/DataStore.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using APSIM.Core;
 using APSIM.Shared.Utilities;
@@ -329,10 +330,11 @@ namespace Models.Storage
             else
             {
                 IModel rootModel = Node.Root().Model as IModel;
-                foreach (IDataStore datastore in rootModel.Node.FindAll<IDataStore>())
+                IEnumerable<IDataStore> dataStores = rootModel.Node.FindAll<IDataStore>();
+                foreach (IDataStore datastore in dataStores)
                     if (datastore.Writer != null)
                         datastore.Writer.WaitForIdle();
-                foreach (IDataStore datastore in rootModel.Node.FindAll<IDataStore>())
+                foreach (IDataStore datastore in dataStores)
                     if (datastore.Reader != null)
                         datastore.Reader.Refresh();
             }

--- a/Models/Storage/DataStoreReader.cs
+++ b/Models/Storage/DataStoreReader.cs
@@ -117,7 +117,10 @@ namespace Models.Storage
         /// <summary>Returns a list of table and view names</summary>
         public List<string> TableAndViewNames { get { return Connection.GetTableAndViewNames().FindAll(t => !t.StartsWith("_")); } }
 
-        /// <summary>Refresh this instance to reflect the database connection. Do not call this directly, refresh the DataStore model directly</summary>
+        /// <summary>
+        /// Refresh this instance to reflect the database connection.
+        /// Do not call this directly; call DataStore.Refresh() instead.
+        /// </summary>
         public void Refresh()
         {
             simulationIDs.Clear();

--- a/Models/Storage/DataStoreReader.cs
+++ b/Models/Storage/DataStoreReader.cs
@@ -117,7 +117,7 @@ namespace Models.Storage
         /// <summary>Returns a list of table and view names</summary>
         public List<string> TableAndViewNames { get { return Connection.GetTableAndViewNames().FindAll(t => !t.StartsWith("_")); } }
 
-        /// <summary>Refresh this instance to reflect the database connection.</summary>
+        /// <summary>Refresh this instance to reflect the database connection. Do not call this directly, refresh the DataStore model directly</summary>
         public void Refresh()
         {
             simulationIDs.Clear();

--- a/Models/Storage/IDataStore.cs
+++ b/Models/Storage/IDataStore.cs
@@ -15,9 +15,6 @@ namespace Models.Storage
         /// <summary>Get a writer to perform write operations on the datastore.</summary>
         IStorageWriter Writer { get; }
 
-        /// <summary>Opens the database connection.</summary>
-        void Open();
-
         /// <summary>Closes the database connection.</summary>
         void Close();
 
@@ -33,5 +30,10 @@ namespace Models.Storage
         /// </summary>
         /// <param name="name">name of the view</param>
         string GetViewSQL(string name);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        void Refresh();
     }
 }

--- a/Models/Storage/IDataStore.cs
+++ b/Models/Storage/IDataStore.cs
@@ -32,7 +32,8 @@ namespace Models.Storage
         string GetViewSQL(string name);
 
         /// <summary>
-        /// 
+        /// Wait until writing has finished to the database, then find and 
+        /// refresh all the datastores in the file.
         /// </summary>
         void Refresh();
     }

--- a/Tests/UnitTests/Core/Run/RunnerTests.cs
+++ b/Tests/UnitTests/Core/Run/RunnerTests.cs
@@ -734,7 +734,7 @@ namespace UnitTests.Core.Run
                 List<Exception> errors = runner.Run();
                 Assert.That(errors.Count, Is.EqualTo(0), errors.Count > 0 ? errors[0].ToString() : "");
 
-                storage.Reader.Refresh();
+                storage.Refresh();
                 DataTable storedData = storage.Reader.GetData(data.TableName);
                 Assert.That(storedData, Is.Not.Null);
                 Assert.That(storedData.Rows.Count, Is.EqualTo(1));
@@ -744,7 +744,7 @@ namespace UnitTests.Core.Run
                 errors = runner.Run();
                 Assert.That(errors.Count, Is.EqualTo(0), errors.Count > 0 ? errors[0].ToString() : "");
 
-                storage.Reader.Refresh();
+                storage.Refresh();
                 storedData = storage.Reader.GetData(data.TableName);
                 Assert.That(storedData.Rows.Count, Is.EqualTo(1), "Post-simulation tool data was not cleaned when running only post-simulation tools");
                 database.CloseDatabase();

--- a/Tests/UnitTests/Functions/AccumulateFunctionGeneralTests.cs
+++ b/Tests/UnitTests/Functions/AccumulateFunctionGeneralTests.cs
@@ -101,7 +101,7 @@ namespace UnitTests.Functions
                 throw new AggregateException(errors);
 
             storage.Writer.Stop();
-            storage.Reader.Refresh();
+            storage.Refresh();
             return storage.Reader.GetData("Report");
         }
 

--- a/Tests/UnitTests/GraphTests.cs
+++ b/Tests/UnitTests/GraphTests.cs
@@ -65,7 +65,6 @@ namespace UnitTests
             Node.Create(sim);
 
             var storage = sim.Children[4] as DataStore;
-            storage.Open();
             var runner = new Runner(sim);
             List<Exception> errors = runner.Run();
 

--- a/Tests/UnitTests/Pasture/PastureBiomassesTest.cs
+++ b/Tests/UnitTests/Pasture/PastureBiomassesTest.cs
@@ -120,7 +120,7 @@ namespace UnitTests
             sim.Prepare();
             sim.Run();
             storage.Writer.Stop();
-            storage.Reader.Refresh();
+            storage.Refresh();
 
             //Get data from the datastore and retrieve data from specific columns
            

--- a/Tests/UnitTests/Pasture/PastureCompositeBiomassTest.cs
+++ b/Tests/UnitTests/Pasture/PastureCompositeBiomassTest.cs
@@ -92,7 +92,7 @@ namespace UnitTests
             sim.Prepare();
             sim.Run();
             storage.Writer.Stop();
-            storage.Reader.Refresh();
+            storage.Refresh();
 
             //Get data from the datastore and retrieve data from specific columns
            

--- a/Tests/UnitTests/Plant/BBCHCanolaTests.cs
+++ b/Tests/UnitTests/Plant/BBCHCanolaTests.cs
@@ -59,7 +59,7 @@ namespace UnitTests.PMF.Phenology.Scales
             sim.Prepare();
             sim.Run();
             storage.Writer.Stop();
-            storage.Reader.Refresh();
+            storage.Refresh();
 
             // Read the Report table
             var dataTable = storage.Reader.GetData("Report");

--- a/Tests/UnitTests/Plant/PlantTests.cs
+++ b/Tests/UnitTests/Plant/PlantTests.cs
@@ -64,7 +64,7 @@ namespace UnitTests.Core
             sim.Prepare();
             sim.Run();
             storage.Writer.Stop();
-            storage.Reader.Refresh();
+            storage.Refresh();
 
             var dataTable = storage.Reader.GetData("Report");
 

--- a/Tests/UnitTests/Plant/RootTests.cs
+++ b/Tests/UnitTests/Plant/RootTests.cs
@@ -50,7 +50,7 @@ namespace UnitTests.Core
             // Get the results.
             DataStore storage = simulations.Node.FindChild<DataStore>(recurse: true);
             storage.Writer.Stop();
-            storage.Reader.Refresh();
+            storage.Refresh();
             var dataTable = storage.Reader.GetData("Report");
 
             var fasw = DataTableUtilities.GetColumnAsDoubles(dataTable, "FASW", CultureInfo.InvariantCulture);

--- a/Tests/UnitTests/Plant/ZadokPMFWheatTests.cs
+++ b/Tests/UnitTests/Plant/ZadokPMFWheatTests.cs
@@ -57,7 +57,7 @@ namespace UnitTests.PMF.Phenology.Scales
             sim.Prepare();
             sim.Run();
             storage.Writer.Stop();
-            storage.Reader.Refresh();
+            storage.Refresh();
 
             // Read the Report table
             var dataTable = storage.Reader.GetData("Report");

--- a/Tests/UnitTests/PostSimulationTools/CreateProfileTableTests.cs
+++ b/Tests/UnitTests/PostSimulationTools/CreateProfileTableTests.cs
@@ -63,7 +63,7 @@ namespace UnitTests
             Utilities.InjectLink(tool, "dataStore", dataStore);
             tool.Run();
             dataStore.Writer.Stop();
-            dataStore.Reader.Refresh();
+            dataStore.Refresh();
             var data = dataStore.Reader.GetData("CreateProfileTable");
 
             DataTable table = Utilities.CreateTable(new string[] { "CheckpointName", "CheckpointID", "SimulationName", "SimulationID", "Year", "Col1", "Col2" },

--- a/Tests/UnitTests/PostSimulationTools/ExcelInputTests.cs
+++ b/Tests/UnitTests/PostSimulationTools/ExcelInputTests.cs
@@ -47,7 +47,7 @@ namespace UnitTests
 
             excelInput.Run();
             dataStore.Writer.Stop();
-            dataStore.Reader.Refresh();
+            dataStore.Refresh();
 
             DataTable dt = dataStore.Reader.GetData("Sheet1");
 

--- a/Tests/UnitTests/PostSimulationTools/PredictedObservedMetadataTests.cs
+++ b/Tests/UnitTests/PostSimulationTools/PredictedObservedMetadataTests.cs
@@ -71,7 +71,7 @@ namespace UnitTests
             Assert.That(errors.Count, Is.EqualTo(0));
 
             DataStore dataStore = simulations.Node.Find<DataStore>();
-            dataStore.Reader.Refresh();
+            dataStore.Refresh();
 
             DataTable dt = dataStore.Reader.GetData("_PredictedObserved");
             Assert.That(dt.Rows.Count, Is.EqualTo(1));

--- a/Tests/UnitTests/PostSimulationTools/PredictedObservedTests.cs
+++ b/Tests/UnitTests/PostSimulationTools/PredictedObservedTests.cs
@@ -84,7 +84,7 @@ namespace UnitTests
             Utilities.InjectLink(PO, "dataStore", dataStore);
             PO.Run();
             dataStore.Writer.Stop();
-            dataStore.Reader.Refresh();
+            dataStore.Refresh();
             var data = dataStore.Reader.GetData("PredictedObserved");
 
             Assert.That(
@@ -144,7 +144,7 @@ namespace UnitTests
             Utilities.InjectLink(PO, "dataStore", dataStore);
             PO.Run();
             dataStore.Writer.Stop();
-            dataStore.Reader.Refresh();
+            dataStore.Refresh();
             var data = dataStore.Reader.GetData("PredictedObserved");
 
             Assert.That(

--- a/Tests/UnitTests/PostSimulationTools/SimulationComparisonTests.cs
+++ b/Tests/UnitTests/PostSimulationTools/SimulationComparisonTests.cs
@@ -65,7 +65,7 @@ namespace UnitTests
             Utilities.InjectLink(tool, "dataStore", dataStore);
             tool.Run();
             dataStore.Writer.Stop();
-            dataStore.Reader.Refresh();
+            dataStore.Refresh();
             var data = dataStore.Reader.GetData("SimulationComparison");
 
             DataTable table = Utilities.CreateTable(new string[] { "CheckpointName", "CheckpointID", "SimulationName", "Year", "Sim1.Col1", "Sim2.Col1", "Sim1.Col2", "Sim2.Col2" },

--- a/Tests/UnitTests/PreSimulationTools/ObservationsTests.cs
+++ b/Tests/UnitTests/PreSimulationTools/ObservationsTests.cs
@@ -55,7 +55,7 @@ namespace UnitTests
                 throw new AggregateException("Errors: ", errors);
 
             dataStore.Writer.Stop();
-            dataStore.Reader.Refresh();
+            dataStore.Refresh();
             DataTable dt = dataStore.Reader.GetData("Observed");
 
             Assert.That(dt.Columns[3].DataType, Is.EqualTo(typeof(DateTime)));

--- a/Tests/UnitTests/Report/ReportTests.cs
+++ b/Tests/UnitTests/Report/ReportTests.cs
@@ -457,7 +457,7 @@ namespace UnitTests.Report
             sim.Prepare();
 
             storage.Writer.WaitForIdle();
-            storage.Reader.Refresh();
+            storage.Refresh();
 
             Assert.That(storage.Reader.GetData("_Factors"), Is.Not.Null);
 
@@ -589,7 +589,7 @@ namespace UnitTests.Report
             Assert.That(errors, Is.Not.Null);
             Assert.That(errors.Count, Is.EqualTo(0));
             datastore.Writer.Stop();
-            datastore.Reader.Refresh();
+            datastore.Refresh();
 
             var data = datastore.Reader.GetData("Report");
             var columnNames = DataTableUtilities.GetColumnNames(data);
@@ -622,7 +622,7 @@ namespace UnitTests.Report
             Assert.That(errors, Is.Not.Null);
             Assert.That(errors.Count, Is.EqualTo(0));
             datastore.Writer.Stop();
-            datastore.Reader.Refresh();
+            datastore.Refresh();
 
             var data = datastore.Reader.GetData("Report");
             var columnNames = DataTableUtilities.GetColumnNames(data);
@@ -654,7 +654,7 @@ namespace UnitTests.Report
             Assert.That(errors, Is.Not.Null);
             Assert.That(errors.Count, Is.EqualTo(0));
             datastore.Writer.Stop();
-            datastore.Reader.Refresh();
+            datastore.Refresh();
 
             var data = datastore.Reader.GetData("Report");
             var columnNames = DataTableUtilities.GetColumnNames(data);


### PR DESCRIPTION
In order to allow multiple datastores, we need them to all work together when accessing the database file. This syncs the refresh between all datastore making it so that no matter which one is talked to, they all update their information.