### PR TITLE
Correct a unit conversion error and make the internal volatilisation pH settable

### DIFF
--- a/Models/Soils/Nutrients/NH3Volatilisation.cs
+++ b/Models/Soils/Nutrients/NH3Volatilisation.cs
@@ -116,7 +116,7 @@ namespace Models.Soils.Nutrients
         ///////////////////////////////////////////////////////////////////////////
 
         /// <summary>Dynamic pH within the volatilisation model</summary>
-        public double[] pH { get; private set; }
+        public double[] pH { get; set; }
 
         /// <summary>Emissability, fraction subject to loss, of NH3 gas by soil layer (0-1)</summary>
         public double[] EmissabilityNH3 { get; private set; }
@@ -344,8 +344,8 @@ namespace Models.Soils.Nutrients
                 if (GasExchangeNH[z] > 0)
                 {
                     EmissionNH3[z] = NH3Gas[z] * GasExchangeNH[z] * EmissabilityNH3[z];      // mg/m2
-                    EmissionNH3[z] = EmissionNH3[z] * 10E+4;                      // mg/ha
-                    EmissionNH3[z] = EmissionNH3[z] * 10E-6;                      // kg/ha
+                    EmissionNH3[z] = EmissionNH3[z] * 1E+4;                      // mg/ha
+                    EmissionNH3[z] = EmissionNH3[z] * 1E-6;                      // kg/ha
                 }
                 else
                     EmissionNH3[z] = 0;


### PR DESCRIPTION
working on #9763

... but please merge for testing.

This fixes an error identified by @hrpasl and makes the internal pH settable within a simulation. 

@hrpasl  - I will message as well but note that this is only the internal pH - Chemical.pH is still used for the deltas.

@KirstenVer 
