### PR TITLE
11435 Have graphs handle null water values

### DIFF
--- a/ApsimNG/Presenters/QuadGraphPresenter.cs
+++ b/ApsimNG/Presenters/QuadGraphPresenter.cs
@@ -332,9 +332,11 @@ namespace UserInterface.Presenters
         private static void PopulateWaterGraph(GraphView graph, double[] thickness, double[] airdry, double[] ll15, double[] dul, double[] sat,
                                                string cllName, double[] swThickness, double[] cll, double[] sw, string llsoilsName, double[] llsoil)
         {
-
             double[] cumulativeThickness = APSIM.Shared.Utilities.SoilUtilities.ToCumThickness(thickness);
-            double[] cumulativeSWThickness = APSIM.Shared.Utilities.SoilUtilities.ToCumThickness(swThickness);
+
+            double[] cumulativeSWThickness = null;
+            if (swThickness != null)
+                cumulativeSWThickness = APSIM.Shared.Utilities.SoilUtilities.ToCumThickness(swThickness);
 
             double[] cllMapped = null;
             if (cll != null)
@@ -430,12 +432,13 @@ namespace UserInterface.Presenters
             xTopMin -= xTopMax * padding;
             xTopMax += xTopMax * padding;
 
-
-            double physicalHeight = MathUtilities.Max(cumulativeThickness);
-            double waterHeight = MathUtilities.Max(cumulativeSWThickness);
-            double height = physicalHeight;
-            if (waterHeight < physicalHeight)
-                height = waterHeight;
+            double height = MathUtilities.Max(cumulativeThickness);
+            if (cumulativeSWThickness != null)
+            {
+                double waterHeight = MathUtilities.Max(cumulativeSWThickness);
+                if (waterHeight < height)
+                    height = waterHeight;
+            }
 
             graph.FormatAxis(AxisPosition.Top, "Volumetric water (mm/mm)", inverted: false, xTopMin, xTopMax, double.NaN, false, false);
             graph.FormatAxis(AxisPosition.Left, "Depth (mm)", inverted: true, 0, height, double.NaN, false, false);

--- a/Models/Soils/Water.cs
+++ b/Models/Soils/Water.cs
@@ -243,7 +243,7 @@ namespace Models.Soils
         {
             get
             {
-                if (Physical != null)
+                if (Physical != null && Thickness != null)
                 {
                     double newFractionFull;
                     double[] dul = SoilUtilities.MapConcentration(Physical.DUL, Physical.Thickness, Thickness, Physical.DUL.Last());


### PR DESCRIPTION
Resolves #11435

Add some checking code to the GUI to prevent trying to draw water values when they are null. This prevents the crash, and has the gui still render the rest of the graph instead of being blank.