### PR TITLE
11222 Remove duplciated Cesario and Stockade from WinterCereal Validation

### DIFF
--- a/Prototypes/WheatWinterCereal/GxExMWinterCereal.apsimx
+++ b/Prototypes/WheatWinterCereal/GxExMWinterCereal.apsimx
@@ -790,47 +790,6 @@
                         "[Phenology].HeadEmergenceLongDayBase.FixedValue = 50",
                         "[Phenology].Phyllochron.BasePhyllochron.FixedValue = 105.0",
                         "[Phenology].PhyllochronPpSensitivity.FixedValue = 0.33",
-                        "[Phenology].CAMP.FLNparams.MinLN = 8",
-                        "[Phenology].CAMP.FLNparams.PpLN = 12",
-                        "[Phenology].CAMP.FLNparams.VrnLN = 12",
-                        "[Phenology].CAMP.FLNparams.VxPLN = 4",
-                        "[Phenology].HeadEmergencePpSensitivity.FixedValue = 8",
-                        "[Phenology].CAMP.EnvData.VrnTreatTemp = 6",
-                        "[Phenology].CAMP.EnvData.VrnTreatDuration = 60",
-                        "[Phenology].GrainFilling.Target.FixedValue = 700"
-                      ],
-                      "Name": "Cesario",
-                      "ResourceName": null,
-                      "Children": [],
-                      "Enabled": true,
-                      "ReadOnly": false
-                    },
-                    {
-                      "$type": "Models.PMF.Cultivar, Models",
-                      "Command": [
-                        "[Phenology].HeadEmergenceLongDayBase.FixedValue = 50",
-                        "[Phenology].Phyllochron.BasePhyllochron.FixedValue = 105.0",
-                        "[Phenology].PhyllochronPpSensitivity.FixedValue = 0.33",
-                        "[Phenology].CAMP.FLNparams.MinLN = 8",
-                        "[Phenology].CAMP.FLNparams.PpLN = 12",
-                        "[Phenology].CAMP.FLNparams.VrnLN = 12",
-                        "[Phenology].CAMP.FLNparams.VxPLN = 4",
-                        "[Phenology].HeadEmergencePpSensitivity.FixedValue = 8",
-                        "[Phenology].CAMP.EnvData.VrnTreatTemp = 6",
-                        "[Phenology].CAMP.EnvData.VrnTreatDuration = 60"
-                      ],
-                      "Name": "Stockade",
-                      "ResourceName": null,
-                      "Children": [],
-                      "Enabled": true,
-                      "ReadOnly": false
-                    },
-                    {
-                      "$type": "Models.PMF.Cultivar, Models",
-                      "Command": [
-                        "[Phenology].HeadEmergenceLongDayBase.FixedValue = 50",
-                        "[Phenology].Phyllochron.BasePhyllochron.FixedValue = 105.0",
-                        "[Phenology].PhyllochronPpSensitivity.FixedValue = 0.33",
                         "[Phenology].CAMP.FLNparams.MinLN = 10",
                         "[Phenology].CAMP.FLNparams.PpLN = 8",
                         "[Phenology].CAMP.FLNparams.VrnLN = 0",

--- a/Prototypes/WheatWinterCereal/WheatWinterCereal.apsimx
+++ b/Prototypes/WheatWinterCereal/WheatWinterCereal.apsimx
@@ -739,47 +739,6 @@
                         "[Phenology].HeadEmergenceLongDayBase.FixedValue = 50",
                         "[Phenology].Phyllochron.BasePhyllochron.FixedValue = 105.0",
                         "[Phenology].PhyllochronPpSensitivity.FixedValue = 0.33",
-                        "[Phenology].CAMP.FLNparams.MinLN = 8",
-                        "[Phenology].CAMP.FLNparams.PpLN = 12",
-                        "[Phenology].CAMP.FLNparams.VrnLN = 12",
-                        "[Phenology].CAMP.FLNparams.VxPLN = 4",
-                        "[Phenology].HeadEmergencePpSensitivity.FixedValue = 8",
-                        "[Phenology].CAMP.EnvData.VrnTreatTemp = 6",
-                        "[Phenology].CAMP.EnvData.VrnTreatDuration = 60",
-                        "[Phenology].GrainFilling.Target.FixedValue = 700"
-                      ],
-                      "Name": "Cesario",
-                      "ResourceName": null,
-                      "Children": [],
-                      "Enabled": true,
-                      "ReadOnly": false
-                    },
-                    {
-                      "$type": "Models.PMF.Cultivar, Models",
-                      "Command": [
-                        "[Phenology].HeadEmergenceLongDayBase.FixedValue = 50",
-                        "[Phenology].Phyllochron.BasePhyllochron.FixedValue = 105.0",
-                        "[Phenology].PhyllochronPpSensitivity.FixedValue = 0.33",
-                        "[Phenology].CAMP.FLNparams.MinLN = 8",
-                        "[Phenology].CAMP.FLNparams.PpLN = 12",
-                        "[Phenology].CAMP.FLNparams.VrnLN = 12",
-                        "[Phenology].CAMP.FLNparams.VxPLN = 4",
-                        "[Phenology].HeadEmergencePpSensitivity.FixedValue = 8",
-                        "[Phenology].CAMP.EnvData.VrnTreatTemp = 6",
-                        "[Phenology].CAMP.EnvData.VrnTreatDuration = 60"
-                      ],
-                      "Name": "Stockade",
-                      "ResourceName": null,
-                      "Children": [],
-                      "Enabled": true,
-                      "ReadOnly": false
-                    },
-                    {
-                      "$type": "Models.PMF.Cultivar, Models",
-                      "Command": [
-                        "[Phenology].HeadEmergenceLongDayBase.FixedValue = 50",
-                        "[Phenology].Phyllochron.BasePhyllochron.FixedValue = 105.0",
-                        "[Phenology].PhyllochronPpSensitivity.FixedValue = 0.33",
                         "[Phenology].CAMP.FLNparams.MinLN = 10",
                         "[Phenology].CAMP.FLNparams.PpLN = 8",
                         "[Phenology].CAMP.FLNparams.VrnLN = 0",


### PR DESCRIPTION
Working on #11222

Following on from #11464

Making the same change there into the WinterCereal validation to avoid confusion.