### PR TITLE
11546 Use LightProfile to pass total canopy energy for AgPasture use

### DIFF
--- a/Models/AgPasture/PastureSpecies.cs
+++ b/Models/AgPasture/PastureSpecies.cs
@@ -65,10 +65,6 @@ namespace Models.AgPasture
         [Link]
         private ISoilTemperature soilTemperature = null;
 
-        /// <summary>Link to micro climate (aboveground resource arbitrator).</summary>
-        [Link]
-        private MicroClimate microClimate = null;
-
         ////- Events >>>  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
         /// <summary>Invoked for incorporating surface OM.</summary>
@@ -193,9 +189,11 @@ namespace Models.AgPasture
                 {
                     InterceptedRadn = 0.0;
                     myLightProfile = value;
+                    double totalRadiationInterceptionOnGreen = 0;
                     foreach (CanopyEnergyBalanceInterceptionlayerType canopyLayer in myLightProfile)
                     {
                         InterceptedRadn += canopyLayer.AmountOnGreen;
+                        totalRadiationInterceptionOnGreen = canopyLayer.AmountOnGreenTotal;
                     }
 
                     // stuff required to calculate photosynthesis using Ecomod approach
@@ -204,7 +202,7 @@ namespace Models.AgPasture
                     swardGreenCover = 0.0;
                     if (InterceptedRadn > 0.0)
                     {
-                        fractionGreenCover = InterceptedRadn / microClimate.RadiationInterceptionOnGreen;
+                        fractionGreenCover = InterceptedRadn / totalRadiationInterceptionOnGreen;
                         swardGreenCover = 1.0 - Math.Exp(-LightExtinctionCoefficient * greenLAI / fractionGreenCover);
                     }
                 }

--- a/Models/Interfaces/ICanopy.cs
+++ b/Models/Interfaces/ICanopy.cs
@@ -69,5 +69,11 @@ namespace Models.Interfaces
 
         ///  <summary>The amount of radiation on dead area</summary>
         public double AmountOnDead;
+
+        ///  <summary>The total amount of radiation on green area for the entire canopy</summary>
+        public double AmountOnGreenTotal;
+
+        ///  <summary>The total amount of radiation on dead area for the entire canopy</summary>
+        public double AmountOnDeadTotal;
     }
 }

--- a/Models/MicroClimate/MicroClimate.cs
+++ b/Models/MicroClimate/MicroClimate.cs
@@ -126,7 +126,14 @@ namespace Models
         [Units("mm")]
         public double PrecipitationInterception
         {
-            get { return microClimatesZones[0].PrecipitationInterception; }
+            get 
+            { 
+                if (microClimatesZones.Count() == 0)
+                    return 0;
+                else if (microClimatesZones.Count() > 1)
+                    throw new Exception("This property cannot be used in a multi-zone simulation");
+                return microClimatesZones[0].PrecipitationInterception; 
+            }
         }
 
         /// <summary>Gets the amount of radiation intercepted by the canopy (MJ/m2).</summary>
@@ -134,14 +141,30 @@ namespace Models
         [Units("MJ/m^2")]
         public double RadiationInterception
         {
-            get { return microClimatesZones == null ? 0 : microClimatesZones[0].RadiationInterception; }
+            get 
+            { 
+                if (microClimatesZones.Count() == 0)
+                    return 0;
+                else if (microClimatesZones.Count() > 1)
+                    throw new Exception("This property cannot be used in a multi-zone simulation");
+                else
+                    return microClimatesZones[0].RadiationInterception; 
+            }
         }
 
         /// <summary>Gets the amount of radiation intercepted by the green elements of canopy (MJ/m2).</summary>
         [Units("MJ/m^2")]
         public double RadiationInterceptionOnGreen
         {
-            get { return microClimatesZones == null ? 0 : microClimatesZones[0].RadiationInterceptionOnGreen; }
+            get 
+            {
+                if (microClimatesZones.Count() == 0)
+                    return 0;
+                else if (microClimatesZones.Count() > 1)
+                    throw new Exception("This property cannot be used in a multi-zone simulation");
+                else
+                    return microClimatesZones[0].RadiationInterceptionOnGreen;
+            }
         }
 
         /// <summary>Gets the total Penman-Monteith potential evapotranspiration (MJ/m2).</summary>
