### PR TITLE
9617 Add file cache to commands to improve loading for virtual

### DIFF
--- a/APSIM.Core/CommandProcessor/CommandProcessor.cs
+++ b/APSIM.Core/CommandProcessor/CommandProcessor.cs
@@ -13,7 +13,26 @@ public class CommandProcessor
     {
         var localRelativeTo = relativeTo;
 
-        foreach (var command in commands)
-            localRelativeTo = command.Run(localRelativeTo, runner);
+        List<string> filePaths = new List<string>();
+        foreach (IModelCommand command in commands)
+        {
+            if (command is ICommandReferenceExternalFile file)
+            {
+                string filePath = file.GetFilePath();
+                if (!string.IsNullOrEmpty(filePath) && !filePaths.Contains(filePath))
+                    if (File.Exists(filePath))
+                        filePaths.Add(filePath);
+            }
+        }
+        List<Node> externalFileCache = new List<Node>();
+        foreach (string filePath in filePaths)
+        {
+            Type simulationsType = ModelRegistry.ModelNameToType("Simulations");
+            Node externalRootNode = FileFormat.ReadFromFile(filePath, simulationsType);
+            externalFileCache.Add(externalRootNode);
+        }
+
+        foreach (IModelCommand command in commands)
+            localRelativeTo = command.Run(localRelativeTo, runner, externalFileCache);
     }
 }

--- a/APSIM.Core/CommandProcessor/Commands/AddCommand.cs
+++ b/APSIM.Core/CommandProcessor/Commands/AddCommand.cs
@@ -3,10 +3,10 @@ using APSIM.Shared.Utilities;
 namespace APSIM.Core;
 
 /// <summary>An add command</summary>
-internal partial class AddCommand : IModelCommand
+internal partial class AddCommand : IModelCommand, ICommandReferenceExternalFile
 {
     /// <summary>A reference to a model.</summary>
-    private readonly IModelReference modelReference;
+    private readonly IModelReference _modelReference;
 
     /// <summary>The path of a model to add a model to.</summary>
     private readonly string _toPath;
@@ -26,10 +26,10 @@ internal partial class AddCommand : IModelCommand
     /// <param name="newName">A new name for the added model</param>
     public AddCommand(IModelReference modelReference, string toPath, bool multiple, string newName = null)
     {
-        this.modelReference = modelReference;
-        this._toPath = toPath;
-        this._multiple = multiple;
-        this._newName = newName;
+        _modelReference = modelReference;
+        _toPath = toPath;
+        _multiple = multiple;
+        _newName = newName;
     }
 
     /// <summary>
@@ -37,9 +37,24 @@ internal partial class AddCommand : IModelCommand
     /// </summary>
     /// <param name="relativeTo">The model the commands are relative to.</param>
     /// <param name="runner">An instance of an APSIM runner.</param>
-    INodeModel IModelCommand.Run(INodeModel relativeTo, IRunner runner)
+    INodeModel IModelCommand.Run(INodeModel relativeTo, IRunner runner, List<Node> externalFileCache)
     {
-        INodeModel modelToAdd = modelReference.GetModel();
+        INodeModel modelToAdd = null;
+        if (_modelReference is ModelInFileReference fileReference)
+        {
+            if (externalFileCache != null)
+                foreach(Node node in externalFileCache)
+                    if (node.FileName == fileReference.GetFilePath())
+                        modelToAdd = fileReference.GetModelUsingCache(node);
+            //if file wasn't in cache, try loading now
+            if (modelToAdd == null)
+                 modelToAdd = _modelReference.GetModel();
+        }
+        else
+        {
+            modelToAdd = _modelReference.GetModel();
+        }
+
         if (!string.IsNullOrEmpty(_newName))
             modelToAdd.Rename(_newName);
 
@@ -66,5 +81,16 @@ internal partial class AddCommand : IModelCommand
             toModel.Node.AddChild(ReflectionUtilities.Clone(modelToAdd) as INodeModel);
 
         return relativeTo;
+    }
+
+    /// <summary>
+    /// Returns the potential filepath for this command.
+    /// </summary>
+    public string GetFilePath()
+    {
+        if (_modelReference is ModelInFileReference fileReference)
+            return fileReference.GetFilePath();
+        else
+            return null;
     }
 }

--- a/APSIM.Core/CommandProcessor/Commands/AddCommand.cs
+++ b/APSIM.Core/CommandProcessor/Commands/AddCommand.cs
@@ -49,6 +49,8 @@ internal partial class AddCommand : IModelCommand, ICommandReferenceExternalFile
             //if file wasn't in cache, try loading now
             if (modelToAdd == null)
                  modelToAdd = _modelReference.GetModel();
