### PR TITLE
Refactor upload-release-assets.sh to simplify process

### DIFF
--- a/.github/workflows/scripts/upload-release-assets.sh
+++ b/.github/workflows/scripts/upload-release-assets.sh
@@ -21,8 +21,5 @@ test -z ${PULL_ID:+x} && ( echo "PULL_ID not set"; exit 1 )
 echo Adding build to DB...
 curl -fsX POST -H "Authorization: bearer $BUILDS_JWT" "https://builds.apsim.info/api/nextgen/add?pullRequestNumber=$PULL_ID"
 
-echo Updating registration website cache
-curl -fs "https://registration.apsim.info/api/updateproducts"
-
-echo Updating netlify build...
-curl -fsX POST -d {} https://api.netlify.com/build_hooks/$NETLIFY_BUILD_HOOK
+echo new build uploaded
+echo finished

--- a/.github/workflows/scripts/upload-release-assets.sh
+++ b/.github/workflows/scripts/upload-release-assets.sh
@@ -12,7 +12,6 @@
 set -euo pipefail
 
 test -z ${DOCKER_METADATA_OUTPUT_VERSION:+x} && ( echo "DOCKER_METADATA_OUTPUT_VERSION not set"; exit 1 )
-test -z ${NETLIFY_BUILD_HOOK:+x} && ( echo "NETLIFY_BUILD_HOOK not set"; exit 1 )
 test -z ${BUILDS_JWT:+x} && ( echo "BUILDS_JWT not set"; exit 1 )
 
 PULL_ID=${DOCKER_METADATA_OUTPUT_VERSION:3}


### PR DESCRIPTION
Removed cache update and Netlify build steps from script, as these are no longer needed due to the Netlify site being retired, and the registration API being rewritten.