### PR TITLE
10017 Increase node limit from 30 to 60

### DIFF
--- a/.github/workflows/run-model-validations.yml
+++ b/.github/workflows/run-model-validations.yml
@@ -122,7 +122,7 @@ jobs:
       # This is required to give the Azure jobs time to start before enabling autoscaling on the pool.
       # If we don't do this, the autoscaling script may run before the jobs have started, resulting in the pool being scaled down to 0 nodes.
       - name: Give Azure jobs time to start
-        run: sleep 600
+        run: sleep 480
 
       - name: Enable autoscaling on Azure pool
         env:

--- a/.github/workflows/scripts/start-azure-pool.sh
+++ b/.github/workflows/scripts/start-azure-pool.sh
@@ -20,7 +20,7 @@ AZURE_ENV_CONTENTS=$(echo -e "$AZURE_ENV_CONTENTS" | tr -d '\r' | tr '\n' ' ')
 ENCODED_STRING=$(jq -rn --arg x "$AZURE_ENV_CONTENTS" '$x|@uri')
 
 # Once the azure env contents are url encoded we can send them via curl
-url="https://digitalag.csiro.au/workflo/create-pool?poolId=${POOL_ID}&envString=${ENCODED_STRING}&nodeNumber=30&isAutoscaled=false"
+url="https://digitalag.csiro.au/workflo/create-pool?poolId=${POOL_ID}&envString=${ENCODED_STRING}&nodeNumber=60&isAutoscaled=false"
 response=$(curl -f -s -w "%{http_code}" -X POST "${url}")
 echo "Response from server: $response"
 


### PR DESCRIPTION
Working on #10017

Going to double the allowed nodes on Azure, should help speed up the validation a bit more since the test set is really growing.