+            //clone to prevent changing cache
+            modelToAdd = ReflectionUtilities.Clone(modelToAdd) as INodeModel;
         }
         else
         {

--- a/APSIM.Core/CommandProcessor/Commands/DeleteCommand.cs
+++ b/APSIM.Core/CommandProcessor/Commands/DeleteCommand.cs
@@ -20,7 +20,7 @@ internal partial class DeleteCommand : IModelCommand
     /// </summary>
     /// <param name="relativeTo">The model the commands are relative to.</param>
     /// <param name="runner">An instance of an APSIM runner.</param>
-    INodeModel IModelCommand.Run(INodeModel relativeTo, IRunner runner)
+    INodeModel IModelCommand.Run(INodeModel relativeTo, IRunner runner, List<Node> externalFileCache)
     {
         var modelToDelete = (INodeModel)relativeTo.Node.Get(modelName, relativeTo: relativeTo)
                            ?? throw new Exception($"Cannot find model {modelName}");

--- a/APSIM.Core/CommandProcessor/Commands/DuplicateCommand.cs
+++ b/APSIM.Core/CommandProcessor/Commands/DuplicateCommand.cs
@@ -27,7 +27,7 @@ internal partial class DuplicateCommand : IModelCommand
     /// </summary>
     /// <param name="relativeTo">The model the commands are relative to.</param>
     /// <param name="runner">An instance of an APSIM runner.</param>
-    INodeModel IModelCommand.Run(INodeModel relativeTo, IRunner runner)
+    INodeModel IModelCommand.Run(INodeModel relativeTo, IRunner runner, List<Node> externalFileCache)
     {
         var modelToDuplicate = (INodeModel)relativeTo.Node.Get(modelName, relativeTo: relativeTo)
                                ?? throw new Exception($"Cannot find model {modelName}");

--- a/APSIM.Core/CommandProcessor/Commands/ICommandReferenceExternalFile.cs
+++ b/APSIM.Core/CommandProcessor/Commands/ICommandReferenceExternalFile.cs
@@ -2,7 +2,7 @@ namespace APSIM.Core;
 
 /// <summary>
 /// An interface for a model command that references an external file
-/// Such as Load, Set, Replace, Add
+/// Such as Load, Replace, Add
 /// </summary>
 public interface ICommandReferenceExternalFile
 {

--- a/APSIM.Core/CommandProcessor/Commands/ICommandReferenceExternalFile.cs
+++ b/APSIM.Core/CommandProcessor/Commands/ICommandReferenceExternalFile.cs
@@ -1,0 +1,13 @@
+namespace APSIM.Core;
+
+/// <summary>
+/// An interface for a model command that references an external file
+/// Such as Load, Set, Replace, Add
+/// </summary>
+public interface ICommandReferenceExternalFile
+{
+    /// <summary>
+    /// Returns the potential filepath for this command.
+    /// </summary>
+    public string GetFilePath();
+}

--- a/APSIM.Core/CommandProcessor/Commands/IModelCommand.cs
+++ b/APSIM.Core/CommandProcessor/Commands/IModelCommand.cs
@@ -10,5 +10,5 @@ public interface IModelCommand
     /// </summary>
     /// <param name="relativeTo">The model the commands are relative to.</param>
     /// <param name="runner">An instance of an APSIM runner.</param>
-    internal INodeModel Run(INodeModel relativeTo, IRunner runner);
+    internal INodeModel Run(INodeModel relativeTo, IRunner runner, List<Node> externalFileCache);
 }

--- a/APSIM.Core/CommandProcessor/Commands/LoadCommand.cs
+++ b/APSIM.Core/CommandProcessor/Commands/LoadCommand.cs
@@ -1,10 +1,10 @@
 namespace APSIM.Core;
 
 /// <summary>A load file command</summary>
-internal partial class LoadCommand : IModelCommand
+internal partial class LoadCommand : IModelCommand, ICommandReferenceExternalFile
 {
     /// <summary>The name of the file to load into memory.</summary>
-    private readonly string fileName;
+    private readonly string _fileName;
 
     /// <summary>
     /// Constructor.
@@ -12,7 +12,7 @@ internal partial class LoadCommand : IModelCommand
     /// <param name="fileName">The name of a file to load.</param>
     public LoadCommand(string fileName)
     {
-        this.fileName = fileName;
+        this._fileName = fileName;
     }
 
     /// <summary>
@@ -20,10 +20,24 @@ internal partial class LoadCommand : IModelCommand
     /// </summary>
     /// <param name="relativeTo">The model the commands are relative to.</param>
     /// <param name="runner">An instance of an APSIM runner.</param>
-    INodeModel IModelCommand.Run(INodeModel relativeTo, IRunner runner)
+    INodeModel IModelCommand.Run(INodeModel relativeTo, IRunner runner, List<Node> externalFileCache)
     {
-        var simulationsType = ModelRegistry.ModelNameToType("Simulations");
-        var externalRootNode = FileFormat.ReadFromFile(fileName, simulationsType);
+        if (externalFileCache != null)
+            foreach(Node node in externalFileCache)
+                if (node.FileName == _fileName)
+                    return node.Model;
+        
+        //if file wasn't in cache, try loading now
+        Type simulationsType = ModelRegistry.ModelNameToType("Simulations");
+        Node externalRootNode = FileFormat.ReadFromFile(_fileName, simulationsType);
         return externalRootNode.Model;
+    }
+
+    /// <summary>
+    /// Returns the potential filepath for this command.
+    /// </summary>
+    public string GetFilePath()
+    {
+        return _fileName;
     }
 }

--- a/APSIM.Core/CommandProcessor/Commands/MoveCommand.cs
+++ b/APSIM.Core/CommandProcessor/Commands/MoveCommand.cs
@@ -30,7 +30,7 @@ internal partial class MoveCommand : IModelCommand
     /// </summary>
     /// <param name="relativeTo">The model the commands are relative to.</param>
     /// <param name="runner">An instance of an APSIM runner.</param>
-    INodeModel IModelCommand.Run(INodeModel relativeTo, IRunner runner)
+    INodeModel IModelCommand.Run(INodeModel relativeTo, IRunner runner, List<Node> externalFileCache)
     {
         INodeModel modelToMove = (INodeModel)relativeTo.Node.Get(_fromPath, relativeTo: relativeTo);
         if (modelToMove == null)

--- a/APSIM.Core/CommandProcessor/Commands/ReplaceCommand.cs
+++ b/APSIM.Core/CommandProcessor/Commands/ReplaceCommand.cs
@@ -7,27 +7,27 @@ namespace APSIM.Core;
 /// <remarks>
 /// The JsonProperty attributes below are needed for JSON serialisation which the APSIM.Server uses.
 /// </remarks>
-public partial class ReplaceCommand : IModelCommand
+public partial class ReplaceCommand : IModelCommand, ICommandReferenceExternalFile
 {
     /// <summary>A reference to a model.</summary>
     [JsonProperty]
-    private readonly IModelReference modelReference;
+    private readonly IModelReference _modelReference;
 
     /// <summary>The path of models to replace.</summary>
     [JsonProperty]
-    private readonly string replacementPath;
+    private readonly string _replacementPath;
 
     /// <summary>Do as many replacements as possible?</summary>
     [JsonProperty]
-    private readonly bool multiple;
+    private readonly bool _multiple;
 
     /// <summary>Match on name and type? If false, will only match when names match.</summary>
     [JsonProperty]
-    private readonly MatchType matchType;
+    private readonly MatchType _matchType;
 
     /// <summary>Name given to model after replacement</summary>
     [JsonProperty]
-    private readonly string newName;
+    private readonly string _newName;
 
     /// <summary>
     /// Specifies how models are matched for replacement: by name, by both name and type, or by either name or type.
@@ -44,11 +44,11 @@ public partial class ReplaceCommand : IModelCommand
     /// <param name="newName">Name given to model after replacement.</param>
     public ReplaceCommand(IModelReference modelReference, string replacementPath, bool multiple, MatchType matchType, string newName = null)
     {
-        this.modelReference = modelReference;
-        this.replacementPath = replacementPath;
-        this.multiple = multiple;
-        this.matchType = matchType;
-        this.newName = newName;
+        _modelReference = modelReference;
+        _replacementPath = replacementPath;
+        _multiple = multiple;
+        _matchType = matchType;
+        _newName = newName;
     }
 
     /// <summary>
@@ -56,29 +56,45 @@ public partial class ReplaceCommand : IModelCommand
     /// </summary>
     /// <param name="relativeTo">The model the commands are relative to.</param>
     /// <param name="runner">An instance of an APSIM runner.</param>
-    INodeModel IModelCommand.Run(INodeModel relativeTo, IRunner runner)
+    INodeModel IModelCommand.Run(INodeModel relativeTo, IRunner runner, List<Node> externalFileCache)
     {
-        INodeModel modelToAdd = modelReference.GetModel();
+
+        INodeModel modelToAdd = null;
+        if (_modelReference is ModelInFileReference fileReference)
+        {
+            if (externalFileCache != null)
+                foreach(Node node in externalFileCache)
+                    if (node.FileName == fileReference.GetFilePath())
+                        modelToAdd = fileReference.GetModelUsingCache(node);
+
+            //if file wasn't in cache, try loading now
+            if (modelToAdd == null)
+                 modelToAdd = _modelReference.GetModel();
+        }
+        else
+        {
+            modelToAdd = _modelReference.GetModel();
+        }
 
         IEnumerable<INodeModel> modelsToReplace;
-        if (replacementPath.Contains('.'))
+        if (_replacementPath.Contains('.'))
         {
-            var modelToReplace = (INodeModel)relativeTo.Node.Get(replacementPath)
-                 ?? throw new Exception($"Cannot find model: {replacementPath}");
-            if (matchType == MatchType.NameAndType && !modelToReplace.GetType().IsAssignableFrom(modelToAdd.GetType()))
-                throw new Exception($"Model {replacementPath} is not of type {modelToAdd.GetType().Name}");
+            var modelToReplace = (INodeModel)relativeTo.Node.Get(_replacementPath)
+                 ?? throw new Exception($"Cannot find model: {_replacementPath}");
+            if (_matchType == MatchType.NameAndType && !modelToReplace.GetType().IsAssignableFrom(modelToAdd.GetType()))
+                throw new Exception($"Model {_replacementPath} is not of type {modelToAdd.GetType().Name}");
             modelsToReplace = [modelToReplace];
         }
         else
         {
-            var replacementPathWithoutBrackets = replacementPath.Replace("[", string.Empty)
+            var replacementPathWithoutBrackets = _replacementPath.Replace("[", string.Empty)
                                                                 .Replace("]", string.Empty);
             modelsToReplace = relativeTo.Node.FindAll(name: replacementPathWithoutBrackets);
-            if (matchType == MatchType.NameAndType)
+            if (_matchType == MatchType.NameAndType)
             {
                 modelsToReplace = modelsToReplace.Where(model => model.GetType().IsAssignableFrom(modelToAdd.GetType()));
             }
-            else if (matchType == MatchType.NameOrType && !modelsToReplace.Any())
+            else if (_matchType == MatchType.NameOrType && !modelsToReplace.Any())
             {
                 // didn't find any matches using name so try by type.
                 Type t = ModelRegistry.ModelNameToType(replacementPathWithoutBrackets);
@@ -87,17 +103,17 @@ public partial class ReplaceCommand : IModelCommand
             }
         }
 
-        if (!multiple)
+        if (!_multiple)
             modelsToReplace = modelsToReplace.Take(1);
 
         // Do model replacement.
         foreach (var modelToReplace in modelsToReplace.ToArray())  // Need the ToArray because modelsToReplace changes because of the ReplaceChild call.
         {
             var newModel = ReflectionUtilities.Clone(modelToAdd) as INodeModel ?? throw new Exception("Cloning the model failed or did not return an INodeModel instance.");
-            if (string.IsNullOrEmpty(newName))
+            if (string.IsNullOrEmpty(_newName))
                 newModel.Rename(modelToReplace.Name);
             else
-                newModel.Rename(newName);
+                newModel.Rename(_newName);
             CopyEnabledStateRecursively(modelToReplace, newModel);
             modelToReplace.Node.Parent.ReplaceChild(modelToReplace, newModel);
         }
@@ -137,6 +153,17 @@ public partial class ReplaceCommand : IModelCommand
     /// </summary>
     public override int GetHashCode()
     {
-        return (modelReference.GetHashCode(), replacementPath, multiple, matchType, newName).GetHashCode();
+        return (_modelReference.GetHashCode(), _replacementPath, _multiple, _matchType, _newName).GetHashCode();
+    }
+
+    /// <summary>
+    /// Returns the potential filepath for this command.
+    /// </summary>
+    public string GetFilePath()
+    {
+        if (_modelReference is ModelInFileReference fileReference)
+            return fileReference.GetFilePath();
+        else
+            return null;
     }
 }

--- a/APSIM.Core/CommandProcessor/Commands/RunCommand.cs
+++ b/APSIM.Core/CommandProcessor/Commands/RunCommand.cs
@@ -12,7 +12,7 @@ internal partial class RunCommand : IModelCommand
     /// </summary>
     /// <param name="relativeTo">The model the commands are relative to.</param>
     /// <param name="runner">An instance of an APSIM runner.</param>
-    INodeModel IModelCommand.Run(INodeModel relativeTo, IRunner runner)
+    INodeModel IModelCommand.Run(INodeModel relativeTo, IRunner runner, List<Node> externalFileCache)
     {
         runner.Run(relativeTo);
         return relativeTo;

--- a/APSIM.Core/CommandProcessor/Commands/SaveCommand.cs
+++ b/APSIM.Core/CommandProcessor/Commands/SaveCommand.cs
@@ -20,7 +20,7 @@ internal partial class SaveCommand : IModelCommand
     /// </summary>
     /// <param name="relativeTo">The model the commands are relative to.</param>
     /// <param name="runner">An instance of an APSIM runner.</param>
-    INodeModel IModelCommand.Run(INodeModel relativeTo, IRunner runner)
+    INodeModel IModelCommand.Run(INodeModel relativeTo, IRunner runner, List<Node> externalFileCache)
     {
         // Write to file.
         string json = FileFormat.WriteToString(relativeTo.Node);

--- a/APSIM.Core/CommandProcessor/Commands/SetPropertyCommand.cs
+++ b/APSIM.Core/CommandProcessor/Commands/SetPropertyCommand.cs
@@ -46,7 +46,7 @@ public partial class SetPropertyCommand : IModelCommand
     /// </summary>
     /// <param name="relativeTo">The model the commands are relative to.</param>
     /// <param name="runner">An instance of an APSIM runner.</param>
-    INodeModel IModelCommand.Run(INodeModel relativeTo, IRunner runner)
+    INodeModel IModelCommand.Run(INodeModel relativeTo, IRunner runner, List<Node> externalFileCache)
     {
         // Read the property value from an external file if necessary.
         string propertyValue = _value;

--- a/APSIM.Core/CommandProcessor/Language/AddCommandLanguage.cs
+++ b/APSIM.Core/CommandProcessor/Language/AddCommandLanguage.cs
@@ -78,14 +78,14 @@ internal partial class AddCommand: IModelCommand
     {
         List<string> parts = ["add"];
 
-        if (modelReference is ModelLocatorReference childModelReference)
+        if (_modelReference is ModelLocatorReference childModelReference)
             parts.Add(childModelReference.modelName);
-        else if (modelReference is NewModelReference newModelReference)
+        else if (_modelReference is NewModelReference newModelReference)
         {
             parts.Add("new");
             parts.Add(newModelReference.newModelType);
         }
-        else if (modelReference is ModelInFileReference modelInFileReference)
+        else if (_modelReference is ModelInFileReference modelInFileReference)
         {
             parts.Add(modelInFileReference.modelName);
             parts.Add("from");

--- a/APSIM.Core/CommandProcessor/Language/LoadCommandLanguage.cs
+++ b/APSIM.Core/CommandProcessor/Language/LoadCommandLanguage.cs
@@ -28,5 +28,5 @@ internal partial class LoadCommand: IModelCommand
     /// Convert an LoadCommand instance to a string.
     /// </summary>
     /// <returns>A command language string.</returns>
-    public override string ToString() => $"{KEYWORD_LOAD}{fileName}";
+    public override string ToString() => $"{KEYWORD_LOAD}{_fileName}";
 }

--- a/APSIM.Core/CommandProcessor/Language/ReplaceCommandLanguage.cs
+++ b/APSIM.Core/CommandProcessor/Language/ReplaceCommandLanguage.cs
@@ -69,25 +69,25 @@ public partial class ReplaceCommand: IModelCommand
     {
         List<string> parts = ["replace"];
 
-        if (multiple)
+        if (_multiple)
             parts.Add("all");
 
-        parts.Add(replacementPath);
+        parts.Add(_replacementPath);
 
         parts.Add("with");
 
-        if (modelReference is ModelLocatorReference childModelReference)
+        if (_modelReference is ModelLocatorReference childModelReference)
             parts.Add(childModelReference.modelName);
-        else if (modelReference is ModelInFileReference modelInFileReference)
+        else if (_modelReference is ModelInFileReference modelInFileReference)
         {
             parts.Add(modelInFileReference.modelName);
             parts.Add("from");
             parts.Add(modelInFileReference.fileName);
         }
-        if (!string.IsNullOrEmpty(newName))
+        if (!string.IsNullOrEmpty(_newName))
         {
             parts.Add("name");
-            parts.Add(newName);
+            parts.Add(_newName);
         }
 
         return string.Join(" ", parts);

--- a/APSIM.Core/CommandProcessor/ModelReference/ModelInFileReference.cs
+++ b/APSIM.Core/CommandProcessor/ModelReference/ModelInFileReference.cs
@@ -22,16 +22,33 @@ internal class ModelInFileReference : IModelReference
         this.modelName = modelName;
     }
 
-    /// <summary>
-    /// Get the model. Throws if model not found.
-    /// </summary>
-    /// <returns>The model</returns>
     INodeModel IModelReference.GetModel()
     {
-        var simulationsType = ModelRegistry.ModelNameToType("Simulations");
+        Type simulationsType = ModelRegistry.ModelNameToType("Simulations");
         string json = File.ReadAllText(fileName);
         (var externalRootNode, _, _) = FileFormat.ReadFromStringAndReturnConvertState(json, simulationsType);
         return (INodeModel)externalRootNode.Get(modelName)
             ?? throw new Exception($"Cannot find model {modelName} in file {fileName}");
+    }
+
+    /// <summary>
+    /// Get the model. Throws if model not found.
+    /// </summary>
+    /// <returns>The model</returns>
+    public INodeModel GetModelUsingCache(Node cachedFile)
+    {
+        INodeModel model = cachedFile.Get(modelName) as INodeModel;
+        if (model is null)
+            throw new Exception($"Cannot find model {modelName} in file {fileName}");
+        else
+            return model;
+    }
+
+    /// <summary>
+    /// Returns the potential filepath for this command.
+    /// </summary>
+    public string GetFilePath()
+    {
+        return fileName;
     }
 }

--- a/Tests/UnitTests/APSIM.Core/CommandOverridesTests.cs
+++ b/Tests/UnitTests/APSIM.Core/CommandOverridesTests.cs
@@ -149,7 +149,7 @@ namespace UnitTests.APSIM.Core.Tests
         public void SetPropertyInTypeMatchedModels()
         {
             SetPropertyCommand command = new("[Report].VariableNames", "=", "x,y,z", multiple: true);
-            (command as IModelCommand).Run(sims1, runner: null);
+            (command as IModelCommand).Run(sims1, runner: null, null);
 
             foreach (var report in sims1.Node.FindAll<Models.Report>())
                 Assert.That(report.VariableNames, Is.EqualTo(new[] { "x", "y", "z" }));
@@ -168,7 +168,7 @@ namespace UnitTests.APSIM.Core.Tests
         public void SetPropertyInNameMatchedModels()
         {
             SetPropertyCommand command = new("[Report1].VariableNames", "=", "x,y,z", multiple: true);
-            (command as IModelCommand).Run(sims1, runner: null);
+            (command as IModelCommand).Run(sims1, null, null);
 
             // It should have changed all Report1 models.
             foreach (var report1 in sims1.Node.FindAll<Models.Report>("Report1"))
@@ -195,7 +195,7 @@ namespace UnitTests.APSIM.Core.Tests
         public void SetDateProperty()
         {
             SetPropertyCommand command = new("[Clock].StartDate", "=", "2000-01-01");
-            (command as IModelCommand).Run(sims1, runner: null);
+            (command as IModelCommand).Run(sims1, null, null);
 
             var clock = sims1.Node.Find<Clock>();
             Assert.That(clock.StartDate, Is.EqualTo(new DateTime(2000, 01, 01)));
@@ -209,11 +209,12 @@ namespace UnitTests.APSIM.Core.Tests
         [Test]
         public void SetModelFromExternalFileFirstMatchingModel()
         {
+            Node externalRootNode = FileFormat.ReadFromFile(extFile, typeof(Simulations));
             IModelCommand cmd = new ReplaceCommand(modelReference: new ModelInFileReference(extFile, "[Clock1]"),
                                                    replacementPath: "[Clock]",
                                                    multiple: false,
                                                    matchType: ReplaceCommand.MatchType.Name);
-            cmd.Run(sims1, runner: null);
+            cmd.Run(sims1, null, [externalRootNode]);
 
             var clock = sims1.Node.Find<Clock>();
             Assert.That(clock.StartDate, Is.EqualTo(new DateTime(2020, 01, 01)));
@@ -223,11 +224,12 @@ namespace UnitTests.APSIM.Core.Tests
         [Test]
         public void SetModelFromExternalFileSpecificModel()
         {
+            Node externalRootNode = FileFormat.ReadFromFile(extFile, typeof(Simulations));
             IModelCommand cmd = new ReplaceCommand(modelReference: new ModelInFileReference(extFile, "[Clock2]"),
                                                    replacementPath: "[Clock]",
                                                    multiple: false,
                                                    matchType: ReplaceCommand.MatchType.NameOrType);
-            cmd.Run(sims1, runner: null);
+            cmd.Run(sims1, null, [externalRootNode]);
 
             var clock = sims1.Node.Find<Clock>();
             Assert.That(clock.StartDate, Is.EqualTo(new DateTime(2021, 01, 01)));
@@ -243,7 +245,7 @@ namespace UnitTests.APSIM.Core.Tests
                                                    replacementPath: "[Report1]",
                                                    multiple: true,
                                                    matchType: ReplaceCommand.MatchType.Name);
-            cmd.Run(sims1, runner: null);
+            cmd.Run(sims1, null, null);
 
             // It should have changed all Report1 models to Report4
             var reports = sims1.Node.FindAll<Models.Report>().ToArray();
@@ -278,7 +280,7 @@ namespace UnitTests.APSIM.Core.Tests
             ];
 
             foreach (var cmd in overrides)
-                cmd.Run(sims1, runner: null);
+                cmd.Run(sims1, null, null);
 
             var stringList = (ListClass<string>)sims1.Node.Find<ListClass<string>>();
 
@@ -302,7 +304,7 @@ namespace UnitTests.APSIM.Core.Tests
         public void TestOverridesErrorsIfNotFound()
         {
             IModelCommand badOverride = new SetPropertyCommand("[Does].Not", "=", "Exist");
-            Assert.Throws<Exception>(() => badOverride.Run(sims1, runner:null));
+            Assert.Throws<Exception>(() => badOverride.Run(sims1, null, null));
         }
     }
 }

--- a/Tests/UnitTests/APSIM.Core/CommandOverridesTests.cs
+++ b/Tests/UnitTests/APSIM.Core/CommandOverridesTests.cs
@@ -149,7 +149,7 @@ namespace UnitTests.APSIM.Core.Tests
         public void SetPropertyInTypeMatchedModels()
         {
             SetPropertyCommand command = new("[Report].VariableNames", "=", "x,y,z", multiple: true);
-            (command as IModelCommand).Run(sims1, runner: null, null);
+            (command as IModelCommand).Run(sims1, null, null);
 
             foreach (var report in sims1.Node.FindAll<Models.Report>())
                 Assert.That(report.VariableNames, Is.EqualTo(new[] { "x", "y", "z" }));

--- a/Tests/UnitTests/APSIM.Core/CommandTests.cs
+++ b/Tests/UnitTests/APSIM.Core/CommandTests.cs
@@ -32,7 +32,7 @@ public class CommandTests
         IModelCommand cmd = new AddCommand(modelReference: new NewModelReference("Report"),
                                            toPath: "[Simulation]",
                                            multiple: false);
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         Assert.That(simulation.Children[0], Is.InstanceOf(typeof(Models.Report)));
     }
@@ -53,7 +53,7 @@ public class CommandTests
         IModelCommand cmd = new AddCommand(modelReference: new NewModelReference("Report"),
                                            toPath: "[Simulation]",
                                            multiple: true);
-        cmd.Run(simulations, runner: null);
+        cmd.Run(simulations, null, null);
 
         Assert.That(simulations.Children[0].Children[0], Is.InstanceOf(typeof(Models.Report)));
         Assert.That(simulations.Children[1].Children[0], Is.InstanceOf(typeof(Models.Report)));
@@ -71,7 +71,7 @@ public class CommandTests
                                            multiple: false,
                                            newName: "NewReport");
 
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         Assert.That(simulation.Children[0].Name, Is.EqualTo("NewReport"));
     }
@@ -98,12 +98,13 @@ public class CommandTests
         Simulation simulation = new();
         Node.Create(simulation);
 
+        Node externalRootNode = FileFormat.ReadFromFile(tempFilePath, typeof(Simulations));
         // Run add command to add report from external file into simulation.
         IModelCommand cmd = new AddCommand(modelReference: new ModelInFileReference(tempFilePath, "Report"),
                                            toPath: "[Simulation]",
                                            multiple: false,
                                            newName: "NewReport");
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, [externalRootNode]);
 
         // Make sure report was added.
         Assert.That(simulation.Children[0].Name, Is.EqualTo("NewReport"));
@@ -126,7 +127,7 @@ public class CommandTests
         Node.Create(simulation);
 
         IModelCommand cmd = new DeleteCommand(modelName: "Report");
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         Assert.That(simulation.Children.Count, Is.EqualTo(0));
     }
@@ -145,7 +146,7 @@ public class CommandTests
         Node.Create(simulation);
 
         IModelCommand cmd = new DuplicateCommand(modelName: "Report", newName: "NewReport");
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         Assert.That(simulation.Children.Count, Is.EqualTo(2));
         Assert.That(simulation.Children[1], Is.InstanceOf<Models.Report>());
@@ -169,7 +170,7 @@ public class CommandTests
         // Run the save command.
         string tempFilePath = Path.GetTempFileName();
         IModelCommand cmd = new SaveCommand(fileName: tempFilePath);
-        var saveModel = cmd.Run(simulations, runner: null);
+        var saveModel = cmd.Run(simulations, null, null);
 
         Assert.That(File.Exists(tempFilePath));
         Node simulationsReadIn = FileFormat.ReadFromFile<Simulations>(tempFilePath);
@@ -197,7 +198,7 @@ public class CommandTests
         Node.Create(simulation);
 
         IModelCommand cmd = new SetPropertyCommand("[Clock].StartDate", "=", "2000-01-01", fileName: null);
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         var clock = simulation.Children.First() as Clock;
         Assert.That(clock.StartDate, Is.EqualTo(new System.DateTime(2000, 1, 1)));
@@ -221,7 +222,7 @@ public class CommandTests
         Node.Create(simulation);
 
         IModelCommand cmd = new SetPropertyCommand("[Clock].StartDate", "=", "2000-01-01", fileName: null);
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         var clock = simulation.Children.First() as Clock;
         Assert.That(clock.StartDate, Is.EqualTo(new System.DateTime(2000, 1, 1)));
@@ -248,7 +249,7 @@ public class CommandTests
         Node.Create(simulation);
 
         IModelCommand cmd = new SetPropertyCommand("[Weather].FileName", "=", "", fileName: null);
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         var weather = simulation.Children.First() as Models.Climate.Weather;
         Assert.That(weather.FileName, Is.Empty);
@@ -271,7 +272,7 @@ public class CommandTests
         Node.Create(simulation);
 
         IModelCommand cmd = new SetPropertyCommand("[Cultivar].Command", "+=", "b=2", fileName: null);
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         var cultivar = simulation.Children.First() as Cultivar;
         Assert.That(cultivar.Command, Is.EqualTo(["a=1", "b=2"]));
@@ -294,7 +295,7 @@ public class CommandTests
         Node.Create(simulation);
 
         IModelCommand cmd = new SetPropertyCommand("[Cultivar].Command", "+=", "a=1", fileName: null);
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         var cultivar = simulation.Children.First() as Cultivar;
         Assert.That(cultivar.Command, Is.EqualTo(["a=1"]));
@@ -317,7 +318,7 @@ public class CommandTests
         Node.Create(simulation);
 
         IModelCommand cmd = new SetPropertyCommand("[Cultivar].Command", "+=", "a=2", fileName: null);
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         var cultivar = simulation.Children.First() as Cultivar;
         Assert.That(cultivar.Command, Is.EqualTo(["a=2"]));
@@ -340,7 +341,7 @@ public class CommandTests
         Node.Create(simulation);
 
         IModelCommand cmd = new SetPropertyCommand("[Cultivar].Command", "=", "b=2,c=3", fileName: null);
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         var cultivar = simulation.Children.First() as Cultivar;
         Assert.That(cultivar.Command, Is.EqualTo(["b=2", "c=3"]));
@@ -363,7 +364,7 @@ public class CommandTests
         Node.Create(simulation);
 
         IModelCommand cmd = new SetPropertyCommand("[Cultivar].Command", "=", "", fileName: null);
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         var cultivar = simulation.Children.First() as Cultivar;
         Assert.That(cultivar.Command, Is.Empty);
@@ -388,7 +389,7 @@ public class CommandTests
         Node.Create(simulation);
 
         IModelCommand cmd = new SetPropertyCommand($"[{modelName}].Command", "=", "", fileName: null);
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         var cultivar = simulation.Children.First() as Cultivar;
         Assert.That(cultivar.Command, Is.Empty);
@@ -413,7 +414,7 @@ public class CommandTests
         Node.Create(simulation);
 
         IModelCommand cmd = SetPropertyCommand.Create($"[{modelName}].Command=", null);
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         var cultivar = simulation.Children.First() as Cultivar;
         Assert.That(cultivar.Command, Is.Empty);
@@ -436,7 +437,7 @@ public class CommandTests
         Node.Create(simulation);
 
         IModelCommand cmd = new SetPropertyCommand("[Cultivar].Command", "=", "null", fileName: null);
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         var cultivar = simulation.Children.First() as Cultivar;
         Assert.That(cultivar.Command, Is.Null);
@@ -459,7 +460,7 @@ public class CommandTests
         Node.Create(simulation);
 
         IModelCommand cmd = new SetPropertyCommand("[Cultivar].Command[1]", "=", "b=1", fileName: null);
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         var cultivar = simulation.Children.First() as Cultivar;
         Assert.That(cultivar.Command, Is.EqualTo(["b=1", "b=2"]));
@@ -483,7 +484,7 @@ public class CommandTests
         Node.Create(simulation);
 
         IModelCommand cmd = new SetPropertyCommand("[Cultivar].Command", "=", "", fileName: null);
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         var cultivar = simulation.Children.First() as Cultivar;
         Assert.That(cultivar.Command.Length, Is.EqualTo(0));
@@ -506,7 +507,7 @@ public class CommandTests
         Node.Create(simulation);
 
         IModelCommand cmd = new SetPropertyCommand("[Cultivar].Command", "-=", "b", fileName: null);
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         var cultivar = simulation.Children.First() as Cultivar;
         Assert.That(cultivar.Command, Is.EqualTo(["a=1"]));
@@ -530,7 +531,7 @@ public class CommandTests
         Node.Create(simulation);
 
         IModelCommand cmd = new SetPropertyCommand("[Cultivar].Command", "-=", "c", fileName: null);
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         var cultivar = simulation.Children.First() as Cultivar;
         Assert.That(cultivar.Command, Is.EqualTo(["a=1", "b=2"]));
@@ -553,11 +554,12 @@ public class CommandTests
         // Run the save command.
         string tempFilePath = Path.GetTempFileName();
         IModelCommand saveCommand = new SaveCommand(fileName: tempFilePath);
-        saveCommand.Run(relativeTo: simulations, runner: null);
+        saveCommand.Run(relativeTo: simulations, null, null);
 
         // Run load command. It should return a relativeTo that is from the temp file.
+        Node externalRootNode = FileFormat.ReadFromFile(tempFilePath, typeof(Simulations));
         IModelCommand loadCommand = new LoadCommand(tempFilePath);
-        var relativeTo = loadCommand.Run(relativeTo: null, runner: null);
+        var relativeTo = loadCommand.Run(relativeTo: null, null, [externalRootNode]);
 
         Assert.That(relativeTo.GetChildren().First().Name, Is.EqualTo("Report"));
     }
@@ -580,7 +582,7 @@ public class CommandTests
 
         // Run the run command.
         IModelCommand cmd = new RunCommand();
-        cmd.Run(simulations, runner: mockRunner);
+        cmd.Run(simulations, mockRunner, null);
 
         Assert.That(mockRunner.RunCalled, Is.True);
         Assert.That(mockRunner.RelativeTo, Is.EqualTo(simulations));
@@ -603,7 +605,7 @@ public class CommandTests
         var newModel = new Models.Report() { Name = "NewReport", VariableNames = [ "2" ] };
         IModelCommand cmd = new ReplaceCommand(new ModelReference(newModel),
                                                replacementPath: "Report", multiple: false, ReplaceCommand.MatchType.NameAndType);
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         var report = simulation.Children[0] as Models.Report;
         Assert.That(report, Is.Not.Null);
@@ -628,7 +630,7 @@ public class CommandTests
         var newModel = new Models.Report() { Name = "NewReport", VariableNames = [ "2" ] };
         IModelCommand cmd = new ReplaceCommand(new ModelReference(newModel),
                                                replacementPath: "Report", multiple: false, ReplaceCommand.MatchType.Name);
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         var report = simulation.Children[0] as Models.Report;
         Assert.That(report, Is.Not.Null, "simulation.Children[0] is not a Report after replacement.");
@@ -654,7 +656,7 @@ public class CommandTests
         var newModel = new Models.Report() { Name = "NewReport" };
         IModelCommand cmd = new ReplaceCommand(new ModelReference(newModel),
                                                replacementPath: "Report", multiple: false, ReplaceCommand.MatchType.Name, newName: "NewName");
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         Assert.That(simulation.Children.First().Name, Is.EqualTo("NewName"));
     }
@@ -676,7 +678,7 @@ public class CommandTests
         var newModel = new Models.Report() { Name = "NewReport", VariableNames = ["2"] };
         IModelCommand cmd = new ReplaceCommand(new ModelReference(newModel),
                                                replacementPath: "Report", multiple: true, ReplaceCommand.MatchType.Name);
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         var reports = simulation.Node.FindChildren<Models.Report>(recurse: true).ToArray();
         Assert.That(reports[0].Name, Is.EqualTo("Report"));
@@ -705,7 +707,7 @@ public class CommandTests
         var newModel = new Soil() { Name = "NewSoil", ApsoilNumber = "2" };
         IModelCommand cmd = new ReplaceCommand(new ModelReference(newModel),
                                                replacementPath: "[Soil]", multiple: true, ReplaceCommand.MatchType.NameOrType);
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         var soil = simulation.Node.FindChild<Soil>(recurse: true);
         Assert.That(soil.Name, Is.EqualTo("SandyClayLoam"));
@@ -728,7 +730,7 @@ public class CommandTests
         var newModel = new Soil() { Name = "NewSoil", Enabled = true };
         IModelCommand cmd = new ReplaceCommand(new ModelReference(newModel),
                                                replacementPath: "[Soil]", multiple: true, ReplaceCommand.MatchType.Name);
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         var soil = simulation.Node.FindChild<Soil>(recurse: true);
         Assert.That(soil.Name, Is.EqualTo("SandyClayLoam"));
@@ -753,7 +755,7 @@ public class CommandTests
         IModelCommand cmd = new ReplaceCommand(new ModelReference(newModel),
                                                replacementPath: "Report", multiple: false, ReplaceCommand.MatchType.Name);
 
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         var reports = simulation.Node.FindChildren<Models.Report>(recurse: true).ToArray();
         Assert.That(reports[0].Name, Is.EqualTo("Report"));
@@ -774,7 +776,7 @@ public class CommandTests
         IModelCommand cmd = new AddCommand(modelReference: new NewModelReference(modelName),
                                            toPath: "[Simulation]",
                                            multiple: false);
-        cmd.Run(simulation, runner: null);
+        cmd.Run(simulation, null, null);
 
         Assert.That(simulation.Children[0], Is.InstanceOf(typeof(Plant)));
     }


### PR DESCRIPTION
Working on #9617

The new Virtual node often needs to open the same file multiple times to copy elements from it, but right now each time it does this, it has to reopen the file completely. This PR build a file cache ahead of time to do this, so the file only need to be opened once.