### PR TITLE
Expand the delete command

### DIFF
--- a/APSIM.Core/CommandProcessor/Commands/DeleteCommand.cs
+++ b/APSIM.Core/CommandProcessor/Commands/DeleteCommand.cs
@@ -3,21 +3,26 @@ namespace APSIM.Core;
 /// <summary>A delete model command</summary>
 internal partial class DeleteCommand : IModelCommand
 {
-    /// <summary>The name of the model to delete.</summary>
+    /// <summary>The name or path of the model to delete.</summary>
     private readonly string _modelName;
 
     /// <summary>Do as many deletes as possible?</summary>
     private readonly bool _multiple;
 
+    /// <summary>The name or path of the model to delete children from.</summary>
+    private readonly string _parentModelName;
+
     /// <summary>
     /// Constructor.
     /// </summary>
-    /// <param name="modelName">The name of a model to delete.</param>
-    /// <param name="multiple">Wether to delete everything that matches</param>
-    public DeleteCommand(string modelName, bool multiple)
+    /// <param name="modelName">The name or path of a model to delete.</param>
+    /// <param name="multiple">Whether to delete every matching model.</param>
+    /// <param name="parentModelName">The name or path of the model containing models to delete.</param>
+    public DeleteCommand(string modelName, bool multiple, string parentModelName = null)
     {
         _modelName = modelName;
         _multiple = multiple;
+        _parentModelName = parentModelName;
     }
 
     /// <summary>
@@ -27,32 +32,39 @@ internal partial class DeleteCommand : IModelCommand
     /// <param name="runner">An instance of an APSIM runner.</param>
     INodeModel IModelCommand.Run(INodeModel relativeTo, IRunner runner, List<Node> externalFileCache)
     {
-        List<INodeModel> modelsToDelete = new List<INodeModel>();
+        INodeModel parentModel = relativeTo;
+        if (!string.IsNullOrEmpty(_parentModelName))
+        {
+            parentModel = relativeTo.Node.Get(_parentModelName) as INodeModel;
+            if (parentModel == null)
+                throw new Exception($"Cannot find model {_parentModelName}");
+        }
+
+        IEnumerable<INodeModel> modelsToDelete;
+
         if (_multiple)
         {
-            IEnumerable<VariableComposite> matches = relativeTo.Node.GetAllObjects(_modelName, LocatorFlags.ModelsOnly);
-            foreach(VariableComposite match in matches)
-                modelsToDelete.Add(match.Value as INodeModel);
+            modelsToDelete = parentModel.Node.GetAllObjects(_modelName, LocatorFlags.ModelsOnly)
+                .Select(match => match.Value as INodeModel)
+                .Where(model => model != null)
+                .ToArray();
         }
         else
         {
-            INodeModel model = (INodeModel)relativeTo.Node.Get(_modelName, relativeTo: relativeTo);
-            if (model != null)
-                modelsToDelete.Add(model);
-            else
+            INodeModel model = parentModel.Node.Get(_modelName) as INodeModel;
+            if (model == null)
                 throw new Exception($"Cannot find model {_modelName}");
-            if (!modelsToDelete.Any())
-                throw new Exception($"Cannot find any models that match: {_modelName}");
+            modelsToDelete = [model];
         }
 
         foreach (INodeModel model in modelsToDelete)
         {
-             // Throw exception if root node.
+            // Throw exception if root node.
             if (model.Node.Parent == null)
-                throw new Exception($"Command 'delete [Simulations]' is an invalid command. [Simulations] node is the top-level node and cannot be deleted. Remove the command from your config file.");
+                throw new Exception($"Command 'delete [Simulations]' is an invalid command. [Simulations] node is the" +
+                    $" top-level node and cannot be deleted. Remove the command from your config file.");
             model.Node.Parent.RemoveChild(model);
-        }
-       
+        }            
         return relativeTo;
     }
 }

--- a/APSIM.Core/CommandProcessor/Commands/DeleteCommand.cs
+++ b/APSIM.Core/CommandProcessor/Commands/DeleteCommand.cs
@@ -46,7 +46,7 @@ internal partial class DeleteCommand : IModelCommand
         {
             modelsToDelete = parentModel.Node.GetAllObjects(_modelName, LocatorFlags.ModelsOnly)
                 .Select(match => match.Value as INodeModel)
-                .Where(model => model != null)
+                .Where(model => model != null && model.Node.WalkParents().Contains(parentModel.Node))
                 .ToArray();
         }
         else