@@ -149,7 +172,15 @@ namespace Models
         [Units("MJ/m^2")]
         public double PetTotal
         {
-            get { return PetRadiationTerm + PetAerodynamicTerm; }
+            get 
+            { 
+                if (microClimatesZones.Count() == 0)
+                    return 0;
+                else if (microClimatesZones.Count() > 1)
+                    throw new Exception("This property cannot be used in a multi-zone simulation");
+                else
+                    return PetRadiationTerm + PetAerodynamicTerm; 
+            }
         }
 
         /// <summary>Gets the radiation term of for the Penman-Monteith PET (mm).</summary>
@@ -157,7 +188,15 @@ namespace Models
         [Units("mm")]
         public double PetRadiationTerm
         {
-            get { return microClimatesZones[0].petr; }
+            get 
+            {
+                if (microClimatesZones.Count() == 0)
+                    return 0;
+                else if (microClimatesZones.Count() > 1)
+                    throw new Exception("This property cannot be used in a multi-zone simulation");
+                else
+                    return microClimatesZones[0].petr;
+            }
         }
 
         /// <summary>Gets the aerodynamic term of for the Penman-Monteith PET (mm).</summary>
@@ -165,7 +204,15 @@ namespace Models
         [Units("mm")]
         public double PetAerodynamicTerm
         {
-            get { return microClimatesZones[0].peta; }
+            get 
+            {
+                if (microClimatesZones.Count() == 0)
+                    return 0;
+                else if (microClimatesZones.Count() > 1)
+                    throw new Exception("This property cannot be used in a multi-zone simulation");
+                else
+                    return microClimatesZones[0].peta;
+            }
         }
 
         /// <summary>Gets the fraction of the daytime in which the leaves are dry (0-1).</summary>
@@ -173,7 +220,15 @@ namespace Models
         [Units("-")]
         public double DryLeafTimeFraction
         {
-            get { return microClimatesZones[0].DryLeafFraction; }
+            get 
+            {
+                if (microClimatesZones.Count() == 0)
+                    return 0;
+                else if (microClimatesZones.Count() > 1)
+                    throw new Exception("This property cannot be used in a multi-zone simulation");
+                else
+                    return microClimatesZones[0].DryLeafFraction;
+            }
         }
 
         /// <summary>Gets the total net radiation, long and short waves (MJ/m2).</summary>
@@ -189,7 +244,15 @@ namespace Models
         [Units("MJ/m^2")]
         public double NetShortWaveRadiation
         {
-            get { return weather.Radn * (1.0 - microClimatesZones[0].Albedo); }
+            get 
+            { 
+                if (microClimatesZones.Count() == 0)
+                    return 0;
+                else if (microClimatesZones.Count() > 1)
+                    throw new Exception("This property cannot be used in a multi-zone simulation");
+                else
+                    return weather.Radn * (1.0 - microClimatesZones[0].Albedo); 
+            }
         }
 
         /// <summary>Gets the net long wave radiation (MJ/m2).</summary>
@@ -197,7 +260,15 @@ namespace Models
         [Units("MJ/m^2")]
         public double NetLongWaveRadiation
         {
-            get { return microClimatesZones[0].NetLongWaveRadiation; }
+            get 
+            { 
+                if (microClimatesZones.Count() == 0)
+                    return 0;
+                else if (microClimatesZones.Count() > 1)
+                    throw new Exception("This property cannot be used in a multi-zone simulation");
+                else
+                    return microClimatesZones[0].NetLongWaveRadiation;
+            }
         }
 
         /// <summary>Gets the flux of heat into the soil (MJ/m2).</summary>
@@ -205,7 +276,15 @@ namespace Models
         [Units("MJ/m^2")]
         public double SoilHeatFlux
         {
-            get { return microClimatesZones[0].SoilHeatFlux; }
+            get 
+            { 
+                if (microClimatesZones.Count() == 0)
+                    return 0;
+                else if (microClimatesZones.Count() > 1)
+                    throw new Exception("This property cannot be used in a multi-zone simulation");
+                else
+                    return microClimatesZones[0].SoilHeatFlux; 
+            }
         }
 
         /// <summary>Gets the total plant cover (0-1).</summary>
@@ -213,14 +292,30 @@ namespace Models
         [Units("-")]
         public double CanopyCover
         {
-            get { return microClimatesZones[0].CanopyCover; }
+            get 
+            { 
+                if (microClimatesZones.Count() == 0)
+                    return 0;
+                else if (microClimatesZones.Count() > 1)
+                    throw new Exception("This property cannot be used in a multi-zone simulation");
+                else
+                    return microClimatesZones[0].CanopyCover;
+            }
         }
 
         /// <summary>The number of canopy layers.</summary>
         [Description("Number of canopy layers")]
         public int NumLayers
         {
-            get { return microClimatesZones[0].DeltaZ.Length; }
+            get 
+            {
+                if (microClimatesZones.Count() == 0)
+                    return 0;
+                else if (microClimatesZones.Count() > 1)
+                    throw new Exception("This property cannot be used in a multi-zone simulation");
+                else
+                    return microClimatesZones[0].DeltaZ.Length;
+            }
         }
 
         /// <summary>Called when simulation starts.</summary>

--- a/Models/MicroClimate/MicroClimate.cs
+++ b/Models/MicroClimate/MicroClimate.cs
@@ -128,7 +128,7 @@ namespace Models
         {
             get 
             { 
-                if (microClimatesZones.Count() == 0)
+                if (microClimatesZones == null || microClimatesZones.Count() == 0)
                     return 0;
                 else if (microClimatesZones.Count() > 1)
                     throw new Exception("This property cannot be used in a multi-zone simulation");
@@ -158,7 +158,7 @@ namespace Models
         {
             get 
             {
-                if (microClimatesZones.Count() == 0)
+                if (microClimatesZones == null || microClimatesZones.Count() == 0)
                     return 0;
                 else if (microClimatesZones.Count() > 1)
                     throw new Exception("This property cannot be used in a multi-zone simulation");
@@ -174,7 +174,7 @@ namespace Models
         {
             get 
             { 
-                if (microClimatesZones.Count() == 0)
+                if (microClimatesZones == null || microClimatesZones.Count() == 0)
                     return 0;
                 else if (microClimatesZones.Count() > 1)
                     throw new Exception("This property cannot be used in a multi-zone simulation");
@@ -190,7 +190,7 @@ namespace Models
         {
             get 
             {
-                if (microClimatesZones.Count() == 0)
+                if (microClimatesZones == null || microClimatesZones.Count() == 0)
                     return 0;
                 else if (microClimatesZones.Count() > 1)
                     throw new Exception("This property cannot be used in a multi-zone simulation");
@@ -206,7 +206,7 @@ namespace Models
         {
             get 
             {
-                if (microClimatesZones.Count() == 0)
+                if (microClimatesZones == null || microClimatesZones.Count() == 0)
                     return 0;
                 else if (microClimatesZones.Count() > 1)
                     throw new Exception("This property cannot be used in a multi-zone simulation");
@@ -222,7 +222,7 @@ namespace Models
         {
             get 
             {
-                if (microClimatesZones.Count() == 0)
+                if (microClimatesZones == null || microClimatesZones.Count() == 0)
                     return 0;
                 else if (microClimatesZones.Count() > 1)
                     throw new Exception("This property cannot be used in a multi-zone simulation");
@@ -246,7 +246,7 @@ namespace Models
         {
             get 
             { 
-                if (microClimatesZones.Count() == 0)
+                if (microClimatesZones == null || microClimatesZones.Count() == 0)
                     return 0;
                 else if (microClimatesZones.Count() > 1)
                     throw new Exception("This property cannot be used in a multi-zone simulation");
@@ -262,7 +262,7 @@ namespace Models
         {
             get 
             { 
-                if (microClimatesZones.Count() == 0)
+                if (microClimatesZones == null || microClimatesZones.Count() == 0)
                     return 0;
                 else if (microClimatesZones.Count() > 1)
                     throw new Exception("This property cannot be used in a multi-zone simulation");
@@ -278,7 +278,7 @@ namespace Models
         {
             get 
             { 
-                if (microClimatesZones.Count() == 0)
+                if (microClimatesZones == null || microClimatesZones.Count() == 0)
                     return 0;
                 else if (microClimatesZones.Count() > 1)
                     throw new Exception("This property cannot be used in a multi-zone simulation");
@@ -294,7 +294,7 @@ namespace Models
         {
             get 
             { 
-                if (microClimatesZones.Count() == 0)
+                if (microClimatesZones == null || microClimatesZones.Count() == 0)
                     return 0;
                 else if (microClimatesZones.Count() > 1)
                     throw new Exception("This property cannot be used in a multi-zone simulation");
@@ -309,7 +309,7 @@ namespace Models
         {
             get 
             {
-                if (microClimatesZones.Count() == 0)
+                if (microClimatesZones == null || microClimatesZones.Count() == 0)
                     return 0;
                 else if (microClimatesZones.Count() > 1)
                     throw new Exception("This property cannot be used in a multi-zone simulation");

--- a/Models/MicroClimate/MicroClimate.cs
+++ b/Models/MicroClimate/MicroClimate.cs
@@ -143,7 +143,7 @@ namespace Models
         {
             get 
             { 
-                if (microClimatesZones.Count() == 0)
+                if (microClimatesZones == null || microClimatesZones.Count() == 0)
                     return 0;
                 else if (microClimatesZones.Count() > 1)
                     throw new Exception("This property cannot be used in a multi-zone simulation");

--- a/Models/MicroClimate/MicroClimateZone.cs
+++ b/Models/MicroClimate/MicroClimateZone.cs
@@ -526,7 +526,23 @@ namespace Models
         /// <summary>Send an energy balance event</summary>
         public void SetCanopyEnergyTerms()
         {
+            //calculate the total green/dead for the canopy first, as AgPasture needs to know this
+            double totalGreen = 0;
+            double totalDead = 0;
             for (int j = 0; j <= Canopies.Count - 1; j++)
+            {
+                if (Canopies[j].Canopy != null)
+                {
+                    for (int i = 0; i <= numLayers - 1; i++)
+                    {
+                        totalGreen += CalculateCanpoyEnergy(Canopies[j].Rs[i], SimulationAreaM2, RadnGreenFraction(j));
+                        totalDead += CalculateCanpoyEnergy(Canopies[j].Rs[i], SimulationAreaM2, 1 - RadnGreenFraction(j));
+                    }
+                }
+            }
+
+            for (int j = 0; j <= Canopies.Count - 1; j++)
+            {
                 if (Canopies[j].Canopy != null)
                 {
                     CanopyEnergyBalanceInterceptionlayerType[] lightProfile = new CanopyEnergyBalanceInterceptionlayerType[numLayers];
@@ -538,8 +554,11 @@ namespace Models
                     {
                         lightProfile[i] = new CanopyEnergyBalanceInterceptionlayerType();
                         lightProfile[i].thickness = DeltaZ[i];
-                        lightProfile[i].AmountOnGreen = Canopies[j].Rs[i] * SimulationAreaM2 * RadnGreenFraction(j);
-                        lightProfile[i].AmountOnDead = Canopies[j].Rs[i] * SimulationAreaM2 * (1 - RadnGreenFraction(j));
+                        lightProfile[i].AmountOnGreen = CalculateCanpoyEnergy(Canopies[j].Rs[i], SimulationAreaM2, RadnGreenFraction(j));
+                        lightProfile[i].AmountOnDead = CalculateCanpoyEnergy(Canopies[j].Rs[i], SimulationAreaM2, 1 - RadnGreenFraction(j));
+                        lightProfile[i].AmountOnGreenTotal = totalGreen;
+                        lightProfile[i].AmountOnDeadTotal = totalDead;
+                        totalDead += lightProfile[i].AmountOnDead;
                         totalPETa += Canopies[j].PETa[i];
                         totalPETr += Canopies[j].PETr[i];
                         totalPotentialEp += Canopies[j].PET[i];
@@ -549,6 +568,13 @@ namespace Models
                     Canopies[j].Canopy.WaterDemand = totalPotentialEp;
                     Canopies[j].Canopy.LightProfile = lightProfile;
                 }
+            }
+        }
+
+        /// <summary>AmountOnGreen and AmountOnDead Calucation for SetCanopyEnergyTerms</summary>
+        private double CalculateCanpoyEnergy(double Rs, double area, double radiation)
+        {
+            return Rs * area * radiation;
         }
 
         /// <summary>Break the combined Canopy into layers</summary>

--- a/Models/MicroClimate/MicroClimateZone.cs
+++ b/Models/MicroClimate/MicroClimateZone.cs
@@ -558,7 +558,6 @@ namespace Models
                         lightProfile[i].AmountOnDead = CalculateCanpoyEnergy(Canopies[j].Rs[i], SimulationAreaM2, 1 - RadnGreenFraction(j));
                         lightProfile[i].AmountOnGreenTotal = totalGreen;
                         lightProfile[i].AmountOnDeadTotal = totalDead;
-                        totalDead += lightProfile[i].AmountOnDead;
                         totalPETa += Canopies[j].PETa[i];
                         totalPETr += Canopies[j].PETr[i];
                         totalPotentialEp += Canopies[j].PET[i];


### PR DESCRIPTION
Resolves #11546

Kind of a tricky one here. AgPasture needs to know the total energy over the canopy, but the existing LightProfile object did not provide this. It was previously asking microclimate for this information, but that only returned the total for the first zone it found, and therefore broke in multi-zone simulations.

This PR fixes the bug, checking what stats damage this causes.