### PR TITLE
Make job count not include disabled Simulation models

### DIFF
--- a/Models/Core/Run/SimulationDescription.cs
+++ b/Models/Core/Run/SimulationDescription.cs
@@ -43,6 +43,11 @@ namespace Models.Core.Run
         }
 
         /// <summary>
+        /// Is the baseSimulation enabled?
+        /// </summary>
+        public bool IsEnabled => baseSimulation.Enabled;
+
+        /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="sim">The simulation to run.</param>

--- a/Models/Core/Run/SimulationGroup.cs
+++ b/Models/Core/Run/SimulationGroup.cs
@@ -291,7 +291,14 @@ namespace Models.Core.Run
                             storage.Writer.Clean(names, false);
                         }
                         foreach (IRunnable job in jobs)
-                            Add(job);
+                        {
+                            if (job is SimulationDescription simDescription)
+                            {
+                                if (simDescription.ToSimulation().Enabled)
+                                    Add(simDescription);
+                            }
+                            else Add(job);
+                        }
                     }
 
                     if (numJobsToRun == 0)

--- a/Models/Core/Run/SimulationGroup.cs
+++ b/Models/Core/Run/SimulationGroup.cs
@@ -294,7 +294,7 @@ namespace Models.Core.Run
                         {
                             if (job is SimulationDescription simDescription)
                             {
-                                if (simDescription.ToSimulation().Enabled)
+                                if (simDescription.IsEnabled)
                                     Add(simDescription);
                             }
                             else Add(job);


### PR DESCRIPTION
resolves #11052

This simply checks if a simulationDescription, when converted to a Simulation, is enabled before adding it to the queue of jobs to run.