### PR TITLE
11294 Added "All" flag to delete command, with tests

### DIFF
--- a/APSIM.Core/CommandProcessor/Commands/DeleteCommand.cs
+++ b/APSIM.Core/CommandProcessor/Commands/DeleteCommand.cs
@@ -6,7 +6,7 @@ internal partial class DeleteCommand : IModelCommand
     /// <summary>The name of the model to delete.</summary>
     private readonly string _modelName;
 
-    /// <summary>Do as many replacements as possible?</summary>
+    /// <summary>Do as many deletes as possible?</summary>
     private readonly bool _multiple;
 
     /// <summary>

--- a/APSIM.Core/CommandProcessor/Commands/DeleteCommand.cs
+++ b/APSIM.Core/CommandProcessor/Commands/DeleteCommand.cs
@@ -4,15 +4,20 @@ namespace APSIM.Core;
 internal partial class DeleteCommand : IModelCommand
 {
     /// <summary>The name of the model to delete.</summary>
-    private readonly string modelName;
+    private readonly string _modelName;
+
+    /// <summary>Do as many replacements as possible?</summary>
+    private readonly bool _multiple;
 
     /// <summary>
     /// Constructor.
     /// </summary>
     /// <param name="modelName">The name of a model to delete.</param>
-    public DeleteCommand(string modelName)
+    /// <param name="multiple">Wether to delete everything that matches</param>
+    public DeleteCommand(string modelName, bool multiple)
     {
-        this.modelName = modelName;
+        _modelName = modelName;
+        _multiple = multiple;
     }
 
     /// <summary>
@@ -22,14 +27,32 @@ internal partial class DeleteCommand : IModelCommand
     /// <param name="runner">An instance of an APSIM runner.</param>
     INodeModel IModelCommand.Run(INodeModel relativeTo, IRunner runner, List<Node> externalFileCache)
     {
-        var modelToDelete = (INodeModel)relativeTo.Node.Get(modelName, relativeTo: relativeTo)
-                           ?? throw new Exception($"Cannot find model {modelName}");
+        List<INodeModel> modelsToDelete = new List<INodeModel>();
+        if (_multiple)
+        {
+            IEnumerable<VariableComposite> matches = relativeTo.Node.GetAllObjects(_modelName, LocatorFlags.ModelsOnly);
+            foreach(VariableComposite match in matches)
+                modelsToDelete.Add(match.Value as INodeModel);
+        }
+        else
+        {
+            INodeModel model = (INodeModel)relativeTo.Node.Get(_modelName, relativeTo: relativeTo);
+            if (model != null)
+                modelsToDelete.Add(model);
+            else
+                throw new Exception($"Cannot find model {_modelName}");
+        }
+        if (!modelsToDelete.Any())
+            throw new Exception($"Cannot find any models that match: {_modelName}");
 
-        // Throw exception if root node.
-        if (modelToDelete.Node.Parent == null)
-            throw new Exception($"Command 'delete [Simulations]' is an invalid command. [Simulations] node is the top-level node and cannot be deleted. Remove the command from your config file.");
-
-        modelToDelete.Node.Parent.RemoveChild(modelToDelete);
+        foreach (INodeModel model in modelsToDelete)
+        {
+             // Throw exception if root node.
+            if (model.Node.Parent == null)
+                throw new Exception($"Command 'delete [Simulations]' is an invalid command. [Simulations] node is the top-level node and cannot be deleted. Remove the command from your config file.");
+            model.Node.Parent.RemoveChild(model);
+        }
+       
         return relativeTo;
     }
 }

--- a/APSIM.Core/CommandProcessor/Language/DeleteCommandLanguage.cs
+++ b/APSIM.Core/CommandProcessor/Language/DeleteCommandLanguage.cs
@@ -3,7 +3,7 @@ namespace APSIM.Core;
 internal partial class DeleteCommand: IModelCommand
 {
     private const string KEYWORD_DELETE = "delete ";
-    private const string PATTERN_DELETE = $@"{KEYWORD_DELETE}(?<model>{CommandLanguage.PATTERN_MODEL_PATH})";
+    private const string PATTERN_DELETE = $@"{KEYWORD_DELETE}(?<all>all )*(?<model>{CommandLanguage.PATTERN_MODEL_PATH})";
 
     /// <summary>
     /// Create a delete command.
@@ -11,16 +11,27 @@ internal partial class DeleteCommand: IModelCommand
     /// <param name="command">The command to parse.</param>
     /// <remarks>
     /// delete [Zone].Report
+    /// delete [Report]
     /// </remarks>
     public static IModelCommand Create(string command)
     {
-        string model = CommandLanguage.ReadCommand(command, KEYWORD_DELETE, PATTERN_DELETE);
-        return new DeleteCommand(model);
+        CommandSegment[] segments = CommandLanguage.ReadCommand(command, [KEYWORD_DELETE], [PATTERN_DELETE]);
+        string model = CommandSegment.GetValue(segments, "model");
+        bool usesAll = CommandSegment.ContainsKey(segments, "all");
+        if (string.IsNullOrEmpty(model))
+            throw new Exception($"Invalid command: {command}");
+        return new DeleteCommand(model, usesAll);
     }
 
     /// <summary>
     /// Convert an DeleteCommand instance to a string.
     /// </summary>
     /// <returns>A command language string.</returns>
-    public override string ToString() => $"{KEYWORD_DELETE}{modelName}";
+    public override string ToString()
+    {
+        if (_multiple)
+            return $"{KEYWORD_DELETE}all {_modelName}";
+        else
+            return $"{KEYWORD_DELETE}{_modelName}";
+    } 
 }

--- a/Tests/UnitTests/APSIM.Core/CommandLanguageTests.cs
+++ b/Tests/UnitTests/APSIM.Core/CommandLanguageTests.cs
@@ -19,6 +19,7 @@ public class CommandLanguageTests
     [TestCase("add [Report] from \"to file.apsimx\" to all [Zone]")]
     [TestCase("add new \"Report to\" to [Zone]")]
     [TestCase("delete [Zone].Report")]
+    [TestCase("delete all [Report]")]
     [TestCase("duplicate [Zone].Report")]
     [TestCase("duplicate [Zone].Report name NewName")]
     [TestCase("save C:\\temp\\test.apsimx")]

--- a/Tests/UnitTests/APSIM.Core/CommandTests.cs
+++ b/Tests/UnitTests/APSIM.Core/CommandTests.cs
@@ -126,7 +126,28 @@ public class CommandTests
         };
         Node.Create(simulation);
 
-        IModelCommand cmd = new DeleteCommand(modelName: "Report");
+        IModelCommand cmd = new DeleteCommand(modelName: "Report", false);
+        cmd.Run(simulation, null, null);
+
+        Assert.That(simulation.Children.Count, Is.EqualTo(0));
+    }
+
+    /// <summary>Ensure the delete command works.</summary>
+    [Test]
+    public void EnsureDeleteMultipleWorks()
+    {
+        Simulations simulation = new()
+        {
+            Children =
+            [
+                new Models.Report() { Name = "NewReport" },
+                new Models.Report() { Name = "NewReport1" },
+                new Models.Report() { Name = "NewReport2" }
+            ]
+        };
+        Node.Create(simulation);
+
+        IModelCommand cmd = new DeleteCommand(modelName: "[Report]", true);
         cmd.Run(simulation, null, null);
 
         Assert.That(simulation.Children.Count, Is.EqualTo(0));


### PR DESCRIPTION
Resolves #11294

This PR add a "all" flag to the delete command, allowing it to delete all models it finds with the given input.

Example: delete all [Report]

Contains tests, follows same functionality as add command.