### PR TITLE
Volatilisation

### DIFF
--- a/Models/Soils/Nutrients/NH3Volatilisation.cs
+++ b/Models/Soils/Nutrients/NH3Volatilisation.cs
@@ -1,9 +1,10 @@
-using Models.Core;
-using System;
-using Models.Interfaces;
-using APSIM.Shared.Utilities;
-using System.Collections.Generic;
 using APSIM.Numerics;
+using APSIM.Shared.Utilities;
+using Models.Climate;
+using Models.Core;
+using Models.Interfaces;
+using System;
+using System.Collections.Generic;
 
 namespace Models.Soils.Nutrients
 {
@@ -336,6 +337,7 @@ namespace Models.Soils.Nutrients
                 NH3Gas[z] = NH3ppm[z] * NH3GtoNH3A;                   // ppm (ug/cm3_air in soil = mg/L)
 
                 // 11-Calc the amount of NH3 in gaseous form and the amount effectivelly lost by volatilization
+                if (weather.Wind < 0.001) summary.WriteMessage(this, "Note that windspeed is very low and this will affect the calculation of volatilisation. If wind is missing from your weather file then you will need to use a ClimateController", MessageType.Information);
                 PotGasExchangeNH = weather.Wind * k_AFPV;   // air filled pore volumes/day
                 AirFilledPoreVolume[z] = (physical.SAT[z] - waterBalance.SW[z]) * physical.Thickness[z];    // L_air/m2
 

--- a/Models/Soils/Nutrients/NH3Volatilisation.cs
+++ b/Models/Soils/Nutrients/NH3Volatilisation.cs
@@ -95,7 +95,7 @@ namespace Models.Soils.Nutrients
 
         /// <summary>The factor for gas exchange</summary>
         [Separator("Gas exchange parameters")]
-        [Description("Factor for soil/atmosphere gas exchange (AFPV/mm):")]
+        [Description("Factor for soil/atmosphere gas exchange (AFPV*sec/m)")]
         public double k_AFPV { get; set; } = 75.0;
 
         /// <summary>The additional limits for volatilisation</summary>
@@ -336,7 +336,7 @@ namespace Models.Soils.Nutrients
                 NH3Gas[z] = NH3ppm[z] * NH3GtoNH3A;                   // ppm (ug/cm3_air in soil = mg/L)
 
                 // 11-Calc the amount of NH3 in gaseous form and the amount effectivelly lost by volatilization
-                PotGasExchangeNH = waterBalance.Eo * k_AFPV;   // air filled pore volumes/day
+                PotGasExchangeNH = weather.Wind * k_AFPV;   // air filled pore volumes/day
                 AirFilledPoreVolume[z] = (physical.SAT[z] - waterBalance.SW[z]) * physical.Thickness[z];    // L_air/m2
 
                 GasExchangeNH[z] = PotGasExchangeNH * AirFilledPoreVolume[z];      // L_air/m2/day


### PR DESCRIPTION
working on #9763 

Still working but please merge this so it is available to testers!

The parameter k_AFPV was pointing to Eo rather than wind speed for reasons 'lost to history' (something from Classic days). This has now been corrected. Testing has ensured that it is robust against wind data not being in the weather file.