### PR TITLE
Stock Model incorrect live consumable biomass to forage provider

### DIFF
--- a/Models/Stock/stock.cs
+++ b/Models/Stock/stock.cs
@@ -4157,7 +4157,7 @@ namespace Models.GrazPlan
                     {
                         if (forageProvider.ForageObj != null)
                         {
-                            pastureGreen = forageProvider.ForageObj.Material.Where(m => m.IsLive)
+                            pastureGreen += forageProvider.ForageObj.Material.Where(m => m.IsLive)
                                                                             .Sum(m => m.Consumable.Wt); // g/m^2
                         }
                     }


### PR DESCRIPTION
Resolves #11456 
If multiple forage providers exist in a paddock, the loop overwrites pastureGreen instead of accumulating it. Therefore changed it add the forages in RequestAvailableToAnimal()