--- a/APSIM.Core/CommandProcessor/Language/DeleteCommandLanguage.cs
+++ b/APSIM.Core/CommandProcessor/Language/DeleteCommandLanguage.cs
@@ -1,9 +1,14 @@
+using System.Text.RegularExpressions;
+
 namespace APSIM.Core;
 
 internal partial class DeleteCommand: IModelCommand
 {
-    private const string KEYWORD_DELETE = "delete ";
-    private const string PATTERN_DELETE = $@"{KEYWORD_DELETE}(?<all>all )*(?<model>{CommandLanguage.PATTERN_MODEL_PATH})";
+    private const string KEYWORD_DELETE = "delete";
+    private const string KEYWORD_FROM = " from ";
+    private const string KEYWORD_ALL = " all ";
+    private const string PATTERN_DELETE = $@"{KEYWORD_DELETE}(?<all>{KEYWORD_ALL})*(?<model>{CommandLanguage.PATTERN_MODEL_PATH})";
+    private const string PATTERN_FROM = $@"{KEYWORD_FROM}(?<parent>{CommandLanguage.PATTERN_MODEL_PATH})";
 
     /// <summary>
     /// Create a delete command.
@@ -15,12 +20,15 @@ internal partial class DeleteCommand: IModelCommand
     /// </remarks>
     public static IModelCommand Create(string command)
     {
-        CommandSegment[] segments = CommandLanguage.ReadCommand(command, [KEYWORD_DELETE], [PATTERN_DELETE]);
+        string[] keywords = [KEYWORD_DELETE, KEYWORD_FROM];
+        string[] patterns = [PATTERN_DELETE, PATTERN_FROM];
+        CommandSegment[] segments = CommandLanguage.ReadCommand(command, keywords, patterns);
         string model = CommandSegment.GetValue(segments, "model");
         bool usesAll = CommandSegment.ContainsKey(segments, "all");
+        string parentModel = CommandSegment.GetValue(segments, "parent");
         if (string.IsNullOrEmpty(model))
             throw new Exception($"Invalid command: {command}");
-        return new DeleteCommand(model, usesAll);
+        return new DeleteCommand(model, usesAll, parentModel);
     }
 
     /// <summary>
@@ -29,9 +37,8 @@ internal partial class DeleteCommand: IModelCommand
     /// <returns>A command language string.</returns>
     public override string ToString()
     {
-        if (_multiple)
-            return $"{KEYWORD_DELETE}all {_modelName}";
-        else
-            return $"{KEYWORD_DELETE}{_modelName}";
+        string all = _multiple ? KEYWORD_ALL : " ";
+        string from = string.IsNullOrEmpty(_parentModelName) ? "" : $"{KEYWORD_FROM}{_parentModelName}";
+        return $"{KEYWORD_DELETE}{all}{_modelName}{from}";
     } 
 }

--- a/Tests/UnitTests/APSIM.Core/CommandTests.cs
+++ b/Tests/UnitTests/APSIM.Core/CommandTests.cs
@@ -13,14 +13,6 @@ namespace UnitTests.APSIM.Core.Tests;
 [TestFixture]
 public class CommandTests
 {
-    /*class ModelA : Model
-    {
-    }
-
-    class ModelB : Model
-    {
-        public int B1 { get { return 3; } }
-    }*/
 
     /// <summary>Ensure the add command works.</summary>
     [Test]
@@ -172,6 +164,52 @@ public class CommandTests
         cmd.Run(simulation, null, null);
 
         Assert.That(simulation.Children.Count, Is.EqualTo(3));
+    }
+
+    /// <summary>Ensure a delete command can target a model beneath a specified parent.</summary>
+    [Test]
+    public void EnsureDeleteWorksFromParent()
+    {
+        Simulations simulations = new()
+        {
+            Children =
+            [
+                new Zone { Name = "Zone", Children = [new Models.Report { Name = "Report" }] },
+                new Zone { Name = "OtherZone", Children = [new Models.Report { Name = "Report" }] }
+            ]
+        };
+        Node.Create(simulations);
+
+        IModelCommand command = CommandLanguage.StringToCommands(["delete [Report] from [Zone]"], simulations, null).Single();
+        command.Run(simulations, null, null);
+
+        Assert.That(simulations.Children[0].Children, Is.Empty);
+        Assert.That(simulations.Children[1].Children, Has.Count.EqualTo(1));
+    }
+
+    /// <summary>Ensure delete all is limited to the specified parent.</summary>
+    [Test]
+    public void EnsureDeleteAllWorksFromParent()
+    {
+        Simulations simulations = new()
+        {
+            Children =
+            [
+                new Zone
+                {
+                    Name = "Zone",
+                    Children = [new Models.Report { Name = "Report1" }, new Models.Report { Name = "Report2" }]
+                },
+                new Zone { Name = "OtherZone", Children = [new Models.Report { Name = "Report" }] }
+            ]
+        };
+        Node.Create(simulations);
+
+        IModelCommand command = CommandLanguage.StringToCommands(["delete all [Report] from [Zone]"], simulations, null).Single();
+        command.Run(simulations, null, null);
+
+        Assert.That(simulations.Children[0].Children, Is.Empty);
+        Assert.That(simulations.Children[1].Children, Has.Count.EqualTo(1));
     }
 
     /// <summary>Ensure the duplicate command works.</summary>


### PR DESCRIPTION
resolves #11518

The delete command can now handle commands like:

```text
delete all [Cultivar] from [Replacements]
```

This should help add some needed precision when deleting